### PR TITLE
feat(governance): worktree-gate commit-blocked — full PR review protocol in instructions

### DIFF
--- a/plugin-scripts/governance/lib/json-rpc.sh
+++ b/plugin-scripts/governance/lib/json-rpc.sh
@@ -79,11 +79,40 @@ error_commit_blocked() {
     # Escape all user-controlled values for valid JSON
     local extra="\"branch\":\"$(json_escape "$branch")\",\"action\":\"$(json_escape "$command")\",\"protocol\":\"C04 - Git Worktree Protocol\""
 
+    local instructions
+    instructions="$(cat <<'INSTRUCTIONS'
+MANDATORY WORKFLOW (do not skip any step):
+
+1. CREATE WORKTREE + FEATURE BRANCH:
+   git worktree add .worktrees/<feature> -b <type>/<feature>
+   Then work inside the worktree directory.
+
+2. COMMIT + PUSH inside the worktree:
+   git add <files> && git commit -m "<type>(<scope>): <description>"
+   git push -u origin <branch>
+
+3. CREATE PR (MANDATORY — no direct merge allowed):
+   gh pr create --title "<type>(<scope>): <description>" --body "..."
+
+4. REVIEW BOT COMMENTS (MANDATORY — do not skip):
+   After PR is created, check for automated review comments from bots
+   (CodeRabbitAI, GitHub Copilot, Dependabot, etc.):
+   gh pr view <number> --json comments,reviews
+
+   For EACH bot comment/suggestion:
+   a) ACCEPT + IMPLEMENT: apply the fix → commit → push (same branch, PR updates automatically)
+   b) REJECT: post a reply on the PR explaining the technical reason for rejection
+      gh pr comment <number> --body "Rejected: <reason>"
+
+5. MERGE only after: PR reviewed + all accepted items implemented + rejections documented.
+INSTRUCTIONS
+)"
+
     json_error \
         "$ERR_COMMIT_BLOCKED" \
         "Direct commits to $(json_escape "$branch") branch are not allowed" \
         "PreToolUse:Bash" \
-        "Create a feature branch first using git worktree: git worktree add .worktrees/feature -b feature/your-change" \
+        "$instructions" \
         "$extra"
 }
 


### PR DESCRIPTION
### **User description**
## Summary

Expands the commit-blocked error message (`error_commit_blocked` in `json-rpc.sh`) with the complete mandatory workflow an AI agent must follow when blocked from committing to a protected branch.

## Problem

The previous `instructions` field only said:
> _"Create a feature branch first using git worktree: git worktree add .worktrees/feature -b feature/your-change"_

Agents would create the worktree, push the branch, create the PR — and then immediately merge without checking automated code review bot comments (CodeRabbitAI, Copilot, Dependabot, etc.).

## Solution

The new `instructions` field defines a **5-step mandatory workflow**:

| Step | Action |
|------|--------|
| 1 | Create worktree + feature branch |
| 2 | Commit + push inside worktree |
| 3 | `gh pr create` — mandatory, no direct merge |
| 4 | Check bot review comments (`gh pr view --json comments,reviews`) — for each: ACCEPT+implement or REJECT+document |
| 5 | Merge only after all items addressed |

## File Changed

`plugin-scripts/governance/lib/json-rpc.sh` — `error_commit_blocked()` function.

## Test Plan
- [x] `json-rpc.sh` syntax valid (bash -n)
- [x] `instructions` field is a heredoc string — no escaping issues
- [x] Step 4 covers both outcomes: accept→implement and reject→document with `gh pr comment`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Expands commit-blocked error message with complete 5-step mandatory workflow

- Adds mandatory PR review bot comment checking before merge

- Ensures AI agents address automated code review feedback

- Covers both acceptance (implement) and rejection (document) paths


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Create Worktree<br/>+ Feature Branch"] --> B["Commit + Push<br/>in Worktree"]
  B --> C["Create PR<br/>gh pr create"]
  C --> D["Check Bot Comments<br/>CodeRabbit, Copilot, etc."]
  D --> E{"Accept or<br/>Reject?"}
  E -->|Accept| F["Implement Fix<br/>+ Push"]
  E -->|Reject| G["Document Reason<br/>gh pr comment"]
  F --> H["Merge PR"]
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>json-rpc.sh</strong><dd><code>Add mandatory PR review workflow to error message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

plugin-scripts/governance/lib/json-rpc.sh

<ul><li>Replaced single-line worktree instruction with comprehensive 5-step <br>workflow<br> <li> Added mandatory PR creation step to prevent direct merges<br> <li> Included bot review comment checking with <code>gh pr view</code> command<br> <li> Documented binary decision paths: ACCEPT+implement or REJECT+document<br> <li> Used heredoc string for multi-line instructions without escaping <br>issues</ul>


</details>


  </td>
  <td><a href="https://github.com/ekson73/multi-agent-os/pull/6/files#diff-e887f4e9d52ade0d691cf69b31857aa56684f713ad75fb72822c6609f9f1b49a">+30/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

