### PR TITLE
fix(governance): worktree-gate PR instructions provider-agnostic (GitHub/Bitbucket/GitLab)

### DIFF
--- a/plugin-scripts/governance/lib/json-rpc.sh
+++ b/plugin-scripts/governance/lib/json-rpc.sh
@@ -80,7 +80,10 @@ error_commit_blocked() {
     local extra="\"branch\":\"$(json_escape "$branch")\",\"action\":\"$(json_escape "$command")\",\"protocol\":\"C04 - Git Worktree Protocol\""
 
     local instructions
-    instructions="$(cat <<'INSTRUCTIONS'
+    # Note: unquoted <<INSTRUCTIONS delimiter (not <<'INSTRUCTIONS') is intentional.
+    # Apostrophes inside $(cat <<'...') break bash $() parsing (treated as string delimiters).
+    # Content has no shell variables to expand, so unquoted delimiter is safe and equivalent.
+    instructions="$(cat <<INSTRUCTIONS
 MANDATORY WORKFLOW (do not skip any step):
 
 1. CREATE WORKTREE + FEATURE BRANCH:
@@ -91,18 +94,28 @@ MANDATORY WORKFLOW (do not skip any step):
    git add <files> && git commit -m "<type>(<scope>): <description>"
    git push -u origin <branch>
 
-3. CREATE PR (MANDATORY — no direct merge allowed):
-   gh pr create --title "<type>(<scope>): <description>" --body "..."
+3. CREATE PULL REQUEST (MANDATORY — no direct merge allowed):
+   Detect the git provider from the remote URL, then use the appropriate tool:
+   - GitHub    (github.com):    gh pr create --title "..." --body "..."
+   - Bitbucket (bitbucket.org): MCP bitbucket_create_pull_request, or BB REST API
+   - GitLab    (gitlab.com):    glab mr create --title "..." --description "..."
+   - Other:                     use the provider CLI, MCP tool, or REST API
 
-4. REVIEW BOT COMMENTS (MANDATORY — do not skip):
-   After PR is created, check for automated review comments from bots
-   (CodeRabbitAI, GitHub Copilot, Dependabot, etc.):
-   gh pr view <number> --json comments,reviews
+4. CHECK REVIEW BOT COMMENTS (MANDATORY — do not skip):
+   After PR is created, poll for automated review comments (CodeRabbitAI,
+   Copilot, Qodo, Dependabot, etc.) using the provider tool.
+   Poll every 60s — bots typically take 1-3 minutes to complete.
+   - GitHub:    gh pr view <number> --json comments,reviews
+   - Bitbucket: MCP bitbucket_get_pr_details or bitbucket_get_pull_requests
+   - GitLab:    glab mr view <number> --comments
+   - Other:     use the provider CLI, MCP tool, or REST API
 
    For EACH bot comment/suggestion:
-   a) ACCEPT + IMPLEMENT: apply the fix → commit → push (same branch, PR updates automatically)
-   b) REJECT: post a reply on the PR explaining the technical reason for rejection
-      gh pr comment <number> --body "Rejected: <reason>"
+   a) ACCEPT + IMPLEMENT: apply the fix -> commit -> push (PR updates automatically)
+   b) REJECT: post a reply on the PR with the technical reason for rejection
+      - GitHub:    gh pr comment <number> --body "Rejected: <reason>"
+      - Bitbucket: MCP or REST API to post a PR comment
+      - GitLab:    glab mr comment <number> --message "Rejected: <reason>"
 
 5. MERGE only after: PR reviewed + all accepted items implemented + rejections documented.
 INSTRUCTIONS

--- a/plugin-scripts/governance/lib/json-rpc.sh
+++ b/plugin-scripts/governance/lib/json-rpc.sh
@@ -79,10 +79,31 @@ error_commit_blocked() {
     # Escape all user-controlled values for valid JSON
     local extra="\"branch\":\"$(json_escape "$branch")\",\"action\":\"$(json_escape "$command")\",\"protocol\":\"C04 - Git Worktree Protocol\""
 
+    # Detect git provider from remote URL — emit targeted commands, not a generic list
+    local remote_url create_pr_cmd view_comments_cmd post_comment_cmd
+    remote_url=$(git config --get remote.origin.url 2>/dev/null || echo "unknown")
+
+    if [[ "$remote_url" == *"github.com"* ]]; then
+        create_pr_cmd='gh pr create --title "<title>" --body "<body>"'
+        view_comments_cmd='gh pr view <number> --json comments,reviews'
+        post_comment_cmd='gh pr comment <number> --body "<message>"'
+    elif [[ "$remote_url" == *"bitbucket.org"* ]]; then
+        create_pr_cmd='MCP bitbucket_create_pull_request (or BB REST API)'
+        view_comments_cmd='MCP bitbucket_get_pr_details or bitbucket_get_pull_requests'
+        post_comment_cmd='MCP or BB REST API to post a PR comment'
+    elif [[ "$remote_url" == *"gitlab.com"* ]]; then
+        create_pr_cmd='glab mr create --title "<title>" --description "<body>"'
+        view_comments_cmd='glab mr view <number> --comments'
+        post_comment_cmd='glab mr comment <number> --message "<message>"'
+    else
+        create_pr_cmd='use the provider CLI, MCP tool, or REST API to open a PR'
+        view_comments_cmd='use the provider CLI, MCP tool, or REST API to list PR comments'
+        post_comment_cmd='use the provider CLI, MCP tool, or REST API to post a PR comment'
+    fi
+
+    # Note: unquoted <<INSTRUCTIONS so provider variables expand correctly.
+    # Angle-bracket placeholders (<feature>, <title>) are not shell variables and are unaffected.
     local instructions
-    # Note: unquoted <<INSTRUCTIONS delimiter (not <<'INSTRUCTIONS') is intentional.
-    # Apostrophes inside $(cat <<'...') break bash $() parsing (treated as string delimiters).
-    # Content has no shell variables to expand, so unquoted delimiter is safe and equivalent.
     instructions="$(cat <<INSTRUCTIONS
 MANDATORY WORKFLOW (do not skip any step):
 
@@ -95,27 +116,17 @@ MANDATORY WORKFLOW (do not skip any step):
    git push -u origin <branch>
 
 3. CREATE PULL REQUEST (MANDATORY — no direct merge allowed):
-   Detect the git provider from the remote URL, then use the appropriate tool:
-   - GitHub    (github.com):    gh pr create --title "..." --body "..."
-   - Bitbucket (bitbucket.org): MCP bitbucket_create_pull_request, or BB REST API
-   - GitLab    (gitlab.com):    glab mr create --title "..." --description "..."
-   - Other:                     use the provider CLI, MCP tool, or REST API
+   $create_pr_cmd
 
 4. CHECK REVIEW BOT COMMENTS (MANDATORY — do not skip):
    After PR is created, poll for automated review comments (CodeRabbitAI,
-   Copilot, Qodo, Dependabot, etc.) using the provider tool.
-   Poll every 60s — bots typically take 1-3 minutes to complete.
-   - GitHub:    gh pr view <number> --json comments,reviews
-   - Bitbucket: MCP bitbucket_get_pr_details or bitbucket_get_pull_requests
-   - GitLab:    glab mr view <number> --comments
-   - Other:     use the provider CLI, MCP tool, or REST API
+   Copilot, Qodo, Dependabot, etc.). Poll every 60s (bots take 1-3 min).
+   $view_comments_cmd
 
    For EACH bot comment/suggestion:
    a) ACCEPT + IMPLEMENT: apply the fix -> commit -> push (PR updates automatically)
    b) REJECT: post a reply on the PR with the technical reason for rejection
-      - GitHub:    gh pr comment <number> --body "Rejected: <reason>"
-      - Bitbucket: MCP or REST API to post a PR comment
-      - GitLab:    glab mr comment <number> --message "Rejected: <reason>"
+      $post_comment_cmd
 
 5. MERGE only after: PR reviewed + all accepted items implemented + rejections documented.
 INSTRUCTIONS

--- a/plugin-scripts/governance/lib/json-rpc.sh
+++ b/plugin-scripts/governance/lib/json-rpc.sh
@@ -79,27 +79,55 @@ error_commit_blocked() {
     # Escape all user-controlled values for valid JSON
     local extra="\"branch\":\"$(json_escape "$branch")\",\"action\":\"$(json_escape "$command")\",\"protocol\":\"C04 - Git Worktree Protocol\""
 
-    # Detect git provider from remote URL — emit targeted commands, not a generic list
-    local remote_url create_pr_cmd view_comments_cmd post_comment_cmd
+    # Detect git provider: SCM_PROVIDER env var takes precedence, then URL pattern matching.
+    # URL matching uses broad patterns (*github*, *bitbucket*, *gitlab*) to cover
+    # both public SaaS (github.com) and enterprise/self-hosted instances (github.mycompany.com).
+    local remote_url provider scm_hostname create_pr_cmd view_comments_cmd post_comment_cmd
     remote_url=$(git config --get remote.origin.url 2>/dev/null || echo "unknown")
 
-    if [[ "$remote_url" == *"github.com"* ]]; then
-        create_pr_cmd='gh pr create --title "<title>" --body "<body>"'
-        view_comments_cmd='gh pr view <number> --json comments,reviews'
-        post_comment_cmd='gh pr comment <number> --body "<message>"'
-    elif [[ "$remote_url" == *"bitbucket.org"* ]]; then
-        create_pr_cmd='MCP bitbucket_create_pull_request (or BB REST API)'
-        view_comments_cmd='MCP bitbucket_get_pr_details or bitbucket_get_pull_requests'
-        post_comment_cmd='MCP or BB REST API to post a PR comment'
-    elif [[ "$remote_url" == *"gitlab.com"* ]]; then
-        create_pr_cmd='glab mr create --title "<title>" --description "<body>"'
-        view_comments_cmd='glab mr view <number> --comments'
-        post_comment_cmd='glab mr comment <number> --message "<message>"'
+    # Extract hostname from remote URL (supports both https and git@host:org/repo formats)
+    scm_hostname=$(echo "$remote_url" | sed -E 's|https?://([^/:]+).*|\1|; s|git@([^:]+):.*|\1|' 2>/dev/null || echo "")
+
+    # Provider resolution: explicit env var > URL pattern
+    if [[ -n "${SCM_PROVIDER:-}" ]]; then
+        provider="$SCM_PROVIDER"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        provider="github"
+    elif [[ "$remote_url" == *"bitbucket"* ]]; then
+        provider="bitbucket"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        provider="gitlab"
     else
-        create_pr_cmd='use the provider CLI, MCP tool, or REST API to open a PR'
-        view_comments_cmd='use the provider CLI, MCP tool, or REST API to list PR comments'
-        post_comment_cmd='use the provider CLI, MCP tool, or REST API to post a PR comment'
+        provider="other"
     fi
+
+    # Enterprise host flags: only added when hostname differs from the public SaaS host
+    local gh_flag="" glab_flag=""
+    [[ "$provider" == "github"    && "$scm_hostname" != "github.com"    && -n "$scm_hostname" ]] && gh_flag=" --hostname $scm_hostname"
+    [[ "$provider" == "gitlab"    && "$scm_hostname" != "gitlab.com"    && -n "$scm_hostname" ]] && glab_flag=" --server https://$scm_hostname"
+
+    case "$provider" in
+        github)
+            create_pr_cmd="gh pr create${gh_flag} --title \"<title>\" --body \"<body>\""
+            view_comments_cmd="gh pr view${gh_flag} <number> --json comments,reviews"
+            post_comment_cmd="gh pr comment${gh_flag} <number> --body \"<message>\""
+            ;;
+        bitbucket)
+            create_pr_cmd='MCP bitbucket_create_pull_request (or BB REST API)'
+            view_comments_cmd='MCP bitbucket_get_pr_details or bitbucket_get_pull_requests'
+            post_comment_cmd='MCP or BB REST API to post a PR comment'
+            ;;
+        gitlab)
+            create_pr_cmd="glab mr create${glab_flag} --title \"<title>\" --description \"<body>\""
+            view_comments_cmd="glab mr view${glab_flag} <number> --comments"
+            post_comment_cmd="glab mr comment${glab_flag} <number> --message \"<message>\""
+            ;;
+        *)
+            create_pr_cmd='use the provider CLI, MCP tool, or REST API to open a PR'
+            view_comments_cmd='use the provider CLI, MCP tool, or REST API to list PR comments'
+            post_comment_cmd='use the provider CLI, MCP tool, or REST API to post a PR comment'
+            ;;
+    esac
 
     # Note: unquoted <<INSTRUCTIONS so provider variables expand correctly.
     # Angle-bracket placeholders (<feature>, <title>) are not shell variables and are unaffected.


### PR DESCRIPTION
### **User description**
## Problem

PR #6 hardcoded GitHub CLI (`gh pr create`, `gh pr view`, `gh pr comment`) in the commit-blocked error instructions. This broke the flow for repos on **Bitbucket** or **GitLab** — agents would receive GitHub-specific commands for a non-GitHub repo.

## Solution

Steps 3 and 4 now detect the git provider from the remote URL and route to the appropriate tool:

| Provider | PR Create | Poll Comments | Post Comment |
|----------|-----------|---------------|--------------|
| GitHub | `gh pr create` | `gh pr view --json` | `gh pr comment` |
| Bitbucket | MCP `bitbucket_create_pull_request` | MCP `bitbucket_get_pr_details` | MCP / REST API |
| GitLab | `glab mr create` | `glab mr view --comments` | `glab mr comment` |
| Other | provider CLI / MCP / REST API | provider CLI / MCP / REST API | provider CLI / MCP / REST API |

## Bonus Fix

Changed `<<'INSTRUCTIONS'` to `<<INSTRUCTIONS` (unquoted heredoc delimiter).  
Apostrophes inside `$(cat <<'HEREDOC'...)` are parsed as bash string delimiters by the `$()` context — causing `bash -n` syntax errors. Unquoted delimiter is safe since the content has no shell variables to expand.

## Test Plan
- [x] `bash -n json-rpc.sh` → syntax OK
- [x] No GitHub-specific CLI (`gh`) in provider-agnostic steps
- [x] All 3 major providers covered (GitHub, Bitbucket, GitLab) + generic fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Make PR instructions provider-agnostic for GitHub, Bitbucket, GitLab

- Detect git provider from remote URL and route to appropriate tool

- Fix bash parsing bug with quoted heredoc delimiter in $() context

- Add polling guidance and provider-specific command examples


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["error_commit_blocked function"] -->|Detect provider| B["GitHub/Bitbucket/GitLab/Other"]
  B -->|Step 3| C["Create PR with provider tool"]
  B -->|Step 4| D["Poll review bot comments"]
  B -->|Step 4b| E["Post rejection reply"]
  C -->|GitHub| F["gh pr create"]
  C -->|Bitbucket| G["MCP bitbucket_create_pull_request"]
  C -->|GitLab| H["glab mr create"]
  D -->|GitHub| I["gh pr view"]
  D -->|Bitbucket| J["MCP bitbucket_get_pr_details"]
  D -->|GitLab| K["glab mr view"]
  E -->|GitHub| L["gh pr comment"]
  E -->|Bitbucket| M["MCP/REST API"]
  E -->|GitLab| N["glab mr comment"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix, enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>json-rpc.sh</strong><dd><code>Provider-agnostic PR instructions with bash parsing fix</code>&nbsp; &nbsp; </dd></summary>
<hr>

plugin-scripts/governance/lib/json-rpc.sh

<ul><li>Changed heredoc delimiter from quoted <code><<'INSTRUCTIONS'</code> to unquoted <code><<INSTRUCTIONS</code> to fix bash $() <br>parsing bug with apostrophes<br> <li> Updated Step 3 (Create PR) to detect git provider and provide <br>provider-specific commands for GitHub, Bitbucket, GitLab, and generic <br>fallback<br> <li> Updated Step 4 (Review bot comments) with provider detection and <br>polling guidance (60s intervals, 1-3 minute bot latency)<br> <li> Added provider-specific commands for posting rejection replies (gh pr <br>comment, MCP/REST API, glab mr comment)<br> <li> Improved formatting and clarity of workflow instructions with better <br>organization</ul>


</details>


  </td>
  <td><a href="https://github.com/ekson73/multi-agent-os/pull/7/files#diff-e887f4e9d52ade0d691cf69b31857aa56684f713ad75fb72822c6609f9f1b49a">+24/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

