### PR TITLE
feat(maos-mcp-hub): D65 pilot with common http/errors + pytest/respx

### DIFF
--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -359,3 +359,7 @@ MIT License — see [LICENSE](LICENSE) for details.
 Contributions welcome! To add a new MCP server integration, see [Adding a New Server](#adding-a-new-server) above.
 
 Issues and PRs: [github.com/your-org/multi-agent-os](https://github.com/your-org/multi-agent-os)
+
+---
+
+Agent Signature: `codex-cli` | Timestamp: `2026-03-04T08:52:33-03:00`

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -30,6 +30,9 @@ hub.py                          ← Universal MCP gateway (STDIO transport)
 │       └── tools.py            ← Tool implementations (TOOLS dict)
 │
 ├── lib/                        ← Shared client libraries
+│   ├── common/
+│   │   ├── errors.py           ← Typed API errors (Auth/NotFound/RateLimit/etc.)
+│   │   └── http.py             ← Shared HTTP layer (retry/backoff/rate-limit/redaction)
 │   └── bitbucket/
 │       ├── client.py           ← Bitbucket Cloud API client (async httpx)
 │       ├── analyzer.py         ← AI-powered failure analysis
@@ -43,6 +46,8 @@ hub.py                          ← Universal MCP gateway (STDIO transport)
 │
 ├── cli.py                      ← Development/testing CLI
 ├── requirements.txt
+├── requirements-dev.txt
+├── tests/
 ├── .env.example
 └── README.md
 ```
@@ -79,6 +84,7 @@ source .venv/bin/activate      # Linux/macOS
 # .venv\Scripts\activate       # Windows
 
 pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 
 ### 3. Configure environment
@@ -150,6 +156,12 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 ```
 
 Restart Claude Desktop. You'll see **42 Bitbucket tools** available.
+
+### 6. Run tests (pilot D65)
+
+```bash
+pytest -q tests/test_bitbucket_client.py tests/test_jira_client.py
+```
 
 ---
 

--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -13,6 +13,8 @@ from typing import Optional
 from urllib.parse import quote
 from aiolimiter import AsyncLimiter
 
+from lib.common.http import request_json, request_text
+
 
 class BitbucketPipelineClient:
     """
@@ -83,6 +85,10 @@ class BitbucketPipelineClient:
             or self._get_repo_slug()
         )
         self.base_url = f"https://api.bitbucket.org/2.0/repositories/{self.repo_slug}"
+        self._provider_name = "Bitbucket"
+        self._auth_hint = (
+            "Verifique BITBUCKET_API_TOKEN e (quando auth basic) BITBUCKET_EMAIL/JIRA_EMAIL/BITBUCKET_USERNAME."
+        )
 
         # Rate limiter: 1000 requests per hour (Bitbucket Cloud API limit)
         self.rate_limiter = AsyncLimiter(max_rate=1000, time_period=3600)
@@ -155,15 +161,16 @@ class BitbucketPipelineClient:
         Raises:
             httpx.HTTPError: If API request fails
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/pipelines",
-                    params={"sort": sort, "pagelen": pagelen},
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pipelines",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"sort": sort, "pagelen": pagelen},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def get_pipeline(self, build_number: int) -> dict:
         """
@@ -178,14 +185,15 @@ class BitbucketPipelineClient:
         Raises:
             httpx.HTTPError: If API request fails (404 if build not found)
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/pipelines/{build_number}",
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pipelines/{build_number}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def get_pipeline_steps(self, build_number: int) -> dict:
         """
@@ -200,14 +208,15 @@ class BitbucketPipelineClient:
         Raises:
             httpx.HTTPError: If API request fails
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/pipelines/{build_number}/steps/",
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pipelines/{build_number}/steps/",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def get_step_log(self, build_number: int, step_uuid: str) -> str:
         """
@@ -231,14 +240,16 @@ class BitbucketPipelineClient:
         # This is required by Bitbucket API
         step_uuid_encoded = quote(step_uuid, safe="")
 
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
-                response = await client.get(
-                    f"{self.base_url}/pipelines/{build_number}/steps/{step_uuid_encoded}/log",
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.text
+        return await request_text(
+            method="GET",
+            url=f"{self.base_url}/pipelines/{build_number}/steps/{step_uuid_encoded}/log",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=60.0,
+            follow_redirects=True,
+            limiter=self.rate_limiter,
+        )
 
     async def get_step_logs(self, build_number: int, step_name: str) -> dict:
         """

--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -159,7 +159,7 @@ class BitbucketPipelineClient:
             dict: Bitbucket API response with 'values' array and pagination info
 
         Raises:
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         return await request_json(
             method="GET",
@@ -183,7 +183,7 @@ class BitbucketPipelineClient:
             dict: Pipeline object with full details
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if build not found)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         return await request_json(
             method="GET",
@@ -206,7 +206,7 @@ class BitbucketPipelineClient:
             dict: Response with 'values' array of step objects
 
         Raises:
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         return await request_json(
             method="GET",
@@ -230,7 +230,7 @@ class BitbucketPipelineClient:
             str: Raw log output (plain text)
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if logs not available)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         # Ensure UUID has curly braces (API requires them)
         if not step_uuid.startswith("{"):
@@ -267,7 +267,7 @@ class BitbucketPipelineClient:
 
         Raises:
             ValueError: If step name not found
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         # Get all steps for this build
         steps_data = await self.get_pipeline_steps(build_number)

--- a/mcp-tools/maos-mcp-hub/lib/common/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/__init__.py
@@ -1,0 +1,2 @@
+"""Common shared utilities for MAOS MCP Hub."""
+

--- a/mcp-tools/maos-mcp-hub/lib/common/errors.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/errors.py
@@ -18,6 +18,10 @@ class ApiError(Exception):
     provider: str
     hint: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        # Keep Exception.args compatible with standard exception handling.
+        super().__init__(self.message)
+
     def __str__(self) -> str:
         base = (
             f"{self.provider} API error ({self.status_code}) at {self.endpoint}: "
@@ -46,4 +50,3 @@ class ServerError(ApiError):
 
 class NetworkError(ApiError):
     """Network/timeout/transport error."""
-

--- a/mcp-tools/maos-mcp-hub/lib/common/errors.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/errors.py
@@ -1,0 +1,49 @@
+"""
+Common typed errors for external API integrations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ApiError(Exception):
+    """Base structured error for upstream API failures."""
+
+    message: str
+    status_code: int
+    endpoint: str
+    provider: str
+    hint: Optional[str] = None
+
+    def __str__(self) -> str:
+        base = (
+            f"{self.provider} API error ({self.status_code}) at {self.endpoint}: "
+            f"{self.message}"
+        )
+        if self.hint:
+            return f"{base} | hint: {self.hint}"
+        return base
+
+
+class AuthError(ApiError):
+    """Authentication/authorization failure (401/403)."""
+
+
+class NotFoundError(ApiError):
+    """Requested resource does not exist (404)."""
+
+
+class RateLimitError(ApiError):
+    """Upstream rate limit reached (429)."""
+
+
+class ServerError(ApiError):
+    """Upstream internal/server-side error (5xx)."""
+
+
+class NetworkError(ApiError):
+    """Network/timeout/transport error."""
+

--- a/mcp-tools/maos-mcp-hub/lib/common/http.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/http.py
@@ -1,0 +1,202 @@
+"""
+Shared async HTTP helpers with retry/backoff/rate-limit and error mapping.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import random
+import re
+from typing import Any, Optional
+
+import httpx
+from aiolimiter import AsyncLimiter
+
+from .errors import (
+    ApiError,
+    AuthError,
+    NetworkError,
+    NotFoundError,
+    RateLimitError,
+    ServerError,
+)
+
+
+def sanitize_text(value: str) -> str:
+    """Redact common secrets in logs/error strings."""
+    text = value
+    text = re.sub(r"Basic [A-Za-z0-9+/=]+", "Basic ***", text)
+    text = re.sub(r"Bearer [A-Za-z0-9._=-]+", "Bearer ***", text)
+    text = re.sub(r"(token|password|secret|api[_-]?key)[=:\\s]+[^\\s,\\)]+", r"\1=***", text, flags=re.IGNORECASE)
+    return text
+
+
+def sanitize_exception(error: Exception) -> str:
+    return sanitize_text(str(error))
+
+
+def _backoff_seconds(attempt: int, base: float = 0.5, cap: float = 8.0) -> float:
+    # Exponential backoff + jitter to reduce thundering herd.
+    delay = min(cap, base * (2 ** max(0, attempt - 1)))
+    return delay + random.uniform(0, 0.3)
+
+
+def _map_http_status_error(
+    error: httpx.HTTPStatusError,
+    *,
+    provider: str,
+    endpoint: str,
+    auth_hint: str,
+) -> ApiError:
+    status_code = error.response.status_code
+    message = sanitize_text(error.response.text or error.response.reason_phrase or str(error))
+
+    if status_code in (401, 403):
+        return AuthError(message, status_code, endpoint, provider, auth_hint)
+    if status_code == 404:
+        return NotFoundError(
+            message,
+            status_code,
+            endpoint,
+            provider,
+            "Verifique identificadores (repo_slug, build_number, issue_key, etc.).",
+        )
+    if status_code == 429:
+        return RateLimitError(
+            message,
+            status_code,
+            endpoint,
+            provider,
+            "Rate limit atingido; tente novamente com menos frequência.",
+        )
+    if 500 <= status_code < 600:
+        return ServerError(
+            message,
+            status_code,
+            endpoint,
+            provider,
+            "Falha temporária no upstream; tente novamente em instantes.",
+        )
+    return ApiError(message, status_code, endpoint, provider)
+
+
+async def request_json(
+    *,
+    method: str,
+    url: str,
+    provider: str,
+    auth_hint: str,
+    auth_kwargs: Optional[dict[str, Any]] = None,
+    params: Optional[dict[str, Any]] = None,
+    json: Optional[dict[str, Any]] = None,
+    timeout: float = 30.0,
+    follow_redirects: bool = False,
+    limiter: Optional[AsyncLimiter] = None,
+    max_retries: int = 3,
+) -> dict[str, Any]:
+    """Perform request and parse JSON with retry + structured errors."""
+    auth_kwargs = auth_kwargs or {}
+    attempts = max(1, max_retries)
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            if limiter:
+                async with limiter:
+                    async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                        response = await client.request(
+                            method, url, params=params, json=json, **auth_kwargs
+                        )
+            else:
+                async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                    response = await client.request(
+                        method, url, params=params, json=json, **auth_kwargs
+                    )
+
+            response.raise_for_status()
+            return response.json()
+
+        except httpx.HTTPStatusError as exc:
+            mapped = _map_http_status_error(
+                exc, provider=provider, endpoint=url, auth_hint=auth_hint
+            )
+            last_error = mapped
+            if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
+                await asyncio.sleep(_backoff_seconds(attempt))
+                continue
+            raise mapped
+        except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
+            last_error = NetworkError(
+                sanitize_exception(exc),
+                0,
+                url,
+                provider,
+                "Erro de rede/transporte. Verifique conectividade e tente novamente.",
+            )
+            if attempt < attempts:
+                await asyncio.sleep(_backoff_seconds(attempt))
+                continue
+            raise last_error
+
+    if isinstance(last_error, ApiError):
+        raise last_error
+    raise ApiError("Erro desconhecido", 0, url, provider)
+
+
+async def request_text(
+    *,
+    method: str,
+    url: str,
+    provider: str,
+    auth_hint: str,
+    auth_kwargs: Optional[dict[str, Any]] = None,
+    params: Optional[dict[str, Any]] = None,
+    timeout: float = 30.0,
+    follow_redirects: bool = False,
+    limiter: Optional[AsyncLimiter] = None,
+    max_retries: int = 3,
+) -> str:
+    """Perform request and return response text with retry + structured errors."""
+    auth_kwargs = auth_kwargs or {}
+    attempts = max(1, max_retries)
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            if limiter:
+                async with limiter:
+                    async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                        response = await client.request(method, url, params=params, **auth_kwargs)
+            else:
+                async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                    response = await client.request(method, url, params=params, **auth_kwargs)
+
+            response.raise_for_status()
+            return response.text
+
+        except httpx.HTTPStatusError as exc:
+            mapped = _map_http_status_error(
+                exc, provider=provider, endpoint=url, auth_hint=auth_hint
+            )
+            last_error = mapped
+            if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
+                await asyncio.sleep(_backoff_seconds(attempt))
+                continue
+            raise mapped
+        except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
+            last_error = NetworkError(
+                sanitize_exception(exc),
+                0,
+                url,
+                provider,
+                "Erro de rede/transporte. Verifique conectividade e tente novamente.",
+            )
+            if attempt < attempts:
+                await asyncio.sleep(_backoff_seconds(attempt))
+                continue
+            raise last_error
+
+    if isinstance(last_error, ApiError):
+        raise last_error
+    raise ApiError("Erro desconhecido", 0, url, provider)
+

--- a/mcp-tools/maos-mcp-hub/lib/common/http.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/http.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import asyncio
 import random
 import re
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
 from typing import Any, Optional
 
 import httpx
@@ -27,7 +29,12 @@ def sanitize_text(value: str) -> str:
     text = value
     text = re.sub(r"Basic [A-Za-z0-9+/=]+", "Basic ***", text)
     text = re.sub(r"Bearer [A-Za-z0-9._=-]+", "Bearer ***", text)
-    text = re.sub(r"(token|password|secret|api[_-]?key)[=:\\s]+[^\\s,\\)]+", r"\1=***", text, flags=re.IGNORECASE)
+    text = re.sub(
+        r"(token|password|secret|api[_-]?key)[=:\s]+[^\s,)]+",
+        r"\1=***",
+        text,
+        flags=re.IGNORECASE,
+    )
     return text
 
 
@@ -39,6 +46,40 @@ def _backoff_seconds(attempt: int, base: float = 0.5, cap: float = 8.0) -> float
     # Exponential backoff + jitter to reduce thundering herd.
     delay = min(cap, base * (2 ** max(0, attempt - 1)))
     return delay + random.uniform(0, 0.3)
+
+
+def _retry_after_seconds(raw: Optional[str]) -> Optional[float]:
+    """Parse Retry-After header as seconds or HTTP-date."""
+    if not raw:
+        return None
+
+    value = raw.strip()
+    if not value:
+        return None
+
+    try:
+        return max(0.0, float(value))
+    except ValueError:
+        pass
+
+    try:
+        dt = parsedate_to_datetime(value)
+        if dt is None:
+            return None
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return max(0.0, (dt - datetime.now(timezone.utc)).total_seconds())
+    except (TypeError, ValueError, OverflowError):
+        return None
+
+
+def _retry_delay(exc: httpx.HTTPStatusError, attempt: int) -> float:
+    """Honor Retry-After when present, never less than local backoff."""
+    local = _backoff_seconds(attempt)
+    retry_after = _retry_after_seconds(exc.response.headers.get("Retry-After"))
+    if retry_after is None:
+        return local
+    return max(local, retry_after)
 
 
 def _map_http_status_error(
@@ -94,9 +135,12 @@ async def request_json(
     limiter: Optional[AsyncLimiter] = None,
     max_retries: int = 3,
 ) -> dict[str, Any]:
-    """Perform request and parse JSON with retry + structured errors."""
+    """Perform request and parse JSON with retry + structured errors.
+
+    `max_retries` means retries after the initial attempt.
+    """
     auth_kwargs = auth_kwargs or {}
-    attempts = max(1, max_retries)
+    attempts = max(1, max_retries + 1)
     last_error: Optional[Exception] = None
 
     for attempt in range(1, attempts + 1):
@@ -122,7 +166,7 @@ async def request_json(
             )
             last_error = mapped
             if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
-                await asyncio.sleep(_backoff_seconds(attempt))
+                await asyncio.sleep(_retry_delay(exc, attempt))
                 continue
             raise mapped
         except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
@@ -156,9 +200,12 @@ async def request_text(
     limiter: Optional[AsyncLimiter] = None,
     max_retries: int = 3,
 ) -> str:
-    """Perform request and return response text with retry + structured errors."""
+    """Perform request and return response text with retry + structured errors.
+
+    `max_retries` means retries after the initial attempt.
+    """
     auth_kwargs = auth_kwargs or {}
-    attempts = max(1, max_retries)
+    attempts = max(1, max_retries + 1)
     last_error: Optional[Exception] = None
 
     for attempt in range(1, attempts + 1):
@@ -180,7 +227,7 @@ async def request_text(
             )
             last_error = mapped
             if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
-                await asyncio.sleep(_backoff_seconds(attempt))
+                await asyncio.sleep(_retry_delay(exc, attempt))
                 continue
             raise mapped
         except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
@@ -199,4 +246,3 @@ async def request_text(
     if isinstance(last_error, ApiError):
         raise last_error
     raise ApiError("Erro desconhecido", 0, url, provider)
-

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -13,6 +13,8 @@ import os
 from typing import Optional
 from aiolimiter import AsyncLimiter
 
+from lib.common.http import request_json
+
 
 class JiraClient:
     """
@@ -59,6 +61,10 @@ class JiraClient:
             )
 
         self.base_url = f"https://api.atlassian.com/ex/jira/{self.cloud_id}/rest/api/3"
+        self._provider_name = "Jira"
+        self._auth_hint = (
+            "Verifique JIRA_EMAIL e JIRA_API_TOKEN (ou ATLASSIAN_API_TOKEN fallback)."
+        )
 
         # Rate limiter: 300 requests per hour (conservative for Jira Cloud)
         self.rate_limiter = AsyncLimiter(max_rate=300, time_period=3600)
@@ -94,15 +100,16 @@ class JiraClient:
         if fields:
             params["fields"] = fields
 
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/issue/{issue_key}",
-                    params=params,
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/issue/{issue_key}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params=params,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     # ========================================================================
     # Attachments API

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -94,7 +94,7 @@ class JiraClient:
             dict: Issue data with key, fields (summary, description, status, etc.)
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if issue not found)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         params = {}
         if fields:

--- a/mcp-tools/maos-mcp-hub/requirements-dev.txt
+++ b/mcp-tools/maos-mcp-hub/requirements-dev.txt
@@ -1,4 +1,4 @@
 # MAOS MCP Hub - Development/Test Dependencies
 
-pytest>=8.3.0
-respx>=0.22.0
+pytest==9.0.2
+respx==0.22.0

--- a/mcp-tools/maos-mcp-hub/requirements-dev.txt
+++ b/mcp-tools/maos-mcp-hub/requirements-dev.txt
@@ -1,0 +1,4 @@
+# MAOS MCP Hub - Development/Test Dependencies
+
+pytest>=8.3.0
+respx>=0.22.0

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -381,6 +381,14 @@ async def get_test_reports(build_number: int, step_name: str, repo_slug: str = "
             "has_failures": report.get("failed_test_count", 0) > 0,
         }
 
+    except ApiError as e:
+        return {
+            "error": "Failed to get test reports",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+            "build_number": build_number,
+            "step_name": step_name,
+        }
     except httpx.HTTPStatusError as e:
         return {
             "error": f"Failed to get test reports: {sanitize_error(e)}",
@@ -459,6 +467,14 @@ async def get_test_cases(build_number: int, step_name: str, status: str = "all",
             "count": len(formatted_cases),
         }
 
+    except ApiError as e:
+        return {
+            "error": "Failed to get test cases",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+            "build_number": build_number,
+            "step_name": step_name,
+        }
     except httpx.HTTPStatusError as e:
         return {
             "error": f"Failed to get test cases: {sanitize_error(e)}",
@@ -549,6 +565,15 @@ async def get_test_case_reasons(build_number: int, step_name: str, test_case_nam
             "failure_reasons": formatted_reasons,
         }
 
+    except ApiError as e:
+        return {
+            "error": "Failed to get test case reasons",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+            "build_number": build_number,
+            "step_name": step_name,
+            "test_case_name": test_case_name,
+        }
     except httpx.HTTPStatusError as e:
         return {
             "error": f"Failed to get test case reasons: {sanitize_error(e)}",

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -16,6 +16,8 @@ from lib.bitbucket.client import BitbucketPipelineClient
 from lib.bitbucket.analyzer import PipelineAnalyzer
 from lib.bitbucket.health import HealthMonitor
 from lib.bitbucket.validators import validate_build_number, validate_step_name, sanitize_error
+from lib.common.errors import ApiError
+from lib.common.http import sanitize_exception
 
 
 # Global singleton instances
@@ -74,7 +76,19 @@ async def get_recent_builds(count: int = 5, repo_slug: str = "") -> dict:
         return {"error": "count must be between 1 and 50"}
 
     client = get_client(repo_slug)
-    pipelines = await client.get_pipelines(pagelen=count)
+    try:
+        pipelines = await client.get_pipelines(pagelen=count)
+    except ApiError as e:
+        return {
+            "error": "Failed to fetch recent builds",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+        }
+    except Exception as e:
+        return {
+            "error": "Failed to fetch recent builds",
+            "details": sanitize_exception(e),
+        }
 
     builds = []
     for p in pipelines.get("values", []):
@@ -100,8 +114,17 @@ async def get_build_details(build_number: int, repo_slug: str = "") -> dict:
 
     try:
         build = await client.get_pipeline(build_number)
+    except ApiError as e:
+        return {
+            "error": f"Failed to fetch build {build_number}",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+        }
     except Exception as e:
-        return {"error": f"Failed to fetch build {build_number}", "details": str(e)}
+        return {
+            "error": f"Failed to fetch build {build_number}",
+            "details": sanitize_exception(e),
+        }
 
     return {
         "build_number": build["build_number"],
@@ -161,8 +184,17 @@ async def get_step_logs(build_number: int, step_name: str, repo_slug: str = "") 
 
     try:
         steps_data = await client.get_pipeline_steps(build_number)
+    except ApiError as e:
+        return {
+            "error": f"Failed to fetch steps for build {build_number}",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+        }
     except Exception as e:
-        return {"error": f"Failed to fetch steps for build {build_number}", "details": str(e)}
+        return {
+            "error": f"Failed to fetch steps for build {build_number}",
+            "details": sanitize_exception(e),
+        }
 
     # Find step by name
     step = next((s for s in steps_data.get("values", []) if s.get("name") == step_name), None)
@@ -186,9 +218,20 @@ async def get_step_logs(build_number: int, step_name: str, repo_slug: str = "") 
             "result": step.get("state", {}).get("result", {}).get("name", "N/A"),
             "logs": logs,
         }
+    except ApiError as e:
+        return {
+            "error": "Logs not available",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+            "step_name": step_name,
+            "step_uuid": step_uuid,
+            "state": step.get("state", {}).get("name", "UNKNOWN"),
+            "result": step.get("state", {}).get("result", {}).get("name", "N/A"),
+        }
     except Exception as e:
         return {
-            "error": f"Logs not available: {str(e)}",
+            "error": "Logs not available",
+            "details": sanitize_exception(e),
             "step_name": step_name,
             "step_uuid": step_uuid,
             "state": step.get("state", {}).get("name", "UNKNOWN"),

--- a/mcp-tools/maos-mcp-hub/servers/jira/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/jira/tools.py
@@ -13,8 +13,6 @@ import base64
 import re
 from typing import Optional
 
-import httpx
-
 from lib.jira.client import JiraClient
 from lib.common.errors import ApiError
 from lib.common.http import sanitize_exception
@@ -207,10 +205,6 @@ async def get_issue(issue_key: str, format: str = "markdown") -> dict:
         if e.status_code == 404:
             return {"error": f"Issue {issue_key} not found"}
         return {"error": f"Jira API error: {sanitize_exception(e)}", "hint": e.hint}
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
-            return {"error": f"Issue {issue_key} not found"}
-        return {"error": f"Jira API error: {_sanitize_error(e)}"}
     except Exception as e:
         return {"error": f"Unexpected error: {_sanitize_error(e)}"}
 
@@ -249,10 +243,10 @@ async def list_attachments(issue_key: str) -> dict:
             ],
         }
 
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+    except ApiError as e:
+        if e.status_code == 404:
             return {"error": f"Issue {issue_key} not found"}
-        return {"error": f"Jira API error: {_sanitize_error(e)}"}
+        return {"error": f"Jira API error: {sanitize_exception(e)}", "hint": e.hint}
     except Exception as e:
         return {"error": f"Unexpected error: {_sanitize_error(e)}"}
 
@@ -305,10 +299,10 @@ async def download_attachment(issue_key: str, filename: str) -> dict:
 
     except ValueError as e:
         return {"error": str(e)}
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+    except ApiError as e:
+        if e.status_code == 404:
             return {"error": f"Attachment '{filename}' not found on {issue_key}"}
-        return {"error": f"Jira API error: {_sanitize_error(e)}"}
+        return {"error": f"Jira API error: {sanitize_exception(e)}", "hint": e.hint}
     except Exception as e:
         return {"error": f"Unexpected error: {_sanitize_error(e)}"}
 
@@ -351,12 +345,12 @@ async def upload_attachment(issue_key: str, filepath: str, filename: str = "") -
 
     except FileNotFoundError as e:
         return {"error": str(e)}
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+    except ApiError as e:
+        if e.status_code == 404:
             return {"error": f"Issue {issue_key} not found"}
-        if e.response.status_code == 403:
+        if e.status_code == 403:
             return {"error": f"No permission to upload attachments to {issue_key}"}
-        return {"error": f"Jira API error: {_sanitize_error(e)}"}
+        return {"error": f"Jira API error: {sanitize_exception(e)}", "hint": e.hint}
     except Exception as e:
         return {"error": f"Unexpected error: {_sanitize_error(e)}"}
 
@@ -382,12 +376,12 @@ async def delete_attachment(attachment_id: str) -> dict:
     try:
         return await client.delete_attachment(attachment_id)
 
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+    except ApiError as e:
+        if e.status_code == 404:
             return {"error": f"Attachment {attachment_id} not found"}
-        if e.response.status_code == 403:
+        if e.status_code == 403:
             return {"error": f"No permission to delete attachment {attachment_id}"}
-        return {"error": f"Jira API error: {_sanitize_error(e)}"}
+        return {"error": f"Jira API error: {sanitize_exception(e)}", "hint": e.hint}
     except Exception as e:
         return {"error": f"Unexpected error: {_sanitize_error(e)}"}
 

--- a/mcp-tools/maos-mcp-hub/servers/jira/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/jira/tools.py
@@ -16,6 +16,8 @@ from typing import Optional
 import httpx
 
 from lib.jira.client import JiraClient
+from lib.common.errors import ApiError
+from lib.common.http import sanitize_exception
 
 
 # ============================================================================
@@ -201,6 +203,10 @@ async def get_issue(issue_key: str, format: str = "markdown") -> dict:
             "attachment_count": len(fields.get("attachment", [])),
         }
 
+    except ApiError as e:
+        if e.status_code == 404:
+            return {"error": f"Issue {issue_key} not found"}
+        return {"error": f"Jira API error: {sanitize_exception(e)}", "hint": e.hint}
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 404:
             return {"error": f"Issue {issue_key} not found"}

--- a/mcp-tools/maos-mcp-hub/tests/conftest.py
+++ b/mcp-tools/maos-mcp-hub/tests/conftest.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+

--- a/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
@@ -1,0 +1,82 @@
+import asyncio
+
+import httpx
+import respx
+
+from lib.bitbucket.client import BitbucketPipelineClient
+from lib.common.errors import NotFoundError
+
+
+def _setup_env(monkeypatch):
+    monkeypatch.setenv("BITBUCKET_API_TOKEN", "test-token")
+    monkeypatch.setenv("BITBUCKET_AUTH_TYPE", "bearer")
+    monkeypatch.delenv("BITBUCKET_EMAIL", raising=False)
+    monkeypatch.delenv("JIRA_EMAIL", raising=False)
+    monkeypatch.delenv("BITBUCKET_USERNAME", raising=False)
+
+
+def test_get_pipelines_success(monkeypatch):
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.get(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pipelines"
+            ).mock(return_value=httpx.Response(200, json={"values": [{"build_number": 10}]}))
+
+            data = await client.get_pipelines(pagelen=1)
+            assert route.called
+            assert data["values"][0]["build_number"] == 10
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_get_pipeline_maps_404_to_not_found(monkeypatch):
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            router.get(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pipelines/999"
+            ).mock(return_value=httpx.Response(404, text='{"error":"not found"}'))
+
+            try:
+                await client.get_pipeline(999)
+                raise AssertionError("Expected NotFoundError was not raised")
+            except NotFoundError as exc:
+                assert exc.status_code == 404
+                assert "workspace/repo" in exc.endpoint
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_get_pipelines_retries_on_429(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setattr("lib.common.http._backoff_seconds", lambda *args, **kwargs: 0)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.get(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pipelines"
+            ).mock(
+                side_effect=[
+                    httpx.Response(429, text='{"error":"rate limit"}'),
+                    httpx.Response(200, json={"values": []}),
+                ]
+            )
+
+            data = await client.get_pipelines(pagelen=2)
+            assert data["values"] == []
+            assert route.call_count == 2
+
+        await client.close()
+
+    asyncio.run(run())
+

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import httpx
+import respx
+
+from lib.common.errors import AuthError
+from lib.jira.client import JiraClient
+
+
+def _setup_env(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_CLOUD_ID", "023bcd49-f455-4451-a096-c50c42c811d7")
+
+
+def test_get_issue_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run():
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/issue/VKS-1247"
+            ).mock(return_value=httpx.Response(200, json={"key": "VKS-1247", "fields": {"summary": "ok"}}))
+
+            issue = await client.get_issue("VKS-1247")
+            assert issue["key"] == "VKS-1247"
+            assert issue["fields"]["summary"] == "ok"
+
+    asyncio.run(run())
+
+
+def test_get_issue_maps_401_to_auth_error(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run():
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/issue/VKS-1248"
+            ).mock(return_value=httpx.Response(401, text='{"error":"unauthorized"}'))
+
+            try:
+                await client.get_issue("VKS-1248")
+                raise AssertionError("Expected AuthError was not raised")
+            except AuthError as exc:
+                assert exc.status_code == 401
+                assert "JIRA_EMAIL" in (exc.hint or "")
+
+    asyncio.run(run())
+
+
+def test_jira_fallback_to_atlassian_token(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.delenv("JIRA_API_TOKEN", raising=False)
+    monkeypatch.setenv("ATLASSIAN_API_TOKEN", "shared-token")
+
+    client = JiraClient()
+    assert client.api_token == "shared-token"
+


### PR DESCRIPTION
## Contexto
Implementa o piloto técnico D65 no `maos-mcp-hub`, convergindo para camada comum de HTTP/erros sem quebrar a API pública atual das tools.

## O que foi implementado
1. Camada comum adicionada:
- `lib/common/errors.py`
- `lib/common/http.py`

2. Piloto integrado em clients críticos:
- `lib/bitbucket/client.py`
  - `get_pipelines`
  - `get_pipeline`
  - `get_pipeline_steps`
  - `get_step_log`
- `lib/jira/client.py`
  - `get_issue`

3. Tools migradas no piloto (sem breaking change):
- `bitbucket_get_recent_builds`
- `bitbucket_get_build_details`
- `bitbucket_get_step_logs`
- `jira_get_issue` (tratamento explícito de `ApiError`)

4. Testes adicionados (`pytest + respx`):
- `tests/test_bitbucket_client.py`
- `tests/test_jira_client.py`
- `tests/conftest.py`
- `requirements-dev.txt`

5. Documentação:
- `README.md` atualizado com camada comum e comando de testes.

## Compatibilidade
- Mantidas assinaturas e contratos externos das tools.
- Sem alteração de naming de tools MCP.

## Validação local
```bash
pytest -q tests/test_bitbucket_client.py tests/test_jira_client.py
# resultado: 6 passed
```

## Próximos passos (fora deste PR)
- Expandir a camada comum para restante das tools/clientes por waves (D65).
- Adicionar testes de contrato das tools (não só clients).
