### PR TITLE
refactor(maos-mcp-hub): Wave 1 PR tools on common HTTP layer

### DIFF
--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -1059,6 +1059,7 @@ class BitbucketPipelineClient:
             json=payload,
             timeout=30.0,
             limiter=self.rate_limiter,
+            max_retries=0,  # non-idempotent operation: avoid duplicate PR creation
         )
 
     async def get_pipeline_schedules(self) -> dict:

--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -905,17 +905,18 @@ class BitbucketPipelineClient:
                   }
 
         Raises:
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/pullrequests",
-                    params={"state": state, "pagelen": pagelen},
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pullrequests",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"state": state, "pagelen": pagelen},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def get_pull_request(self, pr_id: int) -> dict:
         """
@@ -941,16 +942,17 @@ class BitbucketPipelineClient:
                   }
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if PR not found)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/pullrequests/{pr_id}",
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pullrequests/{pr_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def get_pr_statuses(self, pr_id: int, pagelen: int = 50) -> dict:
         """
@@ -979,17 +981,18 @@ class BitbucketPipelineClient:
                   }
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if PR not found)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/pullrequests/{pr_id}/statuses",
-                    params={"pagelen": pagelen},
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pullrequests/{pr_id}/statuses",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"pagelen": pagelen},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def create_pull_request(
         self,
@@ -1024,7 +1027,7 @@ class BitbucketPipelineClient:
                   }
 
         Raises:
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         payload = {
             "title": title,
@@ -1047,15 +1050,16 @@ class BitbucketPipelineClient:
         if reviewers:
             payload["reviewers"] = [{"uuid": uuid} for uuid in reviewers]
 
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.post(
-                    f"{self.base_url}/pullrequests",
-                    json=payload,
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.json()
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/pullrequests",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
     async def get_pipeline_schedules(self) -> dict:
         """

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -1392,7 +1392,13 @@ async def get_pull_requests(state: str = "OPEN", count: int = 10, repo_slug: str
             "pull_requests": formatted_prs
         }
 
-    except httpx.HTTPStatusError as e:
+    except ApiError as e:
+        return {
+            "error": "Failed to get pull requests",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+        }
+    except Exception as e:
         return {"error": f"Failed to get pull requests: {sanitize_error(e)}"}
 
 
@@ -1443,9 +1449,15 @@ async def get_pr_details(pr_id: int, repo_slug: str = "") -> dict:
             }
         }
 
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+    except ApiError as e:
+        if e.status_code == 404:
             return {"error": f"Pull request #{pr_id} not found"}
+        return {
+            "error": "Failed to get PR details",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+        }
+    except Exception as e:
         return {"error": f"Failed to get PR details: {sanitize_error(e)}"}
 
 
@@ -1507,9 +1519,15 @@ async def get_pr_build_statuses(pr_id: int, repo_slug: str = "") -> dict:
             "statuses": formatted_statuses
         }
 
-    except httpx.HTTPStatusError as e:
-        if e.response.status_code == 404:
+    except ApiError as e:
+        if e.status_code == 404:
             return {"error": f"Pull request #{pr_id} not found"}
+        return {
+            "error": "Failed to get PR build statuses",
+            "details": sanitize_exception(e),
+            "hint": e.hint,
+        }
+    except Exception as e:
         return {"error": f"Failed to get PR build statuses: {sanitize_error(e)}"}
 
 
@@ -1555,17 +1573,19 @@ async def create_pull_request(
             "created_on": pr.get("created_on", "")
         }
 
-    except httpx.HTTPStatusError as e:
-        error_detail = ""
-        try:
-            error_body = e.response.json()
-            error_detail = error_body.get("error", {}).get("message", str(e))
-        except Exception:
-            error_detail = str(e)
-
+    except ApiError as e:
         return {
             "success": False,
-            "error": f"Failed to create PR: {error_detail}",
+            "error": f"Failed to create PR: {sanitize_exception(e)}",
+            "hint": e.hint,
+            "status_code": e.status_code,
+            "source_branch": source_branch,
+            "destination_branch": destination_branch
+        }
+    except Exception as e:
+        return {
+            "success": False,
+            "error": f"Failed to create PR: {sanitize_error(e)}",
             "source_branch": source_branch,
             "destination_branch": destination_branch
         }

--- a/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
@@ -80,3 +80,74 @@ def test_get_pipelines_retries_on_429(monkeypatch):
 
     asyncio.run(run())
 
+
+def test_get_pull_requests_success(monkeypatch):
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.get(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests"
+            ).mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"values": [{"id": 11, "title": "feat: wave1"}]},
+                )
+            )
+
+            data = await client.get_pull_requests(state="OPEN", pagelen=1)
+            assert route.called
+            assert data["values"][0]["id"] == 11
+            assert data["values"][0]["title"] == "feat: wave1"
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_get_pull_request_maps_404_to_not_found(monkeypatch):
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            router.get(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/321"
+            ).mock(return_value=httpx.Response(404, text='{"error":"not found"}'))
+
+            try:
+                await client.get_pull_request(321)
+                raise AssertionError("Expected NotFoundError was not raised")
+            except NotFoundError as exc:
+                assert exc.status_code == 404
+                assert "/pullrequests/321" in exc.endpoint
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_get_pr_statuses_retries_on_429(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setattr("lib.common.http._backoff_seconds", lambda *args, **kwargs: 0)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.get(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/42/statuses"
+            ).mock(
+                side_effect=[
+                    httpx.Response(429, text='{"error":"rate limit"}'),
+                    httpx.Response(200, json={"values": [{"state": "SUCCESSFUL"}]}),
+                ]
+            )
+
+            data = await client.get_pr_statuses(42, pagelen=5)
+            assert data["values"][0]["state"] == "SUCCESSFUL"
+            assert route.call_count == 2
+
+        await client.close()
+
+    asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
@@ -4,7 +4,7 @@ import httpx
 import respx
 
 from lib.bitbucket.client import BitbucketPipelineClient
-from lib.common.errors import NotFoundError
+from lib.common.errors import NotFoundError, RateLimitError
 
 
 def _setup_env(monkeypatch):
@@ -147,6 +147,41 @@ def test_get_pr_statuses_retries_on_429(monkeypatch):
             data = await client.get_pr_statuses(42, pagelen=5)
             assert data["values"][0]["state"] == "SUCCESSFUL"
             assert route.call_count == 2
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_create_pull_request_does_not_retry_on_429(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setattr("lib.common.http._backoff_seconds", lambda *args, **kwargs: 0)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests"
+            ).mock(
+                side_effect=[
+                    httpx.Response(429, text='{"error":"rate limit"}'),
+                    httpx.Response(201, json={"id": 777}),
+                ]
+            )
+
+            try:
+                await client.create_pull_request(
+                    title="feat: no-retry-post",
+                    source_branch="feature/no-retry",
+                    destination_branch="main",
+                )
+                raise AssertionError("Expected RateLimitError was not raised")
+            except RateLimitError as exc:
+                assert exc.status_code == 429
+                assert "/pullrequests" in exc.endpoint
+
+            # Non-idempotent POST must not retry automatically.
+            assert route.call_count == 1
 
         await client.close()
 


### PR DESCRIPTION
## Objetivo
Executar a Wave 1 incremental do D66 no `maos-mcp-hub`, migrando um lote fechado de ferramentas de Pull Request do Bitbucket para a camada comum de HTTP/erros (`lib/common`), sem breaking changes de contrato externo.

## Escopo desta PR
### Cliente Bitbucket
- `get_pull_requests` -> `request_json`
- `get_pull_request` -> `request_json`
- `get_pr_statuses` -> `request_json`
- `create_pull_request` -> `request_json`

### Tools Bitbucket
- Harmoniza tratamento de erro para `ApiError` + `sanitize_exception` em:
  - `get_pull_requests`
  - `get_pr_details`
  - `get_pr_build_statuses`
  - `create_pull_request`

### Testes
- adiciona cobertura de cliente para fluxo PR:
  - sucesso em listagem de PRs
  - mapeamento 404 em `get_pull_request`
  - retry em 429 para `get_pr_statuses`

## Validação local
```bash
cd mcp-tools/maos-mcp-hub
pytest -q tests/test_bitbucket_client.py tests/test_jira_client.py
# 9 passed
```

## Risco
Baixo/médio controlado:
- mudança restrita ao bloco PR do Bitbucket;
- assinatura das tools preservada;
- suíte cobrindo cenários de sucesso/erro/retry.
