### PR TITLE
refactor(maos-mcp-hub): convergir jira attachments para camada comum

### DIFF
--- a/mcp-tools/maos-mcp-hub/lib/common/http.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/http.py
@@ -82,6 +82,33 @@ def _retry_delay(exc: httpx.HTTPStatusError, attempt: int) -> float:
     return max(local, retry_after)
 
 
+def _rewind_multipart_files(files: dict[str, Any]) -> None:
+    """Rewind multipart file objects before retrying a request."""
+    for value in files.values():
+        candidate = value
+        if isinstance(value, tuple) and len(value) >= 2:
+            candidate = value[1]
+
+        if candidate is None or isinstance(candidate, (bytes, bytearray, str)):
+            continue
+
+        seek = getattr(candidate, "seek", None)
+        if callable(seek):
+            try:
+                seek(0)
+            except Exception as exc:  # pragma: no cover - defensive
+                raise ValueError(
+                    "Multipart retry requires rewindable file objects. "
+                    "Use bytes payloads or set max_retries=0."
+                ) from exc
+            continue
+
+        raise ValueError(
+            "Multipart retry requires rewindable file objects. "
+            "Use bytes payloads or set max_retries=0."
+        )
+
+
 def _map_http_status_error(
     error: httpx.HTTPStatusError,
     *,
@@ -140,6 +167,7 @@ async def request_json(
     """Perform request and parse JSON with retry + structured errors.
 
     `max_retries` means retries after the initial attempt.
+    For multipart payloads (`files`), retries require rewindable file objects.
     """
     auth_kwargs = auth_kwargs or {}
     attempts = max(1, max_retries + 1)
@@ -147,6 +175,9 @@ async def request_json(
 
     for attempt in range(1, attempts + 1):
         try:
+            if files is not None and attempt > 1:
+                _rewind_multipart_files(files)
+
             if limiter:
                 async with limiter:
                     async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
@@ -182,7 +213,7 @@ async def request_json(
             if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
                 await asyncio.sleep(_retry_delay(exc, attempt))
                 continue
-            raise mapped
+            raise mapped from exc
         except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
             last_error = NetworkError(
                 sanitize_exception(exc),
@@ -194,7 +225,7 @@ async def request_json(
             if attempt < attempts:
                 await asyncio.sleep(_backoff_seconds(attempt))
                 continue
-            raise last_error
+            raise last_error from exc
 
     if isinstance(last_error, ApiError):
         raise last_error
@@ -243,7 +274,7 @@ async def request_text(
             if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
                 await asyncio.sleep(_retry_delay(exc, attempt))
                 continue
-            raise mapped
+            raise mapped from exc
         except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
             last_error = NetworkError(
                 sanitize_exception(exc),
@@ -255,7 +286,7 @@ async def request_text(
             if attempt < attempts:
                 await asyncio.sleep(_backoff_seconds(attempt))
                 continue
-            raise last_error
+            raise last_error from exc
 
     if isinstance(last_error, ApiError):
         raise last_error
@@ -301,7 +332,7 @@ async def request_bytes(
             if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
                 await asyncio.sleep(_retry_delay(exc, attempt))
                 continue
-            raise mapped
+            raise mapped from exc
         except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
             last_error = NetworkError(
                 sanitize_exception(exc),
@@ -313,7 +344,7 @@ async def request_bytes(
             if attempt < attempts:
                 await asyncio.sleep(_backoff_seconds(attempt))
                 continue
-            raise last_error
+            raise last_error from exc
 
     if isinstance(last_error, ApiError):
         raise last_error
@@ -334,7 +365,12 @@ async def request_empty(
     limiter: Optional[AsyncLimiter] = None,
     max_retries: int = 3,
 ) -> int:
-    """Perform request expecting empty body and return HTTP status code."""
+    """Perform request expecting empty body and return HTTP status code.
+
+    `max_retries` means retries after the initial attempt (default: 3).
+    For non-idempotent methods (e.g., DELETE with side effects), callers
+    should set `max_retries=0` or provide explicit idempotency handling.
+    """
     auth_kwargs = auth_kwargs or {}
     attempts = max(1, max_retries + 1)
     last_error: Optional[Exception] = None
@@ -360,7 +396,7 @@ async def request_empty(
             if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
                 await asyncio.sleep(_retry_delay(exc, attempt))
                 continue
-            raise mapped
+            raise mapped from exc
         except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
             last_error = NetworkError(
                 sanitize_exception(exc),
@@ -372,7 +408,7 @@ async def request_empty(
             if attempt < attempts:
                 await asyncio.sleep(_backoff_seconds(attempt))
                 continue
-            raise last_error
+            raise last_error from exc
 
     if isinstance(last_error, ApiError):
         raise last_error

--- a/mcp-tools/maos-mcp-hub/lib/common/http.py
+++ b/mcp-tools/maos-mcp-hub/lib/common/http.py
@@ -130,11 +130,13 @@ async def request_json(
     auth_kwargs: Optional[dict[str, Any]] = None,
     params: Optional[dict[str, Any]] = None,
     json: Optional[dict[str, Any]] = None,
+    data: Optional[dict[str, Any]] = None,
+    files: Optional[dict[str, Any]] = None,
     timeout: float = 30.0,
     follow_redirects: bool = False,
     limiter: Optional[AsyncLimiter] = None,
     max_retries: int = 3,
-) -> dict[str, Any]:
+) -> Any:
     """Perform request and parse JSON with retry + structured errors.
 
     `max_retries` means retries after the initial attempt.
@@ -149,12 +151,24 @@ async def request_json(
                 async with limiter:
                     async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
                         response = await client.request(
-                            method, url, params=params, json=json, **auth_kwargs
+                            method,
+                            url,
+                            params=params,
+                            json=json,
+                            data=data,
+                            files=files,
+                            **auth_kwargs,
                         )
             else:
                 async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
                     response = await client.request(
-                        method, url, params=params, json=json, **auth_kwargs
+                        method,
+                        url,
+                        params=params,
+                        json=json,
+                        data=data,
+                        files=files,
+                        **auth_kwargs,
                     )
 
             response.raise_for_status()
@@ -220,6 +234,123 @@ async def request_text(
 
             response.raise_for_status()
             return response.text
+
+        except httpx.HTTPStatusError as exc:
+            mapped = _map_http_status_error(
+                exc, provider=provider, endpoint=url, auth_hint=auth_hint
+            )
+            last_error = mapped
+            if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
+                await asyncio.sleep(_retry_delay(exc, attempt))
+                continue
+            raise mapped
+        except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
+            last_error = NetworkError(
+                sanitize_exception(exc),
+                0,
+                url,
+                provider,
+                "Erro de rede/transporte. Verifique conectividade e tente novamente.",
+            )
+            if attempt < attempts:
+                await asyncio.sleep(_backoff_seconds(attempt))
+                continue
+            raise last_error
+
+    if isinstance(last_error, ApiError):
+        raise last_error
+    raise ApiError("Erro desconhecido", 0, url, provider)
+
+
+async def request_bytes(
+    *,
+    method: str,
+    url: str,
+    provider: str,
+    auth_hint: str,
+    auth_kwargs: Optional[dict[str, Any]] = None,
+    params: Optional[dict[str, Any]] = None,
+    timeout: float = 30.0,
+    follow_redirects: bool = False,
+    limiter: Optional[AsyncLimiter] = None,
+    max_retries: int = 3,
+) -> bytes:
+    """Perform request and return raw bytes with retry + structured errors."""
+    auth_kwargs = auth_kwargs or {}
+    attempts = max(1, max_retries + 1)
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            if limiter:
+                async with limiter:
+                    async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                        response = await client.request(method, url, params=params, **auth_kwargs)
+            else:
+                async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                    response = await client.request(method, url, params=params, **auth_kwargs)
+
+            response.raise_for_status()
+            return response.content
+
+        except httpx.HTTPStatusError as exc:
+            mapped = _map_http_status_error(
+                exc, provider=provider, endpoint=url, auth_hint=auth_hint
+            )
+            last_error = mapped
+            if isinstance(mapped, (RateLimitError, ServerError)) and attempt < attempts:
+                await asyncio.sleep(_retry_delay(exc, attempt))
+                continue
+            raise mapped
+        except (httpx.TimeoutException, httpx.NetworkError, httpx.TransportError) as exc:
+            last_error = NetworkError(
+                sanitize_exception(exc),
+                0,
+                url,
+                provider,
+                "Erro de rede/transporte. Verifique conectividade e tente novamente.",
+            )
+            if attempt < attempts:
+                await asyncio.sleep(_backoff_seconds(attempt))
+                continue
+            raise last_error
+
+    if isinstance(last_error, ApiError):
+        raise last_error
+    raise ApiError("Erro desconhecido", 0, url, provider)
+
+
+async def request_empty(
+    *,
+    method: str,
+    url: str,
+    provider: str,
+    auth_hint: str,
+    auth_kwargs: Optional[dict[str, Any]] = None,
+    params: Optional[dict[str, Any]] = None,
+    json: Optional[dict[str, Any]] = None,
+    timeout: float = 30.0,
+    follow_redirects: bool = False,
+    limiter: Optional[AsyncLimiter] = None,
+    max_retries: int = 3,
+) -> int:
+    """Perform request expecting empty body and return HTTP status code."""
+    auth_kwargs = auth_kwargs or {}
+    attempts = max(1, max_retries + 1)
+    last_error: Optional[Exception] = None
+
+    for attempt in range(1, attempts + 1):
+        try:
+            if limiter:
+                async with limiter:
+                    async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                        response = await client.request(method, url, params=params, json=json, **auth_kwargs)
+            else:
+                async with httpx.AsyncClient(timeout=timeout, follow_redirects=follow_redirects) as client:
+                    response = await client.request(method, url, params=params, json=json, **auth_kwargs)
+
+            response.raise_for_status()
+            return response.status_code
 
         except httpx.HTTPStatusError as exc:
             mapped = _map_http_status_error(

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -8,12 +8,11 @@ Authentication uses Basic Auth (email:api_token) as per Atlassian Cloud standard
 """
 
 import base64
-import httpx
 import os
 from typing import Optional
 from aiolimiter import AsyncLimiter
 
-from lib.common.http import request_json
+from lib.common.http import request_bytes, request_empty, request_json
 
 
 class JiraClient:
@@ -155,29 +154,31 @@ class JiraClient:
         Raises:
             httpx.HTTPError: If API request fails (404 if attachment not found)
         """
-        # First get the attachment metadata to find the content URL
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.get(
-                    f"{self.base_url}/attachment/{attachment_id}",
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                metadata = response.json()
+        # First get attachment metadata to resolve the content URL.
+        metadata = await request_json(
+            method="GET",
+            url=f"{self.base_url}/attachment/{attachment_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
 
         content_url = metadata.get("content")
         if not content_url:
             raise ValueError(f"Attachment {attachment_id} has no content URL")
 
-        # Download the actual content
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=60.0, follow_redirects=True) as client:
-                response = await client.get(
-                    content_url,
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
-                return response.content
+        return await request_bytes(
+            method="GET",
+            url=content_url,
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=60.0,
+            follow_redirects=True,
+            limiter=self.rate_limiter,
+        )
 
     async def download_attachment_by_name(self, issue_key: str, filename: str) -> bytes:
         """
@@ -231,18 +232,22 @@ class JiraClient:
             "X-Atlassian-Token": "no-check",
         }
 
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=120.0) as client:
-                with open(filepath, "rb") as f:
-                    response = await client.post(
-                        f"{self.base_url}/issue/{issue_key}/attachments",
-                        headers=headers,
-                        files={"file": (fname, f)},
-                    )
-                    response.raise_for_status()
-                    result = response.json()
-                    # API returns array of attachments
-                    return result[0] if isinstance(result, list) and result else result
+        with open(filepath, "rb") as f:
+            result = await request_json(
+                method="POST",
+                url=f"{self.base_url}/issue/{issue_key}/attachments",
+                provider=self._provider_name,
+                auth_hint=self._auth_hint,
+                auth_kwargs={"headers": headers},
+                files={"file": (fname, f)},
+                timeout=120.0,
+                limiter=self.rate_limiter,
+                # POST upload is non-idempotent.
+                max_retries=0,
+            )
+
+        # API usually returns array; keep backward-compatible shape.
+        return result[0] if isinstance(result, list) and result else result
 
     async def delete_attachment(self, attachment_id: str) -> dict:
         """
@@ -257,18 +262,26 @@ class JiraClient:
         Raises:
             httpx.HTTPError: If API request fails (404 if not found, 403 if no permission)
         """
-        async with self.rate_limiter:
-            async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.delete(
-                    f"{self.base_url}/attachment/{attachment_id}",
-                    **self._auth_kwargs,
-                )
-                response.raise_for_status()
+        status = await request_empty(
+            method="DELETE",
+            url=f"{self.base_url}/attachment/{attachment_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            # DELETE can have side effects; avoid automatic retries.
+            max_retries=0,
+        )
 
-                if response.status_code == 204:
-                    return {
-                        "status": "deleted",
-                        "attachment_id": attachment_id,
-                        "message": "Attachment deleted successfully",
-                    }
-                return response.json()
+        if status == 204:
+            return {
+                "status": "deleted",
+                "attachment_id": attachment_id,
+                "message": "Attachment deleted successfully",
+            }
+        return {
+            "status": "success",
+            "attachment_id": attachment_id,
+            "http_status": status,
+        }

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -7,12 +7,18 @@ Jira Cloud REST API to manage issues and attachments.
 Authentication uses Basic Auth (email:api_token) as per Atlassian Cloud standard.
 """
 
+import asyncio
 import base64
 import os
 from typing import Optional
 from aiolimiter import AsyncLimiter
 
 from lib.common.http import request_bytes, request_empty, request_json
+
+
+def _read_file_bytes(path: str) -> bytes:
+    with open(path, "rb") as fh:
+        return fh.read()
 
 
 class JiraClient:
@@ -136,7 +142,7 @@ class JiraClient:
                   ]
 
         Raises:
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         issue = await self.get_issue(issue_key, fields="attachment")
         return issue.get("fields", {}).get("attachment", [])
@@ -152,7 +158,7 @@ class JiraClient:
             bytes: Raw file content
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if attachment not found)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         # First get attachment metadata to resolve the content URL.
         metadata = await request_json(
@@ -193,7 +199,7 @@ class JiraClient:
 
         Raises:
             ValueError: If attachment with given filename not found
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         attachments = await self.list_attachments(issue_key)
         for att in attachments:
@@ -218,7 +224,7 @@ class JiraClient:
 
         Raises:
             FileNotFoundError: If filepath doesn't exist
-            httpx.HTTPError: If API request fails
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         if not os.path.exists(filepath):
             raise FileNotFoundError(f"File not found: {filepath}")
@@ -232,19 +238,19 @@ class JiraClient:
             "X-Atlassian-Token": "no-check",
         }
 
-        with open(filepath, "rb") as f:
-            result = await request_json(
-                method="POST",
-                url=f"{self.base_url}/issue/{issue_key}/attachments",
-                provider=self._provider_name,
-                auth_hint=self._auth_hint,
-                auth_kwargs={"headers": headers},
-                files={"file": (fname, f)},
-                timeout=120.0,
-                limiter=self.rate_limiter,
-                # POST upload is non-idempotent.
-                max_retries=0,
-            )
+        content = await asyncio.to_thread(_read_file_bytes, filepath)
+        result = await request_json(
+            method="POST",
+            url=f"{self.base_url}/issue/{issue_key}/attachments",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs={"headers": headers},
+            files={"file": (fname, content)},
+            timeout=120.0,
+            limiter=self.rate_limiter,
+            # POST upload is non-idempotent.
+            max_retries=0,
+        )
 
         # API usually returns array; keep backward-compatible shape.
         return result[0] if isinstance(result, list) and result else result
@@ -260,7 +266,7 @@ class JiraClient:
             dict: Success confirmation
 
         Raises:
-            httpx.HTTPError: If API request fails (404 if not found, 403 if no permission)
+            ApiError: If API request fails (auth/not-found/rate-limit/server/network)
         """
         status = await request_empty(
             method="DELETE",

--- a/mcp-tools/maos-mcp-hub/tests/test_common_http.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_common_http.py
@@ -1,0 +1,40 @@
+import asyncio
+import io
+
+import httpx
+import respx
+
+from lib.common.http import request_json
+
+
+def test_request_json_rewinds_multipart_files_on_retry() -> None:
+    async def run() -> None:
+        payload = io.BytesIO(b"attachment-content")
+        call_count = {"value": 0}
+        body_lengths: list[int] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            call_count["value"] += 1
+            body_lengths.append(len(request.content))
+            if call_count["value"] == 1:
+                return httpx.Response(500, text='{"error":"temporary"}')
+            return httpx.Response(200, json={"ok": True})
+
+        with respx.mock(assert_all_called=True) as router:
+            router.post("https://api.example.com/upload").mock(side_effect=handler)
+
+            result = await request_json(
+                method="POST",
+                url="https://api.example.com/upload",
+                provider="TestProvider",
+                auth_hint="Set TEST_TOKEN",
+                files={"file": ("sample.txt", payload)},
+                max_retries=1,
+            )
+
+            assert result["ok"] is True
+            assert call_count["value"] == 2
+            assert body_lengths[0] > 0
+            assert body_lengths[1] > 0
+
+    asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -61,3 +61,62 @@ def test_jira_fallback_to_atlassian_token(monkeypatch):
     client = JiraClient()
     assert client.api_token == "shared-token"
 
+
+def test_download_attachment_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run():
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/attachment/10001"
+            ).mock(return_value=httpx.Response(200, json={"id": "10001", "content": "https://api.atlassian.com/mock/content/10001"}))
+            router.get("https://api.atlassian.com/mock/content/10001").mock(return_value=httpx.Response(200, content=b"hello-md"))
+
+            content = await client.download_attachment("10001")
+            assert content == b"hello-md"
+
+    asyncio.run(run())
+
+
+def test_upload_attachment_success(monkeypatch, tmp_path):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    file_path = tmp_path / "sample.md"
+    file_path.write_text("# sample\n", encoding="utf-8")
+
+    async def run():
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.post(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/issue/VKS-1247/attachments"
+            ).mock(return_value=httpx.Response(200, json=[{"id": "20001", "filename": "sample.md"}]))
+
+            result = await client.upload_attachment("VKS-1247", str(file_path))
+            assert result["id"] == "20001"
+            assert result["filename"] == "sample.md"
+
+    asyncio.run(run())
+
+
+def test_delete_attachment_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run():
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.delete(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/attachment/30001"
+            ).mock(return_value=httpx.Response(204))
+
+            result = await client.delete_attachment("30001")
+            assert result["status"] == "deleted"
+            assert result["attachment_id"] == "30001"
+
+    asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -3,7 +3,7 @@ import asyncio
 import httpx
 import respx
 
-from lib.common.errors import AuthError
+from lib.common.errors import AuthError, NotFoundError
 from lib.jira.client import JiraClient
 
 
@@ -17,7 +17,7 @@ def test_get_issue_success(monkeypatch):
     monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
     monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
 
-    async def run():
+    async def run() -> None:
         client = JiraClient()
         with respx.mock(assert_all_called=True) as router:
             router.get(
@@ -36,7 +36,7 @@ def test_get_issue_maps_401_to_auth_error(monkeypatch):
     monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
     monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
 
-    async def run():
+    async def run() -> None:
         client = JiraClient()
         with respx.mock(assert_all_called=True) as router:
             router.get(
@@ -67,7 +67,7 @@ def test_download_attachment_success(monkeypatch):
     monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
     monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
 
-    async def run():
+    async def run() -> None:
         client = JiraClient()
         with respx.mock(assert_all_called=True) as router:
             router.get(
@@ -89,7 +89,7 @@ def test_upload_attachment_success(monkeypatch, tmp_path):
     file_path = tmp_path / "sample.md"
     file_path.write_text("# sample\n", encoding="utf-8")
 
-    async def run():
+    async def run() -> None:
         client = JiraClient()
         with respx.mock(assert_all_called=True) as router:
             router.post(
@@ -108,7 +108,7 @@ def test_delete_attachment_success(monkeypatch):
     monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
     monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
 
-    async def run():
+    async def run() -> None:
         client = JiraClient()
         with respx.mock(assert_all_called=True) as router:
             router.delete(
@@ -118,5 +118,49 @@ def test_delete_attachment_success(monkeypatch):
             result = await client.delete_attachment("30001")
             assert result["status"] == "deleted"
             assert result["attachment_id"] == "30001"
+
+    asyncio.run(run())
+
+
+def test_delete_attachment_maps_404_to_not_found(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.delete(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/attachment/40401"
+            ).mock(return_value=httpx.Response(404, text='{"error":"not found"}'))
+
+            try:
+                await client.delete_attachment("40401")
+                raise AssertionError("Expected NotFoundError was not raised")
+            except NotFoundError as exc:
+                assert exc.status_code == 404
+                assert "/attachment/40401" in exc.endpoint
+
+    asyncio.run(run())
+
+
+def test_delete_attachment_maps_403_to_auth_error(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.delete(
+                "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/attachment/40301"
+            ).mock(return_value=httpx.Response(403, text='{"error":"forbidden"}'))
+
+            try:
+                await client.delete_attachment("40301")
+                raise AssertionError("Expected AuthError was not raised")
+            except AuthError as exc:
+                assert exc.status_code == 403
+                assert "/attachment/40301" in exc.endpoint
 
     asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -1,6 +1,7 @@
 import asyncio
 
 import httpx
+import pytest
 import respx
 
 from lib.common.errors import AuthError, NotFoundError
@@ -134,12 +135,11 @@ def test_delete_attachment_maps_404_to_not_found(monkeypatch):
                 "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/attachment/40401"
             ).mock(return_value=httpx.Response(404, text='{"error":"not found"}'))
 
-            try:
+            with pytest.raises(NotFoundError) as exc_info:
                 await client.delete_attachment("40401")
-                raise AssertionError("Expected NotFoundError was not raised")
-            except NotFoundError as exc:
-                assert exc.status_code == 404
-                assert "/attachment/40401" in exc.endpoint
+            exc = exc_info.value
+            assert exc.status_code == 404
+            assert "/attachment/40401" in exc.endpoint
 
     asyncio.run(run())
 
@@ -156,11 +156,10 @@ def test_delete_attachment_maps_403_to_auth_error(monkeypatch):
                 "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3/attachment/40301"
             ).mock(return_value=httpx.Response(403, text='{"error":"forbidden"}'))
 
-            try:
+            with pytest.raises(AuthError) as exc_info:
                 await client.delete_attachment("40301")
-                raise AssertionError("Expected AuthError was not raised")
-            except AuthError as exc:
-                assert exc.status_code == 403
-                assert "/attachment/40301" in exc.endpoint
+            exc = exc_info.value
+            assert exc.status_code == 403
+            assert "/attachment/40301" in exc.endpoint
 
     asyncio.run(run())


### PR DESCRIPTION
## Resumo\n- migra fluxo de attachments do JiraClient para lib/common/http.py\n- adiciona helpers compartilhados: request_bytes e request_empty\n- estende request_json para multipart (data/files) sem quebra retroativa\n- adiciona testes de attachments no Jira client\n\n## Segurança/Confiabilidade\n- tratamento de erro unificado com redaction/retry da camada comum\n- mantém POST/DELETE de attachment sem retry automático (operações com side-effect)\n\n## Testes\n- pytest -q\n- resultado: 13 passed