### PR TITLE
chore(governance): harden worktree drift containment and local artifact hygiene

### DIFF
--- a/docs/worktrees-guide.md
+++ b/docs/worktrees-guide.md
@@ -128,7 +128,7 @@ git worktree list --porcelain
 
 # 3) Validar se alteracao tracked local e obsoleta vs origin/main
 git fetch origin
-git diff -- path/to/file origin/main -- path/to/file
+git diff origin/main -- path/to/file
 
 # 4) Sincronizar apenas apos limpar drift local
 git pull --ff-only

--- a/docs/worktrees-guide.md
+++ b/docs/worktrees-guide.md
@@ -3,7 +3,7 @@
 
 Este diretorio armazena git worktrees para uso por multiplos AI agents trabalhando em paralelo.
 
-**Versao**: 1.5 | **Atualizado**: 2026-01-07
+**Versao**: 1.6 | **Atualizado**: 2026-03-05
 
 ---
 
@@ -119,6 +119,7 @@ Regra operacional:
 3. smoke/read-only pode rodar em qualquer worktree, desde que `repo_slug/workspace` sejam explicitos quando o remote local nao for o alvo.
 
 Checklist rapido de saneamento:
+
 ```bash
 # 1) Inventariar drift no checkout primario
 git status --short
@@ -136,7 +137,7 @@ git pull --ff-only
 
 Observacao:
 1. backups locais de `.env` e `*.bak-*` nao devem ser versionados;
-2. manter esses artefatos ignorados no escopo do modulo evita ruído operacional.
+2. manter esses artefatos ignorados no escopo do módulo evita ruído operacional.
 
 ---
 

--- a/docs/worktrees-guide.md
+++ b/docs/worktrees-guide.md
@@ -106,6 +106,38 @@ done
 | Branch orfa | Worktree removido sem deletar branch | Avaliar e deletar se merged |
 | Heartbeat > completed_at | Sessao continuou apos ser marcada completa | Atualizar completed_at |
 
+### Contencao de Drift no Checkout Primario (D74)
+
+Sintoma tipico:
+1. `main` com arquivo tracked modificado e varios `*.bak-*` untracked;
+2. `git pull --ff-only` bloqueado no checkout primario;
+3. alteracoes locais intermediarias que ja foram superadas em `origin/main`.
+
+Regra operacional:
+1. checkout primario (`/repo`) e de coordenacao, nao de edicao;
+2. toda edicao de codigo deve ocorrer em worktree dedicado fora do checkout primario;
+3. smoke/read-only pode rodar em qualquer worktree, desde que `repo_slug/workspace` sejam explicitos quando o remote local nao for o alvo.
+
+Checklist rapido de saneamento:
+```bash
+# 1) Inventariar drift no checkout primario
+git status --short
+
+# 2) Conferir worktrees vivos
+git worktree list --porcelain
+
+# 3) Validar se alteracao tracked local e obsoleta vs origin/main
+git fetch origin
+git diff -- path/to/file origin/main -- path/to/file
+
+# 4) Sincronizar apenas apos limpar drift local
+git pull --ff-only
+```
+
+Observacao:
+1. backups locais de `.env` e `*.bak-*` nao devem ser versionados;
+2. manter esses artefatos ignorados no escopo do modulo evita ruído operacional.
+
 ---
 
 ## Quando Usar Worktree (v1.1)
@@ -478,11 +510,12 @@ Todos os agentes devem registrar suas tarefas:
 | Campo | Valor |
 |-------|-------|
 | Criado por | `Claude-Orch-Alpha` |
-| Atualizado por | `Claude-Orch-Prime-20260107-val1` |
-| Data | 2026-01-07 |
-| Versao | 1.5 |
+| Atualizado por | `Codex-GPT5` |
+| Data | 2026-03-05 |
+| Versao | 1.6 |
 
 **Changelog**:
+- v1.6 (2026-03-05): Contencao de drift no checkout primario + checklist de saneamento + higiene de artefatos locais
 - v1.5 (2026-01-07): Guardrails de Integridade v1.0 - 6 regras + checklist + erros comuns
 - v1.4 (2026-01-06): Politica simplificada - worktree obrigatorio para modificacoes (3 excecoes)
 - v1.3 (2026-01-06): Nomenclatura de diretorios e branches padronizada
@@ -490,4 +523,4 @@ Todos os agentes devem registrar suas tarefas:
 - v1.1 (2026-01-06): Referencia a Enhanced Anti-Conflict Protocol v2.0 em CLAUDE.md
 - v1.0 (2026-01-06): Versao inicial
 
-*Assinatura: Claude-Orch-Prime-20260107-val1 | 2026-01-07T00:35:00-03:00*
+*Assinatura: Codex-GPT5 | 2026-03-05T10:00:00-03:00*

--- a/mcp-tools/maos-mcp-hub/.gitignore
+++ b/mcp-tools/maos-mcp-hub/.gitignore
@@ -15,6 +15,8 @@ ENV/
 .env
 *.env.local
 *.env.*.local
+.env.bak-*
+.env.env.bak-*
 
 # macOS
 .DS_Store
@@ -31,6 +33,11 @@ ENV/
 # Logs
 *.log
 logs/
+
+# Local backup artifacts (editor/agent generated)
+*.bak
+*.bak-*
+*.tmp
 
 # Build artifacts
 dist/


### PR DESCRIPTION
## Contexto
Checkout primario do `multi-agent-os` apresentou drift local (tracked mod + backups untracked) enquanto `origin/main` estava adiante. Em ambiente com múltiplos agentes paralelos, isso aumenta risco operacional e bloqueia `pull --ff-only`.

## O que este PR faz
1. Hardening de higiene local no `maos-mcp-hub`:
   - adiciona ignore para artefatos locais de backup (`.env.bak-*`, `.env.env.bak-*`, `*.bak-*`, `*.tmp`).
2. Atualiza `docs/worktrees-guide.md` com seção explícita de contenção de drift no checkout primário:
   - regra de operação (checkout primário = coordenação, worktree = edição)
   - checklist de saneamento rápido
   - metadados/changelog v1.6

## Por que é necessário
- reduzir ruído de arquivos locais gerados por agentes/edições;
- impedir confusão entre estado local e estado canônico remoto;
- reforçar a política mandatória de worktrees em operação multi-agente.

## Escopo
- Sem alteração funcional de runtime.
- Sem mudança de API.
- Apenas governança operacional/documentação + higiene de git.
