### PR TITLE
docs: migrate 5 community docs from user-scope (ECO-004 #23)

### DIFF
--- a/docs/dot-claude-architecture-validation.md
+++ b/docs/dot-claude-architecture-validation.md
@@ -1,0 +1,638 @@
+# Validacao Arquitetural: ~/.claude/ Multi-Repo Management
+
+> **Versao**: 1.0.0
+> **Data**: 2026-01-22
+> **Autor**: Claude-Code (Solution Architect)
+> **Status**: Validado - Pronto para implementacao
+> **Baseado em**: dot-claude-multi-repo-spec.md (BA Analysis)
+
+---
+
+## 1. Resumo Executivo
+
+A analise do BA propoe a solucao **S9+S14 Hybrid** para gerenciar `~/.claude/` com dois repositorios Git (Vek corporativo + Personal). Esta validacao arquitetural **CONFIRMA a viabilidade tecnica** com ajustes importantes.
+
+### Veredicto
+
+| Item | Status | Observacao |
+|------|--------|------------|
+| Solucao S9 (Vek Primary) | **APROVADA** | Estrutura de diretorios viavel |
+| Include via @path | **SUPORTADO NATIVAMENTE** | Claude Code v2.0.64+ |
+| Auto-load .d/ style | **SUPORTADO** via `~/.claude/rules/` | Nativo no Claude Code |
+| Precedencia | **RESOLVIDA** | Posicional via @import inline |
+
+---
+
+## 2. Validacao Tecnica dos GAPs
+
+### GAP01: Sintaxe @path Include
+
+**Status**: RESOLVIDO - Suporte Nativo
+
+O Claude Code **suporta nativamente** a sintaxe `@path/to/file` para inclusao de arquivos:
+
+```markdown
+# Sintaxe suportada:
+@README                           # Relativo ao diretorio atual
+@./docs/guide.md                  # Relativo explicito
+@~/.claude/personal/CLAUDE.md    # Caminho absoluto com ~
+@/absolute/path/file.md           # Caminho absoluto
+```
+
+**Caracteristicas documentadas**:
+
+| Feature | Suporte | Observacao |
+|---------|---------|------------|
+| Caminhos relativos | SIM | `@./file.md`, `@../file.md` |
+| Caminhos absolutos | SIM | `@/path/to/file.md` |
+| Home directory (~) | SIM | `@~/.claude/file.md` |
+| Recursao | SIM | Maximo 5 hops |
+| Dentro de code blocks | NAO | Ignorado (comportamento correto) |
+
+**Fonte**: https://code.claude.com/docs/en/memory
+
+### GAP02: Padrao .d/ Style Auto-Load
+
+**Status**: RESOLVIDO - Funcionalidade Nativa
+
+O Claude Code implementa auto-load via diretorio `rules/`:
+
+```
+~/.claude/
+├── CLAUDE.md           # User Memory (carregado automaticamente)
+└── rules/              # User Rules (TODOS .md carregados automaticamente)
+    ├── core.md
+    ├── git-workflow.md
+    └── ai-native.md
+```
+
+**Comportamento**:
+- Todos os arquivos `.md` em `~/.claude/rules/` sao carregados automaticamente
+- Subdiretorios sao suportados
+- Path-specific rules via YAML frontmatter `paths:` field
+- Mesma prioridade que `~/.claude/CLAUDE.md`
+
+**Implicacao Arquitetural**:
+- Regras Vek corporativas devem ir em `~/.claude/rules/` (auto-load)
+- Regras Personal via `@import` chain (nao auto-load, para isolamento)
+
+### GAP03: Script de Migracao
+
+**Status**: PENDENTE - Especificacao criada
+
+Requisitos do script de migracao:
+
+```bash
+#!/bin/bash
+# ~/.claude/scripts/migrate-to-dual-repo.sh
+
+# 1. Backup atual
+backup_current_config()
+
+# 2. Verificar estado Git atual
+detect_git_status()
+
+# 3. Clonar Vek repo
+clone_vek_repo()
+
+# 4. Criar/Clonar Personal
+setup_personal_repo()
+
+# 5. Migrar arquivos existentes
+migrate_existing_files()
+
+# 6. Configurar .gitignore
+configure_gitignore()
+
+# 7. Validar @import chain
+validate_imports()
+
+# 8. Executar dry-run
+dry_run_validation()
+```
+
+### GAP07: Regras de Precedencia Vek vs Personal
+
+**Status**: RESOLVIDO - Padrao Sanduiche
+
+A precedencia e determinada pela **posicao do @import** no arquivo:
+
+```markdown
+# ~/.claude/CLAUDE.md (Vek)
+
+## [VEK BASE] - Carregado PRIMEIRO
+Regras corporativas obrigatorias...
+
+## Personal Context
+@~/.claude/personal/CLAUDE.md
+
+## [VEK ENFORCE] - Carregado POR ULTIMO (opcional)
+Regras que NAO podem ser sobrescritas...
+```
+
+**Padrao Sanduiche**:
+```
+VEK_BASE (fundacao)
+    -> PERSONAL_OVERRIDE (customizacao)
+        -> VEK_ENFORCE (garantias)
+```
+
+---
+
+## 3. Arquitetura de Includes
+
+### Fluxo de Leitura do Claude Code
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                        HIERARQUIA DE LEITURA CLAUDE CODE                     │
+├─────────────────────────────────────────────────────────────────────────────┤
+│                                                                              │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │ 1. MANAGED POLICY (Enterprise - IT managed)                          │   │
+│  │    /etc/claude-code/CLAUDE.md (Linux)                                │   │
+│  │    /Library/Application Support/ClaudeCode/CLAUDE.md (macOS)         │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                    │                                         │
+│                                    ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │ 2. PROJECT MEMORY                                                     │   │
+│  │    ./CLAUDE.md                                                        │   │
+│  │    ./.claude/CLAUDE.md                                                │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                    │                                         │
+│                                    ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │ 3. PROJECT RULES (auto-load all .md)                                 │   │
+│  │    ./.claude/rules/*.md                                               │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                    │                                         │
+│                                    ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │ 4. USER MEMORY (Vek Corporate)  ◄──────────────────────────────────┐ │   │
+│  │    ~/.claude/CLAUDE.md                                              │ │   │
+│  │    │                                                                │ │   │
+│  │    ├── [VEK BASE RULES]                                             │ │   │
+│  │    │                                                                │ │   │
+│  │    ├── @~/.claude/personal/CLAUDE.md  ◄─────────────────────┐      │ │   │
+│  │    │    │                                                    │      │ │   │
+│  │    │    └── [PERSONAL OVERRIDES]                            │      │ │   │
+│  │    │         │                                               │      │ │   │
+│  │    │         └── @~/.claude/personal/rules/pref.md          │      │ │   │
+│  │    │              (chain import, max 5 hops)                 │      │ │   │
+│  │    │                                                         │      │ │   │
+│  │    └── [VEK ENFORCEMENT] (nao pode ser sobrescrito)         │      │ │   │
+│  │                                                              │      │ │   │
+│  └──────────────────────────────────────────────────────────────│──────┘ │   │
+│                                    │                            │         │   │
+│                                    ▼                            │         │   │
+│  ┌──────────────────────────────────────────────────────────────│──────┐ │   │
+│  │ 5. USER RULES (Vek Rules - auto-load)                        │      │ │   │
+│  │    ~/.claude/rules/*.md ─────────────────────────────────────┘      │ │   │
+│  └──────────────────────────────────────────────────────────────────────┘ │   │
+│                                    │                                         │
+│                                    ▼                                         │
+│  ┌──────────────────────────────────────────────────────────────────────┐   │
+│  │ 6. PROJECT LOCAL (personal, gitignored)                              │   │
+│  │    ./CLAUDE.local.md                                                  │   │
+│  └──────────────────────────────────────────────────────────────────────┘   │
+│                                                                              │
+└─────────────────────────────────────────────────────────────────────────────┘
+```
+
+### Estrutura de Diretorios Final
+
+```
+~/.claude/                              # VEK REPO (git@github.com:vek-servicos/dot-claude.git)
+├── .git/                               # Git Vek
+├── .gitignore                          # Contem: personal/, projects/, plugins/, debug/
+│
+├── CLAUDE.md                           # USER MEMORY - Vek + @import personal
+│   # Conteudo:
+│   # ## Vek Corporate Context
+│   # [regras base]
+│   # ## Personal Context
+│   # @~/.claude/personal/CLAUDE.md
+│   # ## Vek Enforcement
+│   # [regras finais]
+│
+├── rules/                              # USER RULES - Auto-load (Vek)
+│   ├── core-directive.md               # C01 compacto
+│   ├── git-workflow.md                 # Git conventions
+│   ├── ai-native.md                    # AI patterns
+│   └── session-report.md               # C05 report standard
+│
+├── docs/                               # ON-DEMAND - Specs detalhadas
+│   ├── git-worktree-protocol.md        # C04 completo
+│   ├── pr-review-protocol-spec.md      # C07 completo
+│   └── insights/                       # Insights acumulados
+│
+├── commands/                           # Slash commands
+│   └── enhance.md
+│
+├── scripts/                            # Automation scripts
+│   ├── init-worktree.sh
+│   ├── bootstrap-personal.sh
+│   └── migrate-to-dual-repo.sh
+│
+├── templates/                          # Templates reutilizaveis
+│   └── worktree/
+│
+└── personal/                           # PERSONAL REPO (git@github.com:{user}/dot-claude.git)
+    ├── .git/                           # Git Personal (separado)
+    ├── CLAUDE.md                       # Personal overrides
+    │   # Conteudo:
+    │   # ## User Profile
+    │   # [dados pessoais]
+    │   # ## Preferences
+    │   # [preferencias]
+    │   # ## Additional Rules
+    │   # @~/.claude/personal/rules/style.md
+    │
+    ├── rules/                          # Personal rules (via @import chain, NAO auto-load)
+    │   ├── style.md
+    │   └── shortcuts.md
+    │
+    └── .gitignore                      # Arquivos locais pessoais
+```
+
+---
+
+## 4. Resolucao Detalhada dos GAPs
+
+### GAP01: @path Include - Implementacao
+
+**Sintaxe no CLAUDE.md Vek**:
+
+```markdown
+# ~/.claude/CLAUDE.md
+
+## Vek Corporate Context
+
+[... regras corporativas base ...]
+
+---
+
+## Personal Context
+
+> As configuracoes pessoais sao carregadas automaticamente se existirem.
+
+@~/.claude/personal/CLAUDE.md
+
+---
+
+## Vek Enforcement
+
+> Regras abaixo NAO podem ser sobrescritas pelo personal.
+
+[... regras criticas ...]
+```
+
+**Comportamento quando personal nao existe**:
+
+O Claude Code tenta ler o arquivo referenciado. Se nao existir:
+- A referencia `@~/.claude/personal/CLAUDE.md` sera tratada como texto literal
+- Recomendacao: Adicionar texto condicional no Vek CLAUDE.md
+
+**Texto condicional sugerido**:
+
+```markdown
+## Personal Context
+
+> Se `~/.claude/personal/CLAUDE.md` existir, sera incorporado abaixo.
+> Caso contrario, use o script de bootstrap: `~/.claude/scripts/bootstrap-personal.sh`
+
+@~/.claude/personal/CLAUDE.md
+```
+
+### GAP02: .d/ Style - Separacao Vek/Personal
+
+**Regra de ouro**:
+- `~/.claude/rules/*.md` = Vek (auto-load, versionado no repo Vek)
+- `~/.claude/personal/rules/*.md` = Personal (via @import chain, NAO auto-load)
+
+**Por que Personal rules nao ficam em ~/.claude/rules/?**
+
+| Problema | Consequencia |
+|----------|--------------|
+| Namespace collision | Vek e Personal com mesmo nome de arquivo |
+| Git isolation | Nao da para ter dois .git no mesmo diretorio |
+| Merge conflicts | Atualizacoes Vek podem conflitar |
+
+**Solucao: @import chain no personal/CLAUDE.md**:
+
+```markdown
+# ~/.claude/personal/CLAUDE.md
+
+## My Preferences
+- Language: pt-BR
+- Style: Direct
+
+## My Rules (loaded via chain)
+@~/.claude/personal/rules/code-style.md
+@~/.claude/personal/rules/shortcuts.md
+```
+
+Isso mantem:
+- Vek rules em auto-load (obrigatorio para todos)
+- Personal rules isoladas (apenas para quem tem personal)
+- Maximo 5 hops de recursao (suficiente)
+
+### GAP07: Precedencia - Matriz de Overrides
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                      MATRIZ DE PRECEDENCIA                              │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                          │
+│  ORDEM DE LEITURA (primeiro -> ultimo)                                  │
+│  ════════════════════════════════════                                   │
+│                                                                          │
+│  1. ~/.claude/CLAUDE.md [VEK BASE]                                      │
+│       │                                                                  │
+│       ├── Core Directive (C01)                                          │
+│       ├── Main Instructions (C02)                                        │
+│       ├── Ralph Loop (C03)                                               │
+│       └── Git Worktree ref (C04)                                         │
+│              │                                                           │
+│              ▼                                                           │
+│  2. @~/.claude/personal/CLAUDE.md [PERSONAL OVERRIDE]                   │
+│       │                                                                  │
+│       ├── User Profile (name, email, role)                              │
+│       ├── Preferences (language, style)                                  │
+│       └── @~/.claude/personal/rules/*.md (chain)                        │
+│              │                                                           │
+│              ▼                                                           │
+│  3. ~/.claude/CLAUDE.md [VEK ENFORCE] (pos-@import)                     │
+│       │                                                                  │
+│       └── Regras que NAO podem ser sobrescritas                         │
+│              │                                                           │
+│              ▼                                                           │
+│  4. ~/.claude/rules/*.md [VEK RULES - auto-load]                        │
+│       │                                                                  │
+│       ├── core-directive.md                                              │
+│       ├── git-workflow.md                                                │
+│       └── ai-native.md                                                   │
+│                                                                          │
+│  ════════════════════════════════════                                   │
+│  REGRA DE OVERRIDE: Ultimo a declarar VENCE                             │
+│                                                                          │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+**Implicacoes praticas**:
+
+| Cenario | Quem vence | Motivo |
+|---------|------------|--------|
+| Vek diz "pt-BR", Personal diz "en-US" | Personal | Carregado depois do Vek Base |
+| Personal diz "skip tests", Vek Enforce diz "always test" | Vek Enforce | Pos-@import |
+| Vek rules/ diz X, Vek CLAUDE.md diz Y | rules/ | Auto-load apos CLAUDE.md |
+
+---
+
+## 5. Decisoes Arquiteturais (ADR Format)
+
+### ADR-001: Estrutura Vek Primary com Personal Subdirectory
+
+**Titulo**: Adocao da estrutura S9 (Vek Primary + Personal Subdirectory)
+
+**Contexto**:
+- Necessidade de separar conteudo corporativo de pessoal
+- Requisito de versionamento Git independente
+- Restricao de nao usar symlinks (decisao do usuario)
+- Claude Code le `~/.claude/CLAUDE.md` como User Memory
+
+**Decisao**:
+Adotar `~/.claude/` como clone do repo Vek, com `~/.claude/personal/` como clone do repo Personal, gitignored pelo Vek.
+
+**Consequencias**:
+- (+) Governanca clara: Vek controla base
+- (+) Isolamento: Personal e um subdirectory com .git proprio
+- (+) Onboarding simples: Clone Vek, funciona
+- (+) Flexibilidade: Personal e opcional
+- (-) Duas operacoes git (uma em cada repo)
+- (-) Personal rules nao sao auto-loaded
+
+### ADR-002: Mecanismo de Include via @import Nativo
+
+**Titulo**: Uso do @import nativo para incluir Personal
+
+**Contexto**:
+- Personal em subdirectory nao e auto-loaded
+- Claude Code suporta `@path` nativamente
+- Precisamos garantir que Personal seja lido
+
+**Decisao**:
+Usar `@~/.claude/personal/CLAUDE.md` no Vek CLAUDE.md para incluir Personal.
+
+**Consequencias**:
+- (+) Nativo, sem ferramentas extras
+- (+) Funciona cross-platform
+- (+) Recursao ate 5 hops permite chain imports
+- (-) Se arquivo nao existe, texto literal aparece
+- (-) Requer documentacao/convencao
+
+### ADR-003: Padrao Sanduiche para Precedencia
+
+**Titulo**: Vek Base -> Personal Override -> Vek Enforce
+
+**Contexto**:
+- @import expande inline na posicao declarada
+- Precisamos permitir customizacao pessoal
+- Algumas regras corporativas nao podem ser sobrescritas
+
+**Decisao**:
+Estruturar o Vek CLAUDE.md em tres blocos:
+1. Vek Base (antes do @import)
+2. @import Personal (meio)
+3. Vek Enforce (depois do @import)
+
+**Consequencias**:
+- (+) Flexibilidade controlada
+- (+) Regras criticas protegidas
+- (+) Transparente (ordem de leitura e evidente)
+- (-) Requer disciplina na estruturacao do arquivo
+
+### ADR-004: Vek Rules em Auto-Load, Personal via Chain
+
+**Titulo**: Separacao de regras por mecanismo de carregamento
+
+**Contexto**:
+- `~/.claude/rules/` e auto-loaded
+- Personal rules precisam de isolamento Git
+- Nao e possivel ter dois .git em `~/.claude/rules/`
+
+**Decisao**:
+- Vek rules: `~/.claude/rules/` (auto-load, obrigatorio)
+- Personal rules: `~/.claude/personal/rules/` (via @import chain)
+
+**Consequencias**:
+- (+) Isolamento Git perfeito
+- (+) Sem namespace collision
+- (+) Vek rules sempre carregadas
+- (-) Personal rules requerem @import explicito no personal/CLAUDE.md
+- (-) Limite de 5 hops (suficiente na pratica)
+
+---
+
+## 6. Especificacao do Script de Migracao
+
+### Requisitos Funcionais
+
+```bash
+#!/bin/bash
+# migrate-to-dual-repo.sh
+# Versao: 1.0.0
+
+# FUNCOES REQUERIDAS:
+
+# 1. Backup
+backup_current() {
+    # Criar ~/.claude.backup.YYYYMMDD-HHMMSS/
+    # Copiar todo conteudo (exceto runtime: projects, plugins, debug)
+}
+
+# 2. Deteccao de estado
+detect_state() {
+    # Verificar se ja e git repo
+    # Verificar se ja tem personal/
+    # Verificar se tem arquivos nao commitados
+}
+
+# 3. Clone Vek
+clone_vek() {
+    # git clone git@github.com:vek-servicos/dot-claude.git ~/.claude.new
+    # Validar clone
+}
+
+# 4. Migrar arquivos existentes
+migrate_files() {
+    # Identificar arquivos pessoais (email, DOB, etc)
+    # Mover para personal/
+    # Identificar arquivos universais
+    # Manter se nao conflitam com Vek
+}
+
+# 5. Setup Personal
+setup_personal() {
+    # Tentar git clone user/dot-claude ~/.claude.new/personal
+    # Se falhar: mkdir + git init + template CLAUDE.md
+}
+
+# 6. Swap atomico
+atomic_swap() {
+    # mv ~/.claude ~/.claude.old
+    # mv ~/.claude.new ~/.claude
+}
+
+# 7. Validacao
+validate() {
+    # Verificar @import chain funciona
+    # Verificar rules/ auto-load
+    # Teste de dry-run com claude --version
+}
+```
+
+### Flags Suportadas
+
+```bash
+migrate-to-dual-repo.sh [OPTIONS]
+
+OPTIONS:
+  --dry-run           Mostra o que seria feito sem executar
+  --backup-only       Apenas faz backup, nao migra
+  --vek-repo URL      URL do repo Vek (default: git@github.com:vek-servicos/dot-claude.git)
+  --personal-repo URL URL do repo Personal (opcional)
+  --force             Ignora verificacoes de seguranca
+  --verbose           Output detalhado
+  --help              Mostra ajuda
+```
+
+---
+
+## 7. Consideracoes de Seguranca
+
+### Dados Sensiveis
+
+| Tipo | Localizacao | Protecao |
+|------|-------------|----------|
+| Email pessoal | personal/CLAUDE.md | Repo privado |
+| Data de nascimento | personal/CLAUDE.md | Repo privado |
+| API keys | NUNCA em CLAUDE.md | .env ou secret manager |
+| Credenciais Git | ~/.gitconfig (separado) | Nao relacionado |
+
+### Gitignore Obrigatorio (Vek)
+
+```gitignore
+# ~/.claude/.gitignore (Vek repo)
+
+# Runtime - NUNCA versionar
+projects/
+plugins/
+debug/
+todos/
+plans/
+audit/
+cache/
+file-history/
+paste-cache/
+image-cache/
+
+# Credentials - NUNCA versionar
+.credentials.json
+.claude.json
+*.env
+.env*
+
+# Personal repo - Versionado separadamente
+personal/
+
+# OS artifacts
+.DS_Store
+*.swp
+*~
+```
+
+---
+
+## 8. Compatibilidade Cross-Platform
+
+| Plataforma | Suporte | Observacoes |
+|------------|---------|-------------|
+| macOS | TOTAL | Testado |
+| Linux | TOTAL | Testado |
+| Windows + WSL | TOTAL | Via WSL2 |
+| Windows nativo | PARCIAL | Caminhos diferentes |
+
+### Caminhos por Plataforma
+
+| Item | macOS/Linux | Windows WSL | Windows Nativo |
+|------|-------------|-------------|----------------|
+| User home | `~/.claude/` | `~/.claude/` | `%USERPROFILE%\.claude\` |
+| Managed policy | `/etc/claude-code/` | `/etc/claude-code/` | `C:\Program Files\ClaudeCode\` |
+| @import syntax | `@~/.claude/...` | `@~/.claude/...` | `@%USERPROFILE%\.claude\...` (?) |
+
+**Nota**: Windows nativo requer validacao adicional do @import com caminhos Windows.
+
+---
+
+## 9. Proximos Passos
+
+1. **CRIAR** repo `vek-servicos/dot-claude` no GitHub (privado)
+2. **ESTRUTURAR** o CLAUDE.md Vek com padrao sanduiche
+3. **MIGRAR** rules/ existentes para o novo repo
+4. **IMPLEMENTAR** script migrate-to-dual-repo.sh
+5. **TESTAR** com segundo usuario Vek
+6. **DOCUMENTAR** setup no README do repo
+
+---
+
+## 10. Referencias
+
+- Claude Code Memory Documentation: https://code.claude.com/docs/en/memory
+- Plugin Structure: https://github.com/anthropics/claude-code/blob/main/plugins/plugin-dev/skills/plugin-structure/SKILL.md
+- BA Analysis: ~/.claude/docs/dot-claude-multi-repo-spec.md
+
+---
+
+*Assinatura: Claude-Code (SA) | 2026-01-22T14:30:00-03:00*

--- a/docs/dot-claude-multi-repo-spec.md
+++ b/docs/dot-claude-multi-repo-spec.md
@@ -1,0 +1,998 @@
+# Gerenciamento de Repositórios ~/.claude/
+
+> **Versao**: 2.1.0
+> **Criado**: 2026-01-22
+> **Atualizado**: 2026-01-22
+> **Autor**: Claude-Code
+> **Status**: Especificacao final aprovada
+> **Changelog**:
+> - v2.1.0 - Whitelist `sessions/` e `plans/`, ADR05 (session reports commitados)
+> - v2.0.0 - .gitignore v3.0 WHITELIST, nomenclatura genérica (`work` vs `personal`), arquivo renomeado
+> - v1.2.0 - .gitignore v2.0 (75 linhas, proteção secrets)
+> - v1.1.0 - PERSONAL.md → CLAUDE.md, typos corrigidos
+
+---
+
+## Problema
+
+O diretório `~/.claude/` contém configurações de três naturezas:
+
+| Categoria | Conteúdo | Sensibilidade |
+|-----------|----------|---------------|
+| **Work (Corporativo)** | Stack, templates, protocolos, regras | Baixa (interno) |
+| **Personal** | Email pessoal, DOB, preferências | Alta |
+| **Universal** | Core directive, protocolos genéricos | Nenhuma |
+| **Runtime** | Cache, plugins, debug | N/A (não versionar) |
+
+### Requisitos
+
+1. Separar conteúdo pessoal do corporativo
+2. Permitir sync via git para ambos
+3. Funcionar localmente em `~/.claude/`
+4. Não conflitar entre si
+5. Manter hierarquia de leitura do Claude Code
+
+---
+
+## Inventário Atual (2026-01-22)
+
+### Por Tamanho
+
+| Diretório | Tamanho | Versionável |
+|-----------|---------|-------------|
+| `projects/` | 631 MB | ❌ Runtime |
+| `plugins/` | 131 MB | ❌ Runtime |
+| `debug/` | 62 MB | ❌ Runtime |
+| `docs/` | 80 KB | ✅ Config |
+| `rules/` | 24 KB | ✅ Config |
+| `templates/` | 12 KB | ✅ Config |
+| `scripts/` | 8 KB | ✅ Config |
+| `plans/` | 32 KB | ⚠️ Temporário |
+| `todos/` | 4 KB | ⚠️ Temporário |
+
+### Por Categoria
+
+| Arquivo/Pasta | Personal | Work | Universal |
+|---------------|----------|------|-----------|
+| `CLAUDE.md` | ❌ | ✅ | ✅ |
+| `rules/user-rules.md` | ✅ (email, DOB) | ✅ (stack) | ❌ |
+| `rules/pr-review-protocol.md` | ❌ | ❌ | ✅ |
+| `docs/git-worktree-protocol.md` | ❌ | ❌ | ✅ |
+| `docs/insights/` | ❌ | ❌ | ✅ |
+| `templates/worktree/` | ❌ | ✅ | ❌ |
+| `scripts/init-worktree.sh` | ❌ | ✅ | ❌ |
+
+---
+
+## 14 Soluções Analisadas
+
+### Sessão Anterior (S1-S7)
+
+| # | Solução | Resumo | Viabilidade |
+|---|---------|--------|-------------|
+| S1 | Monorepo + .gitignore | Tudo em 1 repo, ignorar pessoal | ⚠️ Médio |
+| S2 | Git Submodules | Personal como submodule do vek | ❌ Complexo |
+| S3 | Git Subtree | Merge de repos com histórico | ❌ Complexo |
+| S4 | Chezmoi | Templates com conditionals | ❌ Overhead |
+| S5 | VCSH | Multi-repos mesmo diretório | ⚠️ Médio |
+| S6 | Branches + Merge | Base + overlays por branch | ❌ Conflitos |
+| S7 | Symlinks + 2 Repos | Simples, links externos | ⚠️ Médio |
+
+### Novas Soluções (S8-S14)
+
+#### S8: Bare Repo Overlay (Multigit)
+
+**Conceito**: Dois bare repos compartilhando o mesmo `GIT_WORK_TREE=$HOME/.claude/`.
+
+```bash
+# Setup
+git init --bare ~/.claude/.git-vek
+git init --bare ~/.claude/.git-personal
+
+# Aliases
+alias claude-vek='git --git-dir=$HOME/.claude/.git-vek --work-tree=$HOME/.claude'
+alias claude-personal='git --git-dir=$HOME/.claude/.git-personal --work-tree=$HOME/.claude'
+
+# Cada repo rastreia apenas seus arquivos
+claude-vek add CLAUDE.md docs/ rules/pr-review-protocol.md
+claude-personal add rules/user-rules.md
+```
+
+**Prós**:
+- Zero conflitos (cada repo rastreia arquivos diferentes)
+- Histórico separado
+- Sem symlinks
+
+**Contras**:
+- Requer aliases
+- Fácil confundir qual repo usar
+- `git status` complexo
+
+**Viabilidade**: ⚠️ Médio
+
+---
+
+#### S9: Work Primary + Personal Subdirectory (Sua Proposta)
+
+**Conceito**: `~/.claude/` = clone do work, `~/.claude/personal/` = clone do personal.
+
+```bash
+# Setup
+cd ~ && rm -rf .claude
+git clone git@github.com:{org}/dot-claude.git .claude
+cd .claude
+git clone git@github.com:{user}/dot-claude.git personal
+echo "personal/" >> .gitignore
+git commit -am "chore: ignore personal subdirectory"
+```
+
+**CLAUDE.md do Work** inclui:
+```markdown
+## Personal Context (Opcional)
+
+Se existir `~/.claude/personal/CLAUDE.md`, incorporar:
+- Preferências de idioma
+- Dados de contato (se necessário)
+- Regras pessoais adicionais
+```
+
+**Prós**:
+- **Oficializa** a estrutura (work controla)
+- Usuário tem flexibilidade (pode ou não ter personal)
+- Setup simples
+- .gitignore protege
+
+**Contras**:
+- Personal fica "escondido" em subdirectory
+- Duas operações git (um em cada diretório)
+
+**Viabilidade**: ✅ Alto
+
+---
+
+#### S10: Personal Primary + Work Subdirectory
+
+**Conceito**: Inverso do S9 - `~/.claude/` = personal, `~/.claude/vek/` = corporativo.
+
+```bash
+# Setup
+cd ~ && rm -rf .claude
+git clone git@github.com:{user}/dot-claude.git .claude
+cd .claude
+git clone git@github.com:{org}/dot-claude.git work
+echo "work/" >> .gitignore
+```
+
+**CLAUDE.md do Personal** inclui:
+```markdown
+## Work Context
+
+> **OBRIGATÓRIO**: Incorporar `~/.claude/work/CLAUDE.md`
+```
+
+**Prós**:
+- Usuário tem controle total
+- Fácil personalização
+
+**Contras**:
+- **Depende do usuário** incluir work no CLAUDE.md
+- Pode esquecer de configurar
+- Menos "oficial"
+
+**Viabilidade**: ⚠️ Médio (depende de disciplina do usuário)
+
+---
+
+#### S11: YADM com Alternates
+
+**Conceito**: Usar yadm com arquivos alternativos por host/classe.
+
+```bash
+# Setup
+yadm clone git@github.com:{org}/dot-claude.git
+
+# Estrutura
+~/.claude/
+├── CLAUDE.md                    # Base (todos)
+├── CLAUDE.md##class.personal    # Overlay pessoal
+├── rules/
+│   ├── user-rules.md            # Base
+│   └── user-rules.md##class.personal  # Overlay
+
+# Ativar classe
+yadm config local.class personal
+yadm alt
+```
+
+**Prós**:
+- Um repo apenas
+- Overlays por classe/host
+- Ferramenta madura
+
+**Contras**:
+- Requer aprender yadm
+- Arquivos duplicados com sufixos
+- Não trivial para novos membros
+
+**Viabilidade**: ⚠️ Médio
+
+---
+
+#### S12: Git Sparse-Checkout com Dois Remotes
+
+**Conceito**: Um repo local com dois remotes, sparse-checkout seletivo.
+
+```bash
+# Setup
+cd ~/.claude
+git init
+git remote add work git@github.com:{org}/dot-claude.git
+git remote add personal git@github.com:{user}/dot-claude.git
+
+# Fetch ambos
+git fetch work && git fetch personal
+
+# Checkout work na raiz
+git checkout work/main -- .
+
+# Checkout personal em subdirectory
+git checkout personal/main -- personal/
+```
+
+**Prós**:
+- Flexível
+- Um diretório .git
+
+**Contras**:
+- Conflitos de merge
+- Histórico confuso
+- Não recomendado pelo git
+
+**Viabilidade**: ❌ Baixo
+
+---
+
+#### S13: Symlink Reverso (Personal Fora)
+
+**Conceito**: `~/.claude/` = vek completo, `~/.claude-personal/` = repo pessoal separado, symlinks de arquivos específicos.
+
+```bash
+# Setup
+git clone git@github.com:{org}/dot-claude.git ~/.claude
+git clone git@github.com:{user}/dot-claude.git ~/.claude-personal
+
+# Symlinks
+ln -sf ~/.claude-personal/user-rules.md ~/.claude/rules/user-rules.md
+ln -sf ~/.claude-personal/CLAUDE.md ~/.claude/personal/CLAUDE.md
+```
+
+**Prós**:
+- Repos completamente separados
+- Work não precisa saber de personal
+
+**Contras**:
+- Symlinks podem quebrar
+- Git do vek vê symlinks, não conteúdo
+- Mais complexo que S9
+
+**Viabilidade**: ⚠️ Médio
+
+---
+
+#### S14: Include Pattern no CLAUDE.md
+
+**Conceito**: Work repo tem CLAUDE.md que faz `include` dinâmico do personal se existir.
+
+```bash
+# Setup (igual S9)
+git clone git@github.com:{org}/dot-claude.git ~/.claude
+mkdir -p ~/.claude/personal  # Não versionado
+```
+
+**CLAUDE.md do Work**:
+```markdown
+# CLAUDE.md — Work Corporate
+
+## Core Rules
+...
+
+## Personal Override (Auto-include)
+
+<!-- Claude Code auto-expands includes -->
+> **Include**: `~/.claude/personal/CLAUDE.md` (se existir)
+
+Se o arquivo acima existir, suas configurações sobrescrevem as corporativas.
+```
+
+**Sem repo personal**: Usuário cria manualmente `~/.claude/personal/CLAUDE.md`.
+**Com repo personal**: Usuário clona dentro de `personal/`.
+
+**Prós**:
+- Extremamente simples
+- Zero conflito git
+- Funciona sem personal
+
+**Contras**:
+- Claude Code não suporta `include` nativamente (precisa documental convention)
+- Personal não versionado por padrão
+
+**Viabilidade**: ✅ Alto (com convenção)
+
+---
+
+## Comparação: work/personal vs personal/work
+
+### Cenário A: Work Primary (`~/.claude/` = work)
+
+```
+~/.claude/                 ← git clone work
+├── .git/                  ← Repo work
+├── .gitignore             ← Inclui "personal/"
+├── CLAUDE.md              ← Work + include personal
+├── personal/              ← git clone personal (ignorado pelo work)
+│   ├── .git/
+│   └── CLAUDE.md
+├── docs/
+├── rules/
+└── templates/
+```
+
+| Critério | Pontuação |
+|----------|-----------|
+| **Oficialidade** | ✅ Work define estrutura |
+| **Controle** | ✅ Work controla CLAUDE.md principal |
+| **Flexibilidade** | ✅ Usuário pode ter ou não personal |
+| **Onboarding** | ✅ Novo membro clona work, funciona |
+| **Manutenção** | ✅ Work atualiza, todos recebem |
+
+**Score**: 5/5
+
+### Cenário B: Personal Primary (`~/.claude/` = personal)
+
+```
+~/.claude/                 ← git clone personal
+├── .git/                  ← Repo personal
+├── .gitignore             ← Inclui "work/"
+├── CLAUDE.md              ← Personal (deve incluir work)
+├── work/                  ← git clone work (ignorado pelo personal)
+│   ├── .git/
+│   └── CLAUDE.md
+├── docs/
+└── rules/
+```
+
+| Critério | Pontuação |
+|----------|-----------|
+| **Oficialidade** | ❌ Depende de cada usuário |
+| **Controle** | ❌ Cada usuário decide se inclui work |
+| **Flexibilidade** | ✅ Total para o usuário |
+| **Onboarding** | ❌ Novo membro precisa configurar manualmente |
+| **Manutenção** | ❌ Atualizações work não propagam automaticamente |
+
+**Score**: 2/5
+
+### Conclusão da Comparação
+
+**work/personal é superior** porque:
+
+1. **Governança**: A organização controla as regras base
+2. **Compliance**: Garante que todos seguem os protocolos corporativos
+3. **Facilidade**: Novo colaborador clona work → funciona imediatamente
+4. **Opcional**: Personal é um "addon", não requisito
+5. **Citação do usuário**: "já oficializamos a obrigatoriedade de chamada ao personal no CLAUDE.md"
+
+---
+
+## Comparação: Localização do Personal
+
+### Opção A: `~/.claude/personal/`
+
+```
+~/.claude/
+├── personal/              ← Subdirectory dedicado
+│   ├── .git/
+│   ├── CLAUDE.md
+│   └── user-overrides.md
+```
+
+| Critério | Score |
+|----------|-------|
+| Separação clara | ✅ 5/5 |
+| Descoberta | ✅ 5/5 (óbvio) |
+| Git isolation | ✅ 5/5 |
+| Namespace conflict | ✅ 5/5 (zero) |
+
+**Total**: 20/20
+
+### Opção B: `~/.claude/docs/personal/`
+
+```
+~/.claude/
+├── docs/
+│   ├── git-worktree-protocol.md  ← Work
+│   ├── personal/                  ← Misturado
+│   │   └── notes.md
+```
+
+| Critério | Score |
+|----------|-------|
+| Separação clara | ❌ 2/5 (misturado) |
+| Descoberta | ⚠️ 3/5 |
+| Git isolation | ❌ 1/5 (precisa nested repo ou gitignore complexo) |
+| Namespace conflict | ❌ 2/5 (pode conflitar) |
+
+**Total**: 8/20
+
+### Opção C: `~/.claude/rules/personal/`
+
+```
+~/.claude/
+├── rules/
+│   ├── pr-review-protocol.md     ← Work
+│   ├── personal/                  ← Misturado
+│   │   └── my-rules.md
+```
+
+| Critério | Score |
+|----------|-------|
+| Separação clara | ❌ 2/5 |
+| Descoberta | ⚠️ 3/5 |
+| Git isolation | ❌ 1/5 |
+| Namespace conflict | ❌ 2/5 |
+
+**Total**: 8/20
+
+### Conclusão da Localização
+
+**`~/.claude/personal/`** é a melhor opção porque:
+
+1. **Raiz clara**: Fácil de encontrar e entender
+2. **Git próprio**: Pode ter seu próprio `.git/` sem conflito
+3. **Gitignore simples**: Apenas `personal/` no .gitignore do vek
+4. **Escalável**: Pode ter subdiretórios (docs, rules, templates pessoais)
+
+---
+
+## Recomendação Final
+
+### Solução Aprovada: S9+S14 Híbrido (Automatizado)
+
+**Decisões**:
+
+| Item | Valor |
+|------|-------|
+| **Nome repo work** | `{org}/dot-claude` (privado) |
+| **Nome repo personal** | `{user}/dot-claude` (privado) |
+| **Dir personal** | `~/.claude/personal/` |
+| **Include** | OBRIGATÓRIO (não opcional) |
+| **Bootstrap** | Automático pelo agente |
+
+### Solução Recomendada: S9 (Work Primary + Personal Subdirectory)
+
+```
+~/.claude/                          ← git@github.com:{org}/dot-claude.git
+├── .git/
+├── .gitignore                      ← Contém: personal/, projects/, plugins/, debug/
+├── CLAUDE.md                       ← Principal (inclui referência ao personal)
+├── personal/                       ← git@github.com:{user}/dot-claude.git (opcional)
+│   ├── .git/
+│   ├── CLAUDE.md                   ← Mesmo formato de ~/.claude/CLAUDE.md
+│   ├── rules/                      ← Regras pessoais (via @import)
+│   └── docs/                       ← Docs pessoais
+├── docs/
+├── rules/
+├── templates/
+└── scripts/
+```
+
+### Setup Recomendado
+
+```bash
+#!/bin/bash
+# ~/.claude/scripts/setup-claude-home.sh
+
+# 1. Clone work config
+cd ~
+rm -rf .claude  # Backup first if needed
+git clone git@github.com:{org}/dot-claude.git .claude
+
+# 2. (Opcional) Clone personal config
+cd ~/.claude
+if [ -n "$CLAUDE_PERSONAL_REPO" ]; then
+    git clone "$CLAUDE_PERSONAL_REPO" personal
+    echo "Personal repo cloned to ~/.claude/personal/"
+else
+    mkdir -p personal
+    echo "# CLAUDE.md - Your personal overrides" > personal/CLAUDE.md
+    echo "Created empty personal directory"
+fi
+
+echo "Setup complete!"
+```
+
+### .gitignore do Work Repo (v3.0 - WHITELIST)
+
+> **Estratégia**: Ignorar TUDO por padrão, adicionar exceções explícitas.
+> **Vantagem**: Segurança máxima - novos arquivos são automaticamente ignorados.
+
+```gitignore
+# ═══════════════════════════════════════════════════════════════════
+# .gitignore para ~/.claude/ (Work Repository)
+# Versão: 3.0.0 | Estratégia: WHITELIST (ignore-all + exceptions)
+# Atualizado: 2026-01-22
+# ═══════════════════════════════════════════════════════════════════
+
+# ─────────────────────────────────────────────────────────────────────
+# PASSO 1: Ignorar TUDO por padrão (segurança máxima)
+# ─────────────────────────────────────────────────────────────────────
+*
+
+# ─────────────────────────────────────────────────────────────────────
+# PASSO 2: Exceções - arquivos raiz que DEVEM ser versionados
+# ─────────────────────────────────────────────────────────────────────
+!.gitignore
+!CLAUDE.md
+!README.md
+
+# ─────────────────────────────────────────────────────────────────────
+# PASSO 3: Exceções - diretórios que DEVEM ser versionados
+# (IMPORTANTE: negar diretório E conteúdo separadamente)
+# ─────────────────────────────────────────────────────────────────────
+
+# docs/
+!docs/
+!docs/**
+
+# rules/
+!rules/
+!rules/**
+
+# scripts/
+!scripts/
+!scripts/**
+
+# templates/
+!templates/
+!templates/**
+
+# commands/
+!commands/
+!commands/**
+
+# hooks/
+!hooks/
+!hooks/**
+
+# agents/ (se necessário)
+!agents/
+!agents/**
+
+# skills/ (se necessário)
+!skills/
+!skills/**
+
+# sessions/ (session reports - C05 standard)
+!sessions/
+!sessions/**
+
+# plans/ (plan mode files)
+!plans/
+!plans/**
+
+# ─────────────────────────────────────────────────────────────────────
+# PASSO 4: Re-ignorar arquivos sensíveis dentro das exceções
+# (Proteção extra - caso alguém coloque secret em docs/)
+# ─────────────────────────────────────────────────────────────────────
+*.env
+.env*
+*credentials*
+*secret*
+*.key
+*.pem
+*.p12
+*.log
+*.bak
+*.backup
+```
+
+### Por que WHITELIST (v3.0) é superior a BLACKLIST (v2.0)?
+
+| Critério | Blacklist (v2.0) | Whitelist (v3.0) |
+|----------|------------------|------------------|
+| **Novos arquivos** | ⚠️ Tracked por padrão | ✅ Ignorados por padrão |
+| **Secrets acidentais** | ⚠️ Risco de exposição | ✅ Proteção automática |
+| **Manutenção** | ❌ Cresce com estrutura | ✅ Estável |
+| **Linhas** | 75 | 55 |
+
+### Arquivos que SERÃO versionados (via exceções)
+
+| Item | Tamanho | Descrição |
+|------|---------|-----------|
+| `.gitignore` | ~2KB | Este arquivo |
+| `CLAUDE.md` | ~53KB | Configuração principal |
+| `README.md` | ~1KB | Documentação raiz |
+| `docs/**` | ~80KB | Documentação |
+| `rules/**` | ~24KB | Regras auto-load |
+| `scripts/**` | ~8KB | Scripts utilitários |
+| `templates/**` | ~12KB | Templates |
+| `commands/**` | ~5KB | Comandos customizados |
+| `hooks/**` | ~10KB | Hooks de sessão |
+| `sessions/**` | ~50KB | Session reports (C05) |
+| `plans/**` | ~32KB | Plan mode files |
+
+**Total versionável**: ~277KB (vs ~800MB total do diretório)
+
+### CLAUDE.md do Work (Trecho)
+
+```markdown
+## Personal Context (Opcional)
+
+> Se existir `~/.claude/personal/CLAUDE.md`, as configurações pessoais são incorporadas.
+>
+> O personal repo é opcional e controlado pelo usuário individual.
+> Setup: `git clone <seu-repo-personal> ~/.claude/personal/`
+
+### Hierarquia de Leitura
+
+1. `~/.claude/CLAUDE.md` (este arquivo - corporativo)
+2. `~/.claude/personal/CLAUDE.md` (pessoal - se existir)
+3. `./CLAUDE.md` (projeto específico)
+```
+
+---
+
+## Bootstrap Automático (C00)
+
+O agente DEVE executar automaticamente no início de TODA sessão:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  FLUXO DE BOOTSTRAP (executar automaticamente, sem perguntar)          │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│  1. Verificar: [ -d ~/.claude/personal ] && [ -f CLAUDE.md ]           │
+│                                                                         │
+│  2. Se NÃO existe:                                                      │
+│     a) Tentar: git clone {user}/dot-claude ~/.claude/personal                   │
+│     b) Se falha: mkdir + git init + criar CLAUDE.md template           │
+│     c) Informar sobre push (não bloquear)                               │
+│                                                                         │
+│  3. Include: LER ~/.claude/personal/CLAUDE.md (OBRIGATÓRIO)            │
+│                                                                         │
+│  4. Continuar com tarefa                                                │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### Script de Bootstrap (Idempotente v1.1.0)
+
+```bash
+#!/bin/bash
+# ~/.claude/scripts/bootstrap-personal.sh
+# Versao: 1.1.0 - Idempotente e cross-platform (macOS/Linux/WSL)
+
+set -euo pipefail
+
+PERSONAL_DIR="$HOME/.claude/personal"
+CLAUDE_MD="$PERSONAL_DIR/CLAUDE.md"
+GITHUB_USER=$(git config --global user.email 2>/dev/null | cut -d'@' -f1 || echo "")
+PERSONAL_REPO="git@github.com:${GITHUB_USER}/dot-claude.git"
+
+# Funcao para verificar se CLAUDE.md e valido (nao vazio, tem conteudo minimo)
+is_valid_claude_md() {
+    local file="$1"
+    [ -f "$file" ] || return 1
+    # Verifica se tem pelo menos 50 bytes
+    local size
+    size=$(wc -c < "$file" | tr -d ' ')
+    [ "$size" -ge 50 ] || return 1
+    # Verifica se contem header esperado
+    grep -q "^# CLAUDE.md" "$file" 2>/dev/null || return 1
+    return 0
+}
+
+# Funcao para criar backup
+backup_file() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+    local backup="${file}.bak.$(date +%Y%m%d_%H%M%S)"
+    cp "$file" "$backup"
+    echo "[Bootstrap] Backup criado: $backup"
+}
+
+# Funcao para criar CLAUDE.md template
+create_claude_md_template() {
+    local created_date
+    created_date=$(date +%Y-%m-%d)
+    cat > "$CLAUDE_MD" << EOF
+# CLAUDE.md — Personal Context
+
+> **Versao**: 1.0.0
+> **Criado**: ${created_date}
+> **Status**: Template inicial
+
+## User Profile
+
+| Campo | Valor |
+|-------|-------|
+| **Name** | [Seu nome] |
+| **Email** | [seu@email.com] |
+| **Role** | [Seu cargo] |
+| **Lang** | pt-BR |
+
+## Preferences
+
+### Idioma e Tom
+- Portugues BR como padrao
+- Tom profissional, direto
+- Evitar advérbios excessivos
+
+### Formato de Saida
+- Markdown para documentacao
+- Tabelas para comparacoes
+- Code blocks com syntax highlighting
+
+## Personal Overrides
+
+<!-- Adicione aqui suas regras pessoais que sobrescrevem as corporativas -->
+
+## Notes
+
+<!-- Anotacoes pessoais, lembretes, contexto adicional -->
+
+---
+*Template gerado automaticamente por bootstrap-personal.sh*
+EOF
+}
+
+# ============================================================
+# FLUXO PRINCIPAL (IDEMPOTENTE)
+# ============================================================
+
+echo "[Bootstrap] Verificando ~/.claude/personal..."
+
+# CASO 1: Diretorio existe E CLAUDE.md e valido -> SKIP
+if [ -d "$PERSONAL_DIR" ] && is_valid_claude_md "$CLAUDE_MD"; then
+    echo "[Bootstrap] OK - Personal ja configurado e valido"
+    exit 0
+fi
+
+# CASO 2: Diretorio existe MAS CLAUDE.md esta vazio/corrompido -> BACKUP + RECRIAR
+if [ -d "$PERSONAL_DIR" ] && [ -f "$CLAUDE_MD" ] && ! is_valid_claude_md "$CLAUDE_MD"; then
+    echo "[Bootstrap] CLAUDE.md existe mas esta invalido/corrompido"
+    backup_file "$CLAUDE_MD"
+    create_claude_md_template
+    echo "[Bootstrap] CLAUDE.md recriado a partir do template"
+    exit 0
+fi
+
+# CASO 3: Diretorio existe MAS sem CLAUDE.md -> CRIAR ARQUIVO
+if [ -d "$PERSONAL_DIR" ] && [ ! -f "$CLAUDE_MD" ]; then
+    echo "[Bootstrap] Diretorio existe mas sem CLAUDE.md"
+    create_claude_md_template
+    if [ -d "$PERSONAL_DIR/.git" ]; then
+        cd "$PERSONAL_DIR"
+        git add CLAUDE.md 2>/dev/null || true
+        git commit -m "chore: add CLAUDE.md template" --quiet 2>/dev/null || true
+    fi
+    echo "[Bootstrap] CLAUDE.md criado"
+    exit 0
+fi
+
+# CASO 4: Diretorio NAO existe -> TENTAR CLONE OU CRIAR LOCAL
+if [ ! -d "$PERSONAL_DIR" ]; then
+    echo "[Bootstrap] Diretorio nao existe, tentando configurar..."
+    mkdir -p "$HOME/.claude"
+    cd "$HOME/.claude"
+
+    # Tentar clone do repo pessoal (silencioso se falhar)
+    if [ -n "$GITHUB_USER" ] && git clone "$PERSONAL_REPO" personal 2>/dev/null; then
+        echo "[Bootstrap] Repo pessoal clonado com sucesso"
+        is_valid_claude_md "$CLAUDE_MD" || create_claude_md_template
+        exit 0
+    fi
+
+    # Clone falhou -> criar local
+    echo "[Bootstrap] Repo remoto nao encontrado, criando local..."
+    mkdir -p "$PERSONAL_DIR" && cd "$PERSONAL_DIR"
+    git init --quiet
+    create_claude_md_template
+
+    cat > .gitignore << 'GITIGNORE'
+# ═══════════════════════════════════════════════════════════════
+# .gitignore para ~/.claude/personal/ (Personal Repository)
+# Versão: 3.0.0 | Estratégia: WHITELIST
+# ═══════════════════════════════════════════════════════════════
+
+# PASSO 1: Ignorar TUDO por padrão
+*
+
+# PASSO 2: Exceções - arquivos raiz
+!.gitignore
+!CLAUDE.md
+!README.md
+
+# PASSO 3: Exceções - diretórios
+!docs/
+!docs/**
+!rules/
+!rules/**
+
+# PASSO 4: Re-ignorar sensíveis
+*.env
+.env*
+*credentials*
+*secret*
+*.key
+*.pem
+*.log
+*.bak
+GITIGNORE
+
+    git add -A
+    git commit -m "chore: initial personal context" --quiet
+
+    [ -n "$GITHUB_USER" ] && git remote add origin "$PERSONAL_REPO" 2>/dev/null || true
+
+    echo ""
+    echo "[Bootstrap] Personal criado em: $PERSONAL_DIR"
+    echo "[Bootstrap] Para sincronizar:"
+    echo "  1. Crie repo: https://github.com/new (dot-claude, privado)"
+    echo "  2. Push: cd $PERSONAL_DIR && git push -u origin main"
+    exit 0
+fi
+
+echo "[Bootstrap] Estado inesperado - verifique manualmente"
+exit 1
+```
+
+### Comportamento do Agente
+
+| Situação | Ação |
+|----------|------|
+| personal/ existe | Include direto |
+| personal/ não existe + repo GitHub existe | Clone → include |
+| personal/ não existe + repo não existe | Criar local → informar push → include |
+
+**O agente NÃO deve**: perguntar, esperar, bloquear
+**O agente DEVE**: executar, informar brevemente, continuar
+
+---
+
+## Justificativa da Recomendação
+
+| Critério | S9 (Recomendado) | Alternativas |
+|----------|------------------|--------------|
+| **Simplicidade** | ✅ 2 clones, 1 gitignore | S5-S8: Ferramentas extras |
+| **Governança** | ✅ Work controla base | S10: Depende do usuário |
+| **Flexibilidade** | ✅ Personal opcional | S1-S4: Rígidos |
+| **Isolamento** | ✅ Repos independentes | S12: Conflitos |
+| **Onboarding** | ✅ Clone work → funciona | S10-S11: Config manual |
+| **Manutenção** | ✅ Git pull em cada | S6: Merge manual |
+
+### Por que não outras soluções?
+
+| Solução | Motivo de Rejeição |
+|---------|-------------------|
+| S1 (Monorepo) | Mistura pessoal no repo corporativo |
+| S2-S3 (Submodules/Subtree) | Complexidade desnecessária |
+| S4 (Chezmoi) | Overhead de ferramenta |
+| S5 (VCSH) | Curva de aprendizado |
+| S6 (Branches) | Conflitos de merge |
+| S7 (Symlinks externos) | Quebra em diferentes máquinas |
+| S8 (Bare overlay) | Confuso para operação diária |
+| S10 (Personal primary) | Perde governança corporativa |
+| S11 (YADM) | Complexo demais |
+| S12 (Sparse checkout) | Anti-pattern git |
+| S13 (Symlinks reversos) | Fragilidade |
+| S14 (Include pattern) | Não suportado nativamente |
+
+---
+
+## ADRs (Architectural Decision Records)
+
+### ADR01: S9 Work Primary + Personal Subdirectory
+
+**Decisão**: Usar `~/.claude/` como work repo e `~/.claude/personal/` como personal repo.
+
+**Justificativa**: Melhor trade-off entre governança corporativa, flexibilidade pessoal e simplicidade de setup. Score 5/5 na comparação (linhas 339-346).
+
+**Alternativas rejeitadas**: S1-S8, S10-S14 (ver tabela de rejeição acima).
+
+---
+
+### ADR02: WHITELIST .gitignore (v3.0)
+
+**Decisão**: Usar estratégia WHITELIST (`*` + exceções) em vez de BLACKLIST.
+
+**Justificativa**: Segurança máxima - novos arquivos são automaticamente ignorados, prevenindo exposição acidental de secrets.
+
+**Trade-off**: Requer manutenção explícita de exceções para novos diretórios versionáveis.
+
+---
+
+### ADR03: Repos Independentes (Não Symlinks)
+
+**Decisão**: Usar dois repos git independentes, não symlinks ou submodules.
+
+**Justificativa**: Symlinks quebram em diferentes máquinas (S13), submodules adicionam complexidade desnecessária (S2-S3).
+
+---
+
+### ADR04: Personal como Subdirectory
+
+**Decisão**: Personal repo fica em `~/.claude/personal/` (não em `~/.claude-personal/` ou outro local).
+
+**Justificativa**: Score 20/20 na comparação de localização - separação clara, git isolation, zero namespace conflict.
+
+---
+
+### ADR05: Session Reports Commitados
+
+**Decisão**: Diretório `sessions/` deve ser commitado (whitelist no .gitignore), não ignorado.
+
+**Justificativa**:
+1. **Continuidade**: Agentes futuros podem ler histórico de sessões anteriores
+2. **Handoff**: Transferência de contexto entre agentes documentada
+3. **Auditoria**: Rastreabilidade de decisões e progresso
+4. **Anti-conflito**: SSID único por agente previne conflitos de merge
+
+**Implementação**: Adicionar `!sessions/` e `!sessions/**` ao .gitignore WHITELIST.
+
+**Referência**: C05 Session Report Standard em `~/.claude/CLAUDE.md`.
+
+---
+
+### ADR06: Hierarquia Sandwich Documentada
+
+**Decisão**: Documentar explicitamente a hierarquia de leitura "sandwich":
+1. Work BASE → 2. Personal → 3. Project → 4. Work ENFORCE
+
+**Justificativa**: Clareza sobre precedência de configurações, evita confusão sobre o que pode ser sobrescrito.
+
+---
+
+### ADR07: Segregação Explícita Work/Personal
+
+**Decisão**: Conteúdo pessoal (nome, email, preferências) apenas em Personal repo; protocolos corporativos [CXX] apenas em Work repo.
+
+**Justificativa**: Permite que múltiplos usuários usem o mesmo Work repo sem conflitos de dados pessoais.
+
+---
+
+## Proximos Passos
+
+1. **Criar** repo `{org}/dot-claude` no GitHub (privado)
+2. **Migrar** conteudo atual de `~/.claude/` (exceto runtime)
+3. **Configurar** .gitignore adequado
+4. **Documentar** setup no README
+5. **Testar** com segundo usuario Work
+6. **(Opcional)** Criar repo `{user}/dot-claude` (privado)
+
+---
+
+## Artefatos Criados
+
+| Artefato | Localizacao | Descricao |
+|----------|-------------|-----------|
+| **Spec Atualizada** | `~/.claude/docs/dot-claude-multi-repo-spec.md` | Este documento |
+| **Template Work** | `~/.claude/templates/repo/CLAUDE.md.work.template` | Estrutura sanduiche |
+| **Template Personal** | `~/.claude/templates/repo/CLAUDE.md.personal.template` | Contexto pessoal |
+| **Bootstrap Script** | `~/.claude/scripts/bootstrap-personal.sh` | Setup idempotente |
+
+---
+
+## Fontes
+
+- [Atlassian: Bare Git Repository for Dotfiles](https://www.atlassian.com/git/tutorials/dotfiles)
+- [ArchWiki: Dotfiles Management](https://wiki.archlinux.org/title/Dotfiles)
+- [Chezmoi: Why Use Chezmoi](https://www.chezmoi.io/why-use-chezmoi/)
+- [YADM vs VCSH Comparison](https://github.com/yadm-dev/yadm/issues/11)
+- [Multigit: Overlapped Git Repositories](https://github.com/capr/multigit)
+- [Germano.dev: VCSH and MR](https://germano.dev/dotfiles/)
+- [GBergatto: Tools for Managing Dotfiles](https://gbergatto.github.io/posts/tools-managing-dotfiles/)
+
+---
+
+*Assinatura: Claude-Code | 2026-01-22T22:30:00-03:00*
+*v2.1.0 - Whitelist sessions/plans, 7 ADRs documentados, compliance 100%*

--- a/docs/insights/git-session-governance.md
+++ b/docs/insights/git-session-governance.md
@@ -1,0 +1,200 @@
+# Insights de Sessoes - Vector Solution
+
+> **Versao**: 1.0.0
+> **Data**: 2026-01-22
+> **Proposito**: Documentar aprendizados para sessoes futuras
+
+---
+
+## Insight 1: Drifts de Working Directory Persistem Entre Checkouts
+
+### Problema
+Ao fazer `git checkout` entre branches, mudancas **unstaged** (nao adicionadas com `git add`) persistem no working directory. Isso causa:
+- Estado inconsistente entre branches
+- Confusao sobre qual conteudo pertence a qual branch
+- Auditorias com resultados incorretos
+
+### Evidencia
+```bash
+# Situacao encontrada
+$ git checkout main
+# Arquivo RELATORIO_MIGRACAO.md aparece como "deleted" mesmo no main
+# Porque a delecao foi feita antes do checkout e nao foi staged
+```
+
+### Solucao
+**ANTES de fazer checkout:**
+```bash
+git stash          # Guarda mudancas locais
+# ou
+git checkout -- .  # Descarta mudancas locais
+# ou
+git add . && git commit  # Commita mudancas
+```
+
+### Regra
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  REGRA: Verificar `git status` ANTES e DEPOIS de checkout             │
+│  ACAO: Working directory DEVE estar limpo antes de trocar de branch   │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Insight 2: Sessoes Podem Criar Artefatos Sem Session Report
+
+### Problema
+Commits podem criar artefatos (documentos, codigo) sem um session report associado. Quando outra sessao faz auditoria, pode:
+- Atribuir credito incorreto (para sessao errada)
+- Inflar/deflar status de sessoes
+- Perder rastreabilidade de quem fez o que
+
+### Evidencia
+- Sessao `ed22` criou catalogos (commits 6ae6ea0, 2040e27)
+- Auditoria atribuiu esses artefatos a sessao `reng`
+- Status de `reng` foi inflado de 60% para 85% incorretamente
+
+### Solucao
+**Verificar ANTES de atribuir progresso:**
+```bash
+# Quem criou este arquivo?
+git log --oneline -- docs/07_database/legado/CATALOGO_DDL.md
+
+# Qual sessao estava ativa nesse commit?
+# Verificar timestamp do commit vs timestamps dos session reports
+```
+
+### Regra
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  REGRA: Rastrear artefatos via `git log` antes de atribuir credito    │
+│  ACAO: Vincular commits a session reports pelo timestamp              │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Insight 3: Session Reports Podem Nao Ser Descobertos
+
+### Problema
+Session reports existentes podem nao ser descobertos em auditorias se:
+- Estao em branches nao merged
+- Foram criados apos o ultimo `git pull`
+- Estao com nomenclatura diferente do esperado
+
+### Evidencia
+- Sessao `ed22` nao foi incluida na auditoria inicial
+- Apenas `svgm` e `reng` foram analisados
+- `ed22` e a sessao que realmente fez o trabalho dos catalogos
+
+### Solucao
+**Listar TODAS as sessoes antes de auditar:**
+```bash
+# Todas as sessoes locais
+ls -la .claude/sessions/*.md
+
+# Todas as sessoes em todas as branches
+git ls-tree -r --name-only HEAD .claude/sessions/
+git ls-tree -r --name-only origin/main .claude/sessions/
+```
+
+### Regra
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  REGRA: Fazer inventario COMPLETO de sessoes antes de auditar         │
+│  ACAO: Verificar .claude/sessions/ em TODAS as branches               │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Insight 4: Interdependencias Reais vs Declaradas
+
+### Problema
+Session reports podem declarar dependencias que nao existem ou omitir dependencias reais. O fluxo real de execucao pode ser diferente do documentado.
+
+### Evidencia
+- `reng` documentou tarefas que foram feitas por `ed22`
+- A sessao `ed22` e continuacao logica de `reng`
+- Mas isso nao estava documentado em nenhum lugar
+
+### Solucao
+**Criar grafo de dependencias:**
+```markdown
+## Grafo de Sessoes
+svgm (migracao)
+  └── reng (estrutura inicial docs)
+        └── ed22 (catalogos e ER)
+              └── [proxima sessao]
+```
+
+### Regra
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  REGRA: Documentar sessao-pai no header do session report             │
+│  FORMATO: > **Parent Session**: {SSID} ou "none" se raiz              │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Insight 5: 100% Completo Requer Auditoria
+
+### Problema
+Sessoes auto-declaradas como 100% frequentemente tem:
+- Claims nao verificados
+- Mudancas nao commitadas
+- Artefatos faltando
+
+### Evidencia
+- `svgm` declarou 100%, auditoria encontrou 98%
+- `reng` declarou 60%, foi corrigido para 85% (erro oposto)
+- `ed22` declara 100%, ainda nao auditado
+
+### Solucao
+**Nenhuma sessao e 100% ate ser auditada:**
+```
+STATUS PERMITIDOS (auto-declarado):
+- pending (0-25%)
+- in_progress (25-75%)
+- review_pending (75-99%)
+- [NAO PERMITIDO] 100% complete
+
+STATUS APOS AUDITORIA:
+- verified_complete (100%)
+- verified_partial (N%)
+```
+
+### Regra
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  REGRA: Status "100% SUCESSO" requer auditoria externa                │
+│  ACAO: Usar "REVIEW_PENDING" ate ser auditado                         │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Matriz de Erros Comuns
+
+| Erro | Sintoma | Causa | Prevencao |
+|------|---------|-------|-----------|
+| Drift WD | Arquivo aparece em branch errada | Checkout sem limpar | `git status` antes/depois |
+| Credito errado | Status inflado/deflado | Nao rastrear origem | `git log` por arquivo |
+| Sessao invisivel | Auditoria incompleta | Nao listar todas | Inventario completo |
+| Dependencia oculta | Fluxo confuso | Nao documentar pai | Campo "Parent Session" |
+| 100% falso | Auditoria falha | Auto-declaracao | Proibir 100% sem auditoria |
+
+---
+
+## Aplicacao
+
+Estes insights DEVEM ser:
+1. Propagados para `~/.claude/CLAUDE.md` como regras globais
+2. Verificados em toda auditoria futura
+3. Usados como checklist pre-commit
+
+---
+
+*Documentado: Claude-Code | 2026-01-22T10:00:00-03:00*

--- a/docs/insights/insight_context_analysis_before_commit.md
+++ b/docs/insights/insight_context_analysis_before_commit.md
@@ -1,0 +1,70 @@
+# Insight: Análise de Contexto ANTES de Commit
+
+> **Data**: 2026-01-25
+> **Categoria**: #git #session #docs
+> **Sessão**: ef47
+
+---
+
+## Problema
+
+Arquivo foi commitado em localização incorreta porque a decisão de "onde commitar" foi baseada em **conveniência operacional** (repo com git funcional) em vez de **análise de conteúdo** (contexto semântico do arquivo).
+
+## Evidência
+
+| Ação | Resultado |
+|------|-----------|
+| Arquivo `prompt-aux-1.md` criado em `~/Projects/` | Sem git tracking |
+| Procurei repo com git funcional | VKS disponível |
+| Commitei em VKS `07_prompts/` | Commit `889f0ab` |
+| Analisei conteúdo posteriormente | Arquivo é GLOBAL (refs a `~/.claude/`) |
+| **Erro detectado** | Arquivo em local incorreto |
+
+## Solução
+
+1. Analisar **CONTEÚDO** do arquivo ANTES de decidir localização
+2. Identificar referências internas (paths, imports, contexto)
+3. Determinar escopo: GLOBAL (`~/.claude/`) vs PROJETO (`./`)
+4. Só então escolher onde commitar
+
+## Regra
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│  REGRA: ANALISAR CONTEÚDO → DETERMINAR CONTEXTO → ESCOLHER LOCAL       │
+│                                                                        │
+│  ERRADO: "Onde tem git?" → Commitar                                    │
+│  CERTO:  "Onde pertence?" → Garantir git → Commitar                    │
+│                                                                        │
+│  Indicadores de escopo GLOBAL:                                         │
+│  - Referências a ~/.claude/                                            │
+│  - Padrões aplicáveis a múltiplos projetos                             │
+│  - Skills, Rules, Specs genéricos                                      │
+│                                                                        │
+│  Indicadores de escopo PROJETO:                                        │
+│  - Referências a paths relativos do projeto                            │
+│  - Dados específicos do domínio                                        │
+│  - Configurações project-specific                                      │
+└────────────────────────────────────────────────────────────────────────┘
+```
+
+## Checklist de Compliance (Nomenclatura)
+
+Antes de criar/mover arquivo:
+
+- [ ] Nome segue snake_case?
+- [ ] Versão incluída se aplicável (_vN)?
+- [ ] Semântica clara (descreve propósito)?
+- [ ] Localização coerente com escopo?
+- [ ] Não duplica artefato existente?
+
+## Exemplo Corretivo
+
+| Antes | Depois |
+|-------|--------|
+| `VKS/07_prompts/prompt-aux-1.md` | `~/.claude/docs/prompts/prompt_sync_harmonization_v5.md` |
+| Commit `889f0ab` (VKS) | Commit `fc51347` (~/.claude) + `c81135e` (remove VKS) |
+
+---
+
+*Criado por: Claude-Code | 2026-01-25T11:20:00-03:00*

--- a/docs/mcp-servers-config-spec.md
+++ b/docs/mcp-servers-config-spec.md
@@ -1,0 +1,356 @@
+# MCP Servers Configuration Specification
+
+> **Versão**: 1.0.0 (2026-01-26)
+> **Status**: Aprovado
+> **Autor**: Claude Opus 4.5 + Emilson Moraes
+> **Rule relacionada**: `~/.claude/rules/mcp-servers-config.md`
+
+---
+
+## 1. Propósito
+
+Definir arquitetura para versionamento seguro de configurações MCP (Model Context Protocol) servers, separando templates públicos de secrets privados.
+
+### 1.1 Problema Resolvido
+
+| Problema | Impacto | Solução |
+|----------|---------|---------|
+| Secrets em `~/.claude.json` não versionados | Perda em reinstalação | Template + secrets separados |
+| Credenciais expostas se commitar config | Vazamento de secrets | Gitignore para `*secret*` |
+| Replicação manual em nova máquina | Erro humano, inconsistência | Script automatizado |
+
+### 1.2 Escopo
+
+| Inclui | Não inclui |
+|--------|------------|
+| MCP servers com secrets (tokens, passwords) | Configurações do Claude Code UI |
+| Template com placeholders | Plugins/marketplaces (já versionados) |
+| Script de aplicação | Autenticação OAuth (browser-based) |
+
+---
+
+## 2. Arquitetura
+
+### 2.1 Visão Geral
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                        FLUXO DE CONFIGURAÇÃO                        │
+├─────────────────────────────────────────────────────────────────────┤
+│                                                                     │
+│  ┌──────────────────┐    ┌──────────────────┐                       │
+│  │ mcp-servers      │    │ mcp-servers      │                       │
+│  │ .template.json   │ +  │ .secrets.json    │                       │
+│  │ (versionado)     │    │ (gitignored)     │                       │
+│  └────────┬─────────┘    └────────┬─────────┘                       │
+│           │                       │                                 │
+│           └───────────┬───────────┘                                 │
+│                       ▼                                             │
+│           ┌──────────────────────┐                                  │
+│           │ apply-mcp-config.sh  │                                  │
+│           │ (substitui ${VARS})  │                                  │
+│           └──────────┬───────────┘                                  │
+│                      ▼                                              │
+│           ┌──────────────────────┐                                  │
+│           │   ~/.claude.json     │                                  │
+│           │   .mcpServers        │                                  │
+│           └──────────────────────┘                                  │
+│                                                                     │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+### 2.2 Componentes
+
+| Arquivo | Localização | Git | Propósito |
+|---------|-------------|-----|-----------|
+| `mcp-servers.template.json` | `~/.claude/personal/dotclaude-configs/` | Commitado | Estrutura com placeholders |
+| `mcp-servers.secrets.json` | `~/.claude/personal/dotclaude-configs/` | Ignorado | Valores dos secrets |
+| `apply-mcp-config.sh` | `~/.claude/personal/dotclaude-configs/scripts/` | Commitado | Merge template + secrets |
+| `~/.claude.json` | `~/` | N/A | Config final aplicada |
+
+### 2.3 Hierarquia de Prioridade
+
+```
+1. ~/.claude.json (user-level)     ← MCP servers vivem aqui
+2. .claude.json (project-level)    ← Override por projeto (se necessário)
+```
+
+---
+
+## 3. Formato dos Arquivos
+
+### 3.1 Template (`mcp-servers.template.json`)
+
+```json
+{
+  "_comment": "Template para MCP Servers. Secrets em mcp-servers.secrets.json",
+  "_usage": "Execute: ./scripts/apply-mcp-config.sh",
+  
+  "nome-do-server": {
+    "type": "stdio|http",
+    "command": "comando ou ${HOME}/path",
+    "args": ["arg1", "arg2"],
+    "env": {
+      "VAR_PUBLICA": "valor-literal",
+      "VAR_SECRETA": "${PLACEHOLDER_NAME}"
+    }
+  },
+  
+  "server-http-exemplo": {
+    "type": "http",
+    "url": "https://api.example.com/mcp?apiKey=${API_KEY_PLACEHOLDER}",
+    "headers": {
+      "Authorization": "Bearer ${TOKEN_PLACEHOLDER}"
+    }
+  }
+}
+```
+
+#### Convenções de Placeholders
+
+| Padrão | Uso | Exemplo |
+|--------|-----|---------|
+| `${HOME}` | Variável de ambiente do sistema | `${HOME}/Projects/...` |
+| `${NOME_SERVICO_TIPO}` | Secret específico | `${BITBUCKET_APP_PASSWORD}` |
+| Valor literal | Config pública | `"npx"`, `"mcp"`, `"start"` |
+
+### 3.2 Secrets (`mcp-servers.secrets.json`)
+
+```json
+{
+  "_comment": "SECRETS - NÃO COMMITAR! Este arquivo está no .gitignore",
+  
+  "BITBUCKET_USERNAME": "seu-usuario",
+  "BITBUCKET_APP_PASSWORD": "seu-app-password",
+  "REF_TOOLS_API_KEY": "ref-xxxxx",
+  "ZAPIER_MCP_TOKEN": "token-base64"
+}
+```
+
+#### Regras de Nomenclatura
+
+| Padrão | Descrição | Exemplo |
+|--------|-----------|---------|
+| `{SERVICO}_{TIPO}` | Identificador único | `BITBUCKET_APP_PASSWORD` |
+| SCREAMING_SNAKE_CASE | Convenção de constantes | `REF_TOOLS_API_KEY` |
+| Sem prefixo `$` | Apenas o nome | `ZAPIER_MCP_TOKEN` (não `$ZAPIER_MCP_TOKEN`) |
+
+---
+
+## 4. Categorização de MCP Servers
+
+### 4.1 Por Tipo de Autenticação
+
+| Categoria | Autenticação | Versionável? | Exemplo |
+|-----------|--------------|--------------|---------|
+| **Public** | Nenhuma | Sim (completo) | `sequential-thinking-mcp` |
+| **OAuth Browser** | Via navegador | Sim (sem secret) | `atlasian-rovo-mcp`, `exa-mcp` |
+| **API Key** | Token estático | Template + secret | `ref-tools-mcp`, `zapier-mcp` |
+| **App Password** | Credencial de serviço | Template + secret | `vekops-mcp-hub` |
+
+### 4.2 Por Tipo de Conexão
+
+| Tipo | Características | Campos Requeridos |
+|------|-----------------|-------------------|
+| `stdio` | Processo local | `command`, `args`, `env` (opcional) |
+| `http` | Endpoint remoto | `url`, `headers` (opcional) |
+
+---
+
+## 5. Processo de Aplicação
+
+### 5.1 Algoritmo do Script
+
+```
+1. VALIDAR arquivos necessários existem
+2. LER secrets.json → extrair pares chave/valor
+3. LER template.json → string
+4. SUBSTITUIR ${HOME} → valor real
+5. PARA CADA secret:
+   - SUBSTITUIR ${CHAVE} → valor
+6. VERIFICAR placeholders não substituídos
+7. BACKUP ~/.claude.json
+8. MERGE mcpServers no ~/.claude.json
+9. SALVAR
+```
+
+### 5.2 Comandos
+
+```bash
+# Dry-run (ver resultado sem aplicar)
+~/.claude/personal/dotclaude-configs/scripts/apply-mcp-config.sh --dry-run
+
+# Aplicar
+~/.claude/personal/dotclaude-configs/scripts/apply-mcp-config.sh
+
+# Verificar resultado
+claude mcp list
+```
+
+---
+
+## 6. Segurança
+
+### 6.1 Proteções Implementadas
+
+| Camada | Mecanismo | Arquivo Protegido |
+|--------|-----------|-------------------|
+| Git | `.gitignore` com `*secret*` | `mcp-servers.secrets.json` |
+| Backup | Automático antes de aplicar | `~/.claude.json.backup.*` |
+| Validação | Alerta de placeholders não substituídos | Template incompleto |
+
+### 6.2 Checklist de Segurança
+
+Antes de commitar:
+
+- [ ] `mcp-servers.secrets.json` NÃO está staged (`git status`)
+- [ ] Template não contém valores reais de secrets
+- [ ] Placeholders seguem padrão `${NOME}`
+
+### 6.3 Rotação de Secrets
+
+```bash
+# 1. Atualizar secret no arquivo local
+vim ~/.claude/personal/dotclaude-configs/mcp-servers.secrets.json
+
+# 2. Reaplicar configuração
+~/.claude/personal/dotclaude-configs/scripts/apply-mcp-config.sh
+
+# 3. Verificar
+claude mcp list
+```
+
+---
+
+## 7. Replicação para Nova Máquina
+
+### 7.1 Workflow Completo
+
+```bash
+# 1. Clone do repositório personal
+git clone git@github.com:vek-emilsonmoraes-pws/dot-claude.git ~/.claude/personal
+
+# 2. Setup symlinks (configs gerais)
+~/.claude/personal/dotclaude-configs/scripts/setup-symlinks.sh
+
+# 3. Criar arquivo de secrets (manual - secrets não vêm do git)
+cat > ~/.claude/personal/dotclaude-configs/mcp-servers.secrets.json << 'EOF'
+{
+  "_comment": "Preencher com seus secrets",
+  "BITBUCKET_USERNAME": "seu-usuario",
+  "BITBUCKET_APP_PASSWORD": "obter-do-bitbucket",
+  "REF_TOOLS_API_KEY": "obter-do-ref-tools",
+  "ZAPIER_MCP_TOKEN": "obter-do-zapier"
+}
+EOF
+
+# 4. Aplicar configuração MCP
+~/.claude/personal/dotclaude-configs/scripts/apply-mcp-config.sh
+
+# 5. Verificar
+claude mcp list
+```
+
+### 7.2 Obtenção de Secrets
+
+| Secret | Onde Obter |
+|--------|------------|
+| `BITBUCKET_APP_PASSWORD` | Bitbucket > Settings > App passwords |
+| `REF_TOOLS_API_KEY` | ref.tools > Dashboard > API Keys |
+| `ZAPIER_MCP_TOKEN` | Zapier > Settings > MCP Integration |
+
+---
+
+## 8. Troubleshooting
+
+### 8.1 Problemas Comuns
+
+| Sintoma | Causa | Solução |
+|---------|-------|---------|
+| `Placeholder não substituído: ${X}` | Secret faltando | Adicionar em `secrets.json` |
+| `MCP server não conecta` | Secret inválido | Verificar/rotacionar credential |
+| `jq: parse error` | JSON inválido | Validar com `jq . arquivo.json` |
+
+### 8.2 Diagnóstico
+
+```bash
+# Verificar template é JSON válido
+jq . ~/.claude/personal/dotclaude-configs/mcp-servers.template.json
+
+# Verificar secrets é JSON válido (cuidado: mostra secrets!)
+jq . ~/.claude/personal/dotclaude-configs/mcp-servers.secrets.json
+
+# Ver config atual aplicada
+jq '.mcpServers' ~/.claude.json
+
+# Testar conexão MCP
+claude mcp list
+```
+
+---
+
+## 9. Extensibilidade
+
+### 9.1 Adicionar Novo MCP Server
+
+1. **Editar template** (`mcp-servers.template.json`):
+   ```json
+   "novo-server": {
+     "type": "http",
+     "url": "https://api.novo.com/mcp?key=${NOVO_API_KEY}"
+   }
+   ```
+
+2. **Adicionar secret** (`mcp-servers.secrets.json`):
+   ```json
+   "NOVO_API_KEY": "valor-real"
+   ```
+
+3. **Aplicar**:
+   ```bash
+   ./scripts/apply-mcp-config.sh
+   ```
+
+4. **Commitar** (apenas template):
+   ```bash
+   git add mcp-servers.template.json
+   git commit -m "feat(mcp): add novo-server"
+   ```
+
+### 9.2 Override por Projeto
+
+Para configuração específica de projeto, usar `.claude.json` no diretório do projeto:
+
+```json
+{
+  "mcpServers": {
+    "projeto-especifico-mcp": {
+      "type": "stdio",
+      "command": "./local-mcp-server.py"
+    }
+  }
+}
+```
+
+---
+
+## 10. Referências
+
+| Documento | Localização | Relação |
+|-----------|-------------|---------|
+| Rule (enforcement) | `~/.claude/rules/mcp-servers-config.md` | Auto-load |
+| README (uso) | `~/.claude/personal/dotclaude-configs/README.md` | Quick start |
+| dotclaude-configs | `~/.claude/personal/dotclaude-configs/` | Implementação |
+| CLAUDE.md [C06] | `~/.claude/CLAUDE.md` | AI-Native Environment |
+
+---
+
+## Changelog
+
+| Versão | Data | Autor | Mudança |
+|--------|------|-------|---------|
+| 1.0.0 | 2026-01-26 | Claude + Emilson | Versão inicial |
+
+---
+
+*Spec completa | Auto-propagada de sessão 2026-01-26*


### PR DESCRIPTION
## Summary
- Migrate 5 generic documentation files from `~/.claude/docs/` to community repo
- Part of ECO-004 artifact classification (item #23 from vks-docs-slt-reveng Appendix A)

## Files
| File | Content |
|------|---------|
| `docs/dot-claude-multi-repo-spec.md` | Multi-repo ~/.claude/ management specification |
| `docs/mcp-servers-config-spec.md` | MCP template+secrets configuration pattern |
| `docs/dot-claude-architecture-validation.md` | Architecture validation for multi-repo |
| `docs/insights/insight_context_analysis_before_commit.md` | R01 context-before-commit learning |
| `docs/insights/git-session-governance.md` | Git session governance insights |

🤖 Generated with [Claude Code](https://claude.com/claude-code)