### PR TITLE
fix(governance): address coderabbit review — co-author format, TLD regex

### DIFF
--- a/docs/co-author-standard.md
+++ b/docs/co-author-standard.md
@@ -144,7 +144,7 @@ Agents SHOULD validate their Co-Author format before committing:
 ```bash
 # Regex validation: Name (Provider/Model) <email>
 # Uses grep -E for POSIX/macOS portability (not grep -P which is GNU-only)
-echo "$CO_AUTHOR" | grep -qE '^[^()<>]+ \([A-Za-z0-9.-]+/[A-Za-z0-9._-]+\) <[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+>$' \
+echo "$CO_AUTHOR" | grep -qE '^[^()<>]+ \([A-Za-z0-9.-]+/[A-Za-z0-9._-]+\) <[a-zA-Z0-9.+_-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}>$' \
   && echo "VALID" || echo "INVALID"
 ```
 

--- a/docs/pr-review-protocol-spec.md
+++ b/docs/pr-review-protocol-spec.md
@@ -102,7 +102,7 @@ cd .worktrees/{session-id}-{feature}
 git add {arquivo}
 git commit -m "{tipo}({escopo}): {descrição}
 
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+Co-Authored-By: Claude-Code (Anthropic/Claude-4-Sonnet) <noreply+claude-code@anthropic.com>"
 ```
 
 **Boas práticas**:

--- a/docs/specs/sync-to-git-spec.md
+++ b/docs/specs/sync-to-git-spec.md
@@ -195,7 +195,7 @@ SYNC_GIT_AUTO_DELEGATE_REVIEWER=true
 SYNC_GIT_REVIEWER_AGENT=code-reviewer
 
 # Commit Configuration
-SYNC_GIT_CO_AUTHOR="Claude Opus 4.5 <noreply@anthropic.com>"
+SYNC_GIT_CO_AUTHOR="Claude-Code (Anthropic/Claude-4-Sonnet) <noreply+claude-code@anthropic.com>"
 SYNC_GIT_CONVENTIONAL_COMMITS=true
 
 # Worktree Integration (C04)
@@ -217,7 +217,7 @@ SYNC_GIT_MANIFEST_ENABLED=true
 ```bash
 git config --local sync.git.remote origin
 git config --local sync.git.protected-branches "main,master"
-git config --global sync.git.co-author "Claude Opus 4.5 <noreply@anthropic.com>"
+git config --global sync.git.co-author "Claude-Code (Anthropic/Claude-4-Sonnet) <noreply+claude-code@anthropic.com>"
 ```
 
 ## Gates de Segurança

--- a/rules/agent-scm.md
+++ b/rules/agent-scm.md
@@ -104,7 +104,7 @@ INPUT (obrigatorio):
   - description: string (o que mudou e POR QUE)
 
 INPUT (opcional):
-  - co_author: string (default: Claude Opus 4.6 <noreply@anthropic.com>)
+  - co_author: string (default: Claude-Code (Anthropic/Claude-4-Sonnet) <noreply+claude-code@anthropic.com>)
   - breaking: boolean (BREAKING CHANGE)
 
 CHECKLIST PRE-COMMIT (R01):

--- a/skills/sync-to-git/SKILL.md
+++ b/skills/sync-to-git/SKILL.md
@@ -157,7 +157,7 @@ fi
 ```bash
 # Usage: sync-commit "type(scope): description"
 MESSAGE="$1"
-CO_AUTHOR="Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
+CO_AUTHOR="Co-Authored-By: Claude-Code (Anthropic/Claude-4-Sonnet) <noreply+claude-code@anthropic.com>"
 
 # Validate conventional commits
 if ! echo "$MESSAGE" | grep -qE "^(feat|fix|docs|chore|refactor|test|style|perf|ci|build)(\(.+\))?:"; then
@@ -199,7 +199,7 @@ gh pr create --title "$TITLE" --body "$(cat <<EOF
 - [ ] Manual testing done
 
 ---
-Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
+Co-Authored-By: Claude-Code (Anthropic/Claude-4-Sonnet) <noreply+claude-code@anthropic.com>
 EOF
 )" --base "$BASE"
 


### PR DESCRIPTION
## Summary
- Updated 6 occurrences of old 2-entity Co-Authored-By format to 3-entity standard across 4 files
- Tightened email TLD validation regex to require minimum 2-char TLD (rejects bare hostnames)

Addresses review comments from coderabbit on PR #16.

## Files Changed
- `skills/sync-to-git/SKILL.md` — 2 co-author format updates
- `docs/pr-review-protocol-spec.md` — 1 co-author format update
- `rules/agent-scm.md` — 1 co-author format update
- `docs/specs/sync-to-git-spec.md` — 2 co-author format updates
- `docs/co-author-standard.md` — TLD regex tightened

## Test plan
- [x] All example domains in co-author standard pass new regex
- [x] Invalid domains (`@localhost`) correctly rejected

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>