### PR TITLE
fix(maos-mcp-hub): normalize account param, add validation, cache limit, tests

### DIFF
--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -15,6 +15,12 @@ from aiolimiter import AsyncLimiter
 
 from lib.common.http import request_json, request_text
 
+_VALID_ACCOUNT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
+
+# Maximum number of per-account client instances kept in memory.
+# Once the limit is reached the oldest entry (FIFO) is evicted.
+MAX_ACCOUNT_CLIENTS = 32
+
 
 class BitbucketPipelineClient:
     """
@@ -32,6 +38,58 @@ class BitbucketPipelineClient:
         BITBUCKET_REPO_SLUG: Override repo slug (format: workspace/repo-name)
     """
 
+    # ------------------------------------------------------------------
+    # Private helpers (shared between __init__ and for_account)
+    # ------------------------------------------------------------------
+
+    def _configure_auth(self, auth_user: Optional[str], api_token: str, auth_type: str) -> None:
+        """Resolve auth strategy and pre-compute httpx auth kwargs.
+
+        Args:
+            auth_user: Basic-auth principal (email or username). May be None for bearer.
+            api_token: API token or app password.
+            auth_type: Explicit auth type ("bearer" or "basic"), or empty for auto-detect.
+        """
+        self.auth_user = auth_user
+        self.api_token = api_token
+
+        auth_type = (auth_type or "").strip().lower()
+        if auth_type in {"bearer", "basic"}:
+            self.use_bearer = auth_type == "bearer"
+        else:
+            # Auto-detect bearer token format unless auth type is explicitly forced.
+            # Official Bitbucket API tokens use Basic auth; legacy bearer tokens
+            # (ATCTT3x...) continue supported for compatibility.
+            self.use_bearer = api_token.startswith("ATCTT3x")
+
+        # Pre-compute auth kwargs for all httpx calls
+        if self.use_bearer:
+            self._auth_kwargs = {"headers": {"Authorization": f"Bearer {self.api_token}"}}
+        else:
+            self._auth_kwargs = {"auth": (self.auth_user, self.api_token)}
+
+    def _configure_repo(self, repo_slug: Optional[str], auth_hint: str) -> None:
+        """Resolve repo slug and set base URL / metadata.
+
+        Args:
+            repo_slug: Explicit slug or None for auto-detection.
+            auth_hint: Human-readable hint shown in error messages.
+        """
+        self.repo_slug = (
+            repo_slug
+            or os.getenv("BITBUCKET_REPO_SLUG")
+            or self._get_repo_slug()
+        )
+        self.base_url = f"https://api.bitbucket.org/2.0/repositories/{self.repo_slug}"
+        self._provider_name = "Bitbucket"
+        self._auth_hint = auth_hint
+        # Rate limiter: 1000 requests per hour (Bitbucket Cloud API limit)
+        self.rate_limiter = AsyncLimiter(max_rate=1000, time_period=3600)
+
+    # ------------------------------------------------------------------
+    # Constructors
+    # ------------------------------------------------------------------
+
     def __init__(self, repo_slug: Optional[str] = None):
         """
         Initialize the Bitbucket Pipeline client
@@ -47,28 +105,25 @@ class BitbucketPipelineClient:
         """
         # Shared principal resolution order:
         # BITBUCKET_EMAIL -> JIRA_EMAIL -> BITBUCKET_USERNAME
-        self.auth_user = (
+        auth_user = (
             os.getenv("BITBUCKET_EMAIL")
             or os.getenv("JIRA_EMAIL")
             or os.getenv("BITBUCKET_USERNAME")
         )
-        self.api_token = os.getenv("BITBUCKET_API_TOKEN") or os.getenv("BITBUCKET_APP_PASSWORD")
+        api_token = os.getenv("BITBUCKET_API_TOKEN") or os.getenv("BITBUCKET_APP_PASSWORD")
 
-        if not self.api_token:
+        if not api_token:
             raise ValueError(
                 "Missing required credentials. "
                 "Please set BITBUCKET_API_TOKEN environment variable "
                 "(legacy fallback: BITBUCKET_APP_PASSWORD)."
             )
 
-        auth_type = os.getenv("BITBUCKET_AUTH_TYPE", "").strip().lower()
-        if auth_type in {"bearer", "basic"}:
-            self.use_bearer = auth_type == "bearer"
-        else:
-            # Auto-detect bearer token format unless auth type is explicitly forced.
-            # Official Bitbucket API tokens use Basic auth; legacy bearer tokens
-            # (ATCTT3x...) continue supported for compatibility.
-            self.use_bearer = self.api_token.startswith("ATCTT3x")
+        self._configure_auth(
+            auth_user=auth_user,
+            api_token=api_token,
+            auth_type=os.getenv("BITBUCKET_AUTH_TYPE", ""),
+        )
 
         if not self.use_bearer and not self.auth_user:
             raise ValueError(
@@ -78,26 +133,40 @@ class BitbucketPipelineClient:
                 "or set BITBUCKET_AUTH_TYPE=bearer for token-only auth."
             )
 
-        # Repo slug: explicit param > env var > git remote
-        self.repo_slug = (
-            repo_slug
-            or os.getenv("BITBUCKET_REPO_SLUG")
-            or self._get_repo_slug()
-        )
-        self.base_url = f"https://api.bitbucket.org/2.0/repositories/{self.repo_slug}"
-        self._provider_name = "Bitbucket"
-        self._auth_hint = (
-            "Verifique BITBUCKET_API_TOKEN e (quando auth basic) BITBUCKET_EMAIL/JIRA_EMAIL/BITBUCKET_USERNAME."
+        self._configure_repo(
+            repo_slug=repo_slug,
+            auth_hint=(
+                "Verifique BITBUCKET_API_TOKEN e (quando auth basic) "
+                "BITBUCKET_EMAIL/JIRA_EMAIL/BITBUCKET_USERNAME."
+            ),
         )
 
-        # Rate limiter: 1000 requests per hour (Bitbucket Cloud API limit)
-        self.rate_limiter = AsyncLimiter(max_rate=1000, time_period=3600)
+    @staticmethod
+    def validate_account_id(account_id: str) -> str:
+        """Normalize and validate an account identifier.
 
-        # Pre-compute auth kwargs for all httpx calls
-        if self.use_bearer:
-            self._auth_kwargs = {"headers": {"Authorization": f"Bearer {self.api_token}"}}
-        else:
-            self._auth_kwargs = {"auth": (self.auth_user, self.api_token)}
+        The account_id is used to construct env-var names
+        (``BITBUCKET_ACCOUNT_{ID}_*``), so it must only contain characters
+        that are safe for that purpose: lowercase alphanumeric, hyphens,
+        and underscores.
+
+        Args:
+            account_id: Raw account identifier supplied by the caller.
+
+        Returns:
+            Normalized (stripped + lowercased) account_id.
+
+        Raises:
+            ValueError: If the account_id contains invalid characters.
+        """
+        normalized = account_id.strip().lower()
+        if not _VALID_ACCOUNT_ID_RE.match(normalized):
+            raise ValueError(
+                f"Invalid account_id '{account_id}'. "
+                "Only lowercase alphanumeric characters, hyphens, and "
+                "underscores are allowed (must start with alphanumeric)."
+            )
+        return normalized
 
     @classmethod
     def for_account(cls, account_id: str, repo_slug: Optional[str] = None) -> "BitbucketPipelineClient":
@@ -112,9 +181,10 @@ class BitbucketPipelineClient:
             {PREFIX}APP_PASSWORD or {PREFIX}API_TOKEN  — credential
             {PREFIX}AUTH_TYPE  — "basic" or "bearer" (falls back to global)
         """
-        if not account_id or account_id == "default":
+        if not account_id or account_id.strip().lower() == "default":
             return cls(repo_slug=repo_slug)
 
+        account_id = cls.validate_account_id(account_id)
         prefix = f"BITBUCKET_ACCOUNT_{account_id.upper()}_"
 
         token = os.getenv(f"{prefix}APP_PASSWORD") or os.getenv(f"{prefix}API_TOKEN")
@@ -129,18 +199,12 @@ class BitbucketPipelineClient:
             or os.getenv(f"{prefix}EMAIL")
         )
 
-        auth_type = os.getenv(f"{prefix}AUTH_TYPE", "").strip().lower()
-        if not auth_type:
-            auth_type = os.getenv("BITBUCKET_AUTH_TYPE", "").strip().lower()
+        auth_type = os.getenv(f"{prefix}AUTH_TYPE", "")
+        if not auth_type.strip():
+            auth_type = os.getenv("BITBUCKET_AUTH_TYPE", "")
 
         instance = cls.__new__(cls)
-        instance.auth_user = user
-        instance.api_token = token
-
-        if auth_type in {"bearer", "basic"}:
-            instance.use_bearer = auth_type == "bearer"
-        else:
-            instance.use_bearer = token.startswith("ATCTT3x")
+        instance._configure_auth(auth_user=user, api_token=token, auth_type=auth_type)
 
         if not instance.use_bearer and not instance.auth_user:
             raise ValueError(
@@ -148,20 +212,10 @@ class BitbucketPipelineClient:
                 f"Set {prefix}USERNAME or {prefix}EMAIL."
             )
 
-        instance.repo_slug = (
-            repo_slug
-            or os.getenv("BITBUCKET_REPO_SLUG")
-            or instance._get_repo_slug()
+        instance._configure_repo(
+            repo_slug=repo_slug,
+            auth_hint=f"Account '{account_id}' credentials.",
         )
-        instance.base_url = f"https://api.bitbucket.org/2.0/repositories/{instance.repo_slug}"
-        instance._provider_name = "Bitbucket"
-        instance._auth_hint = f"Account '{account_id}' credentials."
-        instance.rate_limiter = AsyncLimiter(max_rate=1000, time_period=3600)
-
-        if instance.use_bearer:
-            instance._auth_kwargs = {"headers": {"Authorization": f"Bearer {instance.api_token}"}}
-        else:
-            instance._auth_kwargs = {"auth": (instance.auth_user, instance.api_token)}
 
         return instance
 

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -12,7 +12,7 @@ import httpx
 # Add scripts directory to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
-from lib.bitbucket.client import BitbucketPipelineClient
+from lib.bitbucket.client import BitbucketPipelineClient, MAX_ACCOUNT_CLIENTS
 from lib.bitbucket.analyzer import PipelineAnalyzer
 from lib.bitbucket.health import HealthMonitor
 from lib.bitbucket.validators import validate_build_number, validate_step_name, sanitize_error
@@ -28,8 +28,7 @@ _analyzers_by_repo: dict[str, PipelineAnalyzer] = {}
 _health = None
 _health_by_repo: dict[str, HealthMonitor] = {}
 
-
-
+# Bounded cache for per-account clients (FIFO eviction at MAX_ACCOUNT_CLIENTS).
 _account_clients: dict[str, BitbucketPipelineClient] = {}
 
 
@@ -52,9 +51,18 @@ def get_client(workspace: str = "", repo_slug: str = "") -> BitbucketPipelineCli
 
 
 def get_client_for_account(account: str = "", workspace: str = "", repo_slug: str = "") -> BitbucketPipelineClient:
-    """Get client for a specific account, falling back to default."""
-    if not account or account == "default":
+    """Get client for a specific account, falling back to default.
+
+    The account parameter is normalized (strip + lowercase) and validated
+    before use as a cache key.  The cache is bounded to
+    ``MAX_ACCOUNT_CLIENTS`` entries; when the limit is reached the oldest
+    entry (FIFO) is evicted.
+    """
+    if not account or account.strip().lower() == "default":
         return get_client(workspace=workspace, repo_slug=repo_slug)
+
+    # Normalize early so " Emilson " and "emilson" share the same cache entry.
+    account = BitbucketPipelineClient.validate_account_id(account)
 
     full_slug = ""
     if workspace and repo_slug:
@@ -64,6 +72,11 @@ def get_client_for_account(account: str = "", workspace: str = "", repo_slug: st
 
     cache_key = f"{account}:{full_slug}"
     if cache_key not in _account_clients:
+        # Evict oldest entry when cache is full (FIFO).
+        if len(_account_clients) >= MAX_ACCOUNT_CLIENTS:
+            oldest_key = next(iter(_account_clients))
+            del _account_clients[oldest_key]
+
         _account_clients[cache_key] = BitbucketPipelineClient.for_account(
             account_id=account,
             repo_slug=full_slug or None,

--- a/mcp-tools/maos-mcp-hub/tests/test_account_multi_persona.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_account_multi_persona.py
@@ -1,0 +1,242 @@
+"""
+Tests for multi-persona account parameter:
+- validate_account_id normalization and validation
+- for_account credential resolution
+- get_client_for_account caching and eviction
+"""
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from lib.bitbucket.client import (
+    BitbucketPipelineClient,
+    MAX_ACCOUNT_CLIENTS,
+    _VALID_ACCOUNT_ID_RE,
+)
+
+
+# -----------------------------------------------------------------------
+# Helpers
+# -----------------------------------------------------------------------
+
+def _setup_default_env(monkeypatch):
+    """Set minimal env vars for the *default* (bot) client."""
+    monkeypatch.setenv("BITBUCKET_API_TOKEN", "bot-token")
+    monkeypatch.setenv("BITBUCKET_AUTH_TYPE", "bearer")
+    monkeypatch.delenv("BITBUCKET_EMAIL", raising=False)
+    monkeypatch.delenv("JIRA_EMAIL", raising=False)
+    monkeypatch.delenv("BITBUCKET_USERNAME", raising=False)
+    monkeypatch.delenv("BITBUCKET_REPO_SLUG", raising=False)
+
+
+def _setup_account_env(monkeypatch, account_id: str, token: str = "acct-token",
+                       username: str = "acct-user", auth_type: str = "basic"):
+    """Set env vars for a named account."""
+    upper = account_id.upper()
+    monkeypatch.setenv(f"BITBUCKET_ACCOUNT_{upper}_APP_PASSWORD", token)
+    monkeypatch.setenv(f"BITBUCKET_ACCOUNT_{upper}_USERNAME", username)
+    monkeypatch.setenv(f"BITBUCKET_ACCOUNT_{upper}_AUTH_TYPE", auth_type)
+
+
+# -----------------------------------------------------------------------
+# validate_account_id
+# -----------------------------------------------------------------------
+
+class TestValidateAccountId:
+    def test_valid_simple(self):
+        assert BitbucketPipelineClient.validate_account_id("emilson") == "emilson"
+
+    def test_normalizes_whitespace_and_case(self):
+        assert BitbucketPipelineClient.validate_account_id("  Emilson  ") == "emilson"
+
+    def test_allows_hyphens_and_underscores(self):
+        assert BitbucketPipelineClient.validate_account_id("my-account_1") == "my-account_1"
+
+    def test_rejects_spaces_in_middle(self):
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.validate_account_id("my account")
+
+    def test_rejects_special_characters(self):
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.validate_account_id("acct@evil")
+
+    def test_rejects_path_traversal(self):
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.validate_account_id("../etc")
+
+    def test_rejects_leading_hyphen(self):
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.validate_account_id("-starts-bad")
+
+    def test_rejects_leading_underscore(self):
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.validate_account_id("_starts-bad")
+
+    def test_rejects_empty_after_strip(self):
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.validate_account_id("   ")
+
+
+# -----------------------------------------------------------------------
+# for_account
+# -----------------------------------------------------------------------
+
+class TestForAccount:
+    def test_default_falls_back_to_init(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+        client = BitbucketPipelineClient.for_account("default", repo_slug="ws/repo")
+        assert client.api_token == "bot-token"
+        assert client.use_bearer is True
+
+    def test_empty_falls_back_to_init(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+        client = BitbucketPipelineClient.for_account("", repo_slug="ws/repo")
+        assert client.api_token == "bot-token"
+
+    def test_whitespace_default_falls_back(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+        client = BitbucketPipelineClient.for_account("  DEFAULT  ", repo_slug="ws/repo")
+        assert client.api_token == "bot-token"
+
+    def test_named_account_reads_prefixed_env(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        _setup_account_env(monkeypatch, "emilson")
+        client = BitbucketPipelineClient.for_account("emilson", repo_slug="ws/repo")
+        assert client.api_token == "acct-token"
+        assert client.auth_user == "acct-user"
+        assert client.use_bearer is False
+
+    def test_normalization_applied(self, monkeypatch):
+        """' Emilson ' should normalize to 'emilson' and find EMILSON_ env vars."""
+        _setup_default_env(monkeypatch)
+        _setup_account_env(monkeypatch, "emilson")
+        client = BitbucketPipelineClient.for_account(" Emilson ", repo_slug="ws/repo")
+        assert client.api_token == "acct-token"
+
+    def test_missing_credentials_raises(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        # No BITBUCKET_ACCOUNT_GHOST_* env vars set.
+        with pytest.raises(ValueError, match="No credentials found"):
+            BitbucketPipelineClient.for_account("ghost", repo_slug="ws/repo")
+
+    def test_invalid_account_raises(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            BitbucketPipelineClient.for_account("evil;rm -rf /", repo_slug="ws/repo")
+
+    def test_bearer_account(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        _setup_account_env(monkeypatch, "svc", token="ATCTT3xlegacy-token", auth_type="bearer")
+        client = BitbucketPipelineClient.for_account("svc", repo_slug="ws/repo")
+        assert client.use_bearer is True
+        assert "Bearer ATCTT3xlegacy-token" in str(client._auth_kwargs)
+
+
+# -----------------------------------------------------------------------
+# get_client_for_account (caching + eviction)
+# -----------------------------------------------------------------------
+
+class TestGetClientForAccount:
+    def test_caches_by_normalized_key(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        _setup_account_env(monkeypatch, "emilson")
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+
+        # Import after env setup so module-level code does not fail
+        from servers.bitbucket.tools import get_client_for_account, _account_clients
+        _account_clients.clear()
+
+        c1 = get_client_for_account(account="emilson", repo_slug="ws/repo")
+        c2 = get_client_for_account(account=" Emilson ", repo_slug="ws/repo")
+        assert c1 is c2, "Normalized account should hit the same cache entry"
+
+    def test_default_account_skips_cache(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+
+        from servers.bitbucket.tools import get_client_for_account, _account_clients
+        _account_clients.clear()
+
+        get_client_for_account(account="default")
+        assert len(_account_clients) == 0
+
+    def test_eviction_at_max_capacity(self, monkeypatch):
+        """When the cache reaches MAX_ACCOUNT_CLIENTS, the oldest entry is evicted."""
+        _setup_default_env(monkeypatch)
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+
+        from servers.bitbucket.tools import get_client_for_account, _account_clients
+        _account_clients.clear()
+
+        # Fill the cache to max capacity
+        for i in range(MAX_ACCOUNT_CLIENTS):
+            acct = f"user{i}"
+            _setup_account_env(monkeypatch, acct)
+            get_client_for_account(account=acct, repo_slug="ws/repo")
+
+        assert len(_account_clients) == MAX_ACCOUNT_CLIENTS
+        first_key = next(iter(_account_clients))
+
+        # Add one more -- should evict the first
+        _setup_account_env(monkeypatch, "overflow")
+        get_client_for_account(account="overflow", repo_slug="ws/repo")
+
+        assert len(_account_clients) == MAX_ACCOUNT_CLIENTS
+        assert first_key not in _account_clients
+        assert "overflow:ws/repo" in _account_clients
+
+    def test_invalid_account_raises(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+
+        from servers.bitbucket.tools import get_client_for_account
+        with pytest.raises(ValueError, match="Invalid account_id"):
+            get_client_for_account(account="bad!acct")
+
+
+# -----------------------------------------------------------------------
+# _configure_auth / _configure_repo (refactored shared methods)
+# -----------------------------------------------------------------------
+
+class TestConfigureHelpers:
+    def test_configure_auth_bearer(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+        client = BitbucketPipelineClient(repo_slug="ws/repo")
+        assert client.use_bearer is True
+        assert "Bearer" in str(client._auth_kwargs)
+
+    def test_configure_auth_basic(self, monkeypatch):
+        monkeypatch.setenv("BITBUCKET_API_TOKEN", "basic-token")
+        monkeypatch.setenv("BITBUCKET_AUTH_TYPE", "basic")
+        monkeypatch.setenv("BITBUCKET_EMAIL", "user@example.com")
+        monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
+        monkeypatch.delenv("BITBUCKET_APP_PASSWORD", raising=False)
+        client = BitbucketPipelineClient(repo_slug="ws/repo")
+        assert client.use_bearer is False
+        assert client.auth_user == "user@example.com"
+
+    def test_configure_repo_sets_base_url(self, monkeypatch):
+        _setup_default_env(monkeypatch)
+        client = BitbucketPipelineClient(repo_slug="myws/myrepo")
+        assert client.base_url == "https://api.bitbucket.org/2.0/repositories/myws/myrepo"
+        assert client.repo_slug == "myws/myrepo"
+
+
+# -----------------------------------------------------------------------
+# Regex pattern sanity
+# -----------------------------------------------------------------------
+
+class TestAccountIdRegex:
+    @pytest.mark.parametrize("value", ["a", "abc", "a1", "my-acct", "my_acct", "a-b-c_1"])
+    def test_valid_patterns(self, value):
+        assert _VALID_ACCOUNT_ID_RE.match(value)
+
+    @pytest.mark.parametrize("value", ["", "-abc", "_abc", " abc", "a b", "a@b", "a.b", "../x"])
+    def test_invalid_patterns(self, value):
+        assert not _VALID_ACCOUNT_ID_RE.match(value)


### PR DESCRIPTION
## Summary
Addresses all 6 Copilot review comments on PR #19:

- **Account normalization**: `.strip().lower()` on all entry points, cache keys share normalized value
- **Cache bound**: FIFO eviction at 32 entries in `_account_clients` (prevents unbounded memory)
- **Account ID validation**: Regex `^[a-z0-9][a-z0-9_-]*$` rejects unsafe characters for env-var compatibility
- **Refactored duplication**: Extracted `_configure_auth()` and `_configure_repo()` private methods
- **38 new unit tests**: 5 test classes, 54 total tests pass with zero regressions

## Files Changed
- `lib/bitbucket/client.py` — validation, normalization, refactored init
- `servers/bitbucket/tools.py` — cache normalization + FIFO eviction
- `tests/test_account_multi_persona.py` — 38 new tests (NEW)

## Test plan
- [x] 54 tests pass (`pytest` all green)
- [x] CI governance-validation passing
- [x] Cache eviction verified (>32 entries triggers FIFO)
- [x] Edge cases: whitespace, case, special chars, path traversal

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>