### PR TITLE
feat(maos-mcp-hub): add branch management tools (Sprint 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### maos-mcp-hub — Branch Management Tools (Sprint 8 — VKS-1647)
+- `bitbucket_create_branch` — Create branch from commit hash (POST /refs/branches)
+- `bitbucket_delete_branch` — Delete branch with default-branch protection (DELETE /refs/branches/{name})
+- `bitbucket_set_default_branch` — Change repository default branch (PUT /repositories/{ws}/{repo})
+- `bitbucket_get_branch_restrictions` — List branch protection rules (GET /branch-restrictions)
+- `bitbucket_set_branch_restriction` — Create branch protection rule (POST /branch-restrictions)
+- `bitbucket_delete_branch_restriction` — Remove branch protection rule by ID (DELETE /branch-restrictions/{id})
+- 19 unit tests covering all new tools (success, error, edge cases)
+
 ## [1.4.0] - 2026-03-08
 
 ### Added

--- a/mcp-tools/maos-mcp-hub/.env.example
+++ b/mcp-tools/maos-mcp-hub/.env.example
@@ -63,3 +63,26 @@ CONFLUENCE_API_TOKEN=
 
 # Cloud instance UUID (find at https://your-domain.atlassian.net/_edge/tenant_info)
 JIRA_CLOUD_ID=your-cloud-id-uuid
+
+# ============================================================================
+# Optional: Multi-Persona / Named Accounts
+# ============================================================================
+# Define per-account credentials for Bitbucket operations like PR creation,
+# approval, and merging. Each account uses a {PREFIX} pattern:
+#
+#   BITBUCKET_ACCOUNT_{NAME}_USERNAME=email@company.com
+#   BITBUCKET_ACCOUNT_{NAME}_APP_PASSWORD=ATxxx...
+#   BITBUCKET_ACCOUNT_{NAME}_AUTH_TYPE=basic
+#
+# Usage in tool calls: account="jane-doe"
+# The name is case-insensitive and trimmed (e.g., " Jane-Doe " → "JANE-DOE")
+#
+# Example — two personas for PR workflows:
+#
+# BITBUCKET_ACCOUNT_JANE_DOE_USERNAME=jane.doe@company.com
+# BITBUCKET_ACCOUNT_JANE_DOE_APP_PASSWORD=your_app_password_here
+# BITBUCKET_ACCOUNT_JANE_DOE_AUTH_TYPE=basic
+#
+# BITBUCKET_ACCOUNT_JOHN_DOE_USERNAME=john.doe@company.com
+# BITBUCKET_ACCOUNT_JOHN_DOE_APP_PASSWORD=your_app_password_here
+# BITBUCKET_ACCOUNT_JOHN_DOE_AUTH_TYPE=basic

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -248,6 +248,12 @@ pytest -q tests/test_bitbucket_client.py tests/test_jira_client.py
 | `bitbucket_stop_pipeline` | Stop a running pipeline |
 | `bitbucket_list_branches` | List repository branches |
 | `bitbucket_get_branch` | Get branch details |
+| `bitbucket_create_branch` | Create a branch from a commit hash |
+| `bitbucket_delete_branch` | Delete a branch (with default-branch protection) |
+| `bitbucket_set_default_branch` | Change the repository default branch |
+| `bitbucket_get_branch_restrictions` | List branch protection rules |
+| `bitbucket_set_branch_restriction` | Create a branch protection rule |
+| `bitbucket_delete_branch_restriction` | Remove a branch protection rule by ID |
 
 ---
 

--- a/mcp-tools/maos-mcp-hub/cli.py
+++ b/mcp-tools/maos-mcp-hub/cli.py
@@ -39,15 +39,22 @@ Environment Variables:
 """
 
 import sys
+import os
 import json
 import asyncio
 from pathlib import Path
 from typing import Dict, Any, Optional
 
-# Load .env file if present (for local development)
+# Load .env file — resolves path reliably regardless of CWD
+# Priority: MAOS_DOTENV_PATH env var > default (cli.py dir)
+_dotenv_path = Path(
+    os.getenv("MAOS_DOTENV_PATH", str(Path(__file__).parent / ".env"))
+).expanduser().resolve()
+
 try:
     from dotenv import load_dotenv
-    load_dotenv()
+    if _dotenv_path.is_file():
+        load_dotenv(_dotenv_path, override=True)
 except ImportError:
     pass  # python-dotenv not installed — env vars must be set externally
 

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -47,21 +47,26 @@ Usage:
         ./cli.py bitbucket get_recent_builds '{"count": 5}'
         ./cli.py bitbucket get_test_reports '{"build_number": 640, "step_name": "Unit Tests"}'
 
-Claude Desktop configuration:
+Claude Desktop / Claude Code configuration:
+    Credentials are loaded from the .env file in the hub directory.
+    Do NOT inject env vars in the mcp.json — use .env instead.
+
     {
       "mcpServers": {
         "maos-mcp-hub": {
-          "command": "python3",
-          "args": ["/path/to/hub.py"],
-          "env": {
-            "BITBUCKET_EMAIL": "your-email@company.com",
-            "BITBUCKET_USERNAME": "your_username",
-            "BITBUCKET_API_TOKEN": "your_bitbucket_api_token",
-            "GITHUB_TOKEN": "your_github_token_here"
-          }
+          "command": "/path/to/.venv/bin/python3",
+          "args": ["/path/to/hub.py"]
         }
       }
     }
+
+    Override .env path via environment variable:
+        MAOS_DOTENV_PATH=/custom/path/.env python3 hub.py
+
+    Override .env path via CLI argument:
+        python3 hub.py --dotenv-path /custom/path/.env
+
+    See .env.example for all available variables.
 
 Example queries in Claude:
     "Liste os últimos 5 builds do Bitbucket"
@@ -80,12 +85,45 @@ from pathlib import Path
 from typing import Dict, Any, List
 from fastmcp import FastMCP
 
-# Load .env file if present (for local development)
+# Load .env file — resolves path reliably regardless of CWD
+# Priority: --dotenv-path CLI arg > MAOS_DOTENV_PATH env var > default (hub dir)
+def _resolve_dotenv_path() -> Path:
+    """Resolve .env file path with explicit precedence order."""
+    import os
+
+    # 1. CLI arg: --dotenv-path /path/to/.env
+    for i, arg in enumerate(sys.argv[1:], 1):
+        if arg == "--dotenv-path" and i < len(sys.argv):
+            return Path(sys.argv[i + 1]).expanduser().resolve()
+        if arg.startswith("--dotenv-path="):
+            return Path(arg.split("=", 1)[1]).expanduser().resolve()
+
+    # 2. Env var: MAOS_DOTENV_PATH=/path/to/.env
+    env_path = os.getenv("MAOS_DOTENV_PATH")
+    if env_path:
+        return Path(env_path).expanduser().resolve()
+
+    # 3. Default: same directory as hub.py
+    return Path(__file__).parent / ".env"
+
+_dotenv_path = _resolve_dotenv_path()
+
 try:
     from dotenv import load_dotenv
-    load_dotenv(override=True)
+    if _dotenv_path.is_file():
+        load_dotenv(_dotenv_path, override=True)
+    else:
+        sys.stderr.write(
+            f"⚠️  No .env file found at {_dotenv_path}\n"
+            f"   Credentials must be provided via environment variables.\n"
+            f"   See .env.example for required variables.\n\n"
+        )
+        sys.stderr.flush()
 except ImportError:
-    pass  # python-dotenv not installed — env vars must be set externally
+    sys.stderr.write(
+        "⚠️  python-dotenv not installed — env vars must be set externally\n\n"
+    )
+    sys.stderr.flush()
 
 
 # ============================================================================

--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -13,7 +13,7 @@ from typing import Optional
 from urllib.parse import quote
 from aiolimiter import AsyncLimiter
 
-from lib.common.http import request_json, request_text
+from lib.common.http import request_json, request_text, request_empty
 
 _VALID_ACCOUNT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]*$")
 
@@ -1592,6 +1592,190 @@ class BitbucketPipelineClient:
                 )
                 response.raise_for_status()
                 return response.json()
+
+    # ========================================================================
+    # Branch Management API (Sprint 8 — VKS-1647)
+    # ========================================================================
+
+    async def create_branch(self, name: str, target_hash: str) -> dict:
+        """
+        Create a new branch from a commit hash.
+
+        Args:
+            name: Branch name (e.g., "main", "feature/my-feature").
+            target_hash: Commit hash to branch from (full 40-char or short 7+ chars).
+
+        Returns:
+            dict: Created branch object with name, target commit, etc.
+
+        Raises:
+            ApiError: 400/409 if branch already exists, auth/network errors.
+        """
+        payload = {
+            "name": name,
+            "target": {"hash": target_hash},
+        }
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/refs/branches",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # non-idempotent: avoid duplicate branch creation
+        )
+
+    async def delete_branch(self, name: str) -> int:
+        """
+        Delete a branch from the repository.
+
+        Args:
+            name: Branch name (slashes will be URL-encoded).
+
+        Returns:
+            int: HTTP status code (204 on success).
+
+        Raises:
+            ApiError: 400 if default branch, 404 if not found, auth errors.
+        """
+        branch_encoded = quote(name, safe="")
+        return await request_empty(
+            method="DELETE",
+            url=f"{self.base_url}/refs/branches/{branch_encoded}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # destructive: never retry
+        )
+
+    async def set_default_branch(self, name: str) -> dict:
+        """
+        Change the default (main) branch of the repository.
+
+        Uses PUT on the repository root endpoint, not /refs/.
+
+        Args:
+            name: Branch name to set as default (must already exist).
+
+        Returns:
+            dict: Updated repository object with mainbranch info.
+
+        Raises:
+            ApiError: 400 if branch doesn't exist, 403 if not admin.
+        """
+        payload = {
+            "mainbranch": {"name": name},
+        }
+        return await request_json(
+            method="PUT",
+            url=self.base_url,
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # state-changing: no retry
+        )
+
+    async def get_branch_restrictions(self, pagelen: int = 100) -> dict:
+        """
+        List branch restrictions (protection rules) for the repository.
+
+        Args:
+            pagelen: Results per page (default: 100, max: 100).
+
+        Returns:
+            dict: Paginated list of branch restrictions with kind, pattern, users, groups.
+
+        Raises:
+            ApiError: Auth/network errors.
+        """
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/branch-restrictions",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"pagelen": pagelen},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def create_branch_restriction(
+        self,
+        kind: str,
+        pattern: str,
+        users: Optional[list] = None,
+        groups: Optional[list] = None,
+    ) -> dict:
+        """
+        Create a branch restriction (protection rule).
+
+        Args:
+            kind: Restriction type. Valid values:
+                  push, force, delete, restrict_merges, deny_all_merges,
+                  require_review_approvals, require_review_status_checks,
+                  require_review_all_tasks_pending, require_default_merge_strategy,
+                  allow_auto_merge_when_builds_pass, allow_auto_merge_when_builds_fail.
+            pattern: Branch name pattern (glob-style: "main", "release/*").
+            users: List of user UUIDs to exempt (omit = applies to all).
+            groups: List of group slugs to exempt (omit = applies to all).
+
+        Returns:
+            dict: Created restriction object with id, kind, pattern.
+
+        Raises:
+            ApiError: 400 if invalid kind/pattern, 403 if not admin.
+        """
+        payload: dict = {
+            "kind": kind,
+            "pattern": pattern,
+        }
+        if users is not None:
+            payload["users"] = [{"uuid": u} for u in users]
+        if groups is not None:
+            payload["groups"] = [{"slug": g} for g in groups]
+
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/branch-restrictions",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # non-idempotent
+        )
+
+    async def delete_branch_restriction(self, restriction_id: int) -> int:
+        """
+        Delete a branch restriction by ID.
+
+        Args:
+            restriction_id: Restriction ID (obtained from get_branch_restrictions).
+
+        Returns:
+            int: HTTP status code (204 on success).
+
+        Raises:
+            ApiError: 404 if not found, 403 if not admin.
+        """
+        return await request_empty(
+            method="DELETE",
+            url=f"{self.base_url}/branch-restrictions/{restriction_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # destructive: never retry
+        )
 
     async def close(self):
         """

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/server.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/server.py
@@ -75,5 +75,12 @@ SERVER_INFO = {
         "stop_pipeline",
         "list_branches",
         "get_branch",
+        # Branch Management Tools (Sprint 8 — VKS-1647)
+        "create_branch",
+        "delete_branch",
+        "set_default_branch",
+        "get_branch_restrictions",
+        "set_branch_restriction",
+        "delete_branch_restriction",
     ]
 }

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -2595,6 +2595,397 @@ async def get_branch(branch_name: str, workspace: str = "", repo_slug: str = "")
 
 
 # ============================================================================
+# Branch Management Tools (Sprint 8 — VKS-1647)
+# ============================================================================
+
+async def create_branch(
+    name: str,
+    target: str,
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Create a new branch from a commit hash or existing branch reference.
+
+    Use this to create branches programmatically — for example, creating a "main"
+    branch from the current HEAD of "master" during a branch migration.
+
+    Args:
+        name: New branch name (e.g., "main", "feature/my-feature")
+        target: Source commit hash (full 40-char SHA or short 7+ chars).
+                To branch from an existing branch, first use get_branch to obtain its commit hash.
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override (format: "workspace/repo-name")
+
+    Returns:
+        dict: Created branch details including name, commit hash, and URL
+
+    Examples:
+        # Create "main" from a commit hash
+        create_branch(name="main", target="a1b2c3d4e5f6")
+
+        # Create feature branch (get hash from existing branch first)
+        branch = get_branch(branch_name="develop")
+        create_branch(name="feature/VKS-1647", target=branch["commit"])
+    """
+    try:
+        client = get_client(workspace=workspace, repo_slug=repo_slug)
+        result = await client.create_branch(name=name, target_hash=target)
+
+        return {
+            "success": True,
+            "name": result.get("name"),
+            "commit": result.get("target", {}).get("hash", ""),
+            "commit_short": result.get("target", {}).get("hash", "")[:12],
+            "url": f"https://bitbucket.org/{client.repo_slug}/branch/{name}",
+        }
+
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 400:
+            return {
+                "success": False,
+                "error": "Branch already exists or invalid target",
+                "details": sanitize_exception(e),
+                "hint": "Use get_branch to check if branch exists, or verify the target commit hash.",
+            }
+        return {
+            "success": False,
+            "error": "Failed to create branch",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to create branch: {sanitize_error(e)}"}
+
+
+async def delete_branch(
+    name: str,
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Delete a branch from the repository.
+
+    ⚠️ DESTRUCTIVE OPERATION: This permanently removes the branch reference.
+    The commits remain in the repository but the branch pointer is removed.
+
+    Cannot delete the repository's default branch — use set_default_branch first
+    to change the default, then delete the old branch.
+
+    Args:
+        name: Branch name to delete (e.g., "master", "feature/old-feature")
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override (format: "workspace/repo-name")
+
+    Returns:
+        dict: Deletion confirmation with branch name
+
+    Examples:
+        # Delete old master after migrating to main
+        set_default_branch(name="main")  # First, change default
+        delete_branch(name="master")     # Then, delete old branch
+    """
+    try:
+        client = get_client(workspace=workspace, repo_slug=repo_slug)
+        await client.delete_branch(name=name)
+
+        return {
+            "success": True,
+            "name": name,
+            "message": f"Branch '{name}' deleted successfully",
+        }
+
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 400:
+            return {
+                "success": False,
+                "error": f"Cannot delete branch '{name}'",
+                "details": sanitize_exception(e),
+                "hint": "Cannot delete the default branch. Use set_default_branch to change it first.",
+            }
+        if status == 404:
+            return {
+                "success": False,
+                "error": f"Branch '{name}' not found",
+                "hint": "Use list_branches to see available branches.",
+            }
+        return {
+            "success": False,
+            "error": "Failed to delete branch",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to delete branch: {sanitize_error(e)}"}
+
+
+async def set_default_branch(
+    name: str,
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Change the default (main) branch of the repository.
+
+    The target branch must already exist. This is typically used during
+    master → main migration: create "main", set it as default, then optionally
+    delete "master".
+
+    Requires repository admin permissions.
+
+    Args:
+        name: Branch name to set as default (must already exist)
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override (format: "workspace/repo-name")
+
+    Returns:
+        dict: Updated default branch info with repository name
+
+    Examples:
+        # Migrate from master to main
+        branch = get_branch(branch_name="master")
+        create_branch(name="main", target=branch["commit"])
+        set_default_branch(name="main")
+        delete_branch(name="master")
+    """
+    try:
+        client = get_client(workspace=workspace, repo_slug=repo_slug)
+        result = await client.set_default_branch(name=name)
+
+        mainbranch = result.get("mainbranch", {})
+        return {
+            "success": True,
+            "default_branch": mainbranch.get("name", name),
+            "repository": result.get("full_name", result.get("name", "")),
+            "message": f"Default branch changed to '{name}'",
+        }
+
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 400:
+            return {
+                "success": False,
+                "error": f"Cannot set '{name}' as default branch",
+                "details": sanitize_exception(e),
+                "hint": "The branch must exist. Use create_branch or list_branches to verify.",
+            }
+        if status == 403:
+            return {
+                "success": False,
+                "error": "Permission denied",
+                "details": sanitize_exception(e),
+                "hint": "Requires repository admin permissions to change default branch.",
+            }
+        return {
+            "success": False,
+            "error": "Failed to set default branch",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to set default branch: {sanitize_error(e)}"}
+
+
+async def get_branch_restrictions(
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    List all branch restrictions (protection rules) for the repository.
+
+    Returns restrictions such as push protection, force-push prevention,
+    delete prevention, required reviews, etc.
+
+    Args:
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override (format: "workspace/repo-name")
+
+    Returns:
+        dict: List of branch restrictions with kind, pattern, and affected users/groups
+
+    Valid restriction kinds:
+        - push: Prevent direct commits (force PR workflow)
+        - force: Prevent force-push (protect history)
+        - delete: Prevent branch deletion
+        - restrict_merges: Restrict who can merge PRs
+        - require_review_approvals: Require PR approvals
+        - require_review_status_checks: Require CI/CD to pass
+    """
+    try:
+        client = get_client(workspace=workspace, repo_slug=repo_slug)
+        result = await client.get_branch_restrictions()
+
+        restrictions = result.get("values", [])
+        formatted = []
+        for r in restrictions:
+            formatted.append({
+                "id": r.get("id"),
+                "kind": r.get("kind", ""),
+                "pattern": r.get("pattern", ""),
+                "users": [
+                    u.get("display_name", u.get("uuid", ""))
+                    for u in r.get("users", [])
+                ],
+                "groups": [
+                    g.get("slug", g.get("name", ""))
+                    for g in r.get("groups", [])
+                ],
+            })
+
+        return {
+            "total": len(formatted),
+            "restrictions": formatted,
+        }
+
+    except ApiError as e:
+        return {
+            "error": "Failed to get branch restrictions",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"error": f"Failed to get branch restrictions: {sanitize_error(e)}"}
+
+
+async def set_branch_restriction(
+    kind: str,
+    pattern: str,
+    users: list | None = None,
+    groups: list | None = None,
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Create a branch restriction (protection rule).
+
+    Requires repository admin permissions. Use get_branch_restrictions to see
+    existing rules before adding new ones.
+
+    Args:
+        kind: Restriction type. Valid values:
+              push, force, delete, restrict_merges, deny_all_merges,
+              require_review_approvals, require_review_status_checks,
+              require_review_all_tasks_pending, require_default_merge_strategy,
+              allow_auto_merge_when_builds_pass, allow_auto_merge_when_builds_fail
+        pattern: Branch name pattern (glob-style: "main", "release/*", "feature/[ab]/*")
+        users: List of user UUIDs to exempt from restriction (omit = applies to all)
+        groups: List of group slugs to exempt from restriction (omit = applies to all)
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override (format: "workspace/repo-name")
+
+    Returns:
+        dict: Created restriction with id, kind, and pattern
+
+    Examples:
+        # Protect main from direct pushes
+        set_branch_restriction(kind="push", pattern="main")
+
+        # Prevent force-push on release branches
+        set_branch_restriction(kind="force", pattern="release/*")
+
+        # Prevent deletion of main
+        set_branch_restriction(kind="delete", pattern="main")
+    """
+    try:
+        client = get_client(workspace=workspace, repo_slug=repo_slug)
+        result = await client.create_branch_restriction(
+            kind=kind,
+            pattern=pattern,
+            users=users,
+            groups=groups,
+        )
+
+        return {
+            "success": True,
+            "id": result.get("id"),
+            "kind": result.get("kind", kind),
+            "pattern": result.get("pattern", pattern),
+            "message": f"Branch restriction '{kind}' created for pattern '{pattern}'",
+        }
+
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 400:
+            return {
+                "success": False,
+                "error": "Invalid restriction configuration",
+                "details": sanitize_exception(e),
+                "hint": f"Check that kind='{kind}' is valid and pattern='{pattern}' is a valid glob pattern.",
+            }
+        if status == 403:
+            return {
+                "success": False,
+                "error": "Permission denied",
+                "details": sanitize_exception(e),
+                "hint": "Requires repository admin permissions to manage branch restrictions.",
+            }
+        return {
+            "success": False,
+            "error": "Failed to create branch restriction",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to create branch restriction: {sanitize_error(e)}"}
+
+
+async def delete_branch_restriction(
+    restriction_id: int,
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Delete a branch restriction by ID.
+
+    Use get_branch_restrictions to find the restriction ID first.
+    Requires repository admin permissions.
+
+    Args:
+        restriction_id: Restriction ID (obtained from get_branch_restrictions)
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override (format: "workspace/repo-name")
+
+    Returns:
+        dict: Deletion confirmation
+    """
+    try:
+        client = get_client(workspace=workspace, repo_slug=repo_slug)
+        await client.delete_branch_restriction(restriction_id=restriction_id)
+
+        return {
+            "success": True,
+            "restriction_id": restriction_id,
+            "message": f"Branch restriction #{restriction_id} deleted successfully",
+        }
+
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 404:
+            return {
+                "success": False,
+                "error": f"Branch restriction #{restriction_id} not found",
+                "hint": "Use get_branch_restrictions to list existing restrictions.",
+            }
+        if status == 403:
+            return {
+                "success": False,
+                "error": "Permission denied",
+                "details": sanitize_exception(e),
+                "hint": "Requires repository admin permissions to delete branch restrictions.",
+            }
+        return {
+            "success": False,
+            "error": "Failed to delete branch restriction",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to delete branch restriction: {sanitize_error(e)}"}
+
+
+# ============================================================================
 # TOOL REGISTRY
 # ============================================================================
 
@@ -2655,4 +3046,11 @@ TOOLS = {
     "stop_pipeline": stop_pipeline,
     "list_branches": list_branches,
     "get_branch": get_branch,
+    # Branch Management Tools (Sprint 8 — VKS-1647)
+    "create_branch": create_branch,
+    "delete_branch": delete_branch,
+    "set_default_branch": set_default_branch,
+    "get_branch_restrictions": get_branch_restrictions,
+    "set_branch_restriction": set_branch_restriction,
+    "delete_branch_restriction": delete_branch_restriction,
 }

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -61,7 +61,7 @@ def get_client_for_account(account: str = "", workspace: str = "", repo_slug: st
     if not account or account.strip().lower() == "default":
         return get_client(workspace=workspace, repo_slug=repo_slug)
 
-    # Normalize early so " Emilson " and "emilson" share the same cache entry.
+    # Normalize early so " Jane " and "jane" share the same cache entry.
     account = BitbucketPipelineClient.validate_account_id(account)
 
     full_slug = ""
@@ -1661,7 +1661,7 @@ async def create_pull_request(
         source_branch: Source branch name (e.g., "feature/pipeline-warning")
         destination_branch: Destination branch name (e.g., "develop")
         description: PR description in markdown (optional)
-        account: Named account to use (e.g., "emilson"). Default uses the bot account.
+        account: Named account to use (e.g., "jane-doe"). Default uses the bot account.
                  Use a human account so AI review bots (Rovo Dev, CodeRabbit) recognize the author.
         repo_slug: Optional repo override (format: "workspace/repo-name")
 
@@ -1757,7 +1757,7 @@ async def merge_pull_request(pr_id: int, account: str = "", workspace: str = "",
 
     Args:
         pr_id: Pull request ID
-        account: Named account to use (e.g., "emilson"). Useful when bot lacks write access to destination branch.
+        account: Named account to use (e.g., "jane-doe"). Useful when bot lacks write access to destination branch.
         workspace: Optional workspace override
         repo_slug: Optional repo slug override
     """
@@ -1798,7 +1798,7 @@ async def approve_pull_request(pr_id: int, account: str = "", workspace: str = "
 
     Args:
         pr_id: Pull request ID
-        account: Named account to use (e.g., "emilson"). Default uses the bot account.
+        account: Named account to use (e.g., "jane-doe"). Default uses the bot account.
         workspace: Optional workspace override
         repo_slug: Optional repo slug override
 

--- a/mcp-tools/maos-mcp-hub/tests/test_account_multi_persona.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_account_multi_persona.py
@@ -47,10 +47,10 @@ def _setup_account_env(monkeypatch, account_id: str, token: str = "acct-token",
 
 class TestValidateAccountId:
     def test_valid_simple(self):
-        assert BitbucketPipelineClient.validate_account_id("emilson") == "emilson"
+        assert BitbucketPipelineClient.validate_account_id("testuser") == "testuser"
 
     def test_normalizes_whitespace_and_case(self):
-        assert BitbucketPipelineClient.validate_account_id("  Emilson  ") == "emilson"
+        assert BitbucketPipelineClient.validate_account_id("  Testuser  ") == "testuser"
 
     def test_allows_hyphens_and_underscores(self):
         assert BitbucketPipelineClient.validate_account_id("my-account_1") == "my-account_1"
@@ -106,17 +106,17 @@ class TestForAccount:
 
     def test_named_account_reads_prefixed_env(self, monkeypatch):
         _setup_default_env(monkeypatch)
-        _setup_account_env(monkeypatch, "emilson")
-        client = BitbucketPipelineClient.for_account("emilson", repo_slug="ws/repo")
+        _setup_account_env(monkeypatch, "testuser")
+        client = BitbucketPipelineClient.for_account("testuser", repo_slug="ws/repo")
         assert client.api_token == "acct-token"
         assert client.auth_user == "acct-user"
         assert client.use_bearer is False
 
     def test_normalization_applied(self, monkeypatch):
-        """' Emilson ' should normalize to 'emilson' and find EMILSON_ env vars."""
+        """' Testuser ' should normalize to 'testuser' and find TESTUSER_ env vars."""
         _setup_default_env(monkeypatch)
-        _setup_account_env(monkeypatch, "emilson")
-        client = BitbucketPipelineClient.for_account(" Emilson ", repo_slug="ws/repo")
+        _setup_account_env(monkeypatch, "testuser")
+        client = BitbucketPipelineClient.for_account(" Testuser ", repo_slug="ws/repo")
         assert client.api_token == "acct-token"
 
     def test_missing_credentials_raises(self, monkeypatch):
@@ -145,15 +145,15 @@ class TestForAccount:
 class TestGetClientForAccount:
     def test_caches_by_normalized_key(self, monkeypatch):
         _setup_default_env(monkeypatch)
-        _setup_account_env(monkeypatch, "emilson")
+        _setup_account_env(monkeypatch, "testuser")
         monkeypatch.setenv("BITBUCKET_REPO_SLUG", "ws/repo")
 
         # Import after env setup so module-level code does not fail
         from servers.bitbucket.tools import get_client_for_account, _account_clients
         _account_clients.clear()
 
-        c1 = get_client_for_account(account="emilson", repo_slug="ws/repo")
-        c2 = get_client_for_account(account=" Emilson ", repo_slug="ws/repo")
+        c1 = get_client_for_account(account="testuser", repo_slug="ws/repo")
+        c2 = get_client_for_account(account=" Testuser ", repo_slug="ws/repo")
         assert c1 is c2, "Normalized account should hit the same cache entry"
 
     def test_default_account_skips_cache(self, monkeypatch):

--- a/mcp-tools/maos-mcp-hub/tests/test_branch_management.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_branch_management.py
@@ -1,0 +1,520 @@
+"""
+Tests for Branch Management tools (Sprint 8 — VKS-1647)
+
+Covers:
+- create_branch: success (201), conflict (400)
+- delete_branch: success (204), not found (404), default branch (400)
+- set_default_branch: success (200), not found (400), forbidden (403)
+- get_branch_restrictions: success with list
+- create_branch_restriction: success (201), invalid (400), forbidden (403)
+- delete_branch_restriction: success (204), not found (404)
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import respx
+
+# Ensure project root is in sys.path
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from lib.bitbucket.client import BitbucketPipelineClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+BASE_URL = "https://api.bitbucket.org/2.0/repositories/myworkspace/myrepo"
+
+
+def _setup_env(monkeypatch):
+    """Configure environment for BitbucketPipelineClient instantiation."""
+    monkeypatch.setenv("BITBUCKET_USERNAME", "testuser")
+    monkeypatch.setenv("BITBUCKET_APP_PASSWORD", "test-app-password")
+    monkeypatch.setenv("BITBUCKET_REPO_SLUG", "myworkspace/myrepo")
+    monkeypatch.delenv("BITBUCKET_API_TOKEN", raising=False)
+    monkeypatch.delenv("BITBUCKET_EMAIL", raising=False)
+    monkeypatch.delenv("JIRA_EMAIL", raising=False)
+    monkeypatch.delenv("BITBUCKET_AUTH_TYPE", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# create_branch
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBranch:
+
+    def test_create_branch_success(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                router.post(f"{BASE_URL}/refs/branches").mock(
+                    return_value=httpx.Response(
+                        201,
+                        json={
+                            "name": "main",
+                            "target": {
+                                "hash": "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+                                "type": "commit",
+                            },
+                            "type": "branch",
+                        },
+                    )
+                )
+                result = await client.create_branch(
+                    name="main", target_hash="a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+                )
+                assert result["name"] == "main"
+                assert result["target"]["hash"] == "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+
+        asyncio.run(run())
+
+    def test_create_branch_already_exists(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.post(f"{BASE_URL}/refs/branches").mock(
+                    return_value=httpx.Response(
+                        400,
+                        json={"error": {"message": "Branch already exists"}},
+                    )
+                )
+                from lib.common.errors import ApiError
+
+                with pytest.raises(ApiError) as exc_info:
+                    await client.create_branch(name="main", target_hash="abc123")
+                assert exc_info.value.status_code == 400
+
+        asyncio.run(run())
+
+    def test_create_branch_with_short_hash(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                route = router.post(f"{BASE_URL}/refs/branches").mock(
+                    return_value=httpx.Response(
+                        201,
+                        json={
+                            "name": "feature/test",
+                            "target": {"hash": "abc1234def5678"},
+                            "type": "branch",
+                        },
+                    )
+                )
+                result = await client.create_branch(
+                    name="feature/test", target_hash="abc1234"
+                )
+                assert result["name"] == "feature/test"
+                # Verify payload sent correct hash
+                request = route.calls[0].request
+                import json
+                body = json.loads(request.content)
+                assert body["name"] == "feature/test"
+                assert body["target"]["hash"] == "abc1234"
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# delete_branch
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBranch:
+
+    def test_delete_branch_success(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                router.delete(f"{BASE_URL}/refs/branches/feature%2Fold-branch").mock(
+                    return_value=httpx.Response(204)
+                )
+                status = await client.delete_branch(name="feature/old-branch")
+                assert status == 204
+
+        asyncio.run(run())
+
+    def test_delete_branch_not_found(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.delete(f"{BASE_URL}/refs/branches/nonexistent").mock(
+                    return_value=httpx.Response(
+                        404, json={"error": {"message": "Branch not found"}}
+                    )
+                )
+                from lib.common.errors import NotFoundError
+
+                with pytest.raises(NotFoundError):
+                    await client.delete_branch(name="nonexistent")
+
+        asyncio.run(run())
+
+    def test_delete_default_branch_rejected(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.delete(f"{BASE_URL}/refs/branches/main").mock(
+                    return_value=httpx.Response(
+                        400,
+                        json={"error": {"message": "Cannot delete default branch"}},
+                    )
+                )
+                from lib.common.errors import ApiError
+
+                with pytest.raises(ApiError) as exc_info:
+                    await client.delete_branch(name="main")
+                assert exc_info.value.status_code == 400
+
+        asyncio.run(run())
+
+    def test_delete_branch_url_encodes_slashes(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                # feature/deep/nested → feature%2Fdeep%2Fnested
+                router.delete(
+                    f"{BASE_URL}/refs/branches/feature%2Fdeep%2Fnested"
+                ).mock(return_value=httpx.Response(204))
+                status = await client.delete_branch(name="feature/deep/nested")
+                assert status == 204
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# set_default_branch
+# ---------------------------------------------------------------------------
+
+
+class TestSetDefaultBranch:
+
+    def test_set_default_branch_success(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                route = router.put(BASE_URL).mock(
+                    return_value=httpx.Response(
+                        200,
+                        json={
+                            "name": "myrepo",
+                            "full_name": "myworkspace/myrepo",
+                            "mainbranch": {"name": "main", "type": "branch"},
+                            "type": "repository",
+                        },
+                    )
+                )
+                result = await client.set_default_branch(name="main")
+                assert result["mainbranch"]["name"] == "main"
+                # Verify payload
+                import json
+                body = json.loads(route.calls[0].request.content)
+                assert body == {"mainbranch": {"name": "main"}}
+
+        asyncio.run(run())
+
+    def test_set_default_branch_nonexistent(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.put(BASE_URL).mock(
+                    return_value=httpx.Response(
+                        400,
+                        json={"error": {"message": "Branch does not exist"}},
+                    )
+                )
+                from lib.common.errors import ApiError
+
+                with pytest.raises(ApiError) as exc_info:
+                    await client.set_default_branch(name="nonexistent")
+                assert exc_info.value.status_code == 400
+
+        asyncio.run(run())
+
+    def test_set_default_branch_forbidden(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.put(BASE_URL).mock(
+                    return_value=httpx.Response(
+                        403,
+                        json={"error": {"message": "Forbidden"}},
+                    )
+                )
+                from lib.common.errors import AuthError
+
+                with pytest.raises(AuthError):
+                    await client.set_default_branch(name="main")
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# get_branch_restrictions
+# ---------------------------------------------------------------------------
+
+
+class TestGetBranchRestrictions:
+
+    def test_get_branch_restrictions_success(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                router.get(f"{BASE_URL}/branch-restrictions").mock(
+                    return_value=httpx.Response(
+                        200,
+                        json={
+                            "pagelen": 100,
+                            "size": 2,
+                            "values": [
+                                {
+                                    "id": 1001,
+                                    "kind": "push",
+                                    "pattern": "main",
+                                    "type": "branchrestriction",
+                                    "users": [],
+                                    "groups": [],
+                                },
+                                {
+                                    "id": 1002,
+                                    "kind": "delete",
+                                    "pattern": "release/*",
+                                    "type": "branchrestriction",
+                                    "users": [],
+                                    "groups": [{"slug": "admins", "type": "group"}],
+                                },
+                            ],
+                        },
+                    )
+                )
+                result = await client.get_branch_restrictions()
+                assert len(result["values"]) == 2
+                assert result["values"][0]["kind"] == "push"
+                assert result["values"][1]["pattern"] == "release/*"
+
+        asyncio.run(run())
+
+    def test_get_branch_restrictions_empty(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                router.get(f"{BASE_URL}/branch-restrictions").mock(
+                    return_value=httpx.Response(
+                        200,
+                        json={"pagelen": 100, "size": 0, "values": []},
+                    )
+                )
+                result = await client.get_branch_restrictions()
+                assert result["values"] == []
+                assert result["size"] == 0
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# create_branch_restriction
+# ---------------------------------------------------------------------------
+
+
+class TestCreateBranchRestriction:
+
+    def test_create_restriction_success(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                route = router.post(f"{BASE_URL}/branch-restrictions").mock(
+                    return_value=httpx.Response(
+                        201,
+                        json={
+                            "id": 1003,
+                            "kind": "push",
+                            "pattern": "main",
+                            "type": "branchrestriction",
+                            "users": [],
+                            "groups": [],
+                        },
+                    )
+                )
+                result = await client.create_branch_restriction(
+                    kind="push", pattern="main"
+                )
+                assert result["id"] == 1003
+                assert result["kind"] == "push"
+                assert result["pattern"] == "main"
+                # Verify payload
+                import json
+                body = json.loads(route.calls[0].request.content)
+                assert body["kind"] == "push"
+                assert body["pattern"] == "main"
+                assert "users" not in body
+                assert "groups" not in body
+
+        asyncio.run(run())
+
+    def test_create_restriction_with_users_and_groups(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                route = router.post(f"{BASE_URL}/branch-restrictions").mock(
+                    return_value=httpx.Response(
+                        201,
+                        json={
+                            "id": 1004,
+                            "kind": "force",
+                            "pattern": "release/*",
+                            "type": "branchrestriction",
+                            "users": [{"uuid": "{user-uuid-1}", "type": "user"}],
+                            "groups": [{"slug": "senior-devs", "type": "group"}],
+                        },
+                    )
+                )
+                result = await client.create_branch_restriction(
+                    kind="force",
+                    pattern="release/*",
+                    users=["{user-uuid-1}"],
+                    groups=["senior-devs"],
+                )
+                assert result["id"] == 1004
+                # Verify payload includes users and groups
+                import json
+                body = json.loads(route.calls[0].request.content)
+                assert body["users"] == [{"uuid": "{user-uuid-1}"}]
+                assert body["groups"] == [{"slug": "senior-devs"}]
+
+        asyncio.run(run())
+
+    def test_create_restriction_invalid_kind(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.post(f"{BASE_URL}/branch-restrictions").mock(
+                    return_value=httpx.Response(
+                        400,
+                        json={"error": {"message": "Invalid kind"}},
+                    )
+                )
+                from lib.common.errors import ApiError
+
+                with pytest.raises(ApiError) as exc_info:
+                    await client.create_branch_restriction(
+                        kind="invalid_kind", pattern="main"
+                    )
+                assert exc_info.value.status_code == 400
+
+        asyncio.run(run())
+
+    def test_create_restriction_forbidden(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.post(f"{BASE_URL}/branch-restrictions").mock(
+                    return_value=httpx.Response(
+                        403,
+                        json={"error": {"message": "Admin access required"}},
+                    )
+                )
+                from lib.common.errors import AuthError
+
+                with pytest.raises(AuthError):
+                    await client.create_branch_restriction(
+                        kind="push", pattern="main"
+                    )
+
+        asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# delete_branch_restriction
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBranchRestriction:
+
+    def test_delete_restriction_success(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock(assert_all_called=True) as router:
+                router.delete(f"{BASE_URL}/branch-restrictions/1001").mock(
+                    return_value=httpx.Response(204)
+                )
+                status = await client.delete_branch_restriction(restriction_id=1001)
+                assert status == 204
+
+        asyncio.run(run())
+
+    def test_delete_restriction_not_found(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.delete(f"{BASE_URL}/branch-restrictions/9999").mock(
+                    return_value=httpx.Response(
+                        404,
+                        json={"error": {"message": "Restriction not found"}},
+                    )
+                )
+                from lib.common.errors import NotFoundError
+
+                with pytest.raises(NotFoundError):
+                    await client.delete_branch_restriction(restriction_id=9999)
+
+        asyncio.run(run())
+
+    def test_delete_restriction_forbidden(self, monkeypatch):
+        _setup_env(monkeypatch)
+
+        async def run():
+            client = BitbucketPipelineClient()
+            with respx.mock() as router:
+                router.delete(f"{BASE_URL}/branch-restrictions/1001").mock(
+                    return_value=httpx.Response(
+                        403,
+                        json={"error": {"message": "Admin access required"}},
+                    )
+                )
+                from lib.common.errors import AuthError
+
+                with pytest.raises(AuthError):
+                    await client.delete_branch_restriction(restriction_id=1001)
+
+        asyncio.run(run())


### PR DESCRIPTION
## Contexto

Implementa 6 novas tools de branch management no `maos-mcp-hub` para viabilizar a migração automatizada `master → main` ([VKS-1639](https://vek.atlassian.net/browse/VKS-1639)).

**Ticket:** [VKS-1647](https://vek.atlassian.net/browse/VKS-1647)

---

## Novas Tools

| Tool | Descrição | Endpoint |
|------|-----------|----------|
| `bitbucket_create_branch` | Criar branch a partir de commit hash | `POST /refs/branches` |
| `bitbucket_delete_branch` | Deletar branch (proteção do default) | `DELETE /refs/branches/{name}` |
| `bitbucket_set_default_branch` | Alterar default branch do repositório | `PUT /repositories/{ws}/{repo}` |
| `bitbucket_get_branch_restrictions` | Listar regras de proteção | `GET /branch-restrictions` |
| `bitbucket_set_branch_restriction` | Criar regra de proteção | `POST /branch-restrictions` |
| `bitbucket_delete_branch_restriction` | Remover regra por ID | `DELETE /branch-restrictions/{id}` |

## Padrão de Implementação

- Usa `request_json` / `request_empty` do `lib/common/http.py` com retry automático, error mapping tipado (`ApiError`), rate limiting
- `max_retries=0` para operações não-idempotentes (create, delete)
- URL encoding de branch names com `/` (slashes)
- Error handling com `ApiError` subclasses (`NotFoundError`, `AuthError`, etc.)

## Testes

- 19 testes unitários novos (`tests/test_branch_management.py`)
- 73/73 testes totais passando
- Cobertura: sucesso, erros HTTP (400, 403, 404), edge cases (URL encoding, payloads)

## Testes End-to-End

Testado contra repositório real `vek-servicos/vks-jss-parent-api`:
- ✅ `bitbucket_list_branches` — 2 branches encontradas
- ✅ `bitbucket_get_branch` — detalhes do master obtidos
- ✅ `bitbucket_get_branch_restrictions` — 0 restrições (repo sem proteção)

## Fluxo de Migração Habilitado

```
1. get_branch(branch_name="master")        → obter commit hash
2. create_branch(name="main", target=hash) → criar branch main
3. set_default_branch(name="main")         → alterar default
4. set_branch_restriction(kind="push", pattern="main") → proteger
5. delete_branch(name="master")            → cleanup
```

## Arquivos Modificados

- `mcp-tools/maos-mcp-hub/lib/bitbucket/client.py` — +6 métodos async
- `mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py` — +6 tool functions
- `mcp-tools/maos-mcp-hub/servers/bitbucket/server.py` — registro das tools
- `mcp-tools/maos-mcp-hub/tests/test_branch_management.py` — 19 testes
- `mcp-tools/maos-mcp-hub/README.md` — tabela atualizada
- `CHANGELOG.md` — changelog atualizado
