### PR TITLE
feat(maos-mcp-hub): Jira Agile API — boards & story points (VKS-1692)

### DIFF
--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -66,6 +66,7 @@ class JiraClient:
             )
 
         self.base_url = f"https://api.atlassian.com/ex/jira/{self.cloud_id}/rest/api/3"
+        self.agile_url = f"https://api.atlassian.com/ex/jira/{self.cloud_id}/rest/agile/1.0"
         self._provider_name = "Jira"
         self._auth_hint = (
             "Verifique JIRA_EMAIL e JIRA_API_TOKEN (ou ATLASSIAN_API_TOKEN fallback)."
@@ -254,6 +255,84 @@ class JiraClient:
 
         # API usually returns array; keep backward-compatible shape.
         return result[0] if isinstance(result, list) and result else result
+
+    # ========================================================================
+    # Agile API — Boards & Estimation
+    # ========================================================================
+
+    async def get_boards(self, project_key_or_id: str = "") -> list:
+        """
+        List Scrum/Kanban boards, optionally filtered by project
+
+        Args:
+            project_key_or_id: Project key (e.g., "VKS") or ID to filter boards.
+                               If empty, returns all visible boards.
+
+        Returns:
+            list: Board objects [{id, name, type, ...}]
+        """
+        params = {}
+        if project_key_or_id:
+            params["projectKeyOrId"] = project_key_or_id
+
+        result = await request_json(
+            method="GET",
+            url=f"{self.agile_url}/board",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params=params,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+        return result.get("values", [])
+
+    async def get_estimation(self, issue_key: str, board_id: int) -> dict:
+        """
+        Get story points estimation for an issue
+
+        Args:
+            issue_key: Issue key (e.g., "VKS-1673")
+            board_id: Board ID (from get_boards)
+
+        Returns:
+            dict: {"value": <number>} or {"value": null}
+        """
+        return await request_json(
+            method="GET",
+            url=f"{self.agile_url}/issue/{issue_key}/estimation",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"boardId": board_id},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def set_estimation(self, issue_key: str, board_id: int, value: float) -> dict:
+        """
+        Set story points estimation for an issue
+
+        Args:
+            issue_key: Issue key (e.g., "VKS-1673")
+            board_id: Board ID (from get_boards)
+            value: Story points value (e.g., 8)
+
+        Returns:
+            dict: {"value": <number>} (the set value, echoed back)
+        """
+        return await request_json(
+            method="PUT",
+            url=f"{self.agile_url}/issue/{issue_key}/estimation",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"boardId": board_id},
+            json={"value": value},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # PUT is non-idempotent for estimation
+        )
 
     async def delete_attachment(self, attachment_id: str) -> dict:
         """

--- a/mcp-tools/maos-mcp-hub/servers/jira/server.py
+++ b/mcp-tools/maos-mcp-hub/servers/jira/server.py
@@ -7,10 +7,11 @@ Provides SERVER_INFO for hub auto-discovery.
 SERVER_INFO = {
     "name": "jira",
     "display_name": "Jira Cloud Issue Tracker",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": (
-        "Manage Jira Cloud issues and attachments via REST API v3. "
-        "Supports reading issues, listing/downloading/uploading/deleting attachments."
+        "Manage Jira Cloud issues, attachments, and agile estimation via REST API v3 + Agile API. "
+        "Supports reading issues, attachments (list/download/upload/delete), "
+        "boards, and story points estimation (get/set)."
     ),
     "mcp_server": "hub.py",
     "env_vars": {
@@ -25,5 +26,8 @@ SERVER_INFO = {
         "download_attachment",
         "upload_attachment",
         "delete_attachment",
+        "get_boards",
+        "get_estimation",
+        "set_estimation",
     ],
 }

--- a/mcp-tools/maos-mcp-hub/servers/jira/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/jira/tools.py
@@ -387,6 +387,125 @@ async def delete_attachment(attachment_id: str) -> dict:
 
 
 # ============================================================================
+# AGILE TOOLS — Boards & Estimation (Story Points)
+# ============================================================================
+
+
+async def get_boards(project_key: str = "") -> dict:
+    """
+    List Scrum/Kanban boards, optionally filtered by project.
+
+    Use this to discover the board ID needed for set_estimation/get_estimation.
+
+    Args:
+        project_key: Project key to filter (e.g., "VKS"). Empty returns all boards.
+
+    Returns:
+        dict: List of boards with id, name, type.
+    """
+    client = get_client()
+
+    try:
+        boards = await client.get_boards(project_key)
+        return {
+            "project_filter": project_key or "(all)",
+            "count": len(boards),
+            "boards": [
+                {
+                    "id": b.get("id"),
+                    "name": b.get("name"),
+                    "type": b.get("type"),
+                }
+                for b in boards
+            ],
+        }
+
+    except ApiError as e:
+        return {"error": f"Jira Agile API error: {sanitize_exception(e)}", "hint": e.hint}
+    except Exception as e:
+        return {"error": f"Unexpected error: {_sanitize_error(e)}"}
+
+
+async def get_estimation(issue_key: str, board_id: int) -> dict:
+    """
+    Get story points estimation for an issue.
+
+    Args:
+        issue_key: Issue key (e.g., "VKS-1673")
+        board_id: Board ID (use get_boards to discover)
+
+    Returns:
+        dict: Current estimation value (story points).
+    """
+    validation = _validate_issue_key(issue_key)
+    if validation:
+        return validation
+
+    client = get_client()
+
+    try:
+        result = await client.get_estimation(issue_key, board_id)
+        return {
+            "issue_key": issue_key,
+            "board_id": board_id,
+            "story_points": result.get("value"),
+        }
+
+    except ApiError as e:
+        if e.status_code == 404:
+            return {"error": f"Issue {issue_key} or board {board_id} not found"}
+        return {"error": f"Jira Agile API error: {sanitize_exception(e)}", "hint": e.hint}
+    except Exception as e:
+        return {"error": f"Unexpected error: {_sanitize_error(e)}"}
+
+
+async def set_estimation(issue_key: str, board_id: int, value: float) -> dict:
+    """
+    Set story points estimation for an issue.
+
+    This uses the Jira Software Agile REST API which is the only way to set
+    the Story Points field (customfield managed by the board plugin).
+
+    Args:
+        issue_key: Issue key (e.g., "VKS-1673")
+        board_id: Board ID (use get_boards to discover)
+        value: Story points value (e.g., 1, 2, 3, 5, 8, 13)
+
+    Returns:
+        dict: Confirmation with set value.
+    """
+    validation = _validate_issue_key(issue_key)
+    if validation:
+        return validation
+
+    if value < 0:
+        return {"error": "Story points value must be non-negative"}
+
+    client = get_client()
+
+    try:
+        result = await client.set_estimation(issue_key, board_id, value)
+        return {
+            "issue_key": issue_key,
+            "board_id": board_id,
+            "story_points": result.get("value", value),
+            "message": f"Story points set to {value} for {issue_key}",
+        }
+
+    except ApiError as e:
+        if e.status_code == 404:
+            return {"error": f"Issue {issue_key} or board {board_id} not found"}
+        if e.status_code == 400:
+            return {
+                "error": f"Cannot set estimation: {sanitize_exception(e)}",
+                "hint": "Check if the board uses story points estimation and the issue is on the board.",
+            }
+        return {"error": f"Jira Agile API error: {sanitize_exception(e)}", "hint": e.hint}
+    except Exception as e:
+        return {"error": f"Unexpected error: {_sanitize_error(e)}"}
+
+
+# ============================================================================
 # TOOL REGISTRY
 # ============================================================================
 
@@ -396,4 +515,7 @@ TOOLS = {
     "download_attachment": download_attachment,
     "upload_attachment": upload_attachment,
     "delete_attachment": delete_attachment,
+    "get_boards": get_boards,
+    "get_estimation": get_estimation,
+    "set_estimation": set_estimation,
 }

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -163,3 +163,133 @@ def test_delete_attachment_maps_403_to_auth_error(monkeypatch):
             assert "/attachment/40301" in exc.endpoint
 
     asyncio.run(run())
+
+
+# ========================================================================
+# Agile API — Boards & Estimation
+# ========================================================================
+
+AGILE_BASE = "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/agile/1.0"
+
+
+def test_get_boards_with_project_filter(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(f"{AGILE_BASE}/board").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={
+                        "values": [
+                            {"id": 42, "name": "VKS Board", "type": "scrum"},
+                            {"id": 43, "name": "VKS Kanban", "type": "kanban"},
+                        ]
+                    },
+                )
+            )
+
+            boards = await client.get_boards("VKS")
+            assert len(boards) == 2
+            assert boards[0]["id"] == 42
+            assert boards[0]["name"] == "VKS Board"
+            assert boards[1]["type"] == "kanban"
+
+    asyncio.run(run())
+
+
+def test_get_boards_no_filter(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(f"{AGILE_BASE}/board").mock(
+                return_value=httpx.Response(200, json={"values": []})
+            )
+
+            boards = await client.get_boards()
+            assert boards == []
+
+    asyncio.run(run())
+
+
+def test_get_estimation_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(f"{AGILE_BASE}/issue/VKS-1673/estimation").mock(
+                return_value=httpx.Response(200, json={"value": 5})
+            )
+
+            result = await client.get_estimation("VKS-1673", board_id=42)
+            assert result["value"] == 5
+
+    asyncio.run(run())
+
+
+def test_set_estimation_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.put(f"{AGILE_BASE}/issue/VKS-1673/estimation").mock(
+                return_value=httpx.Response(200, json={"value": 8})
+            )
+
+            result = await client.set_estimation("VKS-1673", board_id=42, value=8)
+            assert result["value"] == 8
+
+    asyncio.run(run())
+
+
+def test_set_estimation_maps_403_to_auth_error(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.put(f"{AGILE_BASE}/issue/VKS-1673/estimation").mock(
+                return_value=httpx.Response(403, text='{"error":"forbidden"}')
+            )
+
+            with pytest.raises(AuthError) as exc_info:
+                await client.set_estimation("VKS-1673", board_id=42, value=8)
+            exc = exc_info.value
+            assert exc.status_code == 403
+
+    asyncio.run(run())
+
+
+def test_get_estimation_maps_404_to_not_found(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(f"{AGILE_BASE}/issue/VKS-9999/estimation").mock(
+                return_value=httpx.Response(404, text='{"error":"not found"}')
+            )
+
+            with pytest.raises(NotFoundError) as exc_info:
+                await client.get_estimation("VKS-9999", board_id=42)
+            exc = exc_info.value
+            assert exc.status_code == 404
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

- Adds 3 new MCP tools for Jira Agile REST API (/rest/agile/1.0):
  - jira_get_boards — list Scrum/Kanban boards filtered by project
  - jira_get_estimation — read story points for issue+board
  - jira_set_estimation — write story points via Agile API (the only way — customfield_10940 is read-only via standard REST)
- Unblocks AI-driven Jira workflow transitions requiring mandatory Story Points field
- Bumps Jira server to v1.1.0

## Changes

| File | What |
|---|---|
| lib/jira/client.py | agile_url base + 3 async methods (get_boards, get_estimation, set_estimation) |
| servers/jira/tools.py | 3 tool functions with input validation + error mapping |
| servers/jira/server.py | v1.1.0, updated description + tools list |
| tests/test_jira_client.py | 6 new tests: boards (filter/empty), estimation (get/set), errors (403/404) |

## Context (VKS-1692)

AI agents creating/executing Jira tasks cannot close them because Jira workflow validators require Story Points, and customfield_10940 is board-managed (read-only via standard REST API v3). The Agile API endpoint PUT /rest/agile/1.0/issue/{key}/estimation?boardId={id} is the only write path.

## Test plan

- [x] All 14 tests pass locally (pytest tests/test_jira_client.py -v)
- [ ] E2E: get boards for VKS project, then set estimation on VKS-1692, verify in Jira UI

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

Generated with Claude Code (claude.ai/code)