### PR TITLE
fix(tests): align test_gateway_jira.py docstring with actual action count (22, not 23)

### DIFF
--- a/.github/workflows/ai-governance-linter.yml
+++ b/.github/workflows/ai-governance-linter.yml
@@ -29,9 +29,10 @@ jobs:
           
       - name: Validar Assinatura da IA Autônoma (Co-Authored-By)
         shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          BODY="${{ github.event.pull_request.body }}"
-          if [[ ! "$BODY" =~ "Co-Authored-By:" ]]; then
+          if [[ ! "$PR_BODY" =~ "Co-Authored-By:" ]]; then
             echo "🛑 [GaaS Failure] O Pull Request carece de atestado de co-autoria da IA."
             echo "Adicione 'Co-Authored-By: <Nome-da-IA> <email-fake@ia.com>' na descrição do PR para compliance SOTA."
             # Uncomment the next line to strictly enforce and fail the action

--- a/mcp-tools/maos-mcp-hub/gateways/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/__init__.py
@@ -1,0 +1,6 @@
+"""
+Gateway registry for meta-tools pattern.
+
+Auto-discovers gateways/ subdirectories, each containing
+gateway.py (GATEWAY_INFO) + actions.py (router setup).
+"""

--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/__init__.py
@@ -1,0 +1,1 @@
+"""Bitbucket gateway — wraps 52 existing tools into meta-tool pattern."""

--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
@@ -1,0 +1,148 @@
+"""
+Bitbucket gateway actions — maps 52 existing tools into resource+operation taxonomy.
+
+All handlers are imported from servers/bitbucket/tools.py (zero rewrite).
+The RESOURCE_MAP defines the hierarchical structure exposed to agents.
+"""
+
+from servers.bitbucket.tools import TOOLS as BB_TOOLS
+
+from lib.gateway.router import MetaToolRouter
+
+from .gateway import GATEWAY_INFO
+
+# ---------------------------------------------------------------------------
+# Resource → Operation mapping (52 tools → 11 resources)
+# ---------------------------------------------------------------------------
+
+RESOURCE_MAP = {
+    "pipeline": {
+        "list": BB_TOOLS["get_recent_builds"],
+        "get": BB_TOOLS["get_build_details"],
+        "get_steps": BB_TOOLS["get_build_steps"],
+        "get_logs": BB_TOOLS["get_step_logs"],
+        "trigger": BB_TOOLS["trigger_pipeline"],
+        "stop": BB_TOOLS["stop_pipeline"],
+        "get_config": BB_TOOLS["get_pipeline_config"],
+        "get_schedules": BB_TOOLS["list_pipeline_schedules"],
+        "get_health": BB_TOOLS["check_pipeline_health"],
+        "get_alerts": BB_TOOLS["check_alerts"],
+        "get_summary": BB_TOOLS["get_executive_summary"],
+        "get_ssh_key": BB_TOOLS["get_ssh_key_info"],
+        "analyze_failures": BB_TOOLS["analyze_failures"],
+        "diagnose": BB_TOOLS["diagnose_pipeline_failure"],
+        "auto_diagnose": BB_TOOLS["auto_diagnose"],
+        "compare": BB_TOOLS["compare_builds"],
+    },
+    "pull_request": {
+        "list": BB_TOOLS["get_pull_requests"],
+        "get": BB_TOOLS["get_pr_details"],
+        "create": BB_TOOLS["create_pull_request"],
+        "merge": BB_TOOLS["merge_pull_request"],
+        "approve": BB_TOOLS["approve_pull_request"],
+        "unapprove": BB_TOOLS["unapprove_pull_request"],
+        "get_comments": BB_TOOLS["get_pr_comments"],
+        "get_build_statuses": BB_TOOLS["get_pr_build_statuses"],
+    },
+    "branch": {
+        "list": BB_TOOLS["list_branches"],
+        "get": BB_TOOLS["get_branch"],
+        "create": BB_TOOLS["create_branch"],
+        "delete": BB_TOOLS["delete_branch"],
+        "set_default": BB_TOOLS["set_default_branch"],
+        "get_restrictions": BB_TOOLS["get_branch_restrictions"],
+        "set_restriction": BB_TOOLS["set_branch_restriction"],
+        "delete_restriction": BB_TOOLS["delete_branch_restriction"],
+    },
+    "deployment": {
+        "list": BB_TOOLS["get_recent_deployments"],
+        "get": BB_TOOLS["get_deployment_details"],
+        "get_environments": BB_TOOLS["get_environments"],
+        "get_env_variables": BB_TOOLS["get_environment_variables"],
+    },
+    "commit": {
+        "get": BB_TOOLS["get_commit_details"],
+        "get_build_statuses": BB_TOOLS["get_commit_build_statuses"],
+        "get_builds": BB_TOOLS["get_builds_for_commit"],
+        "compare_builds": BB_TOOLS["compare_commit_builds"],
+    },
+    "test": {
+        "get_reports": BB_TOOLS["get_test_reports"],
+        "get_cases": BB_TOOLS["get_test_cases"],
+        "get_case_reasons": BB_TOOLS["get_test_case_reasons"],
+    },
+    "cache": {
+        "list": BB_TOOLS["list_caches"],
+        "get": BB_TOOLS["get_cache_details"],
+        "clear": BB_TOOLS["clear_cache"],
+        "analyze_efficiency": BB_TOOLS["analyze_cache_efficiency"],
+    },
+    "variable": {
+        "get_repository": BB_TOOLS["get_repository_variables"],
+        "get_workspace": BB_TOOLS["get_workspace_variables"],
+    },
+    "learning": {
+        "save_fix": BB_TOOLS["save_successful_fix"],
+        "search_fixes": BB_TOOLS["search_learned_fixes"],
+        "get_stats": BB_TOOLS["get_knowledge_base_stats"],
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Governance rules by resource (from OSPPE Exp 16 crossref)
+# ---------------------------------------------------------------------------
+
+_GOVERNANCE = {
+    "pull_request": {
+        "create": ["Jira key obrigatorio no titulo", "governance_level obrigatorio no body"],
+        "merge": [
+            "Pipeline deve estar green",
+            "Minimo 1 approver",
+            "SECURITY_AUDIT obrigatorio se risk_score >= 3",
+        ],
+        "approve": ["Approver nao pode ser o autor"],
+    },
+    "branch": {
+        "create": ["Branch naming regex: feature/|bugfix/|hotfix/|release/"],
+    },
+    "pipeline": {
+        "get_logs": ["Verificar ausencia de secrets/PII nos logs"],
+    },
+}
+
+_NEXT_STEPS = {
+    "pull_request": {
+        "create": ["Aguardar AI bot review", "Verificar pipeline status"],
+        "merge": ["Atualizar Jira ticket status", "Verificar deployment"],
+    },
+    "branch": {
+        "create": ["Criar pull request apos implementacao"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Router builder
+# ---------------------------------------------------------------------------
+
+def build_router() -> MetaToolRouter:
+    """Build the Bitbucket meta-tool router with all 52 actions."""
+    router = MetaToolRouter(
+        tool_name=GATEWAY_INFO["tool_name"],
+        governance=["Bitbucket operations follow S-SDLC governance"],
+    )
+
+    for resource, operations in RESOURCE_MAP.items():
+        res_gov = _GOVERNANCE.get(resource, {})
+        res_next = _NEXT_STEPS.get(resource, {})
+
+        for operation, handler in operations.items():
+            router.register(
+                resource=resource,
+                operation=operation,
+                handler=handler,
+                governance=res_gov.get(operation),
+                next_steps=res_next.get(operation),
+            )
+
+    return router

--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/gateway.py
@@ -1,0 +1,14 @@
+"""Bitbucket gateway metadata."""
+
+GATEWAY_INFO = {
+    "name": "bitbucket",
+    "tool_name": "atlassian_bitbucket",
+    "display_name": "Bitbucket Cloud — Pipelines, PRs, Branches, Deployments",
+    "version": "1.0.0",
+    "description": (
+        "Manage Bitbucket Cloud resources: pipelines, builds, pull requests, "
+        "branches, deployments, caches, commits, tests, and auto-learning. "
+        "Call without params for resource discovery. "
+        "Input: {resource?, operation?, params?}"
+    ),
+}

--- a/mcp-tools/maos-mcp-hub/gateways/common/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/common/__init__.py
@@ -1,1 +1,1 @@
-"""Common gateway — cross-cutting Atlassian actions."""
+"""Common gateway — 4 cross-cutting Atlassian actions."""

--- a/mcp-tools/maos-mcp-hub/gateways/common/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/common/__init__.py
@@ -1,0 +1,1 @@
+"""Common gateway — cross-cutting Atlassian actions."""

--- a/mcp-tools/maos-mcp-hub/gateways/common/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/common/actions.py
@@ -1,9 +1,10 @@
 """Common gateway actions — 4 cross-cutting actions."""
 
 from __future__ import annotations
-import base64, os
-from typing import Optional
-from aiolimiter import AsyncLimiter
+
+import base64
+import os
+
 from lib.common.http import request_json
 from lib.gateway.router import MetaToolRouter
 from .gateway import GATEWAY_INFO
@@ -16,6 +17,8 @@ async def get_user_info() -> dict:
     cloud_id = os.getenv("JIRA_CLOUD_ID", "")
     if not token or not email:
         return {"error": "Missing credentials"}
+    if not cloud_id:
+        return {"error": "Missing JIRA_CLOUD_ID"}
     creds = base64.b64encode(f"{email}:{token}".encode()).decode()
     return await request_json(
         method="GET",
@@ -27,7 +30,11 @@ async def get_user_info() -> dict:
 
 
 async def get_accessible_resources() -> dict:
-    """List accessible Atlassian cloud resources."""
+    """List accessible Atlassian cloud resources.
+
+    Note: This endpoint officially requires OAuth 2.0. With Basic Auth (API token)
+    it may return 401. Use get_user_info or get_server_info as alternatives.
+    """
     email = os.getenv("JIRA_EMAIL", "")
     token = os.getenv("JIRA_API_TOKEN") or os.getenv("ATLASSIAN_API_TOKEN") or ""
     if not token or not email:
@@ -36,7 +43,8 @@ async def get_accessible_resources() -> dict:
     result = await request_json(
         method="GET",
         url="https://api.atlassian.com/oauth/token/accessible-resources",
-        provider="Atlassian", auth_hint="Check credentials.",
+        provider="Atlassian",
+        auth_hint="This endpoint requires OAuth 2.0. Basic Auth may fail — use get_user_info instead.",
         auth_kwargs={"headers": {"Authorization": f"Basic {creds}"}},
         timeout=30.0,
     )
@@ -50,6 +58,8 @@ async def lookup_user(query: str) -> dict:
     cloud_id = os.getenv("JIRA_CLOUD_ID", "")
     if not token or not email:
         return {"error": "Missing credentials"}
+    if not cloud_id:
+        return {"error": "Missing JIRA_CLOUD_ID"}
     creds = base64.b64encode(f"{email}:{token}".encode()).decode()
     return await request_json(
         method="GET",
@@ -67,6 +77,8 @@ async def get_server_info() -> dict:
     cloud_id = os.getenv("JIRA_CLOUD_ID", "")
     if not token or not email:
         return {"error": "Missing credentials"}
+    if not cloud_id:
+        return {"error": "Missing JIRA_CLOUD_ID"}
     creds = base64.b64encode(f"{email}:{token}".encode()).decode()
     return await request_json(
         method="GET",

--- a/mcp-tools/maos-mcp-hub/gateways/common/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/common/actions.py
@@ -1,0 +1,86 @@
+"""Common gateway actions — 4 cross-cutting actions."""
+
+from __future__ import annotations
+import base64, os
+from typing import Optional
+from aiolimiter import AsyncLimiter
+from lib.common.http import request_json
+from lib.gateway.router import MetaToolRouter
+from .gateway import GATEWAY_INFO
+
+
+async def get_user_info() -> dict:
+    """Get current authenticated user info."""
+    email = os.getenv("JIRA_EMAIL", "")
+    token = os.getenv("JIRA_API_TOKEN") or os.getenv("ATLASSIAN_API_TOKEN") or ""
+    cloud_id = os.getenv("JIRA_CLOUD_ID", "")
+    if not token or not email:
+        return {"error": "Missing credentials"}
+    creds = base64.b64encode(f"{email}:{token}".encode()).decode()
+    return await request_json(
+        method="GET",
+        url=f"https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3/myself",
+        provider="Atlassian", auth_hint="Check credentials.",
+        auth_kwargs={"headers": {"Authorization": f"Basic {creds}"}},
+        timeout=30.0,
+    )
+
+
+async def get_accessible_resources() -> dict:
+    """List accessible Atlassian cloud resources."""
+    email = os.getenv("JIRA_EMAIL", "")
+    token = os.getenv("JIRA_API_TOKEN") or os.getenv("ATLASSIAN_API_TOKEN") or ""
+    if not token or not email:
+        return {"error": "Missing credentials"}
+    creds = base64.b64encode(f"{email}:{token}".encode()).decode()
+    result = await request_json(
+        method="GET",
+        url="https://api.atlassian.com/oauth/token/accessible-resources",
+        provider="Atlassian", auth_hint="Check credentials.",
+        auth_kwargs={"headers": {"Authorization": f"Basic {creds}"}},
+        timeout=30.0,
+    )
+    return {"resources": result} if isinstance(result, list) else result
+
+
+async def lookup_user(query: str) -> dict:
+    """Search for Atlassian users by name or email."""
+    email = os.getenv("JIRA_EMAIL", "")
+    token = os.getenv("JIRA_API_TOKEN") or os.getenv("ATLASSIAN_API_TOKEN") or ""
+    cloud_id = os.getenv("JIRA_CLOUD_ID", "")
+    if not token or not email:
+        return {"error": "Missing credentials"}
+    creds = base64.b64encode(f"{email}:{token}".encode()).decode()
+    return await request_json(
+        method="GET",
+        url=f"https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3/user/search",
+        provider="Atlassian", auth_hint="Check credentials.",
+        auth_kwargs={"headers": {"Authorization": f"Basic {creds}"}},
+        params={"query": query}, timeout=30.0,
+    )
+
+
+async def get_server_info() -> dict:
+    """Get Jira server info (version, URLs)."""
+    email = os.getenv("JIRA_EMAIL", "")
+    token = os.getenv("JIRA_API_TOKEN") or os.getenv("ATLASSIAN_API_TOKEN") or ""
+    cloud_id = os.getenv("JIRA_CLOUD_ID", "")
+    if not token or not email:
+        return {"error": "Missing credentials"}
+    creds = base64.b64encode(f"{email}:{token}".encode()).decode()
+    return await request_json(
+        method="GET",
+        url=f"https://api.atlassian.com/ex/jira/{cloud_id}/rest/api/3/serverInfo",
+        provider="Atlassian", auth_hint="Check credentials.",
+        auth_kwargs={"headers": {"Authorization": f"Basic {creds}"}},
+        timeout=30.0,
+    )
+
+
+def build_router() -> MetaToolRouter:
+    router = MetaToolRouter(tool_name=GATEWAY_INFO["tool_name"])
+    router.register("user", "info", get_user_info, description="Get current user info")
+    router.register("user", "search", lookup_user, description="Search users by name/email")
+    router.register("resource", "list", get_accessible_resources, description="List accessible cloud resources")
+    router.register("server", "info", get_server_info, description="Get server info")
+    return router

--- a/mcp-tools/maos-mcp-hub/gateways/common/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/common/gateway.py
@@ -1,0 +1,12 @@
+"""Common gateway metadata."""
+
+GATEWAY_INFO = {
+    "name": "common",
+    "tool_name": "atlassian_common",
+    "display_name": "Atlassian Common — User Info & Resources",
+    "version": "1.0.0",
+    "description": (
+        "Cross-cutting Atlassian operations: user info, resource discovery. "
+        "Input: {resource?, operation?, params?}"
+    ),
+}

--- a/mcp-tools/maos-mcp-hub/gateways/compass/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/compass/__init__.py
@@ -1,0 +1,1 @@
+"""Compass gateway — 6 actions via meta-tool pattern."""

--- a/mcp-tools/maos-mcp-hub/gateways/compass/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/compass/actions.py
@@ -1,0 +1,50 @@
+"""Compass gateway actions — 6 actions across 3 resources."""
+
+from __future__ import annotations
+from typing import Optional
+from lib.compass.client import CompassClient
+from lib.gateway.router import MetaToolRouter
+from .gateway import GATEWAY_INFO
+
+_client: Optional[CompassClient] = None
+
+def get_client() -> CompassClient:
+    global _client
+    if _client is None:
+        _client = CompassClient()
+    return _client
+
+async def get_component(component_id: str) -> dict:
+    """Get component by ID."""
+    return await get_client().get_component(component_id)
+
+async def get_components(limit: int = 25) -> dict:
+    """List components."""
+    return await get_client().get_components(limit=limit)
+
+async def create_component(name: str, type_id: str, description: str = "") -> dict:
+    """Create a component."""
+    return await get_client().create_component(name, type_id, description)
+
+async def create_relationship(source_id: str, target_id: str, type_name: str = "DEPENDS_ON") -> dict:
+    """Create a relationship between components."""
+    return await get_client().create_relationship(source_id, target_id, type_name)
+
+async def get_custom_field_definitions() -> dict:
+    """List custom field definitions."""
+    return await get_client().get_custom_field_definitions()
+
+async def create_custom_field_definition(name: str, field_type: str = "TEXT") -> dict:
+    """Create a custom field definition."""
+    return await get_client().create_custom_field_definition(name, field_type)
+
+def build_router() -> MetaToolRouter:
+    """Build the Compass meta-tool router with 6 actions."""
+    router = MetaToolRouter(tool_name=GATEWAY_INFO["tool_name"])
+    router.register("component", "get", get_component, description="Get component by ID")
+    router.register("component", "list", get_components, description="List components")
+    router.register("component", "create", create_component, description="Create a component")
+    router.register("relationship", "create", create_relationship, description="Create relationship between components")
+    router.register("custom_field", "list", get_custom_field_definitions, description="List custom field definitions")
+    router.register("custom_field", "create", create_custom_field_definition, description="Create custom field definition")
+    return router

--- a/mcp-tools/maos-mcp-hub/gateways/compass/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/compass/gateway.py
@@ -1,0 +1,13 @@
+"""Compass gateway metadata."""
+
+GATEWAY_INFO = {
+    "name": "compass",
+    "tool_name": "atlassian_compass",
+    "display_name": "Compass — Service Registry & Components",
+    "version": "1.0.0",
+    "description": (
+        "Manage Compass service components, relationships, and custom fields. "
+        "Call without params for resource discovery. "
+        "Input: {resource?, operation?, params?}"
+    ),
+}

--- a/mcp-tools/maos-mcp-hub/gateways/confluence/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/confluence/__init__.py
@@ -1,0 +1,1 @@
+"""Confluence gateway — 12 actions via meta-tool pattern."""

--- a/mcp-tools/maos-mcp-hub/gateways/confluence/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/confluence/actions.py
@@ -1,0 +1,121 @@
+"""
+Confluence gateway actions — 12 actions across 4 resources.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from lib.confluence.client import ConfluenceClient
+from lib.gateway.router import MetaToolRouter
+from .gateway import GATEWAY_INFO
+
+_client: Optional[ConfluenceClient] = None
+
+
+def get_client() -> ConfluenceClient:
+    global _client
+    if _client is None:
+        _client = ConfluenceClient()
+    return _client
+
+
+# ---------------------------------------------------------------------------
+# Handlers
+# ---------------------------------------------------------------------------
+
+async def get_page(page_id: str) -> dict:
+    """Get page by ID."""
+    return await get_client().get_page(page_id)
+
+
+async def create_page(space_id: str, title: str, body: str, parent_id: str = "", status: str = "current") -> dict:
+    """Create a page in a space."""
+    return await get_client().create_page(space_id, title, body, parent_id, status)
+
+
+async def update_page(page_id: str, title: str, body: str, version_number: int, status: str = "current") -> dict:
+    """Update a page (requires current version number)."""
+    return await get_client().update_page(page_id, title, body, version_number, status)
+
+
+async def get_pages_in_space(space_id: str, limit: int = 25) -> dict:
+    """List pages in a space."""
+    return await get_client().get_pages_in_space(space_id, limit)
+
+
+async def get_page_descendants(page_id: str) -> dict:
+    """Get child pages of a page."""
+    return await get_client().get_page_descendants(page_id)
+
+
+async def get_spaces(limit: int = 25) -> dict:
+    """List available spaces."""
+    return await get_client().get_spaces(limit)
+
+
+async def get_footer_comments(page_id: str) -> dict:
+    """Get footer comments for a page."""
+    return await get_client().get_footer_comments(page_id)
+
+
+async def get_inline_comments(page_id: str) -> dict:
+    """Get inline comments for a page."""
+    return await get_client().get_inline_comments(page_id)
+
+
+async def create_footer_comment(page_id: str, body: str) -> dict:
+    """Create a footer comment on a page."""
+    return await get_client().create_footer_comment(page_id, body)
+
+
+async def create_inline_comment(page_id: str, body: str) -> dict:
+    """Create an inline comment on a page."""
+    return await get_client().create_inline_comment(page_id, body)
+
+
+async def get_comment_children(comment_id: str) -> dict:
+    """Get child comments of a comment."""
+    return await get_client().get_comment_children(comment_id)
+
+
+async def search_cql(cql: str, limit: int = 25) -> dict:
+    """Search Confluence using CQL."""
+    return await get_client().search_cql(cql, limit)
+
+
+# ---------------------------------------------------------------------------
+# Router builder
+# ---------------------------------------------------------------------------
+
+def build_router() -> MetaToolRouter:
+    """Build the Confluence meta-tool router with 12 actions."""
+    router = MetaToolRouter(
+        tool_name=GATEWAY_INFO["tool_name"],
+        governance=["Confluence operations follow documentation governance"],
+    )
+
+    # Pages
+    router.register("page", "get", get_page, description="Get page by ID")
+    router.register("page", "create", create_page, description="Create a new page",
+                    governance=["DPIA obrigatoria se dados pessoais na pagina"],
+                    next_steps=["Adicionar frontmatter conforme policy"])
+    router.register("page", "update", update_page, description="Update page content",
+                    governance=["Versao obrigatoria — usar version_number correto"])
+    router.register("page", "list_in_space", get_pages_in_space, description="List pages in a space")
+    router.register("page", "get_descendants", get_page_descendants, description="Get child pages")
+
+    # Spaces
+    router.register("space", "list", get_spaces, description="List available spaces")
+
+    # Comments
+    router.register("comment", "get_footer", get_footer_comments, description="Get footer comments")
+    router.register("comment", "get_inline", get_inline_comments, description="Get inline comments")
+    router.register("comment", "create_footer", create_footer_comment, description="Add footer comment")
+    router.register("comment", "create_inline", create_inline_comment, description="Add inline comment")
+    router.register("comment", "get_children", get_comment_children, description="Get child comments")
+
+    # Search
+    router.register("search", "cql", search_cql, description="Search using CQL")
+
+    return router

--- a/mcp-tools/maos-mcp-hub/gateways/confluence/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/confluence/gateway.py
@@ -1,0 +1,13 @@
+"""Confluence gateway metadata."""
+
+GATEWAY_INFO = {
+    "name": "confluence",
+    "tool_name": "atlassian_confluence",
+    "display_name": "Confluence Cloud — Pages, Comments, Spaces, Search",
+    "version": "1.0.0",
+    "description": (
+        "Manage Confluence pages, comments, spaces, and search. "
+        "Call without params for resource discovery. "
+        "Input: {resource?, operation?, params?}"
+    ),
+}

--- a/mcp-tools/maos-mcp-hub/gateways/discover/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/discover/__init__.py
@@ -1,0 +1,1 @@
+"""Discover gateway — macro view of all Atlassian domains."""

--- a/mcp-tools/maos-mcp-hub/gateways/discover/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/discover/actions.py
@@ -51,14 +51,19 @@ async def discover() -> Dict[str, Any]:
             mod = importlib.import_module(info["module"])
             router = mod.build_router()
             action_count = router.action_count
-        except Exception:
+            load_error = None
+        except Exception as exc:
             action_count = 0
+            load_error = str(exc)
 
-        domains[name] = {
+        entry: Dict[str, Any] = {
             "tool": info["tool"],
             "purpose": info["purpose"],
             "actions": action_count,
         }
+        if load_error:
+            entry["error"] = load_error
+        domains[name] = entry
         total_actions += action_count
 
     feedback = AgentFeedback(

--- a/mcp-tools/maos-mcp-hub/gateways/discover/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/discover/actions.py
@@ -1,0 +1,84 @@
+"""
+Discover gateway — returns macro catalog of all Atlassian domains.
+
+This is the entry point for agents that don't know which domain to use.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from lib.gateway.types import AgentFeedback
+
+# Import routers lazily to get action counts
+_DOMAIN_REGISTRY = {
+    "jira": {
+        "tool": "atlassian_jira",
+        "purpose": "Issues, boards, sprints, estimation, comments, worklogs, links, search",
+        "module": "gateways.jira.actions",
+    },
+    "confluence": {
+        "tool": "atlassian_confluence",
+        "purpose": "Pages, comments, spaces, search (CQL)",
+        "module": "gateways.confluence.actions",
+    },
+    "bitbucket": {
+        "tool": "atlassian_bitbucket",
+        "purpose": "Pipelines, pull requests, branches, deployments, tests, caches",
+        "module": "gateways.bitbucket.actions",
+    },
+    "compass": {
+        "tool": "atlassian_compass",
+        "purpose": "Service registry, components, relationships, custom fields",
+        "module": "gateways.compass.actions",
+    },
+    "common": {
+        "tool": "atlassian_common",
+        "purpose": "User info, accessible resources, server info",
+        "module": "gateways.common.actions",
+    },
+}
+
+
+async def discover() -> Dict[str, Any]:
+    """Return catalog of all available Atlassian domains."""
+    domains = {}
+    total_actions = 0
+
+    for name, info in _DOMAIN_REGISTRY.items():
+        try:
+            import importlib
+            mod = importlib.import_module(info["module"])
+            router = mod.build_router()
+            action_count = router.action_count
+        except Exception:
+            action_count = 0
+
+        domains[name] = {
+            "tool": info["tool"],
+            "purpose": info["purpose"],
+            "actions": action_count,
+        }
+        total_actions += action_count
+
+    feedback = AgentFeedback(
+        tool="atlassian_discover",
+        hints=[
+            "Para issues/boards/sprints → atlassian_jira",
+            "Para documentacao/pages → atlassian_confluence",
+            "Para PRs/pipelines/branches → atlassian_bitbucket",
+            "Para service registry → atlassian_compass",
+            "Para user info → atlassian_common",
+        ],
+        governance=[
+            "Declare governance_level antes de criar artefatos",
+            "DARCI roles recomendados para issues NORMAL+CRITICAL",
+        ],
+    )
+
+    return {
+        "domains": domains,
+        "total_actions": total_actions,
+        "total_gateways": len(domains),
+        "_agent_feedback": feedback.to_dict(),
+    }

--- a/mcp-tools/maos-mcp-hub/gateways/discover/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/discover/gateway.py
@@ -1,0 +1,14 @@
+"""Discover gateway metadata."""
+
+GATEWAY_INFO = {
+    "name": "discover",
+    "tool_name": "atlassian_discover",
+    "display_name": "Atlassian Discovery — Domain Catalog",
+    "version": "1.0.0",
+    "description": (
+        "Discover all available Atlassian domains and their capabilities. "
+        "Returns a catalog of gateways (jira, confluence, bitbucket, compass, common) "
+        "with action counts and governance hints. "
+        "No params needed — call to see what is available."
+    ),
+}

--- a/mcp-tools/maos-mcp-hub/gateways/jira/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/__init__.py
@@ -1,0 +1,1 @@
+"""Jira gateway — 23 actions via meta-tool pattern."""

--- a/mcp-tools/maos-mcp-hub/gateways/jira/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/__init__.py
@@ -1,1 +1,1 @@
-"""Jira gateway — 23 actions via meta-tool pattern."""
+"""Jira gateway — 22 actions via meta-tool pattern."""

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -1,12 +1,12 @@
 """
-Jira gateway actions — 23 actions across 8 resources.
+Jira gateway actions — 22 actions across 8 resources.
 
 Wraps existing JiraClient methods + servers/jira/tools.py functions.
 """
 
 from __future__ import annotations
 
-import math
+import base64
 from typing import Any, Dict, Optional
 
 from lib.jira.client import JiraClient
@@ -155,10 +155,16 @@ async def upload_attachment(issue_key: str, filepath: str, filename: str = "") -
 
 
 async def download_attachment(issue_key: str, filename: str) -> dict:
-    """Download an attachment by filename."""
+    """Download an attachment by filename. Returns base64-encoded content for binary safety."""
     client = get_client()
     content = await client.download_attachment_by_name(issue_key, filename)
-    return {"issue_key": issue_key, "filename": filename, "size": len(content), "encoding": "utf-8", "content": content.decode("utf-8", errors="replace")}
+    return {
+        "issue_key": issue_key,
+        "filename": filename,
+        "size": len(content),
+        "encoding": "base64",
+        "content": base64.b64encode(content).decode("ascii"),
+    }
 
 
 async def delete_attachment(attachment_id: str) -> dict:
@@ -250,15 +256,22 @@ async def estimate_story_points(issue_key: str, board_id: int, dry_run: bool = T
 # ---------------------------------------------------------------------------
 
 def _extract_text(adf: Any) -> str:
-    """Best-effort plain text extraction from ADF."""
+    """Best-effort plain text extraction from ADF (recursive)."""
     if not adf or not isinstance(adf, dict):
         return ""
-    parts = []
-    for node in adf.get("content", []):
-        for child in node.get("content", []):
-            if child.get("type") == "text":
-                parts.append(child.get("text", ""))
+    parts: list[str] = []
+    _walk_adf(adf, parts)
     return "\n".join(parts)
+
+
+def _walk_adf(node: Any, parts: list[str]) -> None:
+    """Recursively walk ADF nodes extracting text."""
+    if not isinstance(node, dict):
+        return
+    if node.get("type") == "text":
+        parts.append(node.get("text", ""))
+    for child in node.get("content", []):
+        _walk_adf(child, parts)
 
 
 # ---------------------------------------------------------------------------
@@ -266,7 +279,7 @@ def _extract_text(adf: Any) -> str:
 # ---------------------------------------------------------------------------
 
 def build_router() -> MetaToolRouter:
-    """Build the Jira meta-tool router with 23 actions."""
+    """Build the Jira meta-tool router with 22 actions."""
     router = MetaToolRouter(
         tool_name=GATEWAY_INFO["tool_name"],
         governance=["Jira operations follow DARCI-Expanded governance"],

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -61,10 +61,10 @@ async def create_issue(project_key: str, issue_type: str, summary: str, descript
     return await client.create_issue(project_key, issue_type, summary, **fields)
 
 
-async def edit_issue(issue_key: str, **fields) -> dict:
-    """Update fields on an existing issue."""
+async def edit_issue(issue_key: str, fields: dict = None) -> dict:
+    """Update fields on an existing issue. Pass a dict of field names to values."""
     client = get_client()
-    return await client.edit_issue(issue_key, **fields)
+    return await client.edit_issue(issue_key, **(fields or {}))
 
 
 async def transition_issue(issue_key: str, transition_id: str) -> dict:
@@ -261,17 +261,26 @@ def _extract_text(adf: Any) -> str:
         return ""
     parts: list[str] = []
     _walk_adf(adf, parts)
-    return "\n".join(parts)
+    return "".join(parts).strip()
 
 
 def _walk_adf(node: Any, parts: list[str]) -> None:
     """Recursively walk ADF nodes extracting text."""
     if not isinstance(node, dict):
         return
-    if node.get("type") == "text":
+    node_type = node.get("type")
+    if node_type == "text":
         parts.append(node.get("text", ""))
+    elif node_type == "hardBreak":
+        parts.append("\n")
+    elif node_type == "mention":
+        attrs = node.get("attrs", {})
+        parts.append(attrs.get("text") or attrs.get("displayName") or "")
     for child in node.get("content", []):
         _walk_adf(child, parts)
+    if node_type in ("paragraph", "heading", "blockquote", "codeBlock", "listItem", "tableRow"):
+        if not parts or parts[-1] != "\n":
+            parts.append("\n")
 
 
 # ---------------------------------------------------------------------------

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -61,10 +61,12 @@ async def create_issue(project_key: str, issue_type: str, summary: str, descript
     return await client.create_issue(project_key, issue_type, summary, **fields)
 
 
-async def edit_issue(issue_key: str, fields: dict = None) -> dict:
+async def edit_issue(issue_key: str, fields: dict) -> dict:
     """Update fields on an existing issue. Pass a dict of field names to values."""
+    if not fields:
+        return {"error": "fields must contain at least one update"}
     client = get_client()
-    return await client.edit_issue(issue_key, **(fields or {}))
+    return await client.edit_issue(issue_key, **fields)
 
 
 async def transition_issue(issue_key: str, transition_id: str) -> dict:

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -1,0 +1,322 @@
+"""
+Jira gateway actions — 23 actions across 8 resources.
+
+Wraps existing JiraClient methods + servers/jira/tools.py functions.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, Optional
+
+from lib.jira.client import JiraClient
+from lib.gateway.router import MetaToolRouter
+from .gateway import GATEWAY_INFO
+
+_client: Optional[JiraClient] = None
+
+
+def get_client() -> JiraClient:
+    global _client
+    if _client is None:
+        _client = JiraClient()
+    return _client
+
+
+# ---------------------------------------------------------------------------
+# Handlers — thin wrappers around JiraClient
+# ---------------------------------------------------------------------------
+
+async def get_issue(issue_key: str, format: str = "markdown") -> dict:
+    """Get issue details by key."""
+    client = get_client()
+    issue = await client.get_issue(issue_key)
+    fields = issue.get("fields", {})
+    return {
+        "key": issue.get("key"),
+        "id": issue.get("id"),
+        "summary": fields.get("summary"),
+        "status": fields.get("status", {}).get("name"),
+        "assignee": (fields.get("assignee") or {}).get("displayName"),
+        "reporter": (fields.get("reporter") or {}).get("displayName"),
+        "issue_type": fields.get("issuetype", {}).get("name"),
+        "priority": (fields.get("priority") or {}).get("name"),
+        "labels": fields.get("labels", []),
+        "created": fields.get("created"),
+        "updated": fields.get("updated"),
+        "description": fields.get("description") if format == "raw" else _extract_text(fields.get("description")),
+    }
+
+
+async def create_issue(project_key: str, issue_type: str, summary: str, description: str = "", labels: list = None) -> dict:
+    """Create a new issue."""
+    client = get_client()
+    fields: Dict[str, Any] = {}
+    if description:
+        fields["description"] = {"type": "doc", "version": 1, "content": [
+            {"type": "paragraph", "content": [{"type": "text", "text": description}]}
+        ]}
+    if labels:
+        fields["labels"] = labels
+    return await client.create_issue(project_key, issue_type, summary, **fields)
+
+
+async def edit_issue(issue_key: str, **fields) -> dict:
+    """Update fields on an existing issue."""
+    client = get_client()
+    return await client.edit_issue(issue_key, **fields)
+
+
+async def transition_issue(issue_key: str, transition_id: str) -> dict:
+    """Transition issue to a new workflow status."""
+    client = get_client()
+    return await client.transition_issue(issue_key, transition_id)
+
+
+async def get_transitions(issue_key: str) -> dict:
+    """List available transitions for an issue."""
+    client = get_client()
+    transitions = await client.get_transitions(issue_key)
+    return {"issue_key": issue_key, "transitions": transitions}
+
+
+async def search_jql(jql: str, max_results: int = 50, start_at: int = 0) -> dict:
+    """Search issues using JQL with pagination."""
+    client = get_client()
+    return await client.search_jql(jql, max_results, start_at)
+
+
+async def add_comment(issue_key: str, body: str) -> dict:
+    """Add a comment to an issue."""
+    client = get_client()
+    return await client.add_comment(issue_key, body)
+
+
+async def add_worklog(issue_key: str, time_spent: str, comment: str = "") -> dict:
+    """Add a worklog entry to an issue."""
+    client = get_client()
+    return await client.add_worklog(issue_key, time_spent, comment)
+
+
+async def create_issue_link(link_type: str, inward_issue: str, outward_issue: str) -> dict:
+    """Create a link between two issues."""
+    client = get_client()
+    return await client.create_issue_link(link_type, inward_issue, outward_issue)
+
+
+async def get_issue_link_types() -> dict:
+    """List available issue link types."""
+    client = get_client()
+    types = await client.get_issue_link_types()
+    return {"link_types": types}
+
+
+async def get_remote_issue_links(issue_key: str) -> dict:
+    """Get remote links for an issue."""
+    client = get_client()
+    links = await client.get_remote_issue_links(issue_key)
+    return {"issue_key": issue_key, "remote_links": links}
+
+
+async def get_visible_projects() -> dict:
+    """List all visible projects."""
+    client = get_client()
+    projects = await client.get_visible_projects()
+    return {"projects": projects}
+
+
+async def get_issue_type_metadata(project_key: str) -> dict:
+    """Get issue types and their fields for a project."""
+    client = get_client()
+    types = await client.get_issue_type_metadata(project_key)
+    return {"project_key": project_key, "issue_types": types}
+
+
+async def lookup_account_id(query: str) -> dict:
+    """Search for users by display name or email."""
+    client = get_client()
+    users = await client.lookup_account_id(query)
+    return {"query": query, "users": users}
+
+
+# --- Attachments (existing) ---
+
+async def list_attachments(issue_key: str) -> dict:
+    """List all attachments for an issue."""
+    client = get_client()
+    atts = await client.list_attachments(issue_key)
+    return {"issue_key": issue_key, "attachments": atts}
+
+
+async def upload_attachment(issue_key: str, filepath: str, filename: str = "") -> dict:
+    """Upload a file as attachment to an issue."""
+    client = get_client()
+    return await client.upload_attachment(issue_key, filepath, filename or None)
+
+
+async def download_attachment(issue_key: str, filename: str) -> dict:
+    """Download an attachment by filename."""
+    client = get_client()
+    content = await client.download_attachment_by_name(issue_key, filename)
+    return {"issue_key": issue_key, "filename": filename, "size": len(content), "encoding": "utf-8", "content": content.decode("utf-8", errors="replace")}
+
+
+async def delete_attachment(attachment_id: str) -> dict:
+    """Delete an attachment by ID."""
+    client = get_client()
+    return await client.delete_attachment(attachment_id)
+
+
+# --- Agile (existing) ---
+
+async def get_boards(project_key: str = "") -> dict:
+    """List boards, optionally filtered by project."""
+    client = get_client()
+    boards = await client.get_boards(project_key)
+    return {"boards": boards}
+
+
+async def get_estimation(issue_key: str, board_id: int) -> dict:
+    """Get story points estimation for an issue."""
+    client = get_client()
+    return await client.get_estimation(issue_key, board_id)
+
+
+async def set_estimation(issue_key: str, board_id: int, value: float) -> dict:
+    """Set story points estimation for an issue."""
+    client = get_client()
+    return await client.set_estimation(issue_key, board_id, value)
+
+
+async def estimate_story_points(issue_key: str, board_id: int, dry_run: bool = True) -> dict:
+    """Calculate story points from observable issue data using deterministic formula.
+
+    Formula: base(1) + subtask_w + attachment_w + comment_w + link_w + desc_w + label_bonus
+    × type_multiplier → Fibonacci snap {1, 2, 3, 5, 8, 13}
+    """
+    client = get_client()
+    issue = await client.get_issue(issue_key)
+    fields = issue.get("fields", {})
+
+    subtasks = len(fields.get("subtasks", []))
+    attachments = len(fields.get("attachment", []))
+    comments = fields.get("comment", {}).get("total", 0)
+    links = len(fields.get("issuelinks", []))
+    desc = fields.get("description") or {}
+    desc_len = len(str(desc))
+    labels = [l.lower() for l in fields.get("labels", [])]
+    issue_type = fields.get("issuetype", {}).get("name", "Task")
+
+    # Weights
+    base = 1
+    sub_w = 0 if subtasks == 0 else (1 if subtasks <= 3 else (2 if subtasks <= 6 else 3))
+    att_w = 0 if attachments == 0 else (0.5 if attachments <= 3 else 1)
+    com_w = 0 if comments <= 2 else (0.5 if comments <= 5 else 1)
+    lnk_w = 0 if links == 0 else (0.5 if links <= 2 else 1)
+    dsc_w = 0 if desc_len < 500 else (0.5 if desc_len <= 2000 else 1)
+    lbl_bonus = 1 if any(l in labels for l in ("complex", "security", "migration")) else 0
+
+    # Type multiplier
+    type_mult = {"Epic": 1.5, "Story": 1.0, "Task": 1.0, "Bug": 0.8, "Sub-task": 0.6}.get(issue_type, 1.0)
+
+    raw = (base + sub_w + att_w + com_w + lnk_w + dsc_w + lbl_bonus) * type_mult
+
+    # Fibonacci snap
+    fib = [1, 2, 3, 5, 8, 13]
+    sp = min(fib, key=lambda f: abs(f - raw))
+
+    result = {
+        "issue_key": issue_key,
+        "issue_type": issue_type,
+        "estimated_sp": sp,
+        "raw_score": round(raw, 2),
+        "breakdown": {
+            "base": base, "subtasks": sub_w, "attachments": att_w,
+            "comments": com_w, "links": lnk_w, "description": dsc_w,
+            "label_bonus": lbl_bonus, "type_multiplier": type_mult,
+        },
+        "applied": not dry_run,
+    }
+
+    if not dry_run:
+        await client.set_estimation(issue_key, board_id, sp)
+        result["message"] = f"Story Points set to {sp} on board {board_id}"
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _extract_text(adf: Any) -> str:
+    """Best-effort plain text extraction from ADF."""
+    if not adf or not isinstance(adf, dict):
+        return ""
+    parts = []
+    for node in adf.get("content", []):
+        for child in node.get("content", []):
+            if child.get("type") == "text":
+                parts.append(child.get("text", ""))
+    return "\n".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Router builder
+# ---------------------------------------------------------------------------
+
+def build_router() -> MetaToolRouter:
+    """Build the Jira meta-tool router with 23 actions."""
+    router = MetaToolRouter(
+        tool_name=GATEWAY_INFO["tool_name"],
+        governance=["Jira operations follow DARCI-Expanded governance"],
+    )
+
+    # Issue CRUD
+    router.register("issue", "get", get_issue, description="Get issue details by key")
+    router.register("issue", "create", create_issue, description="Create a new issue",
+                    governance=["governance_level obrigatorio", "DARCI roles recomendados"],
+                    next_steps=["Estimar story points", "Adicionar DARCI roles"])
+    router.register("issue", "edit", edit_issue, description="Update issue fields",
+                    governance=["risk_score pode mudar — reavaliar governance_level"])
+    router.register("issue", "transition", transition_issue, description="Transition issue status",
+                    next_steps=["Verificar se Story Points estao definidos"])
+    router.register("issue", "get_transitions", get_transitions, description="List available transitions")
+
+    # Search
+    router.register("search", "jql", search_jql, description="Search issues using JQL with pagination")
+
+    # Comments
+    router.register("comment", "add", add_comment, description="Add a comment to an issue")
+
+    # Worklogs
+    router.register("worklog", "add", add_worklog, description="Add worklog entry to an issue")
+
+    # Links
+    router.register("link", "create", create_issue_link, description="Create a link between two issues")
+    router.register("link", "get_types", get_issue_link_types, description="List available link types")
+    router.register("link", "get_remote", get_remote_issue_links, description="Get remote links for an issue")
+
+    # Attachments
+    router.register("attachment", "list", list_attachments, description="List attachments on an issue")
+    router.register("attachment", "upload", upload_attachment, description="Upload file as attachment")
+    router.register("attachment", "download", download_attachment, description="Download attachment by filename")
+    router.register("attachment", "delete", delete_attachment, description="Delete attachment by ID")
+
+    # Boards & Estimation
+    router.register("board", "list", get_boards, description="List boards by project")
+    router.register("estimation", "get", get_estimation, description="Get story points for issue")
+    router.register("estimation", "set", set_estimation, description="Set story points for issue")
+    router.register("estimation", "calculate", estimate_story_points,
+                    description="Calculate story points from observable data (deterministic formula)",
+                    governance=["Formula: volume signals × type_multiplier → Fibonacci snap"],
+                    next_steps=["Se dry_run=True, chame com dry_run=False para aplicar"])
+
+    # Projects & Metadata
+    router.register("project", "list", get_visible_projects, description="List visible projects")
+    router.register("project", "get_issue_types", get_issue_type_metadata, description="Get issue types for project")
+
+    # Users
+    router.register("user", "search", lookup_account_id, description="Search users by name or email")
+
+    return router

--- a/mcp-tools/maos-mcp-hub/gateways/jira/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/gateway.py
@@ -1,0 +1,14 @@
+"""Jira gateway metadata."""
+
+GATEWAY_INFO = {
+    "name": "jira",
+    "tool_name": "atlassian_jira",
+    "display_name": "Jira Cloud — Issues, Boards, Search, Estimation",
+    "version": "2.0.0",
+    "description": (
+        "Manage Jira Cloud issues, boards, sprints, comments, worklogs, "
+        "links, and story point estimation. "
+        "Call without params for resource discovery. "
+        "Input: {resource?, operation?, params?}"
+    ),
+}

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -295,13 +295,103 @@ for server_name, server_data in discovered_servers.items():
 
 
 # ============================================================================
+# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 96 actions)
+# ============================================================================
+
+sys.stderr.write("\n📋 Registering Atlassian gateways...\n\n")
+sys.stderr.flush()
+
+total_gateways_registered = 0
+total_gateway_actions = 0
+
+try:
+    from lib.gateway.types import GatewayRequest
+
+    _GATEWAY_MODULES = {
+        "discover": "gateways.discover.actions",
+        "jira": "gateways.jira.actions",
+        "confluence": "gateways.confluence.actions",
+        "bitbucket": "gateways.bitbucket.actions",
+        "compass": "gateways.compass.actions",
+        "common": "gateways.common.actions",
+    }
+
+    _GATEWAY_INFOS = {
+        "discover": "gateways.discover.gateway",
+        "jira": "gateways.jira.gateway",
+        "confluence": "gateways.confluence.gateway",
+        "bitbucket": "gateways.bitbucket.gateway",
+        "compass": "gateways.compass.gateway",
+        "common": "gateways.common.gateway",
+    }
+
+    for gw_name, actions_module_path in _GATEWAY_MODULES.items():
+        try:
+            gw_info_mod = importlib.import_module(_GATEWAY_INFOS[gw_name])
+            gw_info = getattr(gw_info_mod, "GATEWAY_INFO", {})
+            tool_name = gw_info.get("tool_name", f"atlassian_{gw_name}")
+            description = gw_info.get("description", f"Atlassian {gw_name} gateway")
+
+            if gw_name == "discover":
+                # Discover is a special case — single function, not a router
+                actions_mod = importlib.import_module(actions_module_path)
+                discover_fn = getattr(actions_mod, "discover")
+
+                @mcp.tool(name=tool_name, description=description)
+                async def atlassian_discover_tool() -> dict:
+                    """Discover all Atlassian domains and capabilities."""
+                    return await discover_fn()
+
+                total_gateways_registered += 1
+                sys.stderr.write(f"  🌐 {tool_name} (catalog)\n")
+            else:
+                # Standard gateway — build router and register dispatch handler
+                actions_mod = importlib.import_module(actions_module_path)
+                build_router_fn = getattr(actions_mod, "build_router")
+                router = build_router_fn()
+                action_count = router.action_count
+
+                def _register_gateway(r, tn, desc):
+                    @mcp.tool(name=tn, description=desc)
+                    async def gateway_handler(
+                        resource: str = "",
+                        operation: str = "",
+                        params: dict = None,
+                    ) -> dict:
+                        request = GatewayRequest(
+                            resource=resource or None,
+                            operation=operation or None,
+                            params=params,
+                        )
+                        return await r.dispatch(request)
+
+                _register_gateway(router, tool_name, description)
+                total_gateways_registered += 1
+                total_gateway_actions += action_count
+                sys.stderr.write(f"  🌐 {tool_name} ({action_count} actions)\n")
+
+        except Exception as e:
+            sys.stderr.write(f"  ❌ Failed to load gateway '{gw_name}': {e}\n")
+            import traceback
+            traceback.print_exc(file=sys.stderr)
+
+    sys.stderr.write(f"\n  ✅ {total_gateways_registered} gateways registered ({total_gateway_actions} actions)\n\n")
+    sys.stderr.flush()
+
+except Exception as e:
+    sys.stderr.write(f"\n⚠️  Gateway registration failed (flat tools still available): {e}\n\n")
+    sys.stderr.flush()
+
+
+# ============================================================================
 # HUB SUMMARY
 # ============================================================================
 
 sys.stderr.write("=" * 70 + "\n")
 sys.stderr.write(f"✅ MAOS MCP Hub Ready!\n")
-sys.stderr.write(f"   Servers: {len(discovered_servers)}\n")
-sys.stderr.write(f"   Tools: {total_tools_registered}\n")
+sys.stderr.write(f"   Flat servers: {len(discovered_servers)} ({total_tools_registered} tools)\n")
+sys.stderr.write(f"   Gateways: {total_gateways_registered} ({total_gateway_actions} actions)\n")
+sys.stderr.write(f"   Total MCP tools: {total_tools_registered + total_gateways_registered}\n")
 sys.stderr.write("=" * 70 + "\n\n")
 
 for server_name, server_data in discovered_servers.items():

--- a/mcp-tools/maos-mcp-hub/lib/compass/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/compass/__init__.py
@@ -1,0 +1,1 @@
+"""Compass Cloud API client."""

--- a/mcp-tools/maos-mcp-hub/lib/compass/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/compass/client.py
@@ -43,7 +43,7 @@ class CompassClient:
 
     async def _graphql(self, query: str, variables: Optional[Dict[str, Any]] = None) -> dict:
         """Execute a GraphQL query against Compass."""
-        return await request_json(
+        result = await request_json(
             method="POST",
             url=self.graphql_url,
             provider=self._provider_name,
@@ -53,6 +53,11 @@ class CompassClient:
             timeout=30.0,
             limiter=self.rate_limiter,
         )
+        if isinstance(result, dict) and result.get("errors"):
+            errors = result["errors"]
+            msg = "; ".join(e.get("message", str(e)) for e in errors)
+            raise ValueError(f"Compass GraphQL error: {msg}")
+        return result
 
     async def get_component(self, component_id: str) -> dict:
         """Get a Compass component by ID."""

--- a/mcp-tools/maos-mcp-hub/lib/compass/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/compass/client.py
@@ -1,0 +1,120 @@
+"""
+HTTP client for Atlassian Compass API.
+
+Compass uses a GraphQL API at https://api.atlassian.com/graphql.
+Basic Auth supported (same credentials as Jira/Confluence).
+"""
+
+import base64
+import os
+from typing import Any, Dict, Optional
+
+from aiolimiter import AsyncLimiter
+
+from lib.common.http import request_json
+
+
+class CompassClient:
+    """Async HTTP client for Atlassian Compass (GraphQL)."""
+
+    def __init__(self, cloud_id: Optional[str] = None):
+        self.email = os.getenv("JIRA_EMAIL")
+        self.api_token = (
+            os.getenv("COMPASS_API_TOKEN")
+            or os.getenv("ATLASSIAN_API_TOKEN")
+            or os.getenv("JIRA_API_TOKEN")
+        )
+        self.cloud_id = cloud_id or os.getenv("COMPASS_CLOUD_ID") or os.getenv("JIRA_CLOUD_ID")
+
+        if not self.api_token:
+            raise ValueError("Missing token for Compass.")
+        if not self.email:
+            raise ValueError("Missing JIRA_EMAIL.")
+        if not self.cloud_id:
+            raise ValueError("Missing COMPASS_CLOUD_ID or JIRA_CLOUD_ID.")
+
+        self.graphql_url = "https://api.atlassian.com/graphql"
+        self._provider_name = "Compass"
+        self._auth_hint = "Verifique credenciais Atlassian."
+        self.rate_limiter = AsyncLimiter(max_rate=300, time_period=3600)
+
+        credentials = base64.b64encode(f"{self.email}:{self.api_token}".encode()).decode()
+        self._auth_kwargs = {"headers": {"Authorization": f"Basic {credentials}"}}
+
+    async def _graphql(self, query: str, variables: Optional[Dict[str, Any]] = None) -> dict:
+        """Execute a GraphQL query against Compass."""
+        return await request_json(
+            method="POST",
+            url=self.graphql_url,
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={"query": query, "variables": variables or {}},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def get_component(self, component_id: str) -> dict:
+        """Get a Compass component by ID."""
+        query = """
+        query GetComponent($id: ID!) {
+            compass { component(id: $id) { id name type { id name } description labels ownerId } }
+        }
+        """
+        return await self._graphql(query, {"id": component_id})
+
+    async def get_components(self, cloud_id: str = "", limit: int = 25) -> dict:
+        """List Compass components."""
+        cid = cloud_id or self.cloud_id
+        query = """
+        query GetComponents($cloudId: ID!, $limit: Int) {
+            compass { components(cloudId: $cloudId, first: $limit) {
+                nodes { id name type { id name } description }
+            } }
+        }
+        """
+        return await self._graphql(query, {"cloudId": cid, "limit": limit})
+
+    async def create_component(self, name: str, type_id: str, description: str = "") -> dict:
+        """Create a Compass component."""
+        query = """
+        mutation CreateComponent($input: CreateCompassComponentInput!) {
+            compass { createComponent(input: $input) { success componentDetails { id name } } }
+        }
+        """
+        variables = {"input": {"cloudId": self.cloud_id, "name": name, "typeId": type_id}}
+        if description:
+            variables["input"]["description"] = description
+        return await self._graphql(query, variables)
+
+    async def create_relationship(self, source_id: str, target_id: str, type_name: str = "DEPENDS_ON") -> dict:
+        """Create a relationship between two components."""
+        query = """
+        mutation CreateRelationship($input: CreateCompassRelationshipInput!) {
+            compass { createRelationship(input: $input) { success } }
+        }
+        """
+        return await self._graphql(query, {"input": {
+            "sourceComponentId": source_id, "targetComponentId": target_id, "type": type_name,
+        }})
+
+    async def get_custom_field_definitions(self, cloud_id: str = "") -> dict:
+        """List custom field definitions."""
+        cid = cloud_id or self.cloud_id
+        query = """
+        query GetCustomFields($cloudId: ID!) {
+            compass { customFieldDefinitions(cloudId: $cloudId) { nodes { id name type } } }
+        }
+        """
+        return await self._graphql(query, {"cloudId": cid})
+
+    async def create_custom_field_definition(self, name: str, field_type: str = "TEXT") -> dict:
+        """Create a custom field definition."""
+        query = """
+        mutation CreateCustomField($input: CreateCompassCustomFieldDefinitionInput!) {
+            compass { createCustomFieldDefinition(input: $input) { success definition { id name } } }
+        }
+        """
+        return await self._graphql(query, {"input": {
+            "cloudId": self.cloud_id, "name": name, "type": field_type,
+        }})

--- a/mcp-tools/maos-mcp-hub/lib/confluence/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/confluence/__init__.py
@@ -1,0 +1,1 @@
+"""Confluence Cloud REST API v2 client."""

--- a/mcp-tools/maos-mcp-hub/lib/confluence/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/confluence/client.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from aiolimiter import AsyncLimiter
 
-from lib.common.http import request_empty, request_json
+from lib.common.http import request_json
 
 
 class ConfluenceClient:

--- a/mcp-tools/maos-mcp-hub/lib/confluence/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/confluence/client.py
@@ -1,0 +1,231 @@
+"""
+HTTP client for Confluence Cloud REST API v2
+
+Same pattern as JiraClient: Basic Auth, httpx async, AsyncLimiter.
+Shares JIRA_EMAIL + ATLASSIAN_API_TOKEN credentials.
+"""
+
+import base64
+import os
+from typing import Optional
+
+from aiolimiter import AsyncLimiter
+
+from lib.common.http import request_empty, request_json
+
+
+class ConfluenceClient:
+    """Async HTTP client for Confluence Cloud REST API v2."""
+
+    def __init__(self, cloud_id: Optional[str] = None):
+        self.email = os.getenv("JIRA_EMAIL")
+        self.api_token = (
+            os.getenv("CONFLUENCE_API_TOKEN")
+            or os.getenv("ATLASSIAN_API_TOKEN")
+            or os.getenv("JIRA_API_TOKEN")
+        )
+        self.cloud_id = cloud_id or os.getenv("CONFLUENCE_CLOUD_ID") or os.getenv("JIRA_CLOUD_ID")
+
+        if not self.api_token:
+            raise ValueError("Missing token. Set CONFLUENCE_API_TOKEN, ATLASSIAN_API_TOKEN, or JIRA_API_TOKEN.")
+        if not self.email:
+            raise ValueError("Missing JIRA_EMAIL (Atlassian account email).")
+        if not self.cloud_id:
+            raise ValueError("Missing CONFLUENCE_CLOUD_ID or JIRA_CLOUD_ID.")
+
+        self.base_url = f"https://api.atlassian.com/ex/confluence/{self.cloud_id}/wiki/api/v2"
+        self._provider_name = "Confluence"
+        self._auth_hint = "Verifique JIRA_EMAIL e API token (CONFLUENCE/ATLASSIAN/JIRA)."
+        self.rate_limiter = AsyncLimiter(max_rate=300, time_period=3600)
+
+        credentials = base64.b64encode(f"{self.email}:{self.api_token}".encode()).decode()
+        self._auth_kwargs = {"headers": {"Authorization": f"Basic {credentials}"}}
+
+    # ------------------------------------------------------------------
+    # Pages
+    # ------------------------------------------------------------------
+
+    async def get_page(self, page_id: str) -> dict:
+        """Get page by ID with body and version."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pages/{page_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"body-format": "storage"},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def create_page(self, space_id: str, title: str, body: str, parent_id: str = "", status: str = "current") -> dict:
+        """Create a page in a space."""
+        payload: dict = {
+            "spaceId": space_id,
+            "status": status,
+            "title": title,
+            "body": {"representation": "storage", "value": body},
+        }
+        if parent_id:
+            payload["parentId"] = parent_id
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/pages",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    async def update_page(self, page_id: str, title: str, body: str, version_number: int, status: str = "current") -> dict:
+        """Update a page (requires current version number)."""
+        return await request_json(
+            method="PUT",
+            url=f"{self.base_url}/pages/{page_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={
+                "id": page_id,
+                "status": status,
+                "title": title,
+                "body": {"representation": "storage", "value": body},
+                "version": {"number": version_number, "message": "Updated via maos-mcp-hub"},
+            },
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    async def get_pages_in_space(self, space_id: str, limit: int = 25) -> dict:
+        """List pages in a space."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/spaces/{space_id}/pages",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"limit": limit},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def get_page_descendants(self, page_id: str) -> dict:
+        """Get child pages of a page."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pages/{page_id}/children",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    # ------------------------------------------------------------------
+    # Spaces
+    # ------------------------------------------------------------------
+
+    async def get_spaces(self, limit: int = 25) -> dict:
+        """List available spaces."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/spaces",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"limit": limit},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    # ------------------------------------------------------------------
+    # Comments
+    # ------------------------------------------------------------------
+
+    async def get_footer_comments(self, page_id: str) -> dict:
+        """Get footer comments for a page."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pages/{page_id}/footer-comments",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def get_inline_comments(self, page_id: str) -> dict:
+        """Get inline comments for a page."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/pages/{page_id}/inline-comments",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    async def create_footer_comment(self, page_id: str, body: str) -> dict:
+        """Create a footer comment on a page."""
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/footer-comments",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={"pageId": page_id, "body": {"representation": "storage", "value": body}},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    async def create_inline_comment(self, page_id: str, body: str, inline_comment_properties: dict = None) -> dict:
+        """Create an inline comment on a page."""
+        payload: dict = {"pageId": page_id, "body": {"representation": "storage", "value": body}}
+        if inline_comment_properties:
+            payload["inlineCommentProperties"] = inline_comment_properties
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/inline-comments",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    async def get_comment_children(self, comment_id: str) -> dict:
+        """Get child comments of a comment."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/comments/{comment_id}/children",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    # ------------------------------------------------------------------
+    # Search
+    # ------------------------------------------------------------------
+
+    async def search_cql(self, cql: str, limit: int = 25) -> dict:
+        """Search Confluence using CQL."""
+        return await request_json(
+            method="GET",
+            url=f"https://api.atlassian.com/ex/confluence/{self.cloud_id}/wiki/rest/api/search",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"cql": cql, "limit": limit},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )

--- a/mcp-tools/maos-mcp-hub/lib/confluence/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/confluence/client.py
@@ -17,7 +17,7 @@ from lib.common.http import request_json
 class ConfluenceClient:
     """Async HTTP client for Confluence Cloud REST API v2."""
 
-    def __init__(self, cloud_id: Optional[str] = None):
+    def __init__(self, cloud_id: Optional[str] = None) -> None:
         self.email = os.getenv("JIRA_EMAIL")
         self.api_token = (
             os.getenv("CONFLUENCE_API_TOKEN")
@@ -81,7 +81,7 @@ class ConfluenceClient:
         )
 
     async def update_page(self, page_id: str, title: str, body: str, version_number: int, status: str = "current") -> dict:
-        """Update a page (requires current version number)."""
+        """Update a page (requires next version number, i.e., current + 1)."""
         return await request_json(
             method="PUT",
             url=f"{self.base_url}/pages/{page_id}",
@@ -184,7 +184,7 @@ class ConfluenceClient:
             max_retries=0,
         )
 
-    async def create_inline_comment(self, page_id: str, body: str, inline_comment_properties: dict = None) -> dict:
+    async def create_inline_comment(self, page_id: str, body: str, inline_comment_properties: Optional[dict] = None) -> dict:
         """Create an inline comment on a page."""
         payload: dict = {"pageId": page_id, "body": {"representation": "storage", "value": body}}
         if inline_comment_properties:
@@ -218,7 +218,7 @@ class ConfluenceClient:
     # ------------------------------------------------------------------
 
     async def search_cql(self, cql: str, limit: int = 25) -> dict:
-        """Search Confluence using CQL."""
+        """Search Confluence using CQL. Uses v1 REST API (v2 has no CQL search endpoint)."""
         return await request_json(
             method="GET",
             url=f"https://api.atlassian.com/ex/confluence/{self.cloud_id}/wiki/rest/api/search",

--- a/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
@@ -1,0 +1,22 @@
+"""
+Gateway framework for meta-tools pattern.
+
+Provides hierarchical tool routing with typed schemas per level
+and governance feedback injection in every response.
+"""
+
+from .types import GatewayRequest, ActionSchema, AgentFeedback
+from .router import MetaToolRouter
+from .schema_registry import SchemaRegistry
+from .feedback import with_feedback
+from .discovery import build_discovery_response
+
+__all__ = [
+    "GatewayRequest",
+    "ActionSchema",
+    "AgentFeedback",
+    "MetaToolRouter",
+    "SchemaRegistry",
+    "with_feedback",
+    "build_discovery_response",
+]

--- a/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
@@ -12,11 +12,11 @@ from .feedback import with_feedback
 from .discovery import build_discovery_response
 
 __all__ = [
-    "GatewayRequest",
     "ActionSchema",
     "AgentFeedback",
+    "GatewayRequest",
     "MetaToolRouter",
     "SchemaRegistry",
-    "with_feedback",
     "build_discovery_response",
+    "with_feedback",
 ]

--- a/mcp-tools/maos-mcp-hub/lib/gateway/discovery.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/discovery.py
@@ -1,0 +1,101 @@
+"""
+Discovery response builder for meta-tool gateways.
+
+Generates typed responses for each discovery level:
+  Level 0: list resources
+  Level 1: list operations for a resource
+  Level 2: show param schema for a resource+operation
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .schema_registry import SchemaRegistry
+from .types import AgentFeedback
+
+
+def build_discovery_response(
+    tool: str,
+    registry: SchemaRegistry,
+    resource: Optional[str] = None,
+    operation: Optional[str] = None,
+    governance: Optional[List[str]] = None,
+) -> Dict[str, Any]:
+    """Build the appropriate discovery response for the given level.
+
+    Args:
+        tool: Gateway tool name
+        registry: Schema registry for this gateway
+        resource: Resource name (None = level 0)
+        operation: Operation name (None = level 1)
+        governance: Cross-cutting governance hints
+
+    Returns:
+        dict with discovery data + _agent_feedback
+    """
+    feedback = AgentFeedback(
+        tool=tool,
+        resource=resource,
+        operation=operation,
+        governance=list(governance or []),
+    )
+
+    # Level 0: list all resources
+    if resource is None:
+        resources = registry.resources()
+        feedback.hints.append(f"Available resources: {', '.join(resources)}")
+        return {
+            "resources": resources,
+            "_agent_feedback": feedback.to_dict(),
+        }
+
+    # Validate resource exists
+    if not registry.has_resource(resource):
+        available = registry.resources()
+        feedback.hints.append(f"Unknown resource '{resource}'. Available: {', '.join(available)}")
+        return {
+            "error": f"Unknown resource: {resource}",
+            "available_resources": available,
+            "_agent_feedback": feedback.to_dict(),
+        }
+
+    # Level 1: list operations for resource
+    if operation is None:
+        operations = registry.operations(resource)
+        feedback.hints.append(f"Available operations for '{resource}': {', '.join(operations)}")
+        return {
+            "resource": resource,
+            "operations": operations,
+            "_agent_feedback": feedback.to_dict(),
+        }
+
+    # Validate operation exists
+    if not registry.has_operation(resource, operation):
+        available = registry.operations(resource)
+        feedback.hints.append(
+            f"Unknown operation '{operation}' for '{resource}'. Available: {', '.join(available)}"
+        )
+        return {
+            "error": f"Unknown operation: {operation}",
+            "resource": resource,
+            "available_operations": available,
+            "_agent_feedback": feedback.to_dict(),
+        }
+
+    # Level 2: show param schema
+    schema = registry.get_schema(resource, operation)
+    assert schema is not None  # validated above
+
+    feedback.hints.append(
+        f"Call with params to execute: resource='{resource}', operation='{operation}'"
+    )
+
+    return {
+        "resource": resource,
+        "operation": operation,
+        "description": schema.description,
+        "required": schema.required_params,
+        "optional": schema.optional_params,
+        "_agent_feedback": feedback.to_dict(),
+    }

--- a/mcp-tools/maos-mcp-hub/lib/gateway/feedback.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/feedback.py
@@ -1,0 +1,105 @@
+"""
+Feedback decorator for governance hint injection.
+
+Every gateway response (discovery or execution) gets an _agent_feedback
+block with governance rules, hints, and suggested next steps.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, Dict, List, Optional
+
+from lib.common.errors import ApiError
+from lib.common.http import sanitize_exception
+
+from .types import AgentFeedback
+
+
+def with_feedback(
+    tool: str,
+    resource: str,
+    operation: str,
+    governance: Optional[List[str]] = None,
+    next_steps: Optional[List[str]] = None,
+) -> Callable:
+    """Decorator that wraps handler responses with _agent_feedback.
+
+    Args:
+        tool: Gateway tool name (e.g., "atlassian_jira")
+        resource: Resource name (e.g., "issue")
+        operation: Operation name (e.g., "create")
+        governance: Static governance rules for this action
+        next_steps: Suggested follow-up actions
+
+    Usage::
+
+        @with_feedback("atlassian_jira", "issue", "create",
+                       governance=["governance_level obrigatorio"])
+        async def create_issue(project_key: str, ...) -> dict:
+            ...
+    """
+
+    def decorator(fn: Callable) -> Callable:
+        @functools.wraps(fn)
+        async def wrapper(**params: Any) -> Dict[str, Any]:
+            feedback = AgentFeedback(
+                tool=tool,
+                resource=resource,
+                operation=operation,
+                governance=list(governance or []),
+                next_steps=list(next_steps or []),
+            )
+
+            try:
+                result = await fn(**params)
+
+                if isinstance(result, dict) and "error" in result:
+                    _enrich_error_feedback(feedback, result)
+                    result["_agent_feedback"] = feedback.to_dict()
+                    return result
+
+                if isinstance(result, dict):
+                    result["_agent_feedback"] = feedback.to_dict()
+                    return result
+
+                return {
+                    "data": result,
+                    "_agent_feedback": feedback.to_dict(),
+                }
+
+            except ApiError as exc:
+                _enrich_error_feedback(feedback, {"error": str(exc), "status_code": exc.status_code})
+                return {
+                    "error": sanitize_exception(exc),
+                    "status_code": exc.status_code,
+                    "hint": exc.hint,
+                    "_agent_feedback": feedback.to_dict(),
+                }
+            except Exception as exc:
+                feedback.hints.append("Unexpected error — check params and retry")
+                return {
+                    "error": sanitize_exception(exc),
+                    "_agent_feedback": feedback.to_dict(),
+                }
+
+        return wrapper
+
+    return decorator
+
+
+def _enrich_error_feedback(feedback: AgentFeedback, error_dict: Dict[str, Any]) -> None:
+    """Add contextual hints based on error type."""
+    error_msg = str(error_dict.get("error", ""))
+    status = error_dict.get("status_code", 0)
+
+    if status == 401 or "unauthorized" in error_msg.lower():
+        feedback.hints.append("Check credentials (JIRA_EMAIL + API token)")
+    elif status == 403:
+        feedback.hints.append("Permission denied — check account permissions")
+    elif status == 404:
+        feedback.hints.append("Resource not found — verify ID/key")
+    elif status == 429:
+        feedback.hints.append("Rate limit — retry with backoff")
+    elif status >= 500:
+        feedback.hints.append("Server error — retry or check Atlassian status")

--- a/mcp-tools/maos-mcp-hub/lib/gateway/router.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/router.py
@@ -100,7 +100,7 @@ class MetaToolRouter:
         # Execution (level 3)
         resource = request.resource
         operation = request.operation
-        params = request.params or {}
+        params = request.params if request.params is not None else {}
 
         # Validate params is a dict
         if not isinstance(params, dict):

--- a/mcp-tools/maos-mcp-hub/lib/gateway/router.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/router.py
@@ -60,12 +60,15 @@ class MetaToolRouter:
         The handler is wrapped with @with_feedback and its schema
         is registered in the schema registry.
         """
+        # Merge gateway-wide governance with per-action governance
+        merged_governance = list(self.governance) + list(governance or [])
+
         # Wrap handler with feedback
         wrapped = with_feedback(
             tool=self.tool_name,
             resource=resource,
             operation=operation,
-            governance=governance,
+            governance=merged_governance or None,
             next_steps=next_steps,
         )(handler)
 

--- a/mcp-tools/maos-mcp-hub/lib/gateway/router.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/router.py
@@ -102,6 +102,18 @@ class MetaToolRouter:
         operation = request.operation
         params = request.params or {}
 
+        # Validate params is a dict
+        if not isinstance(params, dict):
+            return {
+                "error": "params must be a dict",
+                "resource": resource,
+                "operation": operation,
+                "_agent_feedback": {
+                    "tool": self.tool_name,
+                    "hints": ["Pass params as a JSON object, e.g. {\"key\": \"value\"}"],
+                },
+            }
+
         # Validate resource
         if resource not in self._handlers:
             available = self.registry.resources()

--- a/mcp-tools/maos-mcp-hub/lib/gateway/router.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/router.py
@@ -1,0 +1,138 @@
+"""
+Meta-tool router for gateway pattern.
+
+Routes {resource, operation, params} to the correct handler function,
+or returns discovery responses when called without full params.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional
+
+from .discovery import build_discovery_response
+from .feedback import with_feedback
+from .schema_registry import SchemaRegistry
+from .types import GatewayRequest
+
+
+class MetaToolRouter:
+    """Routes gateway requests to handler functions.
+
+    Usage::
+
+        router = MetaToolRouter("atlassian_jira")
+        router.register("issue", "get", get_issue_handler, description="Get issue by key")
+        router.register("issue", "create", create_issue_handler, ...)
+
+        # Discovery
+        result = await router.dispatch(GatewayRequest())  # level 0
+        result = await router.dispatch(GatewayRequest(resource="issue"))  # level 1
+
+        # Execution
+        result = await router.dispatch(GatewayRequest(
+            resource="issue", operation="get", params={"issue_key": "VKS-1"}
+        ))
+    """
+
+    def __init__(
+        self,
+        tool_name: str,
+        governance: Optional[List[str]] = None,
+    ) -> None:
+        self.tool_name = tool_name
+        self.governance = governance or []
+        self.registry = SchemaRegistry()
+        self._handlers: Dict[str, Dict[str, Callable]] = {}
+
+    def register(
+        self,
+        resource: str,
+        operation: str,
+        handler: Callable,
+        description: str = "",
+        governance: Optional[List[str]] = None,
+        next_steps: Optional[List[str]] = None,
+        required_params: Optional[List[str]] = None,
+        optional_params: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Register a handler for resource+operation pair.
+
+        The handler is wrapped with @with_feedback and its schema
+        is registered in the schema registry.
+        """
+        # Wrap handler with feedback
+        wrapped = with_feedback(
+            tool=self.tool_name,
+            resource=resource,
+            operation=operation,
+            governance=governance,
+            next_steps=next_steps,
+        )(handler)
+
+        self._handlers.setdefault(resource, {})[operation] = wrapped
+
+        # Register schema
+        self.registry.register(
+            resource=resource,
+            operation=operation,
+            handler=handler,  # original fn for signature introspection
+            description=description,
+            required_params=required_params,
+            optional_params=optional_params,
+        )
+
+    async def dispatch(self, request: GatewayRequest) -> Dict[str, Any]:
+        """Route request to handler or return discovery response."""
+
+        # Discovery levels 0-2
+        if request.level < 3:
+            return build_discovery_response(
+                tool=self.tool_name,
+                registry=self.registry,
+                resource=request.resource,
+                operation=request.operation,
+                governance=self.governance,
+            )
+
+        # Execution (level 3)
+        resource = request.resource
+        operation = request.operation
+        params = request.params or {}
+
+        # Validate resource
+        if resource not in self._handlers:
+            available = self.registry.resources()
+            return {
+                "error": f"Unknown resource: {resource}",
+                "available_resources": available,
+                "_agent_feedback": {
+                    "tool": self.tool_name,
+                    "hints": [f"Available resources: {', '.join(available)}"],
+                },
+            }
+
+        # Validate operation
+        if operation not in self._handlers[resource]:
+            available = self.registry.operations(resource)
+            return {
+                "error": f"Unknown operation: {operation}",
+                "resource": resource,
+                "available_operations": available,
+                "_agent_feedback": {
+                    "tool": self.tool_name,
+                    "resource": resource,
+                    "hints": [f"Available operations for '{resource}': {', '.join(available)}"],
+                },
+            }
+
+        # Dispatch to handler (already wrapped with @with_feedback)
+        handler = self._handlers[resource][operation]
+        return await handler(**params)
+
+    @property
+    def resources(self) -> List[str]:
+        return self.registry.resources()
+
+    @property
+    def action_count(self) -> int:
+        return sum(len(ops) for ops in self._handlers.values())

--- a/mcp-tools/maos-mcp-hub/lib/gateway/schema_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/schema_registry.py
@@ -74,6 +74,9 @@ def _params_from_signature(fn: Callable) -> tuple[List[str], Dict[str, str]]:
     for name, param in sig.parameters.items():
         if name in ("self", "cls"):
             continue
+        # Skip variadic params (*args, **kwargs) — they are not named inputs
+        if param.kind in (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD):
+            continue
         if param.default is inspect.Parameter.empty:
             required.append(name)
         else:

--- a/mcp-tools/maos-mcp-hub/lib/gateway/schema_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/schema_registry.py
@@ -1,0 +1,90 @@
+"""
+Schema registry for meta-tool gateways.
+
+Stores typed schemas per (resource, operation) pair and auto-generates
+parameter schemas from handler function signatures when not explicitly defined.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable, Dict, List, Optional
+
+from .types import ActionSchema
+
+
+class SchemaRegistry:
+    """Registry of action schemas for one gateway domain."""
+
+    def __init__(self) -> None:
+        self._schemas: Dict[str, Dict[str, ActionSchema]] = {}
+
+    def register(
+        self,
+        resource: str,
+        operation: str,
+        handler: Callable,
+        description: str = "",
+        required_params: Optional[List[str]] = None,
+        optional_params: Optional[Dict[str, str]] = None,
+    ) -> None:
+        """Register a schema for resource+operation.
+
+        If required_params/optional_params are not provided,
+        they are auto-generated from the handler's signature.
+        """
+        if required_params is None or optional_params is None:
+            auto_req, auto_opt = _params_from_signature(handler)
+            if required_params is None:
+                required_params = auto_req
+            if optional_params is None:
+                optional_params = auto_opt
+
+        schema = ActionSchema(
+            resource=resource,
+            operation=operation,
+            description=description or _doc_summary(handler),
+            required_params=required_params,
+            optional_params=optional_params,
+        )
+        self._schemas.setdefault(resource, {})[operation] = schema
+
+    def resources(self) -> List[str]:
+        return sorted(self._schemas.keys())
+
+    def operations(self, resource: str) -> List[str]:
+        ops = self._schemas.get(resource, {})
+        return sorted(ops.keys())
+
+    def get_schema(self, resource: str, operation: str) -> Optional[ActionSchema]:
+        return self._schemas.get(resource, {}).get(operation)
+
+    def has_resource(self, resource: str) -> bool:
+        return resource in self._schemas
+
+    def has_operation(self, resource: str, operation: str) -> bool:
+        return operation in self._schemas.get(resource, {})
+
+
+def _params_from_signature(fn: Callable) -> tuple[List[str], Dict[str, str]]:
+    """Extract required and optional params from function signature."""
+    sig = inspect.signature(fn)
+    required: List[str] = []
+    optional: Dict[str, str] = {}
+    for name, param in sig.parameters.items():
+        if name in ("self", "cls"):
+            continue
+        if param.default is inspect.Parameter.empty:
+            required.append(name)
+        else:
+            default_repr = repr(param.default) if param.default is not None else "null"
+            optional[name] = default_repr
+    return required, optional
+
+
+def _doc_summary(fn: Callable) -> str:
+    """First line of docstring, or empty."""
+    doc = getattr(fn, "__doc__", None)
+    if not doc:
+        return ""
+    return doc.strip().split("\n")[0].strip()

--- a/mcp-tools/maos-mcp-hub/lib/gateway/types.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/types.py
@@ -1,0 +1,82 @@
+"""
+Core types for the gateway framework.
+
+All meta-tools use these types for request parsing, schema definition,
+and feedback injection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class GatewayRequest:
+    """Parsed input for any meta-tool gateway.
+
+    Levels:
+        - resource=None              → level 0 discovery (list resources)
+        - resource set, operation=None → level 1 discovery (list operations)
+        - resource+operation, no params → level 2 discovery (show param schema)
+        - resource+operation+params    → execution
+    """
+
+    resource: Optional[str] = None
+    operation: Optional[str] = None
+    params: Optional[Dict[str, Any]] = None
+
+    @property
+    def level(self) -> int:
+        if self.resource is None:
+            return 0
+        if self.operation is None:
+            return 1
+        if self.params is None:
+            return 2
+        return 3  # execution
+
+    @classmethod
+    def parse(cls, raw: Dict[str, Any]) -> "GatewayRequest":
+        return cls(
+            resource=raw.get("resource") or None,
+            operation=raw.get("operation") or None,
+            params=raw.get("params"),
+        )
+
+
+@dataclass
+class ActionSchema:
+    """Schema definition for one resource+operation pair."""
+
+    resource: str
+    operation: str
+    description: str
+    required_params: List[str] = field(default_factory=list)
+    optional_params: Dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class AgentFeedback:
+    """Governance hints returned with every response."""
+
+    tool: str
+    resource: Optional[str] = None
+    operation: Optional[str] = None
+    hints: List[str] = field(default_factory=list)
+    governance: List[str] = field(default_factory=list)
+    next_steps: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d: Dict[str, Any] = {"tool": self.tool}
+        if self.resource:
+            d["resource"] = self.resource
+        if self.operation:
+            d["operation"] = self.operation
+        if self.hints:
+            d["hints"] = self.hints
+        if self.governance:
+            d["governance"] = self.governance
+        if self.next_steps:
+            d["next_steps"] = self.next_steps
+        return d

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -334,6 +334,226 @@ class JiraClient:
             max_retries=0,  # PUT is non-idempotent for estimation
         )
 
+    # ========================================================================
+    # Issues CRUD — create, edit, transition, search
+    # ========================================================================
+
+    async def create_issue(
+        self, project_key: str, issue_type: str, summary: str, **fields
+    ) -> dict:
+        """Create a new Jira issue."""
+        body = {
+            "fields": {
+                "project": {"key": project_key},
+                "issuetype": {"name": issue_type},
+                "summary": summary,
+                **fields,
+            }
+        }
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/issue",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=body,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    async def edit_issue(self, issue_key: str, **fields) -> dict:
+        """Update fields on an existing issue."""
+        status = await request_empty(
+            method="PUT",
+            url=f"{self.base_url}/issue/{issue_key}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={"fields": fields},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+        return {"status": "updated", "issue_key": issue_key, "http_status": status}
+
+    async def transition_issue(self, issue_key: str, transition_id: str) -> dict:
+        """Transition issue to a new workflow status."""
+        status = await request_empty(
+            method="POST",
+            url=f"{self.base_url}/issue/{issue_key}/transitions",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={"transition": {"id": transition_id}},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+        return {"status": "transitioned", "issue_key": issue_key, "http_status": status}
+
+    async def get_transitions(self, issue_key: str) -> list:
+        """List available transitions for an issue."""
+        result = await request_json(
+            method="GET",
+            url=f"{self.base_url}/issue/{issue_key}/transitions",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+        return result.get("transitions", [])
+
+    async def search_jql(
+        self, jql: str, max_results: int = 50, start_at: int = 0
+    ) -> dict:
+        """Search issues using JQL with pagination."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/search",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"jql": jql, "maxResults": max_results, "startAt": start_at},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    # ========================================================================
+    # Comments & Worklogs
+    # ========================================================================
+
+    async def add_comment(self, issue_key: str, body: str) -> dict:
+        """Add a comment to an issue (markdown format)."""
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/issue/{issue_key}/comment",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={"body": {"type": "doc", "version": 1, "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": body}]}
+            ]}},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    async def add_worklog(
+        self, issue_key: str, time_spent: str, comment: str = ""
+    ) -> dict:
+        """Add a worklog entry to an issue."""
+        payload: dict = {"timeSpent": time_spent}
+        if comment:
+            payload["comment"] = {"type": "doc", "version": 1, "content": [
+                {"type": "paragraph", "content": [{"type": "text", "text": comment}]}
+            ]}
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/issue/{issue_key}/worklog",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+
+    # ========================================================================
+    # Issue Links
+    # ========================================================================
+
+    async def create_issue_link(
+        self, link_type: str, inward_issue: str, outward_issue: str
+    ) -> dict:
+        """Create a link between two issues."""
+        status = await request_empty(
+            method="POST",
+            url=f"{self.base_url}/issueLink",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json={
+                "type": {"name": link_type},
+                "inwardIssue": {"key": inward_issue},
+                "outwardIssue": {"key": outward_issue},
+            },
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,
+        )
+        return {"status": "linked", "http_status": status}
+
+    async def get_issue_link_types(self) -> list:
+        """List available issue link types."""
+        result = await request_json(
+            method="GET",
+            url=f"{self.base_url}/issueLinkType",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+        return result.get("issueLinkTypes", [])
+
+    async def get_remote_issue_links(self, issue_key: str) -> list:
+        """Get remote links for an issue."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/issue/{issue_key}/remotelink",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
+    # ========================================================================
+    # Projects & Metadata
+    # ========================================================================
+
+    async def get_visible_projects(self) -> list:
+        """List all visible projects."""
+        result = await request_json(
+            method="GET",
+            url=f"{self.base_url}/project/search",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+        return result.get("values", [])
+
+    async def get_issue_type_metadata(self, project_key: str) -> list:
+        """Get issue types and their fields for a project."""
+        result = await request_json(
+            method="GET",
+            url=f"{self.base_url}/issue/createmeta/{project_key}/issuetypes",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+        return result.get("issueTypes", result.get("values", []))
+
+    async def lookup_account_id(self, query: str) -> list:
+        """Search for users by display name or email."""
+        return await request_json(
+            method="GET",
+            url=f"{self.base_url}/user/search",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params={"query": query},
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
     async def delete_attachment(self, attachment_id: str) -> dict:
         """
         Delete an attachment by ID

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_bitbucket.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_bitbucket.py
@@ -1,0 +1,164 @@
+"""Tests for Bitbucket gateway — wrapping 52 tools into meta-tool pattern."""
+
+import asyncio
+import os
+
+import pytest
+
+from gateways.bitbucket.actions import build_router, RESOURCE_MAP
+from lib.gateway.types import GatewayRequest
+from servers.bitbucket.tools import TOOLS as BB_TOOLS
+
+
+# ---------------------------------------------------------------------------
+# Coverage: all 52 tools are mapped
+# ---------------------------------------------------------------------------
+
+def test_all_bitbucket_tools_have_gateway_mapping():
+    """Every tool in BB_TOOLS must appear in RESOURCE_MAP."""
+    mapped_handlers = set()
+    for resource, operations in RESOURCE_MAP.items():
+        for operation, handler in operations.items():
+            mapped_handlers.add(id(handler))
+
+    unmapped = []
+    for tool_name, tool_func in BB_TOOLS.items():
+        if id(tool_func) not in mapped_handlers:
+            unmapped.append(tool_name)
+
+    assert unmapped == [], f"Unmapped tools: {unmapped}"
+
+
+def test_resource_map_has_52_actions():
+    """Total action count matches expected 52."""
+    total = sum(len(ops) for ops in RESOURCE_MAP.values())
+    assert total == 52, f"Expected 52 actions, got {total}"
+
+
+# ---------------------------------------------------------------------------
+# Discovery tests
+# ---------------------------------------------------------------------------
+
+def test_discovery_level0_lists_all_resources():
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        assert "resources" in result
+        resources = result["resources"]
+        assert "pipeline" in resources
+        assert "pull_request" in resources
+        assert "branch" in resources
+        assert "deployment" in resources
+        assert "commit" in resources
+        assert "test" in resources
+        assert "cache" in resources
+        assert "variable" in resources
+        assert "learning" in resources
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discovery_level1_pipeline_operations():
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="pipeline"))
+        assert "operations" in result
+        ops = result["operations"]
+        assert "list" in ops
+        assert "get" in ops
+        assert "trigger" in ops
+        assert "stop" in ops
+        assert "diagnose" in ops
+
+    asyncio.run(run())
+
+
+def test_discovery_level1_pull_request_operations():
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="pull_request"))
+        ops = result["operations"]
+        assert "create" in ops
+        assert "merge" in ops
+        assert "approve" in ops
+        assert "get_comments" in ops
+
+    asyncio.run(run())
+
+
+def test_discovery_level1_branch_operations():
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="branch"))
+        ops = result["operations"]
+        assert "create" in ops
+        assert "delete" in ops
+        assert "set_default" in ops
+        assert "get_restrictions" in ops
+
+    asyncio.run(run())
+
+
+def test_discovery_level2_shows_params():
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="branch", operation="create"))
+        assert "required" in result or "optional" in result
+        assert "description" in result
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discovery_unknown_resource():
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="nonexistent"))
+        assert "error" in result
+        assert "available_resources" in result
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Router properties
+# ---------------------------------------------------------------------------
+
+def test_router_action_count():
+    router = build_router()
+    assert router.action_count == 52
+
+
+def test_router_tool_name():
+    router = build_router()
+    assert router.tool_name == "atlassian_bitbucket"
+
+
+# ---------------------------------------------------------------------------
+# Governance feedback on critical actions
+# ---------------------------------------------------------------------------
+
+def test_pr_create_has_governance():
+    router = build_router()
+    schema = router.registry.get_schema("pull_request", "create")
+    assert schema is not None
+
+
+def test_pr_merge_has_governance():
+    router = build_router()
+    schema = router.registry.get_schema("pull_request", "merge")
+    assert schema is not None
+
+
+def test_branch_create_has_governance():
+    router = build_router()
+    schema = router.registry.get_schema("branch", "create")
+    assert schema is not None

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_confluence.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_confluence.py
@@ -1,0 +1,204 @@
+"""Tests for Confluence gateway — 12 actions via meta-tool pattern."""
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from gateways.confluence.actions import build_router
+from lib.confluence.client import ConfluenceClient
+from lib.gateway.types import GatewayRequest
+
+CLOUD_ID = "023bcd49-f455-4451-a096-c50c42c811d7"
+BASE = f"https://api.atlassian.com/ex/confluence/{CLOUD_ID}/wiki/api/v2"
+SEARCH_BASE = f"https://api.atlassian.com/ex/confluence/{CLOUD_ID}/wiki/rest/api/search"
+
+
+def _setup_env(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_CLOUD_ID", CLOUD_ID)
+    monkeypatch.setenv("JIRA_API_TOKEN", "test-token")
+    monkeypatch.delenv("CONFLUENCE_API_TOKEN", raising=False)
+    monkeypatch.delenv("CONFLUENCE_CLOUD_ID", raising=False)
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+    import gateways.confluence.actions as mod
+    mod._client = None
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def test_discovery_level0(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        assert "resources" in result
+        assert "page" in result["resources"]
+        assert "space" in result["resources"]
+        assert "comment" in result["resources"]
+        assert "search" in result["resources"]
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discovery_level1_page(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="page"))
+        ops = result["operations"]
+        assert "get" in ops
+        assert "create" in ops
+        assert "update" in ops
+        assert "list_in_space" in ops
+        assert "get_descendants" in ops
+
+    asyncio.run(run())
+
+
+def test_discovery_level2_page_create(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="page", operation="create"))
+        assert "required" in result
+        assert "space_id" in result["required"]
+        assert "title" in result["required"]
+        assert "body" in result["required"]
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — page.get
+# ---------------------------------------------------------------------------
+
+def test_execution_page_get(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(f"{BASE}/pages/12345").mock(return_value=httpx.Response(200, json={
+                "id": "12345", "title": "Test Page", "status": "current",
+                "version": {"number": 3},
+            }))
+            result = await router.dispatch(GatewayRequest(
+                resource="page", operation="get", params={"page_id": "12345"}
+            ))
+            assert result["id"] == "12345"
+            assert result["title"] == "Test Page"
+            assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — page.create
+# ---------------------------------------------------------------------------
+
+def test_execution_page_create(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.post(f"{BASE}/pages").mock(return_value=httpx.Response(200, json={
+                "id": "99999", "title": "New Page", "status": "current",
+            }))
+            result = await router.dispatch(GatewayRequest(
+                resource="page", operation="create",
+                params={"space_id": "STG", "title": "New Page", "body": "<p>Content</p>"}
+            ))
+            assert result["id"] == "99999"
+            assert "_agent_feedback" in result
+            fb = result["_agent_feedback"]
+            assert any("DPIA" in g for g in fb.get("governance", []))
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — search.cql
+# ---------------------------------------------------------------------------
+
+def test_execution_search_cql(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(SEARCH_BASE).mock(return_value=httpx.Response(200, json={
+                "results": [{"title": "Found"}], "totalSize": 1,
+            }))
+            result = await router.dispatch(GatewayRequest(
+                resource="search", operation="cql",
+                params={"cql": "type=page AND space=STG"}
+            ))
+            assert "results" in result
+            assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — space.list
+# ---------------------------------------------------------------------------
+
+def test_execution_space_list(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(f"{BASE}/spaces").mock(return_value=httpx.Response(200, json={
+                "results": [{"id": "STG", "name": "Staging"}],
+            }))
+            result = await router.dispatch(GatewayRequest(
+                resource="space", operation="list", params={}
+            ))
+            assert "results" in result
+            assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Router properties
+# ---------------------------------------------------------------------------
+
+def test_router_action_count(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+    assert router.action_count == 12
+
+
+def test_router_tool_name(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+    assert router.tool_name == "atlassian_confluence"
+
+
+# ---------------------------------------------------------------------------
+# Client — credential fallback
+# ---------------------------------------------------------------------------
+
+def test_confluence_uses_jira_cloud_id_fallback(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "token")
+    monkeypatch.setenv("JIRA_CLOUD_ID", CLOUD_ID)
+    monkeypatch.delenv("CONFLUENCE_CLOUD_ID", raising=False)
+    monkeypatch.delenv("CONFLUENCE_API_TOKEN", raising=False)
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    client = ConfluenceClient()
+    assert client.cloud_id == CLOUD_ID
+    assert "confluence" in client.base_url

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
@@ -1,0 +1,149 @@
+"""Tests for Discover gateway + Compass + Common + integration."""
+
+import asyncio
+import os
+
+import pytest
+
+from lib.gateway.types import GatewayRequest
+
+
+def _setup_env(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_CLOUD_ID", "023bcd49-f455-4451-a096-c50c42c811d7")
+    monkeypatch.setenv("JIRA_API_TOKEN", "test-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+    monkeypatch.delenv("CONFLUENCE_API_TOKEN", raising=False)
+    monkeypatch.delenv("CONFLUENCE_CLOUD_ID", raising=False)
+    monkeypatch.delenv("COMPASS_API_TOKEN", raising=False)
+    monkeypatch.delenv("COMPASS_CLOUD_ID", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Discover
+# ---------------------------------------------------------------------------
+
+def test_discover_returns_all_domains(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.discover.actions import discover
+
+    async def run():
+        result = await discover()
+        assert "domains" in result
+        assert "jira" in result["domains"]
+        assert "confluence" in result["domains"]
+        assert "bitbucket" in result["domains"]
+        assert "compass" in result["domains"]
+        assert "common" in result["domains"]
+        assert result["total_gateways"] == 5
+        assert result["total_actions"] > 0
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discover_action_counts(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.discover.actions import discover
+
+    async def run():
+        result = await discover()
+        d = result["domains"]
+        assert d["jira"]["actions"] == 22
+        assert d["confluence"]["actions"] == 12
+        assert d["bitbucket"]["actions"] == 52
+        assert d["compass"]["actions"] == 6
+        assert d["common"]["actions"] == 4
+        assert result["total_actions"] == 96
+
+    asyncio.run(run())
+
+
+def test_discover_feedback_has_hints(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.discover.actions import discover
+
+    async def run():
+        result = await discover()
+        fb = result["_agent_feedback"]
+        assert len(fb["hints"]) >= 5
+        assert any("jira" in h.lower() for h in fb["hints"])
+        assert len(fb["governance"]) >= 1
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Compass gateway
+# ---------------------------------------------------------------------------
+
+def test_compass_discovery_level0(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.compass.actions import build_router
+
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        assert "resources" in result
+        assert "component" in result["resources"]
+        assert "relationship" in result["resources"]
+        assert "custom_field" in result["resources"]
+
+    asyncio.run(run())
+
+
+def test_compass_router_action_count(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.compass.actions import build_router
+    router = build_router()
+    assert router.action_count == 6
+
+
+# ---------------------------------------------------------------------------
+# Common gateway
+# ---------------------------------------------------------------------------
+
+def test_common_discovery_level0(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.common.actions import build_router
+
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        assert "resources" in result
+        assert "user" in result["resources"]
+        assert "resource" in result["resources"]
+        assert "server" in result["resources"]
+
+    asyncio.run(run())
+
+
+def test_common_router_action_count(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.common.actions import build_router
+    router = build_router()
+    assert router.action_count == 4
+
+
+# ---------------------------------------------------------------------------
+# Cross-gateway: total action count = 96
+# ---------------------------------------------------------------------------
+
+def test_total_action_count_across_all_gateways(monkeypatch):
+    _setup_env(monkeypatch)
+    from gateways.jira.actions import build_router as jira_router
+    from gateways.confluence.actions import build_router as conf_router
+    from gateways.bitbucket.actions import build_router as bb_router
+    from gateways.compass.actions import build_router as comp_router
+    from gateways.common.actions import build_router as common_router
+
+    total = (
+        jira_router().action_count
+        + conf_router().action_count
+        + bb_router().action_count
+        + comp_router().action_count
+        + common_router().action_count
+    )
+    assert total == 96, f"Expected 96 total actions, got {total}"

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_feedback.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_feedback.py
@@ -1,0 +1,146 @@
+"""Tests for the feedback decorator — _agent_feedback injection."""
+
+import asyncio
+from typing import Any, Dict
+
+import pytest
+
+from lib.common.errors import ApiError, AuthError, NotFoundError
+from lib.gateway.feedback import with_feedback
+from lib.gateway.types import AgentFeedback
+
+
+# ---------------------------------------------------------------------------
+# Success responses
+# ---------------------------------------------------------------------------
+
+def test_feedback_on_success_dict():
+    @with_feedback("atlassian_jira", "issue", "get")
+    async def handler(issue_key: str) -> Dict[str, Any]:
+        return {"key": issue_key, "summary": "Test"}
+
+    async def run():
+        result = await handler(issue_key="VKS-1")
+        assert result["key"] == "VKS-1"
+        assert "_agent_feedback" in result
+        fb = result["_agent_feedback"]
+        assert fb["tool"] == "atlassian_jira"
+        assert fb["resource"] == "issue"
+        assert fb["operation"] == "get"
+
+    asyncio.run(run())
+
+
+def test_feedback_includes_governance():
+    @with_feedback("atlassian_jira", "issue", "create",
+                   governance=["governance_level obrigatorio"])
+    async def handler(project_key: str, summary: str) -> Dict[str, Any]:
+        return {"key": f"{project_key}-1", "summary": summary}
+
+    async def run():
+        result = await handler(project_key="VKS", summary="Test")
+        fb = result["_agent_feedback"]
+        assert "governance_level obrigatorio" in fb["governance"]
+
+    asyncio.run(run())
+
+
+def test_feedback_includes_next_steps():
+    @with_feedback("atlassian_jira", "issue", "create",
+                   next_steps=["Add DARCI roles"])
+    async def handler(project_key: str, summary: str) -> Dict[str, Any]:
+        return {"key": f"{project_key}-1"}
+
+    async def run():
+        result = await handler(project_key="VKS", summary="Test")
+        fb = result["_agent_feedback"]
+        assert "Add DARCI roles" in fb["next_steps"]
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Error responses (dict with "error" key)
+# ---------------------------------------------------------------------------
+
+def test_feedback_on_error_dict():
+    @with_feedback("atlassian_jira", "issue", "get")
+    async def handler(issue_key: str) -> Dict[str, Any]:
+        return {"error": "Not found", "status_code": 404}
+
+    async def run():
+        result = await handler(issue_key="VKS-9999")
+        assert "error" in result
+        assert "_agent_feedback" in result
+        fb = result["_agent_feedback"]
+        assert any("not found" in h.lower() for h in fb.get("hints", []))
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Exception handling
+# ---------------------------------------------------------------------------
+
+def test_feedback_catches_api_error():
+    @with_feedback("atlassian_jira", "issue", "get")
+    async def handler(issue_key: str) -> Dict[str, Any]:
+        raise AuthError(
+            message="Unauthorized",
+            status_code=401,
+            endpoint="/issue/VKS-1",
+            provider="Jira",
+            hint="Check JIRA_EMAIL",
+        )
+
+    async def run():
+        result = await handler(issue_key="VKS-1")
+        assert "error" in result
+        assert result["status_code"] == 401
+        assert "_agent_feedback" in result
+        fb = result["_agent_feedback"]
+        assert any("credentials" in h.lower() for h in fb.get("hints", []))
+
+    asyncio.run(run())
+
+
+def test_feedback_catches_unexpected_exception():
+    @with_feedback("atlassian_jira", "issue", "get")
+    async def handler(issue_key: str) -> Dict[str, Any]:
+        raise ValueError("something broke")
+
+    async def run():
+        result = await handler(issue_key="VKS-1")
+        assert "error" in result
+        assert "_agent_feedback" in result
+        fb = result["_agent_feedback"]
+        assert any("retry" in h.lower() for h in fb.get("hints", []))
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# AgentFeedback type
+# ---------------------------------------------------------------------------
+
+def test_agent_feedback_to_dict_minimal():
+    fb = AgentFeedback(tool="atlassian_jira")
+    d = fb.to_dict()
+    assert d == {"tool": "atlassian_jira"}
+
+
+def test_agent_feedback_to_dict_full():
+    fb = AgentFeedback(
+        tool="atlassian_jira",
+        resource="issue",
+        operation="create",
+        hints=["Use estimate_story_points"],
+        governance=["governance_level obrigatorio"],
+        next_steps=["Add DARCI roles"],
+    )
+    d = fb.to_dict()
+    assert d["resource"] == "issue"
+    assert d["operation"] == "create"
+    assert len(d["hints"]) == 1
+    assert len(d["governance"]) == 1
+    assert len(d["next_steps"]) == 1

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
@@ -1,0 +1,233 @@
+"""Tests for Jira gateway — 23 actions via meta-tool pattern."""
+
+import asyncio
+
+import httpx
+import pytest
+import respx
+
+from gateways.jira.actions import build_router, estimate_story_points
+from lib.gateway.types import GatewayRequest
+from lib.jira.client import JiraClient
+
+CLOUD_ID = "023bcd49-f455-4451-a096-c50c42c811d7"
+BASE = f"https://api.atlassian.com/ex/jira/{CLOUD_ID}/rest/api/3"
+AGILE = f"https://api.atlassian.com/ex/jira/{CLOUD_ID}/rest/agile/1.0"
+
+
+def _setup_env(monkeypatch):
+    monkeypatch.setenv("JIRA_EMAIL", "dev@example.com")
+    monkeypatch.setenv("JIRA_CLOUD_ID", CLOUD_ID)
+    monkeypatch.setenv("JIRA_API_TOKEN", "test-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+    # Reset singleton
+    import gateways.jira.actions as mod
+    mod._client = None
+
+
+# ---------------------------------------------------------------------------
+# Discovery
+# ---------------------------------------------------------------------------
+
+def test_discovery_level0_lists_resources(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        assert "resources" in result
+        resources = result["resources"]
+        assert "issue" in resources
+        assert "search" in resources
+        assert "comment" in resources
+        assert "estimation" in resources
+        assert "project" in resources
+        assert "user" in resources
+
+    asyncio.run(run())
+
+
+def test_discovery_level1_issue_operations(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="issue"))
+        ops = result["operations"]
+        assert "get" in ops
+        assert "create" in ops
+        assert "edit" in ops
+        assert "transition" in ops
+        assert "get_transitions" in ops
+
+    asyncio.run(run())
+
+
+def test_discovery_level2_issue_create_schema(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="issue", operation="create"))
+        assert "required" in result
+        assert "project_key" in result["required"]
+        assert "issue_type" in result["required"]
+        assert "summary" in result["required"]
+        assert "optional" in result
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — issue.get
+# ---------------------------------------------------------------------------
+
+def test_execution_issue_get(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(f"{BASE}/issue/VKS-1234").mock(return_value=httpx.Response(200, json={
+                "key": "VKS-1234", "id": "12345",
+                "fields": {
+                    "summary": "Test issue", "status": {"name": "TO DO"},
+                    "assignee": {"displayName": "Dev"}, "reporter": {"displayName": "PM"},
+                    "issuetype": {"name": "Task"}, "priority": {"name": "Alta"},
+                    "labels": [], "created": "2026-04-08", "updated": "2026-04-08",
+                    "description": None,
+                }
+            }))
+
+            result = await router.dispatch(GatewayRequest(
+                resource="issue", operation="get", params={"issue_key": "VKS-1234"}
+            ))
+            assert result["key"] == "VKS-1234"
+            assert result["status"] == "TO DO"
+            assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — issue.create
+# ---------------------------------------------------------------------------
+
+def test_execution_issue_create(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.post(f"{BASE}/issue").mock(return_value=httpx.Response(201, json={
+                "id": "99", "key": "VKS-999", "self": "..."
+            }))
+
+            result = await router.dispatch(GatewayRequest(
+                resource="issue", operation="create",
+                params={"project_key": "VKS", "issue_type": "Task", "summary": "Test"}
+            ))
+            assert result["key"] == "VKS-999"
+            assert "_agent_feedback" in result
+            fb = result["_agent_feedback"]
+            assert "governance_level obrigatorio" in fb.get("governance", [])
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — search.jql
+# ---------------------------------------------------------------------------
+
+def test_execution_search_jql(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(f"{BASE}/search").mock(return_value=httpx.Response(200, json={
+                "issues": [{"key": "VKS-1"}], "total": 1, "startAt": 0, "maxResults": 50,
+            }))
+
+            result = await router.dispatch(GatewayRequest(
+                resource="search", operation="jql",
+                params={"jql": "project = VKS", "max_results": 50, "start_at": 0}
+            ))
+            assert "issues" in result
+            assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Execution — estimation.calculate (estimate_story_points)
+# ---------------------------------------------------------------------------
+
+def test_estimate_story_points_dry_run(monkeypatch):
+    _setup_env(monkeypatch)
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(f"{BASE}/issue/VKS-100").mock(return_value=httpx.Response(200, json={
+                "key": "VKS-100",
+                "fields": {
+                    "subtasks": [{"id": "1"}, {"id": "2"}],
+                    "attachment": [],
+                    "comment": {"total": 3},
+                    "issuelinks": [{"id": "1"}],
+                    "description": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Short desc"}]}]},
+                    "labels": [],
+                    "issuetype": {"name": "Task"},
+                }
+            }))
+
+            result = await estimate_story_points(issue_key="VKS-100", board_id=59, dry_run=True)
+            assert "estimated_sp" in result
+            assert result["estimated_sp"] in [1, 2, 3, 5, 8, 13]
+            assert result["applied"] is False
+            assert "breakdown" in result
+
+    asyncio.run(run())
+
+
+def test_estimate_story_points_complex_issue(monkeypatch):
+    _setup_env(monkeypatch)
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.get(f"{BASE}/issue/VKS-200").mock(return_value=httpx.Response(200, json={
+                "key": "VKS-200",
+                "fields": {
+                    "subtasks": [{"id": str(i)} for i in range(8)],  # 8 subtasks = +3
+                    "attachment": [{"id": "1"}, {"id": "2"}, {"id": "3"}, {"id": "4"}, {"id": "5"}],  # 5 = +1
+                    "comment": {"total": 10},  # 10 = +1
+                    "issuelinks": [{"id": "1"}, {"id": "2"}, {"id": "3"}, {"id": "4"}],  # 4 = +1
+                    "description": {"type": "doc", "content": [{"type": "paragraph", "content": [{"type": "text", "text": "x" * 3000}]}]},  # >2000 = +1
+                    "labels": ["security"],  # bonus +1
+                    "issuetype": {"name": "Epic"},  # ×1.5
+                }
+            }))
+
+            result = await estimate_story_points(issue_key="VKS-200", board_id=59, dry_run=True)
+            # base(1) + sub(3) + att(1) + com(1) + link(1) + desc(1) + label(1) = 9 × 1.5 = 13.5 → snap to 13
+            assert result["estimated_sp"] == 13
+            assert result["raw_score"] == 13.5
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Router properties
+# ---------------------------------------------------------------------------
+
+def test_jira_router_action_count(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+    assert router.action_count == 22
+
+
+def test_jira_router_tool_name(monkeypatch):
+    _setup_env(monkeypatch)
+    router = build_router()
+    assert router.tool_name == "atlassian_jira"

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
@@ -1,4 +1,4 @@
-"""Tests for Jira gateway — 23 actions via meta-tool pattern."""
+"""Tests for Jira gateway — 22 actions via meta-tool pattern."""
 
 import asyncio
 

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_router.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_router.py
@@ -1,0 +1,253 @@
+"""Tests for the gateway router — dispatch and discovery at all levels."""
+
+import asyncio
+from typing import Any, Dict
+
+import pytest
+
+from lib.gateway.router import MetaToolRouter
+from lib.gateway.types import GatewayRequest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _mock_get_issue(issue_key: str, format: str = "markdown") -> Dict[str, Any]:
+    """Mock handler for issue.get."""
+    return {"key": issue_key, "summary": "Test issue", "format": format}
+
+
+async def _mock_create_issue(project_key: str, summary: str, issue_type: str = "Task") -> Dict[str, Any]:
+    """Mock handler for issue.create."""
+    return {"key": f"{project_key}-999", "summary": summary, "type": issue_type}
+
+
+async def _mock_list_boards(project_key: str = "") -> Dict[str, Any]:
+    """Mock handler for board.list."""
+    return {"boards": [{"id": 59, "name": "VKS Dev"}]}
+
+
+def _build_router() -> MetaToolRouter:
+    """Build a test router with sample handlers."""
+    router = MetaToolRouter(
+        tool_name="atlassian_jira",
+        governance=["governance_level obrigatorio ao criar issues"],
+    )
+    router.register("issue", "get", _mock_get_issue, description="Get issue by key")
+    router.register(
+        "issue",
+        "create",
+        _mock_create_issue,
+        description="Create a new issue",
+        governance=["governance_level obrigatorio"],
+        next_steps=["Add DARCI roles after creating"],
+    )
+    router.register("board", "list", _mock_list_boards, description="List boards")
+    return router
+
+
+# ---------------------------------------------------------------------------
+# Level 0 — Discovery: list resources
+# ---------------------------------------------------------------------------
+
+def test_discovery_level0_lists_resources():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        assert "resources" in result
+        assert "issue" in result["resources"]
+        assert "board" in result["resources"]
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discovery_level0_includes_feedback():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest())
+        fb = result["_agent_feedback"]
+        assert fb["tool"] == "atlassian_jira"
+        assert len(fb.get("governance", [])) > 0
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Level 1 — Discovery: list operations for resource
+# ---------------------------------------------------------------------------
+
+def test_discovery_level1_lists_operations():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="issue"))
+        assert "operations" in result
+        assert "get" in result["operations"]
+        assert "create" in result["operations"]
+        assert result["resource"] == "issue"
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discovery_level1_unknown_resource():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="nonexistent"))
+        assert "error" in result
+        assert "available_resources" in result
+        assert "issue" in result["available_resources"]
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Level 2 — Discovery: show param schema
+# ---------------------------------------------------------------------------
+
+def test_discovery_level2_shows_schema():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="issue", operation="get"))
+        assert "required" in result
+        assert "issue_key" in result["required"]
+        assert "optional" in result
+        assert "format" in result["optional"]
+        assert result["description"] == "Get issue by key"
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_discovery_level2_unknown_operation():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(resource="issue", operation="delete"))
+        assert "error" in result
+        assert "available_operations" in result
+        assert "get" in result["available_operations"]
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Level 3 — Execution
+# ---------------------------------------------------------------------------
+
+def test_execution_get_issue():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(
+            resource="issue", operation="get", params={"issue_key": "VKS-1234"}
+        ))
+        assert result["key"] == "VKS-1234"
+        assert result["summary"] == "Test issue"
+        assert "_agent_feedback" in result
+        assert result["_agent_feedback"]["tool"] == "atlassian_jira"
+        assert result["_agent_feedback"]["resource"] == "issue"
+        assert result["_agent_feedback"]["operation"] == "get"
+
+    asyncio.run(run())
+
+
+def test_execution_create_issue_with_feedback():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(
+            resource="issue",
+            operation="create",
+            params={"project_key": "VKS", "summary": "Test"},
+        ))
+        assert result["key"] == "VKS-999"
+        fb = result["_agent_feedback"]
+        assert "governance_level obrigatorio" in fb.get("governance", [])
+        assert "Add DARCI roles after creating" in fb.get("next_steps", [])
+
+    asyncio.run(run())
+
+
+def test_execution_unknown_resource():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(
+            resource="unknown", operation="get", params={"id": "1"}
+        ))
+        assert "error" in result
+        assert "available_resources" in result
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_execution_unknown_operation():
+    router = _build_router()
+
+    async def run():
+        result = await router.dispatch(GatewayRequest(
+            resource="issue", operation="destroy", params={"id": "1"}
+        ))
+        assert "error" in result
+        assert "available_operations" in result
+        assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Router properties
+# ---------------------------------------------------------------------------
+
+def test_router_resources():
+    router = _build_router()
+    assert "board" in router.resources
+    assert "issue" in router.resources
+
+
+def test_router_action_count():
+    router = _build_router()
+    assert router.action_count == 3  # get, create, list
+
+
+# ---------------------------------------------------------------------------
+# GatewayRequest parsing
+# ---------------------------------------------------------------------------
+
+def test_request_parse_empty():
+    req = GatewayRequest.parse({})
+    assert req.level == 0
+    assert req.resource is None
+
+
+def test_request_parse_resource_only():
+    req = GatewayRequest.parse({"resource": "issue"})
+    assert req.level == 1
+    assert req.resource == "issue"
+    assert req.operation is None
+
+
+def test_request_parse_full():
+    req = GatewayRequest.parse({
+        "resource": "issue",
+        "operation": "get",
+        "params": {"issue_key": "VKS-1"},
+    })
+    assert req.level == 3
+    assert req.params == {"issue_key": "VKS-1"}
+
+
+def test_request_parse_empty_strings_treated_as_none():
+    req = GatewayRequest.parse({"resource": "", "operation": ""})
+    assert req.level == 0
+    assert req.resource is None


### PR DESCRIPTION
The `test_gateway_jira.py` module docstring claimed 23 actions while `test_jira_router_action_count` asserted `router.action_count == 22` — a stale inconsistency left over from an earlier count fix applied to `gateways/jira/actions.py` but missed in the test file.

- **`tests/test_gateway_jira.py`**: Updated module docstring from `"23 actions"` → `"22 actions"` to match the router registration and the existing test assertion.