### PR TITLE
ci: upgrade actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ai-governance-linter.yml
+++ b/.github/workflows/ai-governance-linter.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checar Padrão de Nomenclatura do PR (C07)
-        uses: amannn/action-semantic-pull-request@v5
+        uses: amannn/action-semantic-pull-request@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -42,7 +42,7 @@ jobs:
           fi
 
       - name: Acionar Linter de Segurança (PII) Local
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - run: |
           echo "Executando Linter SRE Local..."
           # Aqui poderíamos acoplar o script linter_pii.py que está no repo


### PR DESCRIPTION
## Summary

- `actions/checkout@v3` → `@v4` — removes Node.js 20 deprecation warning
- `amannn/action-semantic-pull-request@v5` → `@v6` — latest release with Node.js 24 support

## Context

CI warning surfaced on PR #31:
> Node.js 20 actions are deprecated. Node.js 20 will be removed from runners on 2026-09-16.

`version-sync.yml` already uses `actions/checkout@v4` — only `ai-governance-linter.yml` was outdated.

## Test plan

- [ ] CI pipeline runs without Node.js 20 deprecation warning
- [ ] `governance-validation` job still passes (PR title + Co-Authored-By checks work)
- [ ] Semantic PR check still enforces conventional commit types on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>