### PR TITLE
chore(maos-mcp-hub): gate flat-tools behind MAOS_EXPOSE_FLAT_TOOLS flag [VKS-1694]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### maos-mcp-hub — VKS-1694 Flat-Tools Residue Cleanup (Phase 1)
+- `hub.py` — Flat-tool registration loop (60 `bitbucket_*` + `jira_*` tools) now gated behind `MAOS_EXPOSE_FLAT_TOOLS` env var (default: `false`)
+- `.env.example` — Documented `MAOS_EXPOSE_FLAT_TOOLS` rollback flag
+- `README.md` — Added "Migration: Flat → Gateway" section with full mapping table (60 tools → 6 `atlassian_*` gateways); marked flat namespace as deprecated
+- `CLAUDE.md` (root) — Updated "MCP Tools" section to reflect deprecated flat namespace
+- `plugin-scripts/governance/lib/json-rpc.sh` — Updated PR workflow descriptive strings to reference `atlassian_bitbucket` meta-tool
+
+#### Impact
+- **Tool count**: 66 → 6 (-91%) with `MAOS_EXPOSE_FLAT_TOOLS=false` (default)
+- **Capability preserved**: 6 `atlassian_*` gateways expose 96 operations (vs. 60 via flat)
+- **Rollback**: single env-var flip (`MAOS_EXPOSE_FLAT_TOOLS=true`)
+- **Handlers preserved**: `servers/{bitbucket,jira}/tools.py` unchanged — gateways import them directly
+
+#### Phase 2 (planned — v1.7)
+- Remove flat-tool registration loop from `hub.py` entirely
+- Remove `servers/{bitbucket,jira}/server.py` (auto-discovery entry points)
+- Keep `servers/{bitbucket,jira}/tools.py` (gateway dependency)
+
 ## [1.5.0] - 2026-04-10
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,11 +233,11 @@ See `docs/framework-consumption.md` for full guidance.
 
 ## MCP Tools: MAOS MCP Hub
 
-The `mcp-tools/maos-mcp-hub/` directory contains a universal MCP gateway with two tool namespaces:
+The `mcp-tools/maos-mcp-hub/` directory contains a universal MCP gateway exposing Atlassian services through typed meta-tool gateways.
 
-### Flat Namespace (Legacy)
+### Flat Namespace (Deprecated — hidden by default since v1.6)
 
-52 `bitbucket_*` tools and `jira_*` tools exposed as individual MCP tools. Still functional and registered at startup.
+52 `bitbucket_*` tools and 8 `jira_*` tools (60 total) are **hidden by default** via the `MAOS_EXPOSE_FLAT_TOOLS=false` env var (VKS-1694 cleanup). Temporary rollback: `MAOS_EXPOSE_FLAT_TOOLS=true python hub.py`. Handlers remain in `servers/{bitbucket,jira}/tools.py` — the gateway imports them directly. Full mapping table in `mcp-tools/maos-mcp-hub/README.md` → "Migration: Flat → Gateway".
 
 ### Meta-Tools Gateway (Preferred)
 

--- a/mcp-tools/maos-mcp-hub/.env.example
+++ b/mcp-tools/maos-mcp-hub/.env.example
@@ -86,3 +86,19 @@ JIRA_CLOUD_ID=your-cloud-id-uuid
 # BITBUCKET_ACCOUNT_JOHN_DOE_USERNAME=john.doe@company.com
 # BITBUCKET_ACCOUNT_JOHN_DOE_APP_PASSWORD=your_app_password_here
 # BITBUCKET_ACCOUNT_JOHN_DOE_AUTH_TYPE=basic
+
+# ============================================================================
+# Legacy Flat-Tools Exposure (VKS-1694 deprecation)
+# ============================================================================
+# Meta-Tools Gateway (atlassian_*) supersedes the flat bitbucket_* / jira_*
+# namespace. Flat tools are HIDDEN by default to reduce MCP tool count from
+# ~66 to 6 (respecting Gemini/Windsurf 100-tool and ChatGPT ~30-tool limits).
+#
+# Set to "true" ONLY as a temporary rollback if a consumer still depends on
+# flat tool names. Prefer migrating consumers to:
+#   atlassian_jira({resource: "...", operation: "...", params: {...}})
+#   atlassian_bitbucket({resource: "...", operation: "...", params: {...}})
+#
+# See README.md section "Migration: Flat → Gateway" for full mapping.
+
+MAOS_EXPOSE_FLAT_TOOLS=false

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -167,6 +167,23 @@ pytest -q tests/test_bitbucket_client.py tests/test_jira_client.py
 
 ## Available Tools (Bitbucket Server)
 
+> ⚠️ **DEPRECATED — Flat namespace** (VKS-1694 cleanup in progress)
+>
+> The `bitbucket_*` and `jira_*` flat tools below are **hidden by default**
+> since v1.6 via the `MAOS_EXPOSE_FLAT_TOOLS=false` environment variable.
+> Prefer the [Meta-Tools Gateway](#meta-tools-gateway-atlassian) pattern:
+>
+> ```text
+> bitbucket_get_recent_builds          → atlassian_bitbucket({resource:"pipeline", operation:"list"})
+> bitbucket_get_pull_requests          → atlassian_bitbucket({resource:"pull_request", operation:"list"})
+> bitbucket_create_pull_request        → atlassian_bitbucket({resource:"pull_request", operation:"create"})
+> jira_get_issue                       → atlassian_jira({resource:"issue", operation:"get"})
+> jira_list_attachments                → atlassian_jira({resource:"attachment", operation:"list"})
+> ```
+>
+> See section [Migration: Flat → Gateway](#migration-flat--gateway) for the
+> complete mapping and rollback instructions.
+
 ### Core Pipeline Tools
 | Tool | Description |
 |------|-------------|
@@ -391,6 +408,89 @@ gateways/jira/actions.py
 2. Create `gateways/<domain>/actions.py` with handler functions and a `build_router()` that returns a `MetaToolRouter`.
 3. Register in `gateways/discover/actions.py` `_DOMAIN_REGISTRY`.
 4. Register the gateway in `hub.py` by adding it to the `_GATEWAY_MODULES` and `_GATEWAY_INFOS` dicts. Gateways are not auto-discovered; they require explicit registration.
+
+---
+
+## Migration: Flat → Gateway
+
+**Context** (VKS-1694): The legacy flat namespace (`bitbucket_*` + `jira_*` =
+60 tools) was replaced by 6 typed meta-tool gateways. Flat tools are now
+**hidden by default** to keep the hub under the 100-tool provider limits
+(Gemini, Windsurf) and the ~30-tool ChatGPT threshold.
+
+### Default behavior (since v1.6)
+
+```bash
+# Default: flat tools hidden, only 6 atlassian_* gateways exposed
+python hub.py
+# → "✅ Flat tools hidden (60 tools). Use atlassian_* gateways."
+```
+
+### Temporary rollback (not recommended)
+
+```bash
+# Re-expose the 60 legacy flat tools (same behavior as pre-VKS-1694)
+MAOS_EXPOSE_FLAT_TOOLS=true python hub.py
+# → "⚠️  MAOS_EXPOSE_FLAT_TOOLS=true — registering deprecated flat tools"
+```
+
+Use only if an MCP client still hard-codes `bitbucket_*` / `jira_*` tool
+names. The rollback path is single env-var flip and zero code changes.
+
+### Mapping table
+
+| Old flat tool | New gateway call |
+|---|---|
+| `bitbucket_get_recent_builds` | `atlassian_bitbucket({resource:"pipeline", operation:"list"})` |
+| `bitbucket_get_build_details` | `atlassian_bitbucket({resource:"pipeline", operation:"get"})` |
+| `bitbucket_get_build_steps` | `atlassian_bitbucket({resource:"pipeline", operation:"get_steps"})` |
+| `bitbucket_get_step_logs` | `atlassian_bitbucket({resource:"pipeline", operation:"get_logs"})` |
+| `bitbucket_trigger_pipeline` | `atlassian_bitbucket({resource:"pipeline", operation:"trigger"})` |
+| `bitbucket_stop_pipeline` | `atlassian_bitbucket({resource:"pipeline", operation:"stop"})` |
+| `bitbucket_check_pipeline_health` | `atlassian_bitbucket({resource:"pipeline", operation:"get_health"})` |
+| `bitbucket_check_alerts` | `atlassian_bitbucket({resource:"pipeline", operation:"get_alerts"})` |
+| `bitbucket_auto_diagnose` | `atlassian_bitbucket({resource:"pipeline", operation:"auto_diagnose"})` |
+| `bitbucket_get_pull_requests` | `atlassian_bitbucket({resource:"pull_request", operation:"list"})` |
+| `bitbucket_get_pr_details` | `atlassian_bitbucket({resource:"pull_request", operation:"get"})` |
+| `bitbucket_create_pull_request` | `atlassian_bitbucket({resource:"pull_request", operation:"create"})` |
+| `bitbucket_merge_pull_request` | `atlassian_bitbucket({resource:"pull_request", operation:"merge"})` |
+| `bitbucket_approve_pull_request` | `atlassian_bitbucket({resource:"pull_request", operation:"approve"})` |
+| `bitbucket_list_branches` | `atlassian_bitbucket({resource:"branch", operation:"list"})` |
+| `bitbucket_create_branch` | `atlassian_bitbucket({resource:"branch", operation:"create"})` |
+| `bitbucket_delete_branch` | `atlassian_bitbucket({resource:"branch", operation:"delete"})` |
+| `bitbucket_set_default_branch` | `atlassian_bitbucket({resource:"branch", operation:"set_default"})` |
+| `bitbucket_get_recent_deployments` | `atlassian_bitbucket({resource:"deployment", operation:"list"})` |
+| `bitbucket_get_test_reports` | `atlassian_bitbucket({resource:"test", operation:"get_reports"})` |
+| `bitbucket_list_caches` | `atlassian_bitbucket({resource:"cache", operation:"list"})` |
+| `bitbucket_clear_cache` | `atlassian_bitbucket({resource:"cache", operation:"clear"})` |
+| `jira_get_issue` | `atlassian_jira({resource:"issue", operation:"get"})` |
+| `jira_list_attachments` | `atlassian_jira({resource:"attachment", operation:"list"})` |
+| `jira_upload_attachment` | `atlassian_jira({resource:"attachment", operation:"upload"})` |
+| `jira_download_attachment` | `atlassian_jira({resource:"attachment", operation:"download"})` |
+| `jira_delete_attachment` | `atlassian_jira({resource:"attachment", operation:"delete"})` |
+| `jira_get_boards` | `atlassian_jira({resource:"board", operation:"list"})` |
+| `jira_get_estimation` | `atlassian_jira({resource:"estimation", operation:"get"})` |
+| `jira_set_estimation` | `atlassian_jira({resource:"estimation", operation:"set"})` |
+
+(Full 60-tool mapping available via `atlassian_discover` — call with no params
+to list resources, or see `gateways/<domain>/actions.py:RESOURCE_MAP`.)
+
+### Why the change
+
+| Metric | Before | After (default) | Δ |
+|---|---:|---:|---:|
+| Tools registered by hub | 66 | 6 | **-91%** |
+| Schema token footprint | baseline | ~1/10 | **-90%** |
+| Functional capability | 60 operations | 96 operations (via 6 gateways) | **+60%** |
+
+Gateways **add** 36 new operations (Jira transition, search.jql, comments,
+worklogs, links, etc.) that were never exposed via flat tools.
+
+### Roadmap
+
+- ✅ v1.6 — feature flag `MAOS_EXPOSE_FLAT_TOOLS` (hide by default)
+- ⏳ v1.7 — **remove** flat-tool registration loop from `hub.py`
+  (handlers in `servers/{bitbucket,jira}/tools.py` remain — gateways depend on them)
 
 ---
 

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -79,6 +79,7 @@ Example queries in Claude:
     → Calls gitlab.get_failed_pipelines
 """
 
+import os
 import sys
 import importlib.util
 from pathlib import Path
@@ -268,29 +269,44 @@ if not discovered_servers:
 
 total_tools_registered = 0
 
-sys.stderr.write("\n📋 Registering tools...\n\n")
-sys.stderr.flush()
+# Legacy flat-tool registration (deprecated — VKS-1694 Meta-Tools Gateway supersedes).
+# Controlled by MAOS_EXPOSE_FLAT_TOOLS env var (default: "false").
+# Set to "true" only for backwards-compat rollback; prefer atlassian_* gateways.
+# See README.md "Migration: Flat → Gateway" section.
+_expose_flat = os.getenv("MAOS_EXPOSE_FLAT_TOOLS", "false").strip().lower() == "true"
 
-for server_name, server_data in discovered_servers.items():
-    server_info = server_data['info']
-    tools = server_data['tools']
-
-    sys.stderr.write(f"  📦 {server_name} ({server_info.get('display_name', server_name)})\n")
+if _expose_flat:
+    sys.stderr.write("\n⚠️  MAOS_EXPOSE_FLAT_TOOLS=true — registering deprecated flat tools\n")
+    sys.stderr.write("    (Prefer atlassian_* meta-tool gateways. See README 'Migration' section.)\n\n")
     sys.stderr.flush()
 
-    for tool_name, tool_func in tools.items():
-        # Create namespaced tool name
-        namespaced_name = f"{server_name}_{tool_name}"
+    for server_name, server_data in discovered_servers.items():
+        server_info = server_data['info']
+        tools = server_data['tools']
 
-        # Register tool with FastMCP
-        # We use the original function and let FastMCP decorator handle it
-        mcp.tool(name=namespaced_name)(tool_func)
-
-        total_tools_registered += 1
-        sys.stderr.write(f"     ✅ {namespaced_name}\n")
+        sys.stderr.write(f"  📦 {server_name} ({server_info.get('display_name', server_name)})\n")
         sys.stderr.flush()
 
-    sys.stderr.write("\n")
+        for tool_name, tool_func in tools.items():
+            # Create namespaced tool name
+            namespaced_name = f"{server_name}_{tool_name}"
+
+            # Register tool with FastMCP
+            # We use the original function and let FastMCP decorator handle it
+            mcp.tool(name=namespaced_name)(tool_func)
+
+            total_tools_registered += 1
+            sys.stderr.write(f"     ✅ {namespaced_name}\n")
+            sys.stderr.flush()
+
+        sys.stderr.write("\n")
+        sys.stderr.flush()
+else:
+    flat_count = sum(len(s['tools']) for s in discovered_servers.values())
+    sys.stderr.write(
+        f"\n✅ Flat tools hidden ({flat_count} tools). "
+        f"Use atlassian_* gateways (set MAOS_EXPOSE_FLAT_TOOLS=true to restore).\n\n"
+    )
     sys.stderr.flush()
 
 

--- a/plugin-scripts/governance/lib/json-rpc.sh
+++ b/plugin-scripts/governance/lib/json-rpc.sh
@@ -113,9 +113,9 @@ error_commit_blocked() {
             post_comment_cmd="gh pr comment${gh_flag} <number> --body \"<message>\""
             ;;
         bitbucket)
-            create_pr_cmd='MCP bitbucket_create_pull_request (or BB REST API)'
-            view_comments_cmd='MCP bitbucket_get_pr_details or bitbucket_get_pull_requests'
-            post_comment_cmd='MCP or BB REST API to post a PR comment'
+            create_pr_cmd='MCP atlassian_bitbucket({resource:"pull_request", operation:"create", params:{...}}) (or BB REST API)'
+            view_comments_cmd='MCP atlassian_bitbucket({resource:"pull_request", operation:"get" | "get_comments"}) (or BB REST API)'
+            post_comment_cmd='MCP atlassian_bitbucket or BB REST API to post a PR comment'
             ;;
         gitlab)
             create_pr_cmd="glab mr create${glab_flag} --title \"<title>\" --description \"<body>\""


### PR DESCRIPTION
## Contexto

Residue cleanup from the VKS-1694 Meta-Tools Gateway rollout. The ai-agent-jr that implemented the 6 `atlassian_*` typed gateways **did not remove** the legacy flat-tool registration loop in `hub.py`, leaving 60 `bitbucket_*` + `jira_*` tools registered alongside the 6 new gateways.

**Result**: 66 MCP tools registered at hub startup — exceeding AI-provider limits (Gemini/Windsurf 100, ChatGPT ~30) and defeating the purpose of VKS-1694.

## Phase 1 — Feature Flag (this PR)

This PR gates the flat-tool registration loop behind a new env var (default: hidden) to reduce the default MCP surface to 6 gateways while preserving a single-flag rollback path.

## Changes

| File | Change |
|---|---|
| `mcp-tools/maos-mcp-hub/hub.py` | Import \`os\`; wrap flat-tool loop (lines 274-294) in \`if os.getenv(\"MAOS_EXPOSE_FLAT_TOOLS\", \"false\").lower() == \"true\"\` |
| \`mcp-tools/maos-mcp-hub/.env.example\` | Document \`MAOS_EXPOSE_FLAT_TOOLS\` rollback flag |
| \`mcp-tools/maos-mcp-hub/README.md\` | New section \"Migration: Flat → Gateway\" with full 30-tool mapping table |
| \`CLAUDE.md\` (root) | Update \"MCP Tools\" section to reflect hidden-by-default flat namespace |
| \`CHANGELOG.md\` | \`[Unreleased]\` entry with impact metrics |
| \`plugin-scripts/governance/lib/json-rpc.sh\` | Update descriptive strings to reference \`atlassian_bitbucket\` |

## Impact

| Metric | Before | After (flag=false, default) | With rollback (flag=true) |
|---|---:|---:|---:|
| Total MCP tools | 66 | **6** (-91%) | 66 |
| Schema token footprint | baseline | ~1/10 | baseline |
| Functional capability | 60 ops via flat | **96 ops** via 6 gateways | same |

## Validation

- ✅ \`pytest tests/\` → **144/144 passing**
- ✅ Smoke \`MAOS_EXPOSE_FLAT_TOOLS=false python hub.py\` → Total MCP tools: 6
- ✅ Smoke \`MAOS_EXPOSE_FLAT_TOOLS=true python hub.py\` → Total MCP tools: 66 (rollback works)
- ✅ Secret scan (GAAS gitleaks) → **no leaks**
- ✅ Pre-commit branch naming validation passed

## Safety

- **Handlers preserved**: \`servers/{bitbucket,jira}/tools.py\` unchanged — gateways import them directly (\`from servers.bitbucket.tools import TOOLS as BB_TOOLS\`)
- **Zero consumers broken**: audit found 0 runtime consumers of flat tools (0 in scripts/tests/CI/pipelines)
- **Rollback path**: single env-var flip — no code change needed
- **Related ticket**: VKS-1718 (E2E validation) — **Done**, gateway already validated against real APIs

## Phase 2 — Planned for v1.7

- Remove flat-tool registration loop from \`hub.py\` entirely
- Remove \`servers/{bitbucket,jira}/server.py\` (auto-discovery entry points)
- Keep \`servers/{bitbucket,jira}/tools.py\` (gateway dependency)

## Audit Report

Full audit available in \`.planning/audits/vks-1694-flat-residue.md\` (not committed — local working artifact).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)