### PR TITLE
fix(maos-mcp-hub): migrate Jira search to /search/jql endpoint [VKO-88]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+#### maos-mcp-hub — VKO-88: Jira search endpoint migration (CHANGE-2046)
+- `lib/jira/client.py:search_jql` — Migrated from deprecated `/rest/api/3/search` (HTTP 410) to new `/rest/api/3/search/jql`. Replaced `startAt` integer pagination with `nextPageToken` opaque string. Added optional `fields` and `expand` params for payload control.
+- `gateways/jira/actions.py:search_jql` — Updated signature to match: `next_page_token: str = ""`, `fields: list[str] | None = None`, `expand: str | None = None`. Schema auto-regenerated via `SchemaRegistry` from the new signature.
+- `tests/test_gateway_jira.py` — Updated existing mock to `/search/jql` + `nextPageToken`. Added 2 regression tests: `test_execution_search_jql_with_pagination_and_fields` (token + fields + expand) and `test_execution_search_jql_no_deprecated_startat_sent` (guard against re-introducing `startAt`).
+
+#### Validated
+- pytest tests/ → 153/153 passing (151 + 2 new)
+- Real Jira API smoke test: page 1 returned 3 VKS issues + valid `nextPageToken`, page 2 paginated successfully.
+
 ### Removed
 
 #### maos-mcp-hub — VKS-1694 Flat-Tools Residue Cleanup (Phase 2 / v1.7)

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -82,10 +82,24 @@ async def get_transitions(issue_key: str) -> dict:
     return {"issue_key": issue_key, "transitions": transitions}
 
 
-async def search_jql(jql: str, max_results: int = 50, start_at: int = 0) -> dict:
-    """Search issues using JQL with pagination."""
+async def search_jql(
+    jql: str,
+    max_results: int = 50,
+    next_page_token: str = "",
+    fields: list[str] | None = None,
+    expand: str | None = None,
+) -> dict:
+    """Search issues using JQL (new /search/jql endpoint, token pagination).
+
+    Migrated from deprecated /rest/api/3/search (VKO-88, CHANGE-2046).
+    - `next_page_token`: opaque string returned as `nextPageToken` in a
+      previous response; empty string means "first page".
+    - `fields`: optional list of field names to include (reduces payload).
+    - `expand`: optional expand string (e.g. "changelog", "names,schema").
+    Response shape: `{issues, nextPageToken?, isLast?}`.
+    """
     client = get_client()
-    return await client.search_jql(jql, max_results, start_at)
+    return await client.search_jql(jql, max_results, next_page_token, fields, expand)
 
 
 async def add_comment(issue_key: str, body: str) -> dict:

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -406,16 +406,35 @@ class JiraClient:
         return result.get("transitions", [])
 
     async def search_jql(
-        self, jql: str, max_results: int = 50, start_at: int = 0
+        self,
+        jql: str,
+        max_results: int = 50,
+        next_page_token: str = "",
+        fields: list[str] | None = None,
+        expand: str | None = None,
     ) -> dict:
-        """Search issues using JQL with pagination."""
+        """Search issues using JQL (new /search/jql endpoint).
+
+        Migrated from the deprecated /rest/api/3/search (HTTP 410 as of
+        CHANGE-2046). The new endpoint uses opaque `nextPageToken` pagination
+        instead of `startAt` + `total`; response contains `nextPageToken` and
+        `isLast` fields. See:
+        https://developer.atlassian.com/changelog/#CHANGE-2046
+        """
+        params: dict = {"jql": jql, "maxResults": max_results}
+        if next_page_token:
+            params["nextPageToken"] = next_page_token
+        if fields:
+            params["fields"] = ",".join(fields)
+        if expand:
+            params["expand"] = expand
         return await request_json(
             method="GET",
-            url=f"{self.base_url}/search",
+            url=f"{self.base_url}/search/jql",
             provider=self._provider_name,
             auth_hint=self._auth_hint,
             auth_kwargs=self._auth_kwargs,
-            params={"jql": jql, "maxResults": max_results, "startAt": start_at},
+            params=params,
             timeout=30.0,
             limiter=self.rate_limiter,
         )

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
@@ -141,21 +141,88 @@ def test_execution_issue_create(monkeypatch):
 # ---------------------------------------------------------------------------
 
 def test_execution_search_jql(monkeypatch):
+    """Uses new /search/jql endpoint (VKO-88 migration — CHANGE-2046)."""
     _setup_env(monkeypatch)
     router = build_router()
 
     async def run():
         with respx.mock(assert_all_called=True) as mock:
-            mock.get(f"{BASE}/search").mock(return_value=httpx.Response(200, json={
-                "issues": [{"key": "VKS-1"}], "total": 1, "startAt": 0, "maxResults": 50,
+            mock.get(f"{BASE}/search/jql").mock(return_value=httpx.Response(200, json={
+                "issues": [{"key": "VKS-1"}],
+                "nextPageToken": "abc123",
+                "isLast": False,
             }))
 
             result = await router.dispatch(GatewayRequest(
                 resource="search", operation="jql",
-                params={"jql": "project = VKS", "max_results": 50, "start_at": 0}
+                params={"jql": "project = VKS", "max_results": 50}
             ))
             assert "issues" in result
+            assert result.get("nextPageToken") == "abc123"
             assert "_agent_feedback" in result
+
+    asyncio.run(run())
+
+
+def test_execution_search_jql_with_pagination_and_fields(monkeypatch):
+    """New endpoint honors next_page_token + fields + expand params."""
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            route = mock.get(f"{BASE}/search/jql").mock(
+                return_value=httpx.Response(200, json={
+                    "issues": [], "isLast": True,
+                }),
+            )
+
+            await router.dispatch(GatewayRequest(
+                resource="search", operation="jql",
+                params={
+                    "jql": "project = VKS",
+                    "max_results": 25,
+                    "next_page_token": "xyz789",
+                    "fields": ["summary", "status"],
+                    "expand": "changelog",
+                },
+            ))
+
+            # Verify query params sent to Jira
+            assert route.called
+            request = route.calls.last.request
+            assert request.url.params["jql"] == "project = VKS"
+            assert request.url.params["maxResults"] == "25"
+            assert request.url.params["nextPageToken"] == "xyz789"
+            assert request.url.params["fields"] == "summary,status"
+            assert request.url.params["expand"] == "changelog"
+
+    asyncio.run(run())
+
+
+def test_execution_search_jql_no_deprecated_startat_sent(monkeypatch):
+    """Regression guard: ensure `startAt` is never sent to /search/jql (deprecated)."""
+    _setup_env(monkeypatch)
+    router = build_router()
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            route = mock.get(f"{BASE}/search/jql").mock(
+                return_value=httpx.Response(200, json={"issues": [], "isLast": True}),
+            )
+
+            await router.dispatch(GatewayRequest(
+                resource="search", operation="jql",
+                params={"jql": "project = VKS"},
+            ))
+
+            request = route.calls.last.request
+            assert "startAt" not in request.url.params, (
+                "startAt must NOT be sent to /search/jql (removed in CHANGE-2046)"
+            )
+            assert "nextPageToken" not in request.url.params, (
+                "nextPageToken should be omitted when empty (first page)"
+            )
 
     asyncio.run(run())
 


### PR DESCRIPTION
## Contexto

Linear **VKO-88** (Urgent) — o endpoint legado `/rest/api/3/search` foi decomissionado pela Atlassian ([CHANGE-2046](https://developer.atlassian.com/changelog/#CHANGE-2046)) e retorna `HTTP 410 Gone`. Isso quebra todo `atlassian_jira({resource: "search", operation: "jql"})` via maos-mcp-hub e força fallback via `acli`. Bug confirmado reproduzindo na sessão VKS-1694 (resposta 410 ao buscar VKS tickets).

## Mudanças

| Arquivo | Mudança |
|---|---|
| `lib/jira/client.py` | URL `/search` → `/search/jql`; pagination `startAt` → `nextPageToken`; adicionado `fields` + `expand` opcionais para reduzir payload |
| `gateways/jira/actions.py` | Signature atualizada — `SchemaRegistry` auto-regenera schema |
| `tests/test_gateway_jira.py` | Teste existente migrado + 2 regressões |
| `CHANGELOG.md` | `[Unreleased] / Fixed` com referência à CHANGE-2046 |

## Smoke test (live Jira API)

```
Page 1: 3 issues | nextPageToken=Ck11cGRhdGVkJnVwZGF0... | isLast=False
   VKS-1694 [Aprovado] [INFRA-AI] Meta-Tools Gateway — 6 gateways Atlassian, 96 actions, feedback
   VKS-1789 [Em andamento] [PE] Escrita rascunho User Story - Conferência de movimentos
   VKS-1796 [Em andamento] Benchmarking da User Story
Page 2: 3 issues (token pagination works ✅)
```

## Testes

- pytest: **153/153** passing (151 existentes + 2 novos de regressão)

## Safety

- Endpoint antigo já estava 410 → risco zero de regressão (estado atual é broken)
- Signature changed mas é MCP-tipada; clientes re-descobrem via `atlassian_jira({})` (level 0)
- Rollback trivial via `git revert`

---

🤖 Agent: Claude-Orch-Prime-20260417-88a9 | 2026-04-18T12:35:00-03:00