### PR TITLE
chore(delegation): deprecate atlassian-rovo to Tier-3 fallback [VKS-1706]

### DIFF
--- a/rules/agent-scm.md
+++ b/rules/agent-scm.md
@@ -407,7 +407,9 @@ Fluxo pode ser invocado parcialmente:
 
 ### Bitbucket (VKS Repos)
 - CLI: nao disponivel nativamente
-- MCP: `atlassian-rovo` (PRs, issues, comments)
+- MCP Primario: `maos-mcp-hub` → gateway `atlassian_bitbucket` (PRs, pipelines, branches, approves, merges — cobertura 52 acoes)
+- MCP Fallback: `atlassian-rovo` (apenas quando `maos-mcp-hub` estiver stale/unavailable — ver `protocols/delegation/provider-matrix.md`)
+- CLI Fallback: `acli` (escopo: Jira issues; NAO cobre Bitbucket pipelines/PRs)
 - Reviews: manual ou via MCP
 - Branch protection: force push BLOQUEADO em homolog/master
 - Notificacoes: email (acme-corp) → gog gmail


### PR DESCRIPTION
## Summary

Realign SCM tooling tiers for Bitbucket (VKS repos) with the global directive in `~/.claude/CLAUDE.md §Prioridade de Ferramentas Atlassian`:

```
maos-mcp-hub  →  atlassian-rovo (fallback)  →  acli (CLI fallback)
```

`rules/agent-scm.md §Bitbucket (VKS Repos):410` previously declared `atlassian-rovo` as the sole MCP — misleading now that:

- **VKS-1694 v1.7 (PR #36)** removed the flat-tool namespace and made `maos-mcp-hub`'s `atlassian_bitbucket` gateway the primary with 52 actions covering pipelines/PRs/branches/approves/merges.
- **VKO-88 (PR #38)** migrated the hub's Jira search to `/search/jql` (CHANGE-2046), closing the last primary-tier gap.
- **GaaS/GaaC (PR #39)** codified the fallback chain in `protocols/delegation/provider-matrix.md`, making rovo's role explicit as Fallback 1.

## Scope

Intentionally minimal — **1 file, 4 lines changed**:

| File | Lines | Change |
|------|------:|--------|
| `rules/agent-scm.md` | §Bitbucket block (407-414) | Split `- MCP: atlassian-rovo` into `MCP Primario: maos-mcp-hub` + `MCP Fallback: atlassian-rovo` + `CLI Fallback: acli`. |

### Deliberately NOT in this PR

| What | Why preserved |
|------|---------------|
| `protocols/delegation/provider-matrix.md` Fallback 1 cells (4 rows) | Documented fallback by design — removing breaks resilience promised by GaaS/GaaC framework. |
| `mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py:1665` + `gateways/bitbucket/actions.py` ("Rovo Dev") | Not about the rovo MCP — about Bitbucket bot-reviewer persona. Different concept. |
| `docs/mcp-servers-config-spec.md:147` (OAuth table row) | Docs-only catalog entry; out of scope to rename. |

### Local-only change (outside this PR)

`.claude/settings.local.json` is `.gitignore`d by design. The 3 legacy `mcp__atlassian-rovo__*` permission grants were cleaned **locally** in my working copy (main worktree) — no commit possible and no commit desirable (user-/machine-scoped settings).

## Context

This is the **first real dogfood** of the GaaS/GaaC delegation framework shipped in PR #39:

- \`plugin-scripts/gaac/delegate.sh init --ticket=VKS-1706\` was invoked live. Header emitted: \`TICKET=VKS-1706, TICKET_PROVIDER=jira, VCS_PROVIDER=github, WORKTREE=/Users/…/multi-agent-os, AGENT_HEX=53b9\`.
- Session registered pro-actively in \`.worktrees/sessions.json\` **before** any edit (vs. VKS-1694 88a9 session which had to retrofit — explicit correction of a documented violation).
- Worktree used per \`skills/worktree-policy/SKILL.md\`: \`.worktrees/abbb-vks-1706-rovo-deprecation/\`.
- Commit carries explicit \`Agent: Claude-Orch-Prime-20260420-abbb | 2026-04-20T10:56:52-03:00\` trailer (harmony protocol compliance).

Closes VKS-1706 (Jira) · Relates to VKO-95 (Linear session-continuity handoff from 88a9)

## Test Plan

- [x] \`git diff --stat\` → 1 file, 3 insertions, 1 deletion (minimal scope confirmed)
- [x] \`gitleaks\` pre-commit hook → no leaks
- [x] \`grep -n "atlassian-rovo" rules/agent-scm.md\` after edit → references rovo only as **Fallback** (intentional)
- [x] \`grep -rn "mcp__atlassian-rovo" protocols/delegation/provider-matrix.md\` → 4 matches unchanged (preservation confirmed)
- [x] Branch naming gate: \`chore/vks-1706-deprecate-atlassian-rovo-abbb\` — validated by \`plugin-scripts/pre-push.sh\`
- [ ] CI: \`.github/workflows/\` runs (version-sync Action) — awaiting
- [ ] Copilot + CodeRabbit review findings resolved per \`.claude/rules/pr-reviewer-communication.md\` (Protocolo 7 Mentes)

### Pre-existing validator failure (NOT caused by this PR)

\`tests/validate-plugin.sh\` reports 1 error on both \`main\` and this branch:

\`\`\`
✗ plugin.json missing 'hooks' field (required for hooks)
\`\`\`

\`.claude-plugin/plugin.json\` currently has no \`hooks\` field while \`hooks/hooks.json\` exists. Pre-existing condition unrelated to this change — candidate for a follow-up Boy-Scout fix (out of scope).

## Reviewers

@copilot-pull-request-reviewer @coderabbitai — please review the tier-order rationale and confirm the \`provider-matrix.md\` preservation call is correct. If you have a strong argument for removing rovo from the fallback chain entirely, please justify against the framework's resilience-by-design goal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)