### PR TITLE
fix(maos-mcp-hub): VKS-1853 pull_request ops + params + priority (gaps 6, 7, 8)

### DIFF
--- a/.planning/audits/vks-1694-flat-residue.md
+++ b/.planning/audits/vks-1694-flat-residue.md
@@ -5,6 +5,8 @@
 **Auditor**: Claude-Opus-4.7 (plan mode + auto mode)
 **Status**: FASE 0 concluída, aguardando aprovação humana para FASE 1
 
+> **Snapshot note**: Os inventários e contagens em §1 representam o estado **pré-VKS-1853** (commits anteriores a `4161b01`). VKS-1853 adicionou 3 operações novas em `pull_request` (`add_pr_comment`, `reply_to_pr_comment`, `update_pr_description`), elevando Bitbucket de **52 → 55 tools flat** e o total de ações acessíveis via gateway de **96 → 99**. Tabelas e contagens preservam o snapshot original para fins de auditoria histórica; valores pós-VKS-1853 estão anotados inline quando relevante.
+
 ---
 
 ## 1. Inventário de Flat-Tools Registradas
@@ -54,11 +56,11 @@ for gw_name in ["discover", "jira", "confluence", "bitbucket", "compass", "commo
 
 **Cobertura gateway**: 100% (+ 14 ops novas: transition, search.jql, comment.add, worklog.add, link.*, project.*, user.search, estimation.calculate)
 
-### 1.4. Lista exata — Bitbucket (52 tools flat)
+### 1.4. Lista exata — Bitbucket (52 tools flat — pré-VKS-1853; 55 pós-VKS-1853)
 
 Extraído de `servers/bitbucket/tools.py:2992-3050+`:
 
-```
+```text
 Core: get_recent_builds, get_build_details, get_build_steps, get_step_logs
 Analysis: analyze_failures, auto_diagnose, compare_builds, diagnose_pipeline_failure
 Health: check_pipeline_health, check_alerts, get_executive_summary
@@ -77,6 +79,8 @@ Branches: list_branches, get_branch, create_branch, delete_branch, set_default_b
 ```
 
 **Cobertura gateway**: 100% — todas as 52 tools mapeadas via `gateways/bitbucket/actions.py:RESOURCE_MAP` em 11 resources (pipeline=16 ops, pull_request=8, branch=8, deployment=4, commit=4, test=3, cache=4, variable=2, learning=3).
+
+> **Atualização pós-VKS-1853**: `pull_request` passou de **8 → 11 ops** com a adição de `add_pr_comment`, `reply_to_pr_comment` e `update_pr_description`. Bitbucket total: **52 → 55 tools flat**. Demais resources inalterados.
 
 ---
 
@@ -160,7 +164,7 @@ Branches: list_branches, get_branch, create_branch, delete_branch, set_default_b
 |---|---:|---:|---:|
 | Total MCP tools registradas | 66 | 6 | -91% |
 | Token footprint (schemas) | baseline | 1/10 | ~90% menor |
-| Tools reais disponíveis | 66+6=72 | 6 meta × 96 ações = 6 tools → 96 ações acessíveis | mesma capacidade |
+| Tools reais disponíveis | 66+6=72 | 6 meta × 99 ações = 6 tools → 99 ações acessíveis (pós-VKS-1853; era 96 no snapshot original) | mesma capacidade |
 
 ---
 

--- a/.planning/audits/vks-1694-flat-residue.md
+++ b/.planning/audits/vks-1694-flat-residue.md
@@ -1,0 +1,168 @@
+# VKS-1694 — Audit de Resíduo Flat-Tools em maos-mcp-hub
+
+**Data**: 2026-04-17
+**Sessão**: typed-peacock
+**Auditor**: Claude-Opus-4.7 (plan mode + auto mode)
+**Status**: FASE 0 concluída, aguardando aprovação humana para FASE 1
+
+---
+
+## 1. Inventário de Flat-Tools Registradas
+
+### 1.1. Ponto de registro duplicado em `hub.py`
+
+```python
+# hub.py:268-294 — FLAT TOOL REGISTRATION (resíduo a remover)
+for server_name, server_data in discovered_servers.items():
+    for tool_name, tool_func in tools.items():
+        namespaced_name = f"{server_name}_{tool_name}"
+        mcp.tool(name=namespaced_name)(tool_func)
+        total_tools_registered += 1
+
+# hub.py:297-383 — GATEWAY META-TOOL REGISTRATION (mantém)
+for gw_name in ["discover", "jira", "confluence", "bitbucket", "compass", "common"]:
+    # registra atlassian_* meta-tools
+```
+
+### 1.2. Servers flat existentes
+
+| Server | Arquivo | `TOOLS` dict | Count |
+|---|---|---:|---:|
+| bitbucket | `servers/bitbucket/tools.py:2992` | `TOOLS = {52 entradas}` | **52** |
+| jira | `servers/jira/tools.py:512` | `TOOLS = {8 entradas}` | **8** |
+| confluence | — | (não existe) | 0 |
+| compass | — | (não existe) | 0 |
+| common | — | (não existe) | 0 |
+
+**Total flat expostos hoje**: **60 tools** (52 BB + 8 Jira)
+**Total meta expostos**: 6 (atlassian_*)
+**Total MCP registrado**: **66 tools**
+**Objetivo VKS-1694**: 6 tools
+
+### 1.3. Lista exata — Jira (8 tools flat)
+
+| Flat tool | Handler | Gateway equivalente |
+|---|---|---|
+| `jira_get_issue` | `get_issue()` | `atlassian_jira(resource="issue", operation="get")` |
+| `jira_list_attachments` | `list_attachments()` | `atlassian_jira(resource="attachment", operation="list")` |
+| `jira_download_attachment` | `download_attachment()` | `atlassian_jira(resource="attachment", operation="download")` |
+| `jira_upload_attachment` | `upload_attachment()` | `atlassian_jira(resource="attachment", operation="upload")` |
+| `jira_delete_attachment` | `delete_attachment()` | `atlassian_jira(resource="attachment", operation="delete")` |
+| `jira_get_boards` | `get_boards()` | `atlassian_jira(resource="board", operation="list")` |
+| `jira_get_estimation` | `get_estimation()` | `atlassian_jira(resource="estimation", operation="get")` |
+| `jira_set_estimation` | `set_estimation()` | `atlassian_jira(resource="estimation", operation="set")` |
+
+**Cobertura gateway**: 100% (+ 14 ops novas: transition, search.jql, comment.add, worklog.add, link.*, project.*, user.search, estimation.calculate)
+
+### 1.4. Lista exata — Bitbucket (52 tools flat)
+
+Extraído de `servers/bitbucket/tools.py:2992-3050+`:
+
+```
+Core: get_recent_builds, get_build_details, get_build_steps, get_step_logs
+Analysis: analyze_failures, auto_diagnose, compare_builds, diagnose_pipeline_failure
+Health: check_pipeline_health, check_alerts, get_executive_summary
+Test Reports: get_test_reports, get_test_cases, get_test_case_reasons
+Deployments: get_recent_deployments, get_deployment_details, get_environments,
+             get_environment_variables, get_repository_variables, get_workspace_variables
+Cache: list_caches, get_cache_details, clear_cache, analyze_cache_efficiency
+Commits: get_commit_details, get_commit_build_statuses, get_builds_for_commit, compare_commit_builds
+PRs: get_pull_requests, get_pr_details, get_pr_build_statuses, create_pull_request,
+     get_pr_comments, merge_pull_request, approve_pull_request, unapprove_pull_request
+Pipelines: list_pipeline_schedules, get_pipeline_config, get_ssh_key_info
+Auto-Learning: save_successful_fix, search_learned_fixes, get_knowledge_base_stats
+Control: trigger_pipeline, stop_pipeline
+Branches: list_branches, get_branch, create_branch, delete_branch, set_default_branch,
+          get_branch_restrictions, set_branch_restriction, delete_branch_restriction
+```
+
+**Cobertura gateway**: 100% — todas as 52 tools mapeadas via `gateways/bitbucket/actions.py:RESOURCE_MAP` em 11 resources (pipeline=16 ops, pull_request=8, branch=8, deployment=4, commit=4, test=3, cache=4, variable=2, learning=3).
+
+---
+
+## 2. Consumers Externos Descobertos
+
+### 2.1. Consumers ATIVOS (precisam migração)
+
+| Arquivo | Linhas | Tool referenciada | Ação |
+|---|---|---|---|
+| `~/.claude/agents/ops-strategist.md` | 53, 64, 68 | `jira_get_issue`, `bitbucket_get_recent_builds`, `bitbucket_check_pipeline_health`, `bitbucket_get_pull_requests` | **MIGRAR** — atualizar para gateway |
+| `multi-agent-os/plugin-scripts/governance/lib/json-rpc.sh` | 116-117 | (string descritiva) | **ATUALIZAR** texto para referenciar gateway |
+
+### 2.2. Consumers HISTÓRICOS (read-only artifacts — NÃO migrar)
+
+| Arquivo | Tipo | Decisão |
+|---|---|---|
+| `~/.claude/plans/hazy-scribbling-simon.md` | plano antigo | Ignorar — artefato histórico |
+| `~/.claude/plans/do-leia-o-moonlit-lemur.md` | plano antigo | Ignorar |
+| `vek-docs-trellis/.planning/osppe/34-convergence-10-meta-critique.md` | análise histórica | Ignorar |
+| `~/.claude/plans/vamos-continuar-com-vks-1694-typed-peacock.md` | este plano | Self-reference, ok |
+
+### 2.3. Consumers em infraestrutura executável
+
+- **Tests**: ZERO referências em `tests/`, `test_*.py`
+- **CI/Pipelines**: ZERO referências em `.yml`, `.yaml`
+- **Python/JS/TS runtime**: ZERO
+- **Shell executáveis**: ZERO (json-rpc.sh só exibe texto, não invoca)
+
+**Risco de regressão em runtime**: **MUITO BAIXO** — apenas 1 agente prompt precisa atualização.
+
+---
+
+## 3. Classificação & Decisão
+
+| Item | Classificação | Decisão |
+|---|---|---|
+| 52 Bitbucket flat tools | Safe to deprecate | Hide via flag → delete |
+| 8 Jira flat tools | Safe to deprecate | Hide via flag → delete |
+| `ops-strategist.md` | Needs migration | Atualizar refs para gateway (FASE 1) |
+| `json-rpc.sh:116-117` | Nit (apenas texto) | Atualizar texto informativo (FASE 1) |
+| Planos antigos + meta-critique | Ignore (histórico) | — |
+
+---
+
+## 4. Safety Assessment
+
+| Critério | Status | Evidência |
+|---|---|---|
+| Gateway cobre 100% das flat-tools? | ✅ SIM | Bitbucket 52/52, Jira 8/8 |
+| Handlers preservados? | ✅ SIM | Gateway importa `from servers.X.tools import TOOLS` |
+| E2E validation rodou? | ✅ SIM | VKS-1718 — Done |
+| Consumers runtime externos? | ✅ ZERO | Apenas 1 prompt + 1 texto descritivo |
+| Feature flag possível? | ✅ SIM | `MAOS_EXPOSE_FLAT_TOOLS` (default=false) |
+| Rollback rápido? | ✅ SIM | env var flip ou `git revert` |
+
+**Veredicto final**: **SAFE TO DEPRECATE** via processo faseado (flag → validation → hard delete).
+
+---
+
+## 5. Recommended Next Steps (FASE 1+)
+
+1. Abrir PR em `multi-agent-os` contendo:
+   - `hub.py` — envolver loop flat em `if os.getenv("MAOS_EXPOSE_FLAT_TOOLS", "false").lower() == "true":`
+   - `.env.example` — documentar variável
+   - `README.md` — seção Migration guide + remover "Flat Namespace (Legacy)"
+   - `~/.claude/agents/ops-strategist.md` — migrar 3 refs para gateway pattern
+   - `plugin-scripts/governance/lib/json-rpc.sh:116-117` — atualizar strings descritivas
+   - `CHANGELOG.md` — entrada `### Changed` (não `### Removed` ainda — isso é FASE 3)
+
+2. Rodar `pytest tests/` + smoke test do hub.
+
+3. Validation window (FASE 2): 1 dia observando.
+
+4. FASE 3 hard-delete após validation.
+
+---
+
+## 6. Métricas Previstas
+
+| Métrica | Antes | Depois (FASE 3) | Redução |
+|---|---:|---:|---:|
+| Total MCP tools registradas | 66 | 6 | -91% |
+| Token footprint (schemas) | baseline | 1/10 | ~90% menor |
+| Tools reais disponíveis | 66+6=72 | 6 meta × 96 ações = 6 tools → 96 ações acessíveis | mesma capacidade |
+
+---
+
+**Relatório gerado por**: Claude-Opus-4.7 | sessão typed-peacock | 2026-04-17
+**Próximo passo**: Apresentar via AskUserQuestion e aguardar aprovação.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### maos-mcp-hub v2.2.0 — VKS-1853: PR Interaction Ops + Params Standardization + Priority Support (Gaps 6, 7, 8)
+
+- `servers/bitbucket/tools.py` — 3 new tools: `add_pr_comment` (top-level or threaded), `update_pr_description` (PUT-only body), `reply_to_pr_comment` (explicit threading wrapper). Standardizes params across ALL `pull_request.*` operations: every op now accepts both `pr_id` (canonical) and `pull_request_id` (alias), plus `account` for multi-persona auth. Helper `_normalize_pr_id(pr_id, pull_request_id)` handles disambiguation (raises on conflict, supports equal values).
+- `lib/bitbucket/client.py` — 2 new HTTP methods: `add_pr_comment(pr_id, content, parent_id=None)` → `POST /pullrequests/{id}/comments` and `update_pr_description(pr_id, description)` → `PUT /pullrequests/{id}`. Both `max_retries=0` (non-idempotent; protects against race with concurrent edits for description, against duplicate comments for comments).
+- `gateways/bitbucket/actions.py` — `RESOURCE_MAP["pull_request"]` now has 11 ops (was 8). Added governance hints and next-steps for the 3 new ops (e.g., "preferir reply_to_comment para manter threading", "idempotente mas NAO preserva mudancas concorrentes").
+- `gateways/jira/actions.py:create_issue` — Now accepts optional `priority: str` (serialized as `{"name": value}`, Jira canonical form) and `assignee_account_id`. When a screen-scheme rejection occurs (e.g., issue type `Intervenção Técnica - I.A.` id 10407 in project VKS), surfaces a `screen_scheme_hint: True` result with a descriptive `hint` instead of a cryptic 400 — unblocks automated issue creation for IT-IA workflow.
+- `docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md` — Decision record: custom wrapper chosen over Rovo Dev API (Route B) because PR #40 already demoted atlassian-rovo to Tier-3 fallback. Delegating new functionality *back* to Rovo would reverse the architectural direction.
+- `tests/test_bitbucket_client.py` — 5 new tests for PR methods (top-level, threaded reply, 404, update, non-idempotent-no-retry).
+- `tests/test_gateway_bitbucket.py` — 9 new tests (11-ops assertion, governance for 3 new ops, `_normalize_pr_id` edge cases: canonical, alias, both equal, both missing, conflict).
+- `tests/test_gateway_jira.py` — 4 new tests for priority handling (serialization, omission, screen-scheme rejection, non-priority error propagation).
+
+### Changed
+
+- `hub.py:HUB_VERSION` bumped from `1.0.0` → `2.2.0` (SemVer minor: 3 new ops are additive; existing `pr_id`-only callers still work).
+- Gateway action count: Bitbucket 52 → 55 (cross-gateway total 96 → 99). Updated `tests/test_gateway_discover.py` and `tests/test_hub_registration.py` assertions accordingly.
+- `servers/bitbucket/__init__.py:__version__` bumped `2.0.0` → `2.2.0`.
+- README.md updated to reflect 55-action Bitbucket gateway and 99-action total; new v2.2 History entry.
+
+### Validated
+
+- `pytest` → 171/171 passing (18 new VKS-1853 tests + 153 existing).
+- Non-breaking: all existing positional-or-keyword call sites (`pr_id=42`) continue to work. Agents using `pull_request_id=42` now work too.
+- Safety: `_normalize_pr_id` raises `ValueError` on conflict or missing — bad calls fail fast with clear message.
+
 #### GaaS/GaaC Agentic Delegation Framework (v1.0)
 - `protocols/delegation/provider-matrix.md` — cross-provider lookup (Jira/Linear × Bitbucket/GitHub/GitLab × Secrets × Observability) citing source-of-truth files per cell
 - `protocols/delegation/delegation-init-prompt.md` (~894 tok) — start-of-delegation prompt (4 cognitive lenses, Anti-Conflict Phase-1, provider detection, output contract)

--- a/docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md
+++ b/docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md
@@ -1,6 +1,7 @@
 # ADR-002: Pull Request Operations — Custom Wrapper over Rovo Dev API
 
 ## Status
+
 **Accepted** (2026-04-23)
 
 ## Context

--- a/docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md
+++ b/docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md
@@ -66,9 +66,9 @@ This ADR covers the three DoD items of VKS-1853:
 
 **Gap 6 — `pull_request` missing ops**
 Add three new tools in `servers/bitbucket/tools.py`:
-- `add_pr_comment(pr_id, content, parent_id=None, account="", workspace="", repo_slug="")`
-- `update_pr_description(pr_id, description, account="", workspace="", repo_slug="")`
-- `reply_to_pr_comment(pr_id, parent_id, content, account="", workspace="", repo_slug="")` — thin wrapper over `add_pr_comment` with `parent_id` required
+- `add_pr_comment(content, pr_id=None, pull_request_id=None, parent_id=None, account="", workspace="", repo_slug="")` — `content` first positional; `pr_id` keyword-only with `pull_request_id` as forward-compat alias (Gap 7).
+- `update_pr_description(description, pr_id=None, pull_request_id=None, account="", workspace="", repo_slug="")` — `description` first positional; `pr_id` keyword-only aliased.
+- `reply_to_pr_comment(parent_id, content, pr_id=None, pull_request_id=None, account="", workspace="", repo_slug="")` — `parent_id` first positional (required); thin wrapper over `add_pr_comment`.
 
 Registered in `RESOURCE_MAP["pull_request"]` as operations `add_comment`, `update_description`, `reply_to_comment`.
 

--- a/docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md
+++ b/docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md
@@ -1,0 +1,107 @@
+# ADR-002: Pull Request Operations — Custom Wrapper over Rovo Dev API
+
+## Status
+**Accepted** (2026-04-23)
+
+## Context
+
+### Problem Statement
+
+The `maos-mcp-hub` `atlassian_bitbucket.pull_request` resource is missing three critical operations required for the full autonomous PR review loop (Step 8 of the AI-Native Protocol, "7 Mentes"):
+
+- `add_comment` — responding to AI bot findings (Qodo, CodeRabbit, Copilot, RovoDev)
+- `update_description` — updating Bot Scorecard in the PR body after review cycles
+- `reply_to_comment` — threaded replies to specific bot comments
+
+Additionally, parameter naming is inconsistent across operations on the same resource:
+
+- `create` accepts `account` (multi-persona auth) — correct
+- `get` and `get_comments` accept only `pr_id` and NOT `account` — inconsistent
+- Agents must memorize operation-specific contracts, violating DNA Geracional item 3 (Independência Agnóstica — padronizar)
+
+Finally, `createJiraIssue` rejects the `priority` field when issue type is `Intervenção Técnica - I.A.` (id 10407), forcing 2 round-trips (create + edit) to set priority. This was empirically reproduced in VKS-1851 and VKS-1853 creation sessions.
+
+Tracking ticket: **[VKS-1853](https://vek.atlassian.net/browse/VKS-1853)**.
+
+### Decision Space
+
+Three routes were considered (per ticket guidance — "Mente Agnóstica — pesquisa antes de implementar"):
+
+**Route A — Rovo Dev MCP / atlassian-rovo as primary**
+Delegate the gateway to proxy calls into the `atlassian-rovo` MCP server (which has native Atlassian auth).
+
+**Route B — Bitbucket Cloud REST API v2.0 (custom wrapper in `maos-mcp-hub`)**
+Implement new tools in `servers/bitbucket/tools.py` and new client methods in `lib/bitbucket/client.py`, using endpoints:
+- `POST /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}/comments`
+- `PUT /2.0/repositories/{workspace}/{repo_slug}/pullrequests/{pr_id}`
+
+**Route C — Hybrid**
+Use Rovo where available, fall back to custom for gaps.
+
+### Prior Art / Constraints
+
+- **PR #40** (commit `c8db272`, 2026-04-20): `chore(delegation): deprecate atlassian-rovo to Tier-3 fallback [VKS-1706]`. The repository already made the architectural decision that `atlassian-rovo` is a **fallback only**, not a primary dependency. The `maos-mcp-hub` is the primary Tier-1 tool. Expanding coverage by delegating *back* into `atlassian-rovo` would reverse this architectural direction.
+- **PR #36** (VKS-1694 v1.7): `atlassian_bitbucket` gateway already wraps 52 local actions directly — zero external MCP dependencies for core flows.
+- **VKO-88** (PR #38): last primary-tier gap on Jira was closed by fixing JQL search *inside* the hub, confirming the hub-first architecture.
+- **Bitbucket Cloud REST API v2.0** natively supports the required endpoints (PR comments, PR update) with the same auth layer already used by the existing 52 actions (`get_client` / `get_client_for_account`).
+- **atlassian-rovo MCP** does not expose `add_comment` / `update_description` for Bitbucket PRs at the time of this ADR (confirmed empirically and via PR #40 rationale — Rovo's Bitbucket coverage is read-heavy, and VKS operates on Bitbucket Cloud via the workspace-level token pool).
+
+## Decision
+
+Adopt **Route B — Custom Wrapper in `maos-mcp-hub`**.
+
+### Rationale
+
+1. **Architectural alignment**: PR #40 explicitly demoted `atlassian-rovo` to Tier-3 fallback. Delegating new functionality back into Rovo (Route A) would contradict the documented ecosystem direction.
+2. **Coverage**: Rovo Dev does not natively expose the required PR comment / description endpoints for Bitbucket Cloud in a multi-persona / multi-account shape. Route A is not feasible end-to-end.
+3. **Consistency**: The 52 existing BB actions already flow through `lib/bitbucket/client.py` with the same auth, rate limiting, retry semantics, account pool, and governance hooks. Adding 3 more PR methods there preserves the architecture and returns identical error shapes.
+4. **Testability**: `tests/test_bitbucket_client.py` and `tests/test_gateway_bitbucket.py` already mock the same `request_json` infrastructure via `respx`. Extending the test matrix is straightforward.
+5. **Zero new dependencies**: No new Python packages, no new MCP servers, no new env vars.
+
+Hybrid (Route C) is unnecessary given that Route A has zero reusable surface for these three specific operations.
+
+### Scope
+
+This ADR covers the three DoD items of VKS-1853:
+
+**Gap 6 — `pull_request` missing ops**
+Add three new tools in `servers/bitbucket/tools.py`:
+- `add_pr_comment(pr_id, content, parent_id=None, account="", workspace="", repo_slug="")`
+- `update_pr_description(pr_id, description, account="", workspace="", repo_slug="")`
+- `reply_to_pr_comment(pr_id, parent_id, content, account="", workspace="", repo_slug="")` — thin wrapper over `add_pr_comment` with `parent_id` required
+
+Registered in `RESOURCE_MAP["pull_request"]` as operations `add_comment`, `update_description`, `reply_to_comment`.
+
+**Gap 7 — Params standardization**
+- All `pull_request.*` operations will accept **both** `pr_id` (canonical, existing) **and** `pull_request_id` (alias, forward-compat alternative) to support agents that prefer resource-name-matched params.
+- All `pull_request.*` operations will accept `account` (currently some do, some do not). Where it was implicit, it becomes explicit and documented.
+- Backwards compatibility: `pr_id` remains the canonical parameter name. No breaking change.
+
+**Gap 8 — Jira `priority` rejected for issue type 10407**
+- Root cause hypothesis (to confirm via `getIssueTypeMetaWithFields`): the `priority` field is not in the Jira screen scheme for issue type 10407 in project VKS.
+- Fix in wrapper: `create_issue` gateway action will accept `priority` as an optional parameter, serialize it as `{"name": priority}` (Jira-standard) when the issue type allows, and surface a descriptive error message ("priority not available for this issue type / screen scheme") when the server rejects it, rather than a generic 400.
+- Ideal long-term fix is at the Jira screen-scheme config level (not in wrapper scope), but the wrapper change unblocks agents with a graceful-degrade path and clear hint for humans.
+
+### Consequences
+
+**Positive**:
+- Full autonomous PR loop (Step 8 of AI-Native Protocol) unblocked. Agents can respond to bot reviews and update Bot Scorecards programmatically.
+- Consistent params contract (`account + pr_id + payload`) across all `pull_request.*` operations.
+- Hub-first architecture preserved; `atlassian-rovo` remains Tier-3 fallback.
+
+**Negative**:
+- Three new HTTP endpoints to maintain against Bitbucket API evolution. Mitigated by reusing the same `request_json` / `ApiError` infrastructure as 52 existing actions.
+- If Bitbucket ever introduces a breaking change to PR comment API (unlikely, v2.0 is stable), we pay maintenance cost — but so would Rovo, so the cost is architecture-independent.
+
+**Neutral**:
+- `pull_request_id` alias adds minor schema complexity; kept internal to the wrapper, agents see a cleaner contract.
+
+## References
+
+- VKS-1853 (primary ticket)
+- PR #40 / VKS-1706 (atlassian-rovo demotion to Tier-3)
+- PR #36 / VKS-1694 v1.7 (52-action gateway)
+- PR #38 / VKO-88 (Jira JQL hub migration)
+- Memory: `~/.claude/projects/-Users-emilson-moraes-Projects-vek-docs-trellis/memory/feedback_maos_mcp_hub_gaps.md`
+- Bitbucket Cloud REST API v2.0 — Pullrequests endpoints
+- ADR-001 (session identity) — same ADR format template

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -155,7 +155,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-Restart Claude Desktop. You'll see the **6 `atlassian_*` gateway tools** (discover, jira, confluence, bitbucket, compass, common) covering 96 actions total.
+Restart Claude Desktop. You'll see the **6 `atlassian_*` gateway tools** (discover, jira, confluence, bitbucket, compass, common) covering 99 actions total (v2.2.0, VKS-1853).
 
 ### 6. Run tests (pilot D65)
 
@@ -177,18 +177,18 @@ AI providers impose tool-count limits that break flat namespaces at scale:
 | Windsurf | 100       |
 | ChatGPT  | ~30       |
 
-With 52 Bitbucket tools already registered and Jira, Confluence, Compass on the roadmap, the flat namespace (`bitbucket_get_recent_builds`, `jira_get_issue`, ...) would hit limits immediately.
+With 55 Bitbucket tools and Jira/Confluence/Compass on the roadmap, the flat namespace (`bitbucket_get_recent_builds`, `jira_get_issue`, ...) would hit limits immediately.
 
 ### Solution: 6 Typed Gateways
 
-The Meta-Tools Gateway collapses **96 actions** into **6 MCP tools**. Five domain gateways accept a uniform `{resource?, operation?, params?}` input; `atlassian_discover` is parameterless:
+The Meta-Tools Gateway collapses **99 actions** (v2.2.0) into **6 MCP tools**. Five domain gateways accept a uniform `{resource?, operation?, params?}` input; `atlassian_discover` is parameterless:
 
 | Gateway | Tool Name | Actions | Purpose |
 |---------|-----------|---------|---------|
 | **Discover** | `atlassian_discover` | -- | Catalog of all domains and action counts |
 | **Jira** | `atlassian_jira` | 22 | Issues, boards, sprints, estimation, comments, worklogs, links, search |
 | **Confluence** | `atlassian_confluence` | 12 | Pages, comments, spaces, search (CQL) |
-| **Bitbucket** | `atlassian_bitbucket` | 52 | Pipelines, PRs, branches, deployments, tests, caches |
+| **Bitbucket** | `atlassian_bitbucket` | 55 | Pipelines, PRs (incl. add/reply comment, update description — VKS-1853), branches, deployments, tests, caches |
 | **Compass** | `atlassian_compass` | 6 | Service registry, components, relationships, custom fields |
 | **Common** | `atlassian_common` | 4 | User info, accessible resources, server info |
 
@@ -262,7 +262,7 @@ gateways/                          ← Meta-tool gateway layer
 │   └── actions.py                 ← 12 actions across 4 resources
 ├── bitbucket/
 │   ├── gateway.py
-│   └── actions.py                 ← 52 actions across 9 resources
+│   └── actions.py                 ← 55 actions across 9 resources (VKS-1853)
 ├── compass/
 │   ├── gateway.py
 │   └── actions.py                 ← 6 actions across 3 resources
@@ -318,7 +318,7 @@ hub is considered ready when these lines appear:
 ```text
 ======================================================================
 ✅ MAOS MCP Hub Ready!
-   Gateways: 6 (96 actions)
+   Gateways: 6 (99 actions)
    Total MCP tools: 6
 ======================================================================
 ```
@@ -328,6 +328,13 @@ indicates a fail-closed registration — v1.7 has no flat-tool fallback.
 
 ### History
 
+- **v2.2 (VKS-1853, 2026-04-23)** added 3 new `pull_request` ops
+  (`add_comment`, `update_description`, `reply_to_comment`) and
+  standardized params across all `pull_request.*` operations
+  (`pr_id`/`pull_request_id` alias, `account` on every op). Also made
+  `createJiraIssue` surface a helpful `screen_scheme_hint` when
+  `priority` is rejected by a screen scheme (e.g., issue type 10407
+  "Intervenção Técnica - I.A." in project VKS). Total actions: 99.
 - **v1.6** introduced `MAOS_EXPOSE_FLAT_TOOLS` env flag (default `false`).
   The var and rollback path were **removed in v1.7**.
 - If you are on v1.6 and need to set the flag temporarily, upgrade to v1.7

--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/__init__.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/__init__.py
@@ -1,1 +1,1 @@
-"""Bitbucket gateway — wraps 52 existing tools into meta-tool pattern."""
+"""Bitbucket gateway — wraps 55 tools into meta-tool pattern (VKS-1853)."""

--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
@@ -142,9 +142,10 @@ _GOVERNANCE = {
             "Usar mesmo account que criou o PR para preservar autoria consistente",
         ],
         "update_description": [
-            "Operacao idempotente mas NAO preserva mudancas concorrentes — fazer read-modify-write",
-            "Para append (Bot Scorecard no final), fetch via pull_request.get primeiro",
-            "account determina quem aparece como 'edited by' na UI Bitbucket",
+            "PUT replaces o body inteiro — chamadas concorrentes podem perder-update (write-write race). Fazer SEMPRE read-modify-write: `pull_request.get` primeiro, merge, depois update.",
+            "Cliente usa max_retries=0 para esta operacao — retry automatico em 429/5xx transientes agravaria races (um PUT retried pode sobrescrever edicao concorrente que aterrissou no meio).",
+            "Para append (ex: Bot Scorecard no final do body), fetch via `pull_request.get` primeiro, concatenar a nova secao, e entao chamar com o resultado merged.",
+            "`account` determina quem aparece como 'edited by' na UI Bitbucket; preferir o account do autor do PR em cenarios de governance para evitar atribuicao drift.",
         ],
     },
     "branch": {

--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
@@ -1,8 +1,13 @@
 """
-Bitbucket gateway actions — maps 52 existing tools into resource+operation taxonomy.
+Bitbucket gateway actions — maps 55 existing tools into resource+operation taxonomy.
 
 All handlers are imported from servers/bitbucket/tools.py (zero rewrite).
 The RESOURCE_MAP defines the hierarchical structure exposed to agents.
+
+History:
+- v1.7 (VKS-1694 / PR #36): 52 actions across 9 resources.
+- v2.2 (VKS-1853 / 2026-04-23): +3 pull_request ops (add_comment,
+  update_description, reply_to_comment) — unblocks Step 8 PDCA loop.
 """
 
 from servers.bitbucket.tools import TOOLS as BB_TOOLS
@@ -12,7 +17,7 @@ from lib.gateway.router import MetaToolRouter
 from .gateway import GATEWAY_INFO
 
 # ---------------------------------------------------------------------------
-# Resource → Operation mapping (52 tools → 11 resources)
+# Resource → Operation mapping (55 tools → 9 resources, VKS-1853)
 # ---------------------------------------------------------------------------
 
 RESOURCE_MAP = {
@@ -43,6 +48,10 @@ RESOURCE_MAP = {
         "unapprove": BB_TOOLS["unapprove_pull_request"],
         "get_comments": BB_TOOLS["get_pr_comments"],
         "get_build_statuses": BB_TOOLS["get_pr_build_statuses"],
+        # VKS-1853 (2026-04-23) — unblock Step 8 7-Mentes PDCA loop
+        "add_comment": BB_TOOLS["add_pr_comment"],
+        "reply_to_comment": BB_TOOLS["reply_to_pr_comment"],
+        "update_description": BB_TOOLS["update_pr_description"],
     },
     "branch": {
         "list": BB_TOOLS["list_branches"],
@@ -122,6 +131,21 @@ _GOVERNANCE = {
             "Verificar contagem de commits — se houver commit de bot (copilot-swe-agent) investigar diff",
             "Comparar reviewers presentes vs bots esperados (CodeRabbit, Qodo, Copilot, RovoDev)",
         ],
+        "add_comment": [
+            "Usar account humano quando possivel — bots de review ignoram comments de outros bots",
+            "Para threaded reply, passar parent_id obtido via pull_request.get_comments",
+            "Markdown suportado — Bot Scorecards ficam melhor renderizados com tabelas",
+        ],
+        "reply_to_comment": [
+            "parent_id obrigatorio — esse e o metodo explicito para responder findings de bots",
+            "Uma reply por finding (accept/reject/defer com justificativa)",
+            "Usar mesmo account que criou o PR para preservar autoria consistente",
+        ],
+        "update_description": [
+            "Operacao idempotente mas NAO preserva mudancas concorrentes — fazer read-modify-write",
+            "Para append (Bot Scorecard no final), fetch via pull_request.get primeiro",
+            "account determina quem aparece como 'edited by' na UI Bitbucket",
+        ],
     },
     "branch": {
         "create": ["Branch naming regex: feature/|bugfix/|hotfix/|release/"],
@@ -155,6 +179,18 @@ _NEXT_STEPS = {
             "Se CI failing — diagnosticar antes de analisar reviews",
             "Se CHANGES_REQUESTED — ler comments com 7 mentes ativadas",
         ],
+        "add_comment": [
+            "Se bot scorecard — preferir update_description para persistir no body do PR",
+            "Se responder a bot — preferir reply_to_comment para manter threading",
+        ],
+        "reply_to_comment": [
+            "Atualizar bot scorecard (precisao por bot) apos resolver finding",
+            "Se aceitou finding — implementar correcao e referenciar novo commit",
+        ],
+        "update_description": [
+            "Apos update, verificar que apenas o body foi alterado (title/reviewers intactos)",
+            "Comunicar ao time via comment que scorecard foi atualizado (trigger human review)",
+        ],
     },
     "branch": {
         "create": ["Criar pull request apos implementacao"],
@@ -167,7 +203,7 @@ _NEXT_STEPS = {
 # ---------------------------------------------------------------------------
 
 def build_router() -> MetaToolRouter:
-    """Build the Bitbucket meta-tool router with all 52 actions."""
+    """Build the Bitbucket meta-tool router with all 55 actions (VKS-1853)."""
     router = MetaToolRouter(
         tool_name=GATEWAY_INFO["tool_name"],
         governance=["Bitbucket operations follow S-SDLC governance"],

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -97,7 +97,17 @@ async def create_issue(
     try:
         return await client.create_issue(project_key, issue_type, summary, **fields)
     except Exception as e:
-        # VKS-1853 Gap 8: surface screen-scheme errors with a clear hint
+        # VKS-1853 Gap 8: surface screen-scheme errors with a clear hint.
+        # CodeRabbit PR #42 iteration 2 refinement: gate the hint translation on
+        # an HTTP 400 status to avoid mis-translating unrelated failures (e.g.
+        # network/timeout/5xx) that might happen to contain similar phrases.
+        status_code = getattr(e, "status_code", None)
+        if status_code is None:
+            response = getattr(e, "response", None)
+            status_code = getattr(response, "status_code", None)
+        if status_code != 400:
+            raise
+
         msg = str(e)
         # Only treat as screen-scheme mismatch when the error message contains
         # explicit screen-related phrases. The previous overbroad condition

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -48,8 +48,37 @@ async def get_issue(issue_key: str, format: str = "markdown") -> dict:
     }
 
 
-async def create_issue(project_key: str, issue_type: str, summary: str, description: str = "", labels: list = None) -> dict:
-    """Create a new issue."""
+async def create_issue(
+    project_key: str,
+    issue_type: str,
+    summary: str,
+    description: str = "",
+    labels: list | None = None,
+    priority: str | None = None,
+    assignee_account_id: str | None = None,
+) -> dict:
+    """Create a new issue.
+
+    Args:
+        project_key: Jira project key (e.g., "VKS").
+        issue_type: Issue type name (e.g., "Story", "Intervenção Técnica - I.A.").
+        summary: Issue summary (title).
+        description: Plain-text description (converted to ADF automatically).
+        labels: Optional list of string labels.
+        priority: Optional priority name ("Highest", "High", "Medium", "Low",
+            "Lowest"). VKS-1853 note: some issue types (e.g., "Intervenção
+            Técnica - I.A." id 10407) in project VKS do NOT expose the
+            priority field in their screen scheme. In that case Jira returns
+            400 with a hint pointing to the screen-scheme mismatch. The
+            wrapper forwards this hint verbatim so callers can either
+            (a) create without priority and `editJiraIssue` afterward, or
+            (b) request a Jira admin to add priority to the screen scheme.
+        assignee_account_id: Optional assignee accountId (Atlassian 24-byte id).
+
+    Returns:
+        dict: Created issue on success, or
+            {"error": str, "hint": str, "screen_scheme_hint": bool} on 400.
+    """
     client = get_client()
     fields: Dict[str, Any] = {}
     if description:
@@ -58,7 +87,39 @@ async def create_issue(project_key: str, issue_type: str, summary: str, descript
         ]}
     if labels:
         fields["labels"] = labels
-    return await client.create_issue(project_key, issue_type, summary, **fields)
+    if priority:
+        # Jira REST API v3 expects {"name": "Medium"} or {"id": "3"}.
+        # We accept the friendlier string form and serialize canonically.
+        fields["priority"] = {"name": priority}
+    if assignee_account_id:
+        fields["assignee"] = {"accountId": assignee_account_id}
+
+    try:
+        return await client.create_issue(project_key, issue_type, summary, **fields)
+    except Exception as e:
+        # VKS-1853 Gap 8: surface screen-scheme errors with a clear hint
+        msg = str(e)
+        if priority and (
+            "priority" in msg.lower()
+            or "cannot be set" in msg.lower()
+            or "is not on the appropriate screen" in msg.lower()
+        ):
+            return {
+                "error": "Priority not available on this screen scheme for this issue type",
+                "details": msg,
+                "hint": (
+                    f"Issue type '{issue_type}' in project '{project_key}' does not "
+                    "expose the 'priority' field on its Create screen. Options: "
+                    "(a) retry without `priority` and call `issue.edit` with "
+                    "priority afterward; (b) ask a Jira admin to add 'Priority' "
+                    "to the screen scheme of this issue type."
+                ),
+                "screen_scheme_hint": True,
+                "issue_type": issue_type,
+                "project_key": project_key,
+                "rejected_priority": priority,
+            }
+        raise
 
 
 async def edit_issue(issue_key: str, fields: dict) -> dict:

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -99,10 +99,15 @@ async def create_issue(
     except Exception as e:
         # VKS-1853 Gap 8: surface screen-scheme errors with a clear hint
         msg = str(e)
+        # Only treat as screen-scheme mismatch when the error message contains
+        # explicit screen-related phrases. The previous overbroad condition
+        # (`"priority" in msg.lower()`) matched any error mentioning priority
+        # and emitted a misleading hint for unrelated validation failures
+        # (CodeRabbit PR #42 finding 4 — VKS-1853 Gap 8 refinement).
         if priority and (
-            "priority" in msg.lower()
-            or "cannot be set" in msg.lower()
+            "cannot be set" in msg.lower()
             or "is not on the appropriate screen" in msg.lower()
+            or "not on the appropriate screen" in msg.lower()
         ):
             return {
                 "error": "Priority not available on this screen scheme for this issue type",

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -5,7 +5,8 @@ Protocol: MCP 1.0 (JSON-RPC 2.0)
 Transport: STDIO (stdin/stdout)
 
 Since v1.7 (VKS-1694 Phase 2), this hub exposes exactly 6 typed `atlassian_*`
-meta-tool gateways (96 actions total) — no legacy flat namespace.
+meta-tool gateways. v2.2 (VKS-1853) adds 3 pull_request interaction ops →
+99 actions total.
 
 Architecture:
     hub.py
@@ -14,7 +15,7 @@ Architecture:
     ├── discover/   → atlassian_discover   (catalog)
     ├── jira/       → atlassian_jira       (22 actions)
     ├── confluence/ → atlassian_confluence (12 actions)
-    ├── bitbucket/  → atlassian_bitbucket  (52 actions)
+    ├── bitbucket/  → atlassian_bitbucket  (55 actions, VKS-1853 v2.2)
     ├── compass/    → atlassian_compass    (6 actions)
     └── common/     → atlassian_common     (4 actions)
 
@@ -131,7 +132,7 @@ except ImportError:
 # ============================================================================
 
 HUB_NAME = "maos-mcp-hub"
-HUB_VERSION = "1.0.0"
+HUB_VERSION = "2.2.0"  # VKS-1853: +3 pull_request ops + params standardization
 SERVERS_DIR = Path(__file__).parent / "servers"
 
 
@@ -239,7 +240,7 @@ mcp = FastMCP(
     name=HUB_NAME,
     instructions=(
         f"MAOS MCP Hub v{HUB_VERSION} — Atlassian meta-tools gateway. "
-        "Exposes 6 typed `atlassian_*` gateways (96 actions total) with "
+        "Exposes 6 typed `atlassian_*` gateways (99 actions total) with "
         "4-level progressive discovery and governance feedback. "
         "Legacy flat namespace (bitbucket_*, jira_*) was removed in v1.7."
     ),
@@ -264,7 +265,7 @@ if not discovered_servers:
 
 
 # ============================================================================
-# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 96 actions)
+# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 99 actions)
 # ============================================================================
 #
 # Note (VKS-1694, v1.7):

--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -1365,6 +1365,103 @@ class BitbucketPipelineClient:
             max_retries=0,  # non-idempotent operation: avoid duplicate PR creation
         )
 
+    async def add_pr_comment(
+        self,
+        pr_id: int,
+        content: str,
+        parent_id: Optional[int] = None,
+    ) -> dict:
+        """
+        Add a comment to a pull request.
+
+        When `parent_id` is provided, the new comment becomes a threaded reply
+        to that comment (Bitbucket Cloud supports one-level threading per
+        comment). Use `add_pr_comment` for top-level comments and pass
+        `parent_id` to reply to bot findings (CodeRabbit, Qodo, Copilot,
+        RovoDev) programmatically.
+
+        Bitbucket API: POST /2.0/repositories/{workspace}/{repo}/pullrequests/{id}/comments
+
+        Args:
+            pr_id: Pull request ID
+            content: Comment body (markdown). Bitbucket renders markdown in
+                the PR UI; plain text is safe too.
+            parent_id: Optional parent comment ID to make this a reply.
+
+        Returns:
+            dict: Created comment details
+                  Format: {
+                      "id": 12345,
+                      "content": {"raw": "...", "markup": "markdown", ...},
+                      "user": {"display_name": "...", "uuid": "..."},
+                      "created_on": "...",
+                      "parent": {"id": 12340}  # if reply
+                  }
+
+        Raises:
+            ApiError: If API request fails (404 if PR or parent not found,
+                401/403 on auth, 429 on rate limit, etc.)
+        """
+        payload: dict = {
+            "content": {"raw": content},
+        }
+        if parent_id is not None:
+            payload["parent"] = {"id": parent_id}
+
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/pullrequests/{pr_id}/comments",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # non-idempotent: avoid duplicate comments
+        )
+
+    async def update_pr_description(
+        self,
+        pr_id: int,
+        description: str,
+    ) -> dict:
+        """
+        Update the description (body) of an existing pull request.
+
+        Preserves title, reviewers, source/destination branches and all other
+        PR metadata by only sending the `description` field in the payload.
+        This is useful for updating Bot Scorecards, governance evidence, or
+        per-session status blocks within the PR body after review cycles.
+
+        Bitbucket API: PUT /2.0/repositories/{workspace}/{repo}/pullrequests/{id}
+
+        Args:
+            pr_id: Pull request ID
+            description: New PR description (markdown). Replaces existing
+                description entirely — callers must read-modify-write if
+                they want to append.
+
+        Returns:
+            dict: Updated PR details (same shape as get_pull_request)
+
+        Raises:
+            ApiError: If API request fails (404 if PR not found, 403 if no
+                write access, etc.)
+        """
+        payload = {"description": description}
+
+        return await request_json(
+            method="PUT",
+            url=f"{self.base_url}/pullrequests/{pr_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=payload,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # non-idempotent: avoid race with concurrent edits
+        )
+
     async def get_pipeline_schedules(self) -> dict:
         """
         Get configured pipeline schedules (cron-based triggers)

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/__init__.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/__init__.py
@@ -3,9 +3,14 @@ Bitbucket — Gateway-only handler module (VKS-1694 / v1.7).
 
 Not exposed as a standalone flat-namespace MCP server since v1.7. The
 TOOLS dict is imported directly by gateways/bitbucket/actions.py.
+
+v2.2.0 (VKS-1853, 2026-04-23): added 3 pull_request interaction tools
+(add_pr_comment, update_pr_description, reply_to_pr_comment) and
+standardized params across all pull_request.* ops (pr_id / pull_request_id
+alias, account on all ops).
 """
 
-__version__ = "2.0.0"
+__version__ = "2.2.0"
 __all__ = ['TOOLS']
 
 from .tools import TOOLS

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -1851,7 +1851,7 @@ async def merge_pull_request(
     except ApiError as e:
         status = getattr(e, "status_code", getattr(e, "status", None))
         if status == 404:
-            return {"error": f"Pull request #{effective_pr_id} not found"}
+            return {"success": False, "error": f"Pull request #{effective_pr_id} not found"}
         return {
             "success": False,
             "error": "Failed to merge PR",
@@ -1859,7 +1859,7 @@ async def merge_pull_request(
             "hint": getattr(e, "hint", ""),
         }
     except Exception as e:
-        return {"error": f"Failed to merge PR: {sanitize_error(e)}"}
+        return {"success": False, "error": f"Failed to merge PR: {sanitize_error(e)}"}
 
 
 async def approve_pull_request(

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -1516,20 +1516,37 @@ async def get_pull_requests(state: str = "OPEN", count: int = 10, workspace: str
         return {"error": f"Failed to get pull requests: {sanitize_error(e)}"}
 
 
-async def get_pr_details(pr_id: int, workspace: str = "", repo_slug: str = "") -> dict:
+async def get_pr_details(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
     """
-    Get detailed information about a specific pull request
+    Get detailed information about a specific pull request.
 
     Args:
-        pr_id: Pull request ID
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
+            Pass exactly one of `pr_id` or `pull_request_id`.
+        account: Named account to use (e.g., "jane-doe"). Default uses
+            the bot account. Standardized across pull_request.* ops.
+        workspace: Optional workspace override.
+        repo_slug: Optional repo slug override.
 
     Returns:
         dict: PR details with reviewers, description, merge info
     """
-    client = get_client(workspace=workspace, repo_slug=repo_slug)
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"error": str(ve)}
+
+    client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
 
     try:
-        pr = await client.get_pull_request(pr_id)
+        pr = await client.get_pull_request(effective_pr_id)
 
         # Format reviewers
         reviewers = []
@@ -1565,7 +1582,7 @@ async def get_pr_details(pr_id: int, workspace: str = "", repo_slug: str = "") -
 
     except ApiError as e:
         if e.status_code == 404:
-            return {"error": f"Pull request #{pr_id} not found"}
+            return {"error": f"Pull request #{effective_pr_id} not found"}
         return {
             "error": "Failed to get PR details",
             "details": sanitize_exception(e),
@@ -1575,20 +1592,35 @@ async def get_pr_details(pr_id: int, workspace: str = "", repo_slug: str = "") -
         return {"error": f"Failed to get PR details: {sanitize_error(e)}"}
 
 
-async def get_pr_build_statuses(pr_id: int, workspace: str = "", repo_slug: str = "") -> dict:
+async def get_pr_build_statuses(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
     """
-    Get all build statuses for a specific pull request
+    Get all build statuses for a specific pull request.
 
     Args:
-        pr_id: Pull request ID
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
+        account: Named account to use. Default uses the bot account.
+        workspace: Optional workspace override.
+        repo_slug: Optional repo slug override.
 
     Returns:
         dict: Build statuses with overall state
     """
-    client = get_client(workspace=workspace, repo_slug=repo_slug)
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"error": str(ve)}
+
+    client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
 
     try:
-        statuses_response = await client.get_pr_statuses(pr_id)
+        statuses_response = await client.get_pr_statuses(effective_pr_id)
         statuses = statuses_response.get("values", [])
 
         # Count by state
@@ -1626,7 +1658,7 @@ async def get_pr_build_statuses(pr_id: int, workspace: str = "", repo_slug: str 
             overall_state = "UNKNOWN"
 
         return {
-            "pr_id": pr_id,
+            "pr_id": effective_pr_id,
             "total_statuses": len(statuses),
             "overall_state": overall_state,
             "state_counts": state_counts,
@@ -1635,7 +1667,7 @@ async def get_pr_build_statuses(pr_id: int, workspace: str = "", repo_slug: str 
 
     except ApiError as e:
         if e.status_code == 404:
-            return {"error": f"Pull request #{pr_id} not found"}
+            return {"error": f"Pull request #{effective_pr_id} not found"}
         return {
             "error": "Failed to get PR build statuses",
             "details": sanitize_exception(e),
@@ -1707,26 +1739,49 @@ async def create_pull_request(
             "destination_branch": destination_branch
         }
 
-async def get_pr_comments(pr_id: int, pagelen: int = 50, workspace: str = "", repo_slug: str = "") -> dict:
+async def get_pr_comments(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    pagelen: int = 50,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
     """
-    Get all comments for a specific pull request
+    Get all comments for a specific pull request.
 
     Args:
-        pr_id: Pull request ID
-        pagelen: Items per page
-        workspace: Optional workspace override
-        repo_slug: Optional repo slug override
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
+            Pass exactly one of `pr_id` or `pull_request_id`.
+        pagelen: Items per page (default 50).
+        account: Named account to use. Default uses the bot account.
+            Standardized across pull_request.* ops.
+        workspace: Optional workspace override.
+        repo_slug: Optional repo slug override.
+
+    Returns:
+        dict with pr_id, total_comments, and comments array.
+        Each comment exposes: id, parent_id (for threading), content, author,
+        created_on, updated_on.
     """
-    client = get_client(workspace=workspace, repo_slug=repo_slug)
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"error": str(ve)}
+
+    client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
 
     try:
-        response = await client.get_pr_comments(pr_id=pr_id, pagelen=pagelen)
+        response = await client.get_pr_comments(pr_id=effective_pr_id, pagelen=pagelen)
         comments = response.get("values", [])
-        
+
         formatted_comments = []
         for c in comments:
+            parent = c.get("parent") or {}
             formatted_comments.append({
                 "id": c.get("id"),
+                "parent_id": parent.get("id"),
                 "content": c.get("content", {}).get("raw", ""),
                 "author": c.get("user", {}).get("display_name", "Unknown"),
                 "created_on": c.get("created_on", ""),
@@ -1734,14 +1789,14 @@ async def get_pr_comments(pr_id: int, pagelen: int = 50, workspace: str = "", re
             })
 
         return {
-            "pr_id": pr_id,
+            "pr_id": effective_pr_id,
             "total_comments": len(formatted_comments),
             "comments": formatted_comments
         }
     except ApiError as e:
         status = getattr(e, "status_code", getattr(e, "status", None))
         if status == 404:
-            return {"error": f"Pull request #{pr_id} not found or no comments"}
+            return {"error": f"Pull request #{effective_pr_id} not found or no comments"}
         return {
             "error": "Failed to get PR comments",
             "details": sanitize_exception(e),
@@ -1751,20 +1806,32 @@ async def get_pr_comments(pr_id: int, pagelen: int = 50, workspace: str = "", re
         return {"error": f"Failed to get PR comments: {sanitize_error(e)}"}
 
 
-async def merge_pull_request(pr_id: int, account: str = "", workspace: str = "", repo_slug: str = "") -> dict:
+async def merge_pull_request(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
     """
     Merge a pull request
 
     Args:
-        pr_id: Pull request ID
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
         account: Named account to use (e.g., "jane-doe"). Useful when bot lacks write access to destination branch.
         workspace: Optional workspace override
         repo_slug: Optional repo slug override
     """
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"success": False, "error": str(ve)}
+
     client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
 
     try:
-        pr = await client.merge_pull_request(pr_id=pr_id)
+        pr = await client.merge_pull_request(pr_id=effective_pr_id)
         
         return {
             "success": True,
@@ -1777,7 +1844,7 @@ async def merge_pull_request(pr_id: int, account: str = "", workspace: str = "",
     except ApiError as e:
         status = getattr(e, "status_code", getattr(e, "status", None))
         if status == 404:
-            return {"error": f"Pull request #{pr_id} not found"}
+            return {"error": f"Pull request #{effective_pr_id} not found"}
         return {
             "success": False,
             "error": "Failed to merge PR",
@@ -1788,7 +1855,13 @@ async def merge_pull_request(pr_id: int, account: str = "", workspace: str = "",
         return {"error": f"Failed to merge PR: {sanitize_error(e)}"}
 
 
-async def approve_pull_request(pr_id: int, account: str = "", workspace: str = "", repo_slug: str = "") -> dict:
+async def approve_pull_request(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
     """
     Approve a pull request.
 
@@ -1797,7 +1870,8 @@ async def approve_pull_request(pr_id: int, account: str = "", workspace: str = "
     When using a named account, the approval is registered under that identity.
 
     Args:
-        pr_id: Pull request ID
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
         account: Named account to use (e.g., "jane-doe"). Default uses the bot account.
         workspace: Optional workspace override
         repo_slug: Optional repo slug override
@@ -1805,14 +1879,19 @@ async def approve_pull_request(pr_id: int, account: str = "", workspace: str = "
     Returns:
         dict: Approval result with approver identity and PR state
     """
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"success": False, "error": str(ve)}
+
     client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
 
     try:
-        result = await client.approve_pull_request(pr_id=pr_id)
+        result = await client.approve_pull_request(pr_id=effective_pr_id)
 
         return {
             "success": True,
-            "pr_id": pr_id,
+            "pr_id": effective_pr_id,
             "approved": True,
             "approved_by": result.get("user", {}).get("display_name", "MCP Hub Bot"),
             "role": result.get("role", "PARTICIPANT"),
@@ -1822,12 +1901,12 @@ async def approve_pull_request(pr_id: int, account: str = "", workspace: str = "
         if status == 409:
             return {
                 "success": True,
-                "pr_id": pr_id,
+                "pr_id": effective_pr_id,
                 "approved": True,
                 "message": "PR was already approved by this user",
             }
         if status == 404:
-            return {"success": False, "error": f"Pull request #{pr_id} not found"}
+            return {"success": False, "error": f"Pull request #{effective_pr_id} not found"}
         return {
             "success": False,
             "error": "Failed to approve PR",
@@ -1838,12 +1917,19 @@ async def approve_pull_request(pr_id: int, account: str = "", workspace: str = "
         return {"success": False, "error": f"Failed to approve PR: {sanitize_error(e)}"}
 
 
-async def unapprove_pull_request(pr_id: int, account: str = "", workspace: str = "", repo_slug: str = "") -> dict:
+async def unapprove_pull_request(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
     """
     Remove approval from a pull request.
 
     Args:
-        pr_id: Pull request ID
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
         account: Named account to use. Default uses the bot account.
         workspace: Optional workspace override
         repo_slug: Optional repo slug override
@@ -1851,20 +1937,25 @@ async def unapprove_pull_request(pr_id: int, account: str = "", workspace: str =
     Returns:
         dict: Unapproval confirmation
     """
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"success": False, "error": str(ve)}
+
     client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
 
     try:
-        await client.unapprove_pull_request(pr_id=pr_id)
+        await client.unapprove_pull_request(pr_id=effective_pr_id)
         return {
             "success": True,
-            "pr_id": pr_id,
+            "pr_id": effective_pr_id,
             "approved": False,
             "message": "Approval removed successfully",
         }
     except ApiError as e:
         status = getattr(e, "status_code", getattr(e, "status", None))
         if status == 404:
-            return {"success": False, "error": f"Pull request #{pr_id} not found"}
+            return {"success": False, "error": f"Pull request #{effective_pr_id} not found"}
         return {
             "success": False,
             "error": "Failed to unapprove PR",
@@ -1873,6 +1964,255 @@ async def unapprove_pull_request(pr_id: int, account: str = "", workspace: str =
         }
     except Exception as e:
         return {"success": False, "error": f"Failed to unapprove PR: {sanitize_error(e)}"}
+
+
+# ---------------------------------------------------------------------------
+# PR Interaction tools — add_comment / update_description / reply_to_comment
+# (VKS-1853: unblock Step 8 of AI-Native Protocol — 7 Mentes PDCA loop)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_pr_id(pr_id: int | None, pull_request_id: int | None) -> int:
+    """Accept either `pr_id` (canonical) or `pull_request_id` (alias).
+
+    Raises ValueError if both are missing or both are provided with different
+    values. When both are provided and equal, `pr_id` wins (canonical).
+    """
+    if pr_id is None and pull_request_id is None:
+        raise ValueError(
+            "Missing required parameter: pass either `pr_id` (canonical) or "
+            "`pull_request_id` (alias)."
+        )
+    if pr_id is not None and pull_request_id is not None and pr_id != pull_request_id:
+        raise ValueError(
+            f"Conflicting params: pr_id={pr_id} vs pull_request_id="
+            f"{pull_request_id}. Pass only one."
+        )
+    return pr_id if pr_id is not None else pull_request_id  # type: ignore[return-value]
+
+
+async def add_pr_comment(
+    content: str,
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    parent_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Add a comment to a pull request (top-level or threaded reply).
+
+    Use this to respond to bot reviews (CodeRabbit, Qodo, Copilot, RovoDev),
+    post Bot Scorecards, or add per-finding accept/reject/defer justifications
+    as part of the autonomous PR loop (Step 8 of AI-Native Protocol).
+
+    Args:
+        content: Comment body (markdown supported).
+        pr_id: Pull request ID (canonical name).
+        pull_request_id: Alias for pr_id (standardization for VKS-1853).
+            Pass exactly one of `pr_id` or `pull_request_id`.
+        parent_id: Optional parent comment ID. When provided, this comment
+            becomes a threaded reply to that comment (Bitbucket supports
+            one-level threading per top-level comment).
+        account: Named account to use (e.g., "jane-doe"). Default uses the
+            bot account. Use a human account so AI review bots recognize
+            the author.
+        workspace: Optional workspace override.
+        repo_slug: Optional repo slug override (format: "workspace/repo-name").
+
+    Returns:
+        dict: Created comment details
+              Format on success:
+              {
+                "success": True,
+                "comment_id": 12345,
+                "pr_id": 42,
+                "content": "...",
+                "author": "Display Name",
+                "parent_id": 12340,  # if reply
+                "created_on": "...",
+                "url": "https://bitbucket.org/.../pull-requests/42/_/diff#comment-12345"
+              }
+
+    Examples:
+        # Top-level Bot Scorecard comment
+        add_pr_comment(pr_id=42, content="## Bot Scorecard\\n...", account="jane")
+
+        # Reply to a specific finding
+        add_pr_comment(
+            pr_id=42, parent_id=12340,
+            content="Rejected: stylistic preference, not a bug. See CLAUDE.md §X.",
+            account="jane"
+        )
+    """
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"success": False, "error": str(ve)}
+
+    client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
+
+    try:
+        comment = await client.add_pr_comment(
+            pr_id=effective_pr_id,
+            content=content,
+            parent_id=parent_id,
+        )
+
+        parent = comment.get("parent") or {}
+        return {
+            "success": True,
+            "comment_id": comment.get("id"),
+            "pr_id": effective_pr_id,
+            "content": (comment.get("content") or {}).get("raw", content),
+            "author": (comment.get("user") or {}).get("display_name", ""),
+            "parent_id": parent.get("id"),
+            "created_on": comment.get("created_on", ""),
+            "url": (comment.get("links") or {}).get("html", {}).get("href", ""),
+        }
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 404:
+            if parent_id is not None:
+                return {
+                    "success": False,
+                    "error": f"Pull request #{effective_pr_id} or parent comment #{parent_id} not found",
+                    "hint": "Use get_pr_comments to list available parent comment IDs.",
+                }
+            return {"success": False, "error": f"Pull request #{effective_pr_id} not found"}
+        return {
+            "success": False,
+            "error": "Failed to add PR comment",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to add PR comment: {sanitize_error(e)}"}
+
+
+async def reply_to_pr_comment(
+    parent_id: int,
+    content: str,
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Reply to a specific PR comment (convenience wrapper over add_pr_comment).
+
+    Semantically equivalent to `add_pr_comment(parent_id=...)` but makes the
+    intent explicit for agents analysing bot findings. Useful for 7-Mentes
+    per-finding responses where each reply must attach to the originating
+    bot comment for threading.
+
+    Args:
+        parent_id: Parent comment ID (required — the bot finding you are
+            replying to). Obtain from `pull_request.get_comments`.
+        content: Reply body (markdown).
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id.
+        account: Named account to use. Default uses the bot account.
+        workspace: Optional workspace override.
+        repo_slug: Optional repo slug override.
+
+    Returns:
+        dict: Same shape as add_pr_comment (with `parent_id` populated).
+    """
+    return await add_pr_comment(
+        content=content,
+        pr_id=pr_id,
+        pull_request_id=pull_request_id,
+        parent_id=parent_id,
+        account=account,
+        workspace=workspace,
+        repo_slug=repo_slug,
+    )
+
+
+async def update_pr_description(
+    description: str,
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Replace the description (body) of an existing pull request.
+
+    Use this to update Bot Scorecards, governance evidence, DoD checkboxes
+    or per-session status blocks within the PR body after review cycles.
+    The PR title, reviewers, source/destination branches are preserved.
+
+    NOTE: Replaces the description entirely. Callers that want to append
+    or surgically edit should first fetch via `pull_request.get` and then
+    post the merged result.
+
+    Args:
+        description: New PR description (markdown). Replaces existing body.
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id.
+        account: Named account to use (e.g., "jane-doe"). Default uses the
+            bot account. Use the PR author's account to avoid changing
+            "edited by" attribution in governance-sensitive scenarios.
+        workspace: Optional workspace override.
+        repo_slug: Optional repo slug override.
+
+    Returns:
+        dict: Updated PR details
+              Format on success:
+              {
+                "success": True,
+                "pr_id": 42,
+                "title": "...",
+                "state": "OPEN",
+                "url": "https://bitbucket.org/.../pull-requests/42",
+                "updated_on": "..."
+              }
+    """
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"success": False, "error": str(ve)}
+
+    client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
+
+    try:
+        pr = await client.update_pr_description(
+            pr_id=effective_pr_id,
+            description=description,
+        )
+
+        return {
+            "success": True,
+            "pr_id": pr.get("id", effective_pr_id),
+            "title": pr.get("title", ""),
+            "state": pr.get("state", ""),
+            "url": (pr.get("links") or {}).get("html", {}).get("href", ""),
+            "updated_on": pr.get("updated_on", ""),
+        }
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 404:
+            return {"success": False, "error": f"Pull request #{effective_pr_id} not found"}
+        if status == 403:
+            return {
+                "success": False,
+                "error": "Permission denied",
+                "details": sanitize_exception(e),
+                "hint": "Requires write access on the repository. Use account=<PR author> or a write-scoped token.",
+            }
+        return {
+            "success": False,
+            "error": "Failed to update PR description",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to update PR description: {sanitize_error(e)}"}
 
 
 async def list_pipeline_schedules(workspace: str = "", repo_slug: str = "") -> dict:
@@ -3034,6 +3374,10 @@ TOOLS = {
     "merge_pull_request": merge_pull_request,
     "approve_pull_request": approve_pull_request,
     "unapprove_pull_request": unapprove_pull_request,
+    # PR Interaction tools — VKS-1853 (2026-04-23) — unblock Step 8 7-Mentes loop
+    "add_pr_comment": add_pr_comment,
+    "update_pr_description": update_pr_description,
+    "reply_to_pr_comment": reply_to_pr_comment,
     "list_pipeline_schedules": list_pipeline_schedules,
     "get_pipeline_config": get_pipeline_config,
     "get_ssh_key_info": get_ssh_key_info,

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -1559,7 +1559,14 @@ async def get_pr_details(
         return {
             "id": pr.get("id"),
             "title": pr.get("title", ""),
-            "description": pr.get("description", "")[:500],  # Truncate long descriptions
+            # Return both a UI-friendly preview (truncated) and the raw full body.
+            # Callers doing read-modify-write via update_pr_description must use
+            # raw_full_description to avoid silently dropping the tail. The
+            # truncated description field is preserved for backward compatibility
+            # with consumers that only render a preview (CodeRabbit PR #42 finding 5).
+            "description": pr.get("description", "")[:500],
+            "description_truncated": len(pr.get("description") or "") > 500,
+            "raw_full_description": pr.get("description", ""),
             "state": pr.get("state", ""),
             "author": pr.get("author", {}).get("display_name", "Unknown"),
             "reviewers": reviewers,

--- a/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
@@ -186,3 +186,143 @@ def test_create_pull_request_does_not_retry_on_429(monkeypatch):
         await client.close()
 
     asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# VKS-1853: PR interaction methods
+# ---------------------------------------------------------------------------
+
+def test_add_pr_comment_top_level_success(monkeypatch):
+    """VKS-1853: add_pr_comment posts to /pullrequests/{id}/comments."""
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/42/comments"
+            ).mock(return_value=httpx.Response(201, json={
+                "id": 12345,
+                "content": {"raw": "Bot Scorecard"},
+                "user": {"display_name": "Bot"},
+            }))
+
+            data = await client.add_pr_comment(pr_id=42, content="Bot Scorecard")
+            assert route.called
+            assert data["id"] == 12345
+            # Verify payload shape
+            request = route.calls.last.request
+            import json as _json
+            payload = _json.loads(request.content)
+            assert payload == {"content": {"raw": "Bot Scorecard"}}
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_add_pr_comment_threaded_reply_includes_parent(monkeypatch):
+    """VKS-1853: add_pr_comment with parent_id includes parent in payload."""
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/42/comments"
+            ).mock(return_value=httpx.Response(201, json={"id": 99, "parent": {"id": 12340}}))
+
+            data = await client.add_pr_comment(
+                pr_id=42, content="Rejected: stylistic.", parent_id=12340
+            )
+            assert data["id"] == 99
+            import json as _json
+            payload = _json.loads(route.calls.last.request.content)
+            assert payload == {
+                "content": {"raw": "Rejected: stylistic."},
+                "parent": {"id": 12340},
+            }
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_add_pr_comment_404_maps_to_not_found(monkeypatch):
+    """VKS-1853: add_pr_comment returns NotFoundError for unknown PR."""
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            router.post(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/999/comments"
+            ).mock(return_value=httpx.Response(404, text='{"error":"not found"}'))
+
+            try:
+                await client.add_pr_comment(pr_id=999, content="hi")
+                raise AssertionError("Expected NotFoundError")
+            except NotFoundError as exc:
+                assert exc.status_code == 404
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_update_pr_description_success(monkeypatch):
+    """VKS-1853: update_pr_description PUTs only description field."""
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.put(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/42"
+            ).mock(return_value=httpx.Response(200, json={
+                "id": 42,
+                "title": "Original title (preserved)",
+                "description": "NEW BODY",
+                "state": "OPEN",
+            }))
+
+            data = await client.update_pr_description(pr_id=42, description="NEW BODY")
+            assert data["id"] == 42
+            assert data["title"] == "Original title (preserved)"
+            import json as _json
+            payload = _json.loads(route.calls.last.request.content)
+            assert payload == {"description": "NEW BODY"}
+
+        await client.close()
+
+    asyncio.run(run())
+
+
+def test_update_pr_description_non_idempotent_no_retry(monkeypatch):
+    """VKS-1853: update_pr_description must not retry on 429 (race safety)."""
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.put(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/42"
+            ).mock(
+                side_effect=[
+                    httpx.Response(429, text='{"error":"rate limit"}'),
+                    httpx.Response(200, json={"id": 42}),
+                ]
+            )
+
+            try:
+                await client.update_pr_description(pr_id=42, description="x")
+                raise AssertionError("Expected RateLimitError")
+            except RateLimitError as exc:
+                assert exc.status_code == 429
+
+            # Must not retry — protects against overwriting concurrent edits
+            assert route.call_count == 1
+
+        await client.close()
+
+    asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_bitbucket_client.py
@@ -298,6 +298,41 @@ def test_update_pr_description_success(monkeypatch):
     asyncio.run(run())
 
 
+def test_add_pr_comment_non_idempotent_no_retry(monkeypatch):
+    """CodeRabbit PR #42 finding 6: add_pr_comment must not retry on 429.
+
+    POST /pullrequests/{id}/comments is non-idempotent — a retried POST that
+    succeeds after a 429 would create a duplicate comment. Verify max_retries=0
+    is honored and a RateLimitError surfaces immediately.
+    """
+    _setup_env(monkeypatch)
+
+    async def run():
+        client = BitbucketPipelineClient(repo_slug="workspace/repo")
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(
+                "https://api.bitbucket.org/2.0/repositories/workspace/repo/pullrequests/42/comments"
+            ).mock(
+                side_effect=[
+                    httpx.Response(429, text='{"error":"rate limit"}'),
+                    httpx.Response(201, json={"id": 12345}),
+                ]
+            )
+
+            try:
+                await client.add_pr_comment(pr_id=42, content="Bot Scorecard")
+                raise AssertionError("Expected RateLimitError")
+            except RateLimitError as exc:
+                assert exc.status_code == 429
+
+            # Must not retry — a retried POST creates a duplicate comment.
+            assert route.call_count == 1
+
+        await client.close()
+
+    asyncio.run(run())
+
+
 def test_update_pr_description_non_idempotent_no_retry(monkeypatch):
     """VKS-1853: update_pr_description must not retry on 429 (race safety)."""
     _setup_env(monkeypatch)

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_bitbucket.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_bitbucket.py
@@ -1,4 +1,4 @@
-"""Tests for Bitbucket gateway — wrapping 52 tools into meta-tool pattern."""
+"""Tests for Bitbucket gateway — wrapping 55 tools into meta-tool pattern (VKS-1853)."""
 
 import asyncio
 import os
@@ -11,7 +11,7 @@ from servers.bitbucket.tools import TOOLS as BB_TOOLS
 
 
 # ---------------------------------------------------------------------------
-# Coverage: all 52 tools are mapped
+# Coverage: all 55 tools are mapped (52 legacy + 3 VKS-1853 PR ops)
 # ---------------------------------------------------------------------------
 
 def test_all_bitbucket_tools_have_gateway_mapping():
@@ -29,10 +29,10 @@ def test_all_bitbucket_tools_have_gateway_mapping():
     assert unmapped == [], f"Unmapped tools: {unmapped}"
 
 
-def test_resource_map_has_52_actions():
-    """Total action count matches expected 52."""
+def test_resource_map_has_55_actions():
+    """Total action count matches expected 55 (52 legacy + 3 VKS-1853)."""
     total = sum(len(ops) for ops in RESOURCE_MAP.values())
-    assert total == 52, f"Expected 52 actions, got {total}"
+    assert total == 55, f"Expected 55 actions, got {total}"
 
 
 # ---------------------------------------------------------------------------
@@ -86,8 +86,79 @@ def test_discovery_level1_pull_request_operations():
         assert "merge" in ops
         assert "approve" in ops
         assert "get_comments" in ops
+        # VKS-1853: new PR interaction operations
+        assert "add_comment" in ops
+        assert "reply_to_comment" in ops
+        assert "update_description" in ops
 
     asyncio.run(run())
+
+
+def test_vks1853_pull_request_has_11_ops():
+    """VKS-1853: pull_request must expose 11 ops (8 legacy + 3 new)."""
+    pr_ops = RESOURCE_MAP["pull_request"]
+    expected = {
+        "list", "get", "create", "merge", "approve", "unapprove",
+        "get_comments", "get_build_statuses",
+        # VKS-1853 additions
+        "add_comment", "reply_to_comment", "update_description",
+    }
+    assert set(pr_ops.keys()) == expected, (
+        f"pull_request ops mismatch: expected {expected}, got {set(pr_ops.keys())}"
+    )
+
+
+def test_vks1853_pr_add_comment_has_governance():
+    """VKS-1853: add_comment must carry governance metadata for agents."""
+    router = build_router()
+    schema = router.registry.get_schema("pull_request", "add_comment")
+    assert schema is not None
+
+
+def test_vks1853_pr_update_description_has_governance():
+    """VKS-1853: update_description must carry governance metadata."""
+    router = build_router()
+    schema = router.registry.get_schema("pull_request", "update_description")
+    assert schema is not None
+
+
+def test_vks1853_pr_reply_to_comment_has_governance():
+    """VKS-1853: reply_to_comment must carry governance metadata."""
+    router = build_router()
+    schema = router.registry.get_schema("pull_request", "reply_to_comment")
+    assert schema is not None
+
+
+def test_vks1853_normalize_pr_id_accepts_canonical():
+    """VKS-1853: _normalize_pr_id returns pr_id when only pr_id is provided."""
+    from servers.bitbucket.tools import _normalize_pr_id
+    assert _normalize_pr_id(pr_id=42, pull_request_id=None) == 42
+
+
+def test_vks1853_normalize_pr_id_accepts_alias():
+    """VKS-1853: _normalize_pr_id returns pull_request_id when only alias provided."""
+    from servers.bitbucket.tools import _normalize_pr_id
+    assert _normalize_pr_id(pr_id=None, pull_request_id=42) == 42
+
+
+def test_vks1853_normalize_pr_id_both_equal_ok():
+    """VKS-1853: _normalize_pr_id accepts both when equal (canonical wins)."""
+    from servers.bitbucket.tools import _normalize_pr_id
+    assert _normalize_pr_id(pr_id=42, pull_request_id=42) == 42
+
+
+def test_vks1853_normalize_pr_id_both_missing_raises():
+    """VKS-1853: _normalize_pr_id raises when both are missing."""
+    from servers.bitbucket.tools import _normalize_pr_id
+    with pytest.raises(ValueError, match="pr_id.*pull_request_id"):
+        _normalize_pr_id(pr_id=None, pull_request_id=None)
+
+
+def test_vks1853_normalize_pr_id_conflict_raises():
+    """VKS-1853: _normalize_pr_id raises when values differ."""
+    from servers.bitbucket.tools import _normalize_pr_id
+    with pytest.raises(ValueError, match="Conflicting"):
+        _normalize_pr_id(pr_id=42, pull_request_id=43)
 
 
 def test_discovery_level1_branch_operations():
@@ -134,7 +205,7 @@ def test_discovery_unknown_resource():
 
 def test_router_action_count():
     router = build_router()
-    assert router.action_count == 52
+    assert router.action_count == 55
 
 
 def test_router_tool_name():

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
@@ -51,10 +51,10 @@ def test_discover_action_counts(monkeypatch):
         d = result["domains"]
         assert d["jira"]["actions"] == 22
         assert d["confluence"]["actions"] == 12
-        assert d["bitbucket"]["actions"] == 52
+        assert d["bitbucket"]["actions"] == 55  # VKS-1853: +3 PR ops
         assert d["compass"]["actions"] == 6
         assert d["common"]["actions"] == 4
-        assert result["total_actions"] == 96
+        assert result["total_actions"] == 99  # VKS-1853: 96 + 3
 
     asyncio.run(run())
 
@@ -128,7 +128,7 @@ def test_common_router_action_count(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Cross-gateway: total action count = 96
+# Cross-gateway: total action count = 99 (VKS-1853: 96 + 3)
 # ---------------------------------------------------------------------------
 
 def test_total_action_count_across_all_gateways(monkeypatch):
@@ -146,4 +146,4 @@ def test_total_action_count_across_all_gateways(monkeypatch):
         + comp_router().action_count
         + common_router().action_count
     )
-    assert total == 96, f"Expected 96 total actions, got {total}"
+    assert total == 99, f"Expected 99 total actions (VKS-1853: 96 + 3), got {total}"

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
@@ -298,3 +298,111 @@ def test_jira_router_tool_name(monkeypatch):
     _setup_env(monkeypatch)
     router = build_router()
     assert router.tool_name == "atlassian_jira"
+
+
+# ---------------------------------------------------------------------------
+# VKS-1853 Gap 8: priority field for issue type "Intervenção Técnica - I.A."
+# ---------------------------------------------------------------------------
+
+def test_vks1853_create_issue_serializes_priority(monkeypatch):
+    """VKS-1853: create_issue with priority serializes as {name: value}."""
+    _setup_env(monkeypatch)
+    from gateways.jira.actions import create_issue
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(f"{BASE}/issue").mock(
+                return_value=httpx.Response(201, json={
+                    "id": "12345",
+                    "key": "VKS-2000",
+                })
+            )
+            result = await create_issue(
+                project_key="VKS",
+                issue_type="Story",
+                summary="test priority",
+                priority="Medium",
+            )
+            assert result["key"] == "VKS-2000"
+            import json as _json
+            payload = _json.loads(route.calls.last.request.content)
+            assert payload["fields"]["priority"] == {"name": "Medium"}
+
+    asyncio.run(run())
+
+
+def test_vks1853_create_issue_without_priority_omits_field(monkeypatch):
+    """VKS-1853: create_issue without priority must NOT include priority key."""
+    _setup_env(monkeypatch)
+    from gateways.jira.actions import create_issue
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            route = mock.post(f"{BASE}/issue").mock(
+                return_value=httpx.Response(201, json={"id": "12346", "key": "VKS-2001"})
+            )
+            await create_issue(
+                project_key="VKS",
+                issue_type="Intervenção Técnica - I.A.",
+                summary="no priority",
+            )
+            import json as _json
+            payload = _json.loads(route.calls.last.request.content)
+            assert "priority" not in payload["fields"]
+
+    asyncio.run(run())
+
+
+def test_vks1853_create_issue_priority_rejected_surfaces_hint(monkeypatch):
+    """VKS-1853: when priority is rejected by screen scheme, return helpful hint."""
+    _setup_env(monkeypatch)
+    from gateways.jira.actions import create_issue
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.post(f"{BASE}/issue").mock(
+                return_value=httpx.Response(400, json={
+                    "errorMessages": [],
+                    "errors": {
+                        "priority": "Field 'priority' cannot be set. It is not on the appropriate screen, or unknown."
+                    }
+                })
+            )
+            result = await create_issue(
+                project_key="VKS",
+                issue_type="Intervenção Técnica - I.A.",
+                summary="meta-test of gap 8",
+                priority="Medium",
+            )
+            assert "error" in result
+            assert result.get("screen_scheme_hint") is True
+            assert result["rejected_priority"] == "Medium"
+            assert result["issue_type"] == "Intervenção Técnica - I.A."
+            hint = result["hint"].lower()
+            assert "screen" in hint
+
+    asyncio.run(run())
+
+
+def test_vks1853_create_issue_non_priority_error_reraises(monkeypatch):
+    """VKS-1853: non-priority errors must propagate (not be swallowed)."""
+    _setup_env(monkeypatch)
+    from gateways.jira.actions import create_issue
+
+    async def run():
+        with respx.mock(assert_all_called=True) as mock:
+            mock.post(f"{BASE}/issue").mock(
+                return_value=httpx.Response(500, text='{"errorMessages":["server error"]}')
+            )
+            raised = False
+            try:
+                await create_issue(
+                    project_key="VKS",
+                    issue_type="Story",
+                    summary="server error case",
+                )
+            except Exception:
+                raised = True
+            assert raised, "Non-priority errors must propagate (not be swallowed)."
+
+    asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
@@ -63,9 +63,13 @@ def test_hub_exposes_exactly_six_mcp_tools():
 
 
 def test_hub_registers_six_atlassian_gateways():
-    """All 6 atlassian_* gateways must be registered with 96 actions total."""
+    """All 6 atlassian_* gateways must be registered with 99 actions total.
+
+    VKS-1853 (2026-04-23): +3 pull_request ops (add_comment,
+    update_description, reply_to_comment) bring total from 96 to 99.
+    """
     log = _run_hub()
-    assert "6 gateways registered (96 actions)" in log, log
+    assert "6 gateways registered (99 actions)" in log, log
 
 
 def test_hub_does_not_register_flat_bitbucket_tools():


### PR DESCRIPTION
## Summary

Closes the three gaps tracked by [VKS-1853](https://vek.atlassian.net/browse/VKS-1853) blocking Step 8 of the AI-Native Protocol (7-Mentes PDCA loop):

- **Gap 6**: `pull_request` resource was missing `add_comment`, `update_description`, and `reply_to_comment` — subagents could not respond to bot reviews or update Bot Scorecards.
- **Gap 7**: `pr_id` vs `pull_request_id` and `account` param inconsistency across operations of the same resource.
- **Gap 8**: `createJiraIssue` rejected `priority` with a cryptic 400 for issue types whose screen scheme does not expose priority (e.g., "Intervenção Técnica - I.A." id 10407).

Decision: implement as a custom wrapper inside `maos-mcp-hub`, **not** by delegating to `atlassian-rovo` — see [ADR-002](docs/adrs/ADR-002-pull-request-ops-custom-wrapper.md). Rationale: PR #40 (VKS-1706) already demoted Rovo to Tier-3 fallback, so delegating new functionality back to it would reverse the documented direction.

## Changes

### New PR Interaction Operations (Gap 6)
- `lib/bitbucket/client.py`: `add_pr_comment(pr_id, content, parent_id=None)` → `POST /pullrequests/{id}/comments` and `update_pr_description(pr_id, description)` → `PUT /pullrequests/{id}`. Both `max_retries=0` (non-idempotent).
- `servers/bitbucket/tools.py`: `add_pr_comment`, `reply_to_pr_comment`, `update_pr_description` — all with `account` for multi-persona auth.
- `gateways/bitbucket/actions.py`: `RESOURCE_MAP["pull_request"]` 8 ops → 11 ops, with governance hints + next-steps for each new op.

### Params Standardization (Gap 7)
- Helper `_normalize_pr_id(pr_id, pull_request_id)` accepts either canonical (`pr_id`) or alias (`pull_request_id`). Raises `ValueError` on conflict.
- ALL `pull_request.*` ops now accept both param names AND `account` for consistency.
- Backwards compatible: existing `pr_id`-only callers keep working.

### Priority Screen-Scheme Hint (Gap 8)
- `gateways/jira/actions.py:create_issue` now accepts optional `priority` and `assignee_account_id`.
- When Jira rejects `priority` via screen scheme (matching error-message patterns), returns `screen_scheme_hint: True` plus a descriptive `hint` listing two actionable options (retry-without-priority + edit, OR request Jira admin to add priority to screen scheme). Non-priority errors propagate unchanged.

### Docs + Version
- ADR-002 documents the routing decision with pros/cons of Route A (Rovo) vs Route B (custom wrapper in hub).
- `hub.py:HUB_VERSION` 1.0.0 → **2.2.0** (SemVer minor; additive only).
- `servers/bitbucket/__init__.py:__version__` 2.0.0 → 2.2.0.
- CHANGELOG + README updated; action counts now 55 (BB) / 99 (total).

## Test plan

- [x] 18 new tests added, all passing.
- [x] Full suite `pytest` → 171/171 green in ~5.4s (153 pre-existing + 18 new).
- [x] `_normalize_pr_id` edge cases: canonical, alias, both-equal, both-missing (raises), conflict (raises).
- [x] `add_pr_comment` payload assertions (top-level + threaded reply with parent.id).
- [x] `update_pr_description` asserts only `description` is sent (title/reviewers preserved) + no-retry on 429 (race safety).
- [x] `create_issue` with priority: serializes as `{"name": value}`; rejects gracefully with `screen_scheme_hint=True`; non-priority errors propagate.
- [x] Pre-commit GaaS hooks: branch validation + gitleaks secret scan passing on every commit.
- [x] Pre-push GaaS hooks: naming-convention checks passing.

## Migration notes

Existing callers using `pr_id=42` (positional or keyword) are unchanged. Callers can optionally migrate to `pull_request_id=42` for self-documenting consistency with the resource name. Both forms are permanent; no deprecation is planned.

🤖 Generated by Claude Opus 4.7 subagent D under delegation for VKS-1853.

[VKS-1853]: https://vek.atlassian.net/browse/VKS-1853?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ