### PR TITLE
docs(provider-matrix): canonical GitHub org (private org rename, identifiers redacted)

### DIFF
--- a/protocols/delegation/provider-matrix.md
+++ b/protocols/delegation/provider-matrix.md
@@ -42,7 +42,7 @@ Legend: `→` means fallback. Paths are relative to repo root unless noted.
 
 ## VCS operations
 
-### GitHub (`github.com/ekson73/*`, `github.com/vek-servicos/*`)
+### GitHub (`github.com/ekson73/*`, `github.com/vek-im/*`)
 
 | Operation | Primary | Fallback 1 | Fallback 2 |
 |---|---|---|---|


### PR DESCRIPTION
## Summary

The private organization's GitHub org was renamed from `${FORMER_PRIVATE_GITHUB_ORG}` to `${PRIVATE_GITHUB_ORG}` (display "(legal name redacted)"). This 1-line fix updates the example in `protocols/delegation/provider-matrix.md` L45.

## Scope (surgical)

| File | Line | Change |
|---|---|---|
| `protocols/delegation/provider-matrix.md` | 45 | `github.com/${FORMER_PRIVATE_GITHUB_ORG}/*` → `github.com/${PRIVATE_GITHUB_ORG}/*` |

## Preserved intentionally

L56 — `### Bitbucket (\`bitbucket.org/${PRIVATE_BITBUCKET_WORKSPACE}/*\` — private-project repos)`. **Bitbucket workspace** `${PRIVATE_BITBUCKET_WORKSPACE}` IS canonical (validated via Bitbucket API).

## Validation

Validated against the original (now-redacted) concrete identifiers at authoring time, not
against these placeholder tokens (`gh api orgs/<value>` and `bitbucket.org workspaces/<value>`
are not literally runnable as shown below):

- `gh api orgs/${PRIVATE_GITHUB_ORG}` → historically returned: exists
- `gh api orgs/${FORMER_PRIVATE_GITHUB_ORG}` → historically returned: 404
- Bitbucket `workspaces/${PRIVATE_BITBUCKET_WORKSPACE}` → historically returned: exists

## Context

Cross-repo cleanup of legacy GitHub org refs (the private organization's internal Jira (private ticket ref removed)). MAOS mentions the private organization in its provider matrix as example consumer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
