### PR TITLE
feat(converge): lint script + test rig + CI workflow (closes #50)

### DIFF
--- a/.github/workflows/converge-tests.yml
+++ b/.github/workflows/converge-tests.yml
@@ -1,0 +1,35 @@
+name: converge tooling tests
+
+on:
+  pull_request:
+    paths:
+      - "skills/converge/**"
+      - "scripts/converge-*.sh"
+      - "tests/converge/**"
+      - ".github/workflows/converge-tests.yml"
+  push:
+    branches: [main]
+    paths:
+      - "skills/converge/**"
+      - "scripts/converge-*.sh"
+      - "tests/converge/**"
+      - ".github/workflows/converge-tests.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  converge-lint-tests:
+    name: Run converge-lint test rig
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run lint script self-check (--help)
+        run: ./scripts/converge-lint.sh --help
+
+      - name: Run test rig (3 known proposal cases)
+        run: ./tests/converge/run.sh

--- a/scripts/converge-lint.sh
+++ b/scripts/converge-lint.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# converge-lint.sh — Lint converge skill output for spec violations (issue #50)
+#
+# SCOPE: Format-only validation of a converge-protocol output document. Checks
+# structural compliance, Invariant 6 (audit-not-persuasion), and bias-disclosure
+# fields. Does NOT validate subjective content quality.
+#
+# SPEC SOURCE: skills/converge/SKILL.md (versions ≥1.1.1)
+#
+# USAGE:
+#   converge-lint.sh [--help|--version] <converge-output.md>
+#   converge-lint.sh <file1.md> <file2.md> ...
+#
+# EXIT CODES:
+#   0  no violations
+#   1  violations detected
+#   2  invocation error / file not found
+#
+# OUTPUT:
+#   stdout: one violation per line:  <file>:<line>:<rule-id>:<message>
+#   stderr: summary line: "converge-lint: N violation(s) across M file(s)"
+#
+# CAPABILITY DETECTION:
+#   - Works under BSD grep/awk (no GNU-only flags). Tested macOS + Linux.
+#   - No Python / Node / jq dependency.
+#
+# DNA Geracional:
+#   1. Liberdade com Responsabilidade — operator can suppress per-rule via
+#      `# converge-lint: ignore <rule-id>` HTML comment on the offending line.
+#   2. Previsibilidade Holística — false positives are bugs; report + fix.
+#   3. Independência Agnóstica — sh + POSIX awk + grep only.
+
+set -eu
+
+PROG="converge-lint.sh"
+VERSION="0.1.0"
+
+usage() {
+  cat <<'EOF'
+converge-lint.sh — Lint converge skill output (spec issue #50)
+
+USAGE:
+    converge-lint.sh [--help|--version] <file.md> [<file.md>...]
+
+RULES:
+    CL001  Section completeness — §1 (Steelman), §2 (Critique), §3 (Compare),
+           §4 (Synthesize), §5 (Reject log), §6 (Provenance), §7 (Decisions),
+           §8 (Open questions), §9 (Audit chain) all required.
+    CL002  Leading-question detection — patterns suggesting consensus to
+           next agent ("Você concorda em…", "Do you agree…", "Wouldn't you
+           say…", "Don't you think…").
+    CL003  Asymmetric framing detection — §6/§7 word-frequency disparity
+           between proposals (proposal-A descriptors disproportionately
+           positive vs proposal-B).
+    CL004  Ungrounded-claim detection — §3 critique entries lacking either
+           a quoted excerpt (e.g., `> "..."`) or source citation.
+    CL005  Missing parity-check evidence — §4 must reference the
+           end-of-ACT-4 impartiality scan outcome.
+    CL006  Missing Invariant-6 audit disclosures — §9 must contain
+           `output_language` AND `bias_techniques_applied` fields.
+
+EXIT CODES:
+    0  no violations
+    1  violations detected
+    2  invocation error
+
+EOF
+}
+
+if [ $# -eq 0 ]; then usage; exit 2; fi
+case "${1:-}" in
+  --help|-h) usage; exit 0;;
+  --version|-V) echo "$PROG $VERSION"; exit 0;;
+esac
+
+violations=0
+files_scanned=0
+
+# ---------------------------------------------------------------------------
+# Per-file scanner
+# ---------------------------------------------------------------------------
+scan_file() {
+  f="$1"
+  if [ ! -f "$f" ]; then
+    echo "$f:0:CLERR:file not found"
+    violations=$((violations + 1))
+    return
+  fi
+
+  files_scanned=$((files_scanned + 1))
+
+  # CL001 — section completeness
+  # Accept either numeric heading ("## §1", "## 1.", "## ACT 1") OR
+  # well-known section keywords.
+  for sec in steelman critique compare synthesize reject provenance decision open audit; do
+    if ! grep -qiE "^#{1,6} .*${sec}" "$f"; then
+      echo "$f:1:CL001:missing-section §${sec}"
+      violations=$((violations + 1))
+    fi
+  done
+
+  # CL002 — leading-question patterns (pt + en)
+  # Use POSIX BRE compatible with BSD grep -n -E.
+  cl002_out=$(awk -v file="$f" '
+    /converge-lint: ignore CL002/ { next }
+    /[Vv]oc[eê] concorda em/        { printf "%s:%d:CL002:leading-question (pt): %s\n", file, NR, $0 }
+    /[Dd]o you agree[ ,]/           { printf "%s:%d:CL002:leading-question (en): %s\n", file, NR, $0 }
+    /[Ww]ould.t you say/            { printf "%s:%d:CL002:leading-question (en-contraction): %s\n", file, NR, $0 }
+    /[Dd]on.t you think/            { printf "%s:%d:CL002:leading-question (en-contraction): %s\n", file, NR, $0 }
+    /[Nn][aã]o concorda[ ,?]/       { printf "%s:%d:CL002:leading-question (pt-neg): %s\n", file, NR, $0 }
+  ' "$f")
+  if [ -n "$cl002_out" ]; then
+    echo "$cl002_out"
+    cl002_n=$(echo "$cl002_out" | wc -l | tr -d ' ')
+    violations=$((violations + cl002_n))
+  fi
+
+  # CL003 — asymmetric framing
+  # Heuristic v0.1: count positive descriptors near "proposal A/B" mentions.
+  # For v0.1 we only flag if a proposal is described with >5 positive
+  # adjectives while the other has <2. Implementation deferred to v0.2 —
+  # for now emit advisory CL003-skipped marker.
+  # (Operator can opt-in stricter heuristic in v0.2.)
+
+  # CL004 — ungrounded claims in §3 Compare/critique
+  # Find blocks under any §3-equivalent heading; flag list items lacking
+  # any inline quote (`>`, `\`...\``, or "L<num>" citation).
+  cl004_out=$(awk -v file="$f" '
+    BEGIN { in_sec3 = 0; line_no = 0 }
+    /^#{1,6} .*[Cc]ompare|^#{1,6} .*ACT *3|^#{1,6} .*§3|^#{1,6} .*[Cc]ritique/ { in_sec3 = 1; next }
+    /^#{1,6} / && in_sec3 == 1 { in_sec3 = 0 }
+    in_sec3 == 1 && /^[ \t]*[-*] / {
+      has_evidence = 0
+      if ($0 ~ /`[^`]+`/)               has_evidence = 1
+      if ($0 ~ /^[ \t]*>/)              has_evidence = 1
+      if ($0 ~ /L[0-9]+|line *[0-9]+/)  has_evidence = 1
+      if (!has_evidence) {
+        printf "%s:%d:CL004:ungrounded-critique (no quote/citation): %s\n", file, NR, substr($0, 1, 80)
+      }
+    }
+  ' "$f")
+  if [ -n "$cl004_out" ]; then
+    echo "$cl004_out"
+    cl004_n=$(echo "$cl004_out" | wc -l | tr -d ' ')
+    violations=$((violations + cl004_n))
+  fi
+
+  # CL005 — §4 must reference impartiality scan
+  if grep -qiE "^#{1,6} .*synthesize|^#{1,6} .*ACT *4|^#{1,6} .*§4" "$f"; then
+    if ! grep -qiE "impartiality scan|end-of-ACT-4|persuasive framing|Invariant 6" "$f"; then
+      echo "$f:1:CL005:missing-parity-check-evidence"
+      violations=$((violations + 1))
+    fi
+  fi
+
+  # CL006 — Invariant-6 audit disclosures in §9
+  if grep -qiE "^#{1,6} .*audit chain|^#{1,6} .*ACT *9|^#{1,6} .*§9" "$f"; then
+    if ! grep -qE "output_language" "$f"; then
+      echo "$f:1:CL006:missing-output_language-in-audit-chain"
+      violations=$((violations + 1))
+    fi
+    if ! grep -qE "bias_techniques_applied" "$f"; then
+      echo "$f:1:CL006:missing-bias_techniques_applied-in-audit-chain"
+      violations=$((violations + 1))
+    fi
+  fi
+}
+
+for f in "$@"; do
+  scan_file "$f"
+done
+
+if [ "$violations" -eq 0 ]; then
+  echo "$PROG: OK — $files_scanned file(s) scanned, 0 violations." >&2
+  exit 0
+else
+  echo "$PROG: $violations violation(s) across $files_scanned file(s)." >&2
+  exit 1
+fi

--- a/scripts/converge-lint.sh
+++ b/scripts/converge-lint.sh
@@ -115,27 +115,67 @@ scan_file() {
     violations=$((violations + cl002_n))
   fi
 
-  # CL003 — asymmetric framing
-  # Heuristic v0.1: count positive descriptors near "proposal A/B" mentions.
-  # For v0.1 we only flag if a proposal is described with >5 positive
-  # adjectives while the other has <2. Implementation deferred to v0.2 —
-  # for now emit advisory CL003-skipped marker.
-  # (Operator can opt-in stricter heuristic in v0.2.)
+  # CL003 — asymmetric framing detection (lightweight v0.1)
+  # Heuristic: scan §6 Provenance + §7 Decisions for proposal-A vs proposal-B
+  # mentions; count positive descriptors per proposal. Flag if disparity > 3x.
+  # Positive descriptor set is intentionally short to minimize false positives.
+  cl003_out=$(awk -v file="$f" '
+    BEGIN {
+      in_target = 0; pos_a = 0; pos_b = 0
+      neg_a = 0; neg_b = 0  # also track negatives to refine signal
+    }
+    /^#{1,6} .*([Pp]rovenance|ACT *6|§6|[Dd]ecisions|ACT *7|§7)/ { in_target = 1; next }
+    /^#{1,6} / && in_target == 1 { in_target = 0 }
+    in_target == 1 {
+      # tally positive/negative-affect lexemes per proposal — only when line
+      # mentions ONE proposal (skip cross-comparative sentences to avoid
+      # signal cross-pollution).
+      mentions_a = ($0 ~ /[Pp]roposal *[Aa]/) || ($0 ~ /[Aa]gent-A/) || ($0 ~ /[Pp]roposta *A/) || ($0 ~ /opç[aã]o *A/)
+      mentions_b = ($0 ~ /[Pp]roposal *[Bb]/) || ($0 ~ /[Aa]gent-B/) || ($0 ~ /[Pp]roposta *B/) || ($0 ~ /opç[aã]o *B/)
+      # Word-level tally: count occurrences of positive/negative tokens, not lines
+      if (mentions_a && !mentions_b) {
+        line_lc = tolower($0)
+        n_pos = gsub(/best|optimal|robust|elegant|cleaner|superior|bold|comprehensive|excellent|ideal/, "", line_lc)
+        n_neg = gsub(/weak|brittle|sloppy|inferior|naive|simplistic|risky|fragile/, "", line_lc)
+        pos_a += n_pos; neg_a += n_neg
+      } else if (mentions_b && !mentions_a) {
+        line_lc = tolower($0)
+        n_pos = gsub(/best|optimal|robust|elegant|cleaner|superior|bold|comprehensive|excellent|ideal/, "", line_lc)
+        n_neg = gsub(/weak|brittle|sloppy|inferior|naive|simplistic|risky|fragile/, "", line_lc)
+        pos_b += n_pos; neg_b += n_neg
+      }
+    }
+    END {
+      # Net favor = positives - negatives per proposal
+      net_a = pos_a - neg_a
+      net_b = pos_b - neg_b
+      gap = (net_a > net_b ? net_a - net_b : net_b - net_a)
+      if ((pos_a + pos_b + neg_a + neg_b) >= 4 && gap >= 4) {
+        printf "%s:1:CL003:asymmetric-framing in §6/§7 (proposal-A net=%d, proposal-B net=%d, gap=%d, pos_a=%d neg_a=%d pos_b=%d neg_b=%d)\n", file, net_a, net_b, gap, pos_a, neg_a, pos_b, neg_b
+      }
+    }
+  ' "$f")
+  if [ -n "$cl003_out" ]; then
+    echo "$cl003_out"
+    cl003_n=$(echo "$cl003_out" | wc -l | tr -d ' ')
+    violations=$((violations + cl003_n))
+  fi
 
   # CL004 — ungrounded claims in §3 Compare/critique
-  # Find blocks under any §3-equivalent heading; flag list items lacking
-  # any inline quote (`>`, `\`...\``, or "L<num>" citation).
+  # Requires a blockquote excerpt (`> "..."`) OR a line citation (`L<num>`).
+  # Inline code (backticks) does NOT count as grounding — per spec §3 definition.
   cl004_out=$(awk -v file="$f" '
-    BEGIN { in_sec3 = 0; line_no = 0 }
+    BEGIN { in_sec3 = 0 }
     /^#{1,6} .*[Cc]ompare|^#{1,6} .*ACT *3|^#{1,6} .*§3|^#{1,6} .*[Cc]ritique/ { in_sec3 = 1; next }
     /^#{1,6} / && in_sec3 == 1 { in_sec3 = 0 }
     in_sec3 == 1 && /^[ \t]*[-*] / {
       has_evidence = 0
-      if ($0 ~ /`[^`]+`/)               has_evidence = 1
-      if ($0 ~ /^[ \t]*>/)              has_evidence = 1
-      if ($0 ~ /L[0-9]+|line *[0-9]+/)  has_evidence = 1
+      # Only blockquote OR line citation counts as evidence
+      if ($0 ~ /> *["'\''"]/)            has_evidence = 1   # inline blockquote with quote
+      if ($0 ~ /^[ \t]*>/)               has_evidence = 1   # blockquote on same line
+      if ($0 ~ /L[0-9]+|line *[0-9]+/)   has_evidence = 1   # line citation
       if (!has_evidence) {
-        printf "%s:%d:CL004:ungrounded-critique (no quote/citation): %s\n", file, NR, substr($0, 1, 80)
+        printf "%s:%d:CL004:ungrounded-critique (no quote-excerpt or L<num> citation): %s\n", file, NR, substr($0, 1, 80)
       }
     }
   ' "$f")
@@ -145,22 +185,33 @@ scan_file() {
     violations=$((violations + cl004_n))
   fi
 
-  # CL005 — §4 must reference impartiality scan
-  if grep -qiE "^#{1,6} .*synthesize|^#{1,6} .*ACT *4|^#{1,6} .*§4" "$f"; then
-    if ! grep -qiE "impartiality scan|end-of-ACT-4|persuasive framing|Invariant 6" "$f"; then
-      echo "$f:1:CL005:missing-parity-check-evidence"
+  # CL005 — §4 must REFERENCE impartiality scan WITHIN the §4 section body
+  # (section-scoped per Qodo PR #51 finding — was previously whole-file grep).
+  sec4_body=$(awk '
+    /^#{1,6} .*synthesize|^#{1,6} .*ACT *4|^#{1,6} .*§4/ { in_sec = 1; next }
+    /^#{1,6} / && in_sec == 1 { in_sec = 0 }
+    in_sec == 1 { print }
+  ' "$f")
+  if [ -n "$sec4_body" ]; then
+    if ! echo "$sec4_body" | grep -qiE "impartiality scan|end-of-ACT-4|persuasive framing|Invariant 6"; then
+      echo "$f:1:CL005:missing-parity-check-evidence-within-§4"
       violations=$((violations + 1))
     fi
   fi
 
-  # CL006 — Invariant-6 audit disclosures in §9
-  if grep -qiE "^#{1,6} .*audit chain|^#{1,6} .*ACT *9|^#{1,6} .*§9" "$f"; then
-    if ! grep -qE "output_language" "$f"; then
-      echo "$f:1:CL006:missing-output_language-in-audit-chain"
+  # CL006 — Invariant-6 audit disclosures WITHIN §9 (section-scoped)
+  sec9_body=$(awk '
+    /^#{1,6} .*audit chain|^#{1,6} .*ACT *9|^#{1,6} .*§9/ { in_sec = 1; next }
+    /^#{1,6} / && in_sec == 1 { in_sec = 0 }
+    in_sec == 1 { print }
+  ' "$f")
+  if [ -n "$sec9_body" ]; then
+    if ! echo "$sec9_body" | grep -qE "output_language"; then
+      echo "$f:1:CL006:missing-output_language-within-§9-audit-chain"
       violations=$((violations + 1))
     fi
-    if ! grep -qE "bias_techniques_applied" "$f"; then
-      echo "$f:1:CL006:missing-bias_techniques_applied-in-audit-chain"
+    if ! echo "$sec9_body" | grep -qE "bias_techniques_applied"; then
+      echo "$f:1:CL006:missing-bias_techniques_applied-within-§9-audit-chain"
       violations=$((violations + 1))
     fi
   fi

--- a/tests/converge/README.md
+++ b/tests/converge/README.md
@@ -1,0 +1,47 @@
+# tests/converge — converge skill test rig
+
+Closes the **tooling** portion of issue [#50](https://github.com/ekson73/multi-agent-os/issues/50) (follow-up to #45).
+
+## What's here
+
+| Path | Purpose |
+|---|---|
+| `case-01-balanced/output.md` | Well-formed converge output (§1-§9 present, Invariant 6 honored) — expected to PASS lint |
+| `case-02-missing-sections/output.md` | Output missing §1 Steelman, §5 Reject log, §8 Open questions — expected to fail with CL001+CL005+CL006 |
+| `case-03-leading-question/output.md` | Output with persuasive framing ("Você concorda em…", "Don't you think A would also work?") — expected to fail with CL002 |
+| `case-NN/expected.txt` | `exit_code=<N>` + optional `expected_rules=<list>` declaring the assertion |
+| `run.sh` | POSIX-sh test runner; invokes `../../scripts/converge-lint.sh` on each case + asserts |
+
+## Usage
+
+```bash
+# Run the full rig locally
+./tests/converge/run.sh
+
+# Or run lint on a single output you produced
+./scripts/converge-lint.sh /path/to/your-converge-output.md
+```
+
+## CI
+
+`.github/workflows/converge-tests.yml` runs the rig on every PR touching `skills/converge/**`, `scripts/converge-*.sh`, `tests/converge/**`, or the workflow itself.
+
+## Adding a new case
+
+1. Create `tests/converge/case-NN-<name>/output.md` with the markdown content
+2. Create `tests/converge/case-NN-<name>/expected.txt`:
+   ```
+   exit_code=0      # or 1
+   expected_rules=CL00X CL00Y   # optional, space-separated
+   ```
+3. Re-run `./tests/converge/run.sh` to verify
+
+## Format-only validation
+
+The rig asserts **structure** (sections present, fields populated, framing-anti-bias guards). It does NOT score subjective content quality — that remains a human responsibility.
+
+## Refs
+
+- Skill spec: [`skills/converge/SKILL.md`](../../skills/converge/SKILL.md) v1.1.1+
+- Issues: [#45](https://github.com/ekson73/multi-agent-os/issues/45) (original dogfooding) · [#50](https://github.com/ekson73/multi-agent-os/issues/50) (this tooling)
+- Lint rules documented in `scripts/converge-lint.sh --help`

--- a/tests/converge/README.md
+++ b/tests/converge/README.md
@@ -9,6 +9,8 @@ Closes the **tooling** portion of issue [#50](https://github.com/ekson73/multi-a
 | `case-01-balanced/output.md` | Well-formed converge output (§1-§9 present, Invariant 6 honored) — expected to PASS lint |
 | `case-02-missing-sections/output.md` | Output missing §1 Steelman, §5 Reject log, §8 Open questions — expected to fail with CL001+CL005+CL006 |
 | `case-03-leading-question/output.md` | Output with persuasive framing ("Você concorda em…", "Don't you think A would also work?") — expected to fail with CL002 |
+| `case-04-contradictory/output.md` | Output with `no-convergence-possible` verdict (axiom-level disagreement) — expected to PASS lint (verdict is content, not structural violation) |
+| `case-05-asymmetric-loud/output.md` | Output with heavily-positive framing on Proposal A + heavily-negative on Proposal B in §6/§7 — expected to fail with CL003 (asymmetric framing detection) |
 | `case-NN/expected.txt` | `exit_code=<N>` + optional `expected_rules=<list>` declaring the assertion |
 | `run.sh` | POSIX-sh test runner; invokes `../../scripts/converge-lint.sh` on each case + asserts |
 

--- a/tests/converge/case-01-balanced/expected.txt
+++ b/tests/converge/case-01-balanced/expected.txt
@@ -1,0 +1,2 @@
+exit_code=0
+violations=0

--- a/tests/converge/case-01-balanced/output.md
+++ b/tests/converge/case-01-balanced/output.md
@@ -1,0 +1,53 @@
+# Converge output — case-01-balanced (well-formed, all sections present)
+
+## §1 Steelman
+
+### Proposal A steelman
+Strongest argument for A: it addresses the root cause directly with measurable outcomes.
+
+### Proposal B steelman
+Strongest argument for B: it preserves backward compatibility and minimizes blast radius.
+
+## §2 Critique
+
+- Proposal A weakness: assumes upstream cooperation `> "we need their endorsement"` (line 12 of proposal-A).
+- Proposal B weakness: defers the underlying issue to a later cycle (citation: L34).
+
+## §3 Compare
+
+- A is bolder, B is safer (`> "minimize blast radius"`, L8 of B).
+- A requires 2 weeks of work; B requires 3 days (citation: L41).
+- Both agree on the desired end state (`> "tenant isolation by default"`).
+
+## §4 Synthesize
+
+End-of-ACT-4 impartiality scan applied (Invariant 6): no leading questions detected; framing parity confirmed across proposals.
+
+Recommended synthesis: adopt B for the immediate cycle + plan A for next quarter.
+
+## §5 Reject log
+
+- Considered: hybrid approach combining A & B → REJECTED because it introduces a third state that increases test surface 3x.
+- Considered: defer entirely → REJECTED because the underlying issue is causing weekly incidents.
+
+## §6 Provenance
+
+- Proposal A author: Agent-A (run 2026-05-12 14:00 UTC)
+- Proposal B author: Agent-B (run 2026-05-12 14:05 UTC)
+- Synthesis author: Agent-C (run 2026-05-12 14:15 UTC)
+
+## §7 Decisions
+
+- DECIDED: adopt B for cycle N.
+- DEFERRED: A for cycle N+1, contingent on B success metrics.
+
+## §8 Open questions
+
+- What constitutes "B success" for the cycle N+1 gate?
+
+## §9 Audit chain
+
+- output_language: pt
+- bias_techniques_applied: ["parity-check-acted", "steelman-first"]
+- sources: proposals/A.md, proposals/B.md
+- timestamp: 2026-05-12T14:15:00Z

--- a/tests/converge/case-02-missing-sections/expected.txt
+++ b/tests/converge/case-02-missing-sections/expected.txt
@@ -1,0 +1,2 @@
+exit_code=1
+expected_rules=CL001 CL005 CL006

--- a/tests/converge/case-02-missing-sections/output.md
+++ b/tests/converge/case-02-missing-sections/output.md
@@ -1,0 +1,28 @@
+# Converge output — case-02-missing-sections (missing §1, §5, §8)
+
+## §2 Critique
+
+- A has weak evidence.
+- B has stronger backing.
+
+## §3 Compare
+
+- A vs B differ in scope.
+- A is more ambitious.
+
+## §4 Synthesize
+
+Synthesis recommendation: B.
+
+## §6 Provenance
+
+- A: Agent-A
+- B: Agent-B
+
+## §7 Decisions
+
+- DECIDED: B.
+
+## §9 Audit chain
+
+- timestamp: 2026-05-12

--- a/tests/converge/case-03-leading-question/expected.txt
+++ b/tests/converge/case-03-leading-question/expected.txt
@@ -1,0 +1,2 @@
+exit_code=1
+expected_rules=CL002

--- a/tests/converge/case-03-leading-question/output.md
+++ b/tests/converge/case-03-leading-question/output.md
@@ -1,0 +1,43 @@
+# Converge output — case-03-leading-question (persuasive framing detected)
+
+## §1 Steelman
+
+Both proposals defended.
+
+## §2 Critique
+
+- A has a real weakness `> "scope creep"`.
+- B has a weakness `> "deferred root cause"` (L12).
+
+## §3 Compare
+
+- Both differ in scope `> "ambitious vs conservative"`.
+
+## §4 Synthesize
+
+End-of-ACT-4 impartiality scan: passed. Invariant 6 honored.
+
+Recommend B. Você concorda em adotar B nesta wave?
+
+## §5 Reject log
+
+- Hybrid was REJECTED — increases surface.
+
+## §6 Provenance
+
+- A: Agent-A
+- B: Agent-B
+
+## §7 Decisions
+
+- DECIDED: B (pending confirmation). Don't you think A would also work?
+
+## §8 Open questions
+
+- None at this time.
+
+## §9 Audit chain
+
+- output_language: pt
+- bias_techniques_applied: ["steelman-first"]
+- timestamp: 2026-05-12

--- a/tests/converge/case-04-contradictory/expected.txt
+++ b/tests/converge/case-04-contradictory/expected.txt
@@ -1,0 +1,2 @@
+exit_code=0
+violations=0

--- a/tests/converge/case-04-contradictory/output.md
+++ b/tests/converge/case-04-contradictory/output.md
@@ -1,0 +1,53 @@
+# Converge output — case-04-contradictory (no-convergence-possible verdict)
+
+## §1 Steelman
+
+### Proposal A steelman
+Use schema-per-tenant for hard isolation guarantees.
+
+### Proposal B steelman
+Use row-level-security with tenant_id column for simpler operational model.
+
+## §2 Critique
+
+- Proposal A: requires N schemas at scale, complex migrations `> "schema migration matrix"` (L23).
+- Proposal B: relies on RLS policies being correct per-table; one bug = data leak (citation: L41).
+
+## §3 Compare
+
+- A favors hard isolation `> "physical separation"`, B favors operational simplicity `> "single schema"` (L8).
+- A: high migration cost. B: low (citation: L14).
+- Disagreement at axiom level (L1 of A vs L1 of B): data isolation vs operational uniformity.
+
+## §4 Synthesize
+
+End-of-ACT-4 impartiality scan applied (Invariant 6): no leading questions; framing parity confirmed.
+
+**Verdict: `no-convergence-possible`** — proposals differ at the axiom level (data isolation model). No synthesis preserves both A's strict-separation invariant AND B's single-schema invariant simultaneously. Escalate to architecture decision (ADR required).
+
+## §5 Reject log
+
+- Considered: hybrid (schema-per-tenant for PII tables + RLS for ops tables) → REJECTED because it inherits weaknesses of both: schema migration complexity AND RLS policy correctness burden.
+
+## §6 Provenance
+
+- Proposal A author: Agent-A (DBA-specialist mind-set, run 2026-05-12)
+- Proposal B author: Agent-B (DevOps-pragmatist mind-set, run 2026-05-12)
+
+## §7 Decisions
+
+- DECIDED: no-convergence-possible — escalate to ADR + CTO review.
+- DEFERRED: implementation choice until ADR ratified.
+
+## §8 Open questions
+
+- Which invariant takes precedence: data isolation OR operational simplicity?
+- Are there regulatory constraints (LGPD/GDPR) that force one over the other?
+
+## §9 Audit chain
+
+- output_language: en
+- bias_techniques_applied: ["axiom-level-disagreement-detection", "no-forced-synthesis"]
+- sources: proposals/A.md, proposals/B.md
+- timestamp: 2026-05-12T22:00:00Z
+- verdict: no-convergence-possible

--- a/tests/converge/case-05-asymmetric-loud/expected.txt
+++ b/tests/converge/case-05-asymmetric-loud/expected.txt
@@ -1,0 +1,2 @@
+exit_code=1
+expected_rules=CL003

--- a/tests/converge/case-05-asymmetric-loud/output.md
+++ b/tests/converge/case-05-asymmetric-loud/output.md
@@ -1,0 +1,49 @@
+# Converge output — case-05-asymmetric-loud (CL003 trigger via §6/§7 framing)
+
+This case intentionally demonstrates an output where one proposal gets heavily-positive framing in §6/§7 while the other gets heavily-negative framing — CL003 must detect this.
+
+## §1 Steelman
+
+### Proposal A steelman
+Adopt approach A — optimal for our needs.
+
+### Proposal B steelman
+Adopt approach B — simpler implementation.
+
+## §2 Critique
+
+- A: requires more effort `> "more upfront work"` (L23).
+- B: defers underlying issue (citation: L41).
+
+## §3 Compare
+
+- A is better architected `> "cleaner long-term"` (L8 of A).
+- B is faster to ship (citation: L14 of B).
+
+## §4 Synthesize
+
+End-of-ACT-4 impartiality scan applied (Invariant 6). Recommend A.
+
+## §5 Reject log
+
+- Hybrid REJECTED — increases surface.
+
+## §6 Provenance
+
+- Proposal A author: Agent-A — robust, elegant, cleaner architecture. Optimal solution.
+- Proposal B author: Agent-B — weak, brittle, sloppy implementation. Inferior approach. Fragile.
+
+## §7 Decisions
+
+- DECIDED: Proposal A is comprehensive and excellent. Proposal B is naive and risky.
+
+## §8 Open questions
+
+- Timeline for A rollout.
+
+## §9 Audit chain
+
+- output_language: en
+- bias_techniques_applied: ["NOTE: this output INTENTIONALLY violates impartiality for test fixture purposes — CL003 must detect"]
+- sources: proposals/A.md, proposals/B.md
+- timestamp: 2026-05-12

--- a/tests/converge/run.sh
+++ b/tests/converge/run.sh
@@ -1,0 +1,76 @@
+#!/bin/sh
+# tests/converge/run.sh — Run the converge-lint script across known fixtures
+# and assert each case matches its expected.txt declaration.
+#
+# USAGE:
+#   ./tests/converge/run.sh
+#
+# Exit 0 if all cases pass; exit 1 otherwise.
+
+set -u  # do NOT set -e — we expect non-zero exits from some test runs
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+LINT="$ROOT/scripts/converge-lint.sh"
+CASES_DIR="$ROOT/tests/converge"
+
+if [ ! -x "$LINT" ]; then
+  echo "FAIL: lint script not found or not executable at $LINT" >&2
+  exit 1
+fi
+
+total=0
+passed=0
+failed=0
+
+for case_dir in "$CASES_DIR"/case-*/; do
+  [ -d "$case_dir" ] || continue
+  case_name="$(basename "$case_dir")"
+  output_md="$case_dir/output.md"
+  expected_txt="$case_dir/expected.txt"
+
+  if [ ! -f "$output_md" ] || [ ! -f "$expected_txt" ]; then
+    echo "[SKIP] $case_name — missing output.md or expected.txt"
+    continue
+  fi
+
+  total=$((total + 1))
+
+  # Run the lint; capture exit + stdout
+  actual_out="$(set +e; "$LINT" "$output_md" 2>/dev/null; echo "EXIT=$?")"
+  actual_exit="$(echo "$actual_out" | sed -n 's/^EXIT=//p' | tail -1)"
+  actual_stdout="$(echo "$actual_out" | sed '$d')"
+
+  # Parse expected
+  expected_exit="$(grep '^exit_code=' "$expected_txt" | head -1 | sed 's/^exit_code=//')"
+  expected_rules="$(grep '^expected_rules=' "$expected_txt" | head -1 | sed 's/^expected_rules=//')"
+
+  pass=1
+
+  if [ "$actual_exit" != "$expected_exit" ]; then
+    echo "[FAIL] $case_name — exit code mismatch (expected=$expected_exit, actual=$actual_exit)"
+    pass=0
+  fi
+
+  # If expected_rules listed, assert each appears in stdout
+  if [ -n "${expected_rules:-}" ]; then
+    for rule in $expected_rules; do
+      if ! echo "$actual_stdout" | grep -q ":$rule:"; then
+        echo "[FAIL] $case_name — expected rule $rule not detected"
+        pass=0
+      fi
+    done
+  fi
+
+  if [ "$pass" -eq 1 ]; then
+    echo "[ OK ] $case_name (exit=$actual_exit)"
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    echo "       --- actual stdout ---"
+    echo "$actual_stdout" | sed 's/^/       /'
+  fi
+done
+
+echo ""
+echo "Summary: $passed/$total passed, $failed failed"
+[ "$failed" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Closes [#50](https://github.com/ekson73/multi-agent-os/issues/50) — the deferred tooling tier from the original [#45](https://github.com/ekson73/multi-agent-os/issues/45) dogfooding spec.

The mandatory spec changes (Invariant 6 audit-not-persuasion, impartiality scan, `output_language`, `bias_techniques_applied`) and nice-to-haves (§11 handoff template, `no-convergence-possible` example, worktree note, bidirectional cross-refs) already landed in #46 (v1.1.0) and #48 (v1.1.1). This PR adds the guardrails to **enforce** them at PR-time.

## Deliverables

### 1. `scripts/converge-lint.sh` (v0.1.0)

POSIX-sh + BSD-grep/awk compatible linter. Zero deps (no Python/Node/jq). 6 rules:

| Rule | Detects |
|---|---|
| **CL001** | Missing required sections (§1 Steelman, §2 Critique, §3 Compare, §4 Synthesize, §5 Reject log, §6 Provenance, §7 Decisions, §8 Open questions, §9 Audit chain) |
| **CL002** | Leading-question patterns ("Você concorda em…", "Do you agree…", "Wouldn't you say…", "Don't you think…", "Não concorda…") — pt + en |
| **CL003** | Asymmetric framing (placeholder — heuristic deferred to v0.2) |
| **CL004** | Ungrounded critique (§3 list items lacking inline quote, backtick code, or `L<num>` line citation) |
| **CL005** | Missing parity-check evidence — §4 must reference end-of-ACT-4 impartiality scan |
| **CL006** | Missing Invariant-6 audit disclosures — §9 must contain `output_language` AND `bias_techniques_applied` |

Operator suppression per-line: `# converge-lint: ignore CL002` HTML comment.
Exit codes: 0 clean, 1 violations, 2 invocation error.

### 2. `tests/converge/` — 3 known proposal cases + runner

| Case | Expected behavior |
|---|---|
| `case-01-balanced` | Well-formed output → PASS (exit 0) |
| `case-02-missing-sections` | Missing §1, §5, §8 → FAIL with CL001+CL005+CL006 |
| `case-03-leading-question` | Persuasive framing ("Você concorda em…", "Don't you think…") → FAIL with CL002 |

`run.sh` is the POSIX-sh runner; per-case `expected.txt` declares `exit_code=<N>` + optional `expected_rules=<list>`.

### 3. `.github/workflows/converge-tests.yml`

Runs the rig on PRs touching `skills/converge/**`, `scripts/converge-*.sh`, `tests/converge/**`, or this workflow.

## Local validation (pre-commit)

```bash
$ ./scripts/converge-lint.sh --help        # → exit 0, prints rule reference
$ ./tests/converge/run.sh                  # → 3/3 passed, 0 failed
$ gitleaks detect --no-git --source .      # → 0 leaks in working tree
```

## Out of scope (v0.2 backlog)

- CL003 stricter heuristic (word-frequency comparison between proposals)
- Multi-language regex beyond pt + en (es, fr, de — depends on real cross-lingual usage)
- LLM-based subjective content evaluation
- Negative-case allowlist (e.g., paragraphs in §8 Open questions ARE allowed to be questions)

## Refs

- Parent issue: [#45](https://github.com/ekson73/multi-agent-os/issues/45) (closed)
- This issue: [#50](https://github.com/ekson73/multi-agent-os/issues/50) (closes on merge)
- Skill: `skills/converge/SKILL.md` v1.1.1+
- Memory rule: `feedback_audit_regex_completeness.md` — informed CL001/CL002 defensive regex
- Auto-orchestrator: spawned this PR per operator command "work on #50" (2026-05-12)

🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.7