### PR TITLE
fix(ci): allow `deps` and `deps-dev` types in C07 nomenclature check

### DIFF
--- a/.github/workflows/ai-governance-linter.yml
+++ b/.github/workflows/ai-governance-linter.yml
@@ -25,6 +25,8 @@ jobs:
             ci
             chore
             revert
+            deps
+            deps-dev
           requireScope: false
           
       - name: Validar Assinatura da IA Autônoma (Co-Authored-By)


### PR DESCRIPTION
## Summary

**Auto-orchestrator Tree 1** — unblocks 6 Dependabot PRs (#55, #57, #60, #61, #62, #63) blocked by a config mismatch shipped in PR #53.

## The bug

`commit-message.prefix: "deps"` / `prefix-development: "deps-dev"` were set in `.github/dependabot.yml` (PR #53). Dependabot emits PR titles like `deps(deps): update fastmcp requirement...`. The C07 nomenclature check at `.github/workflows/ai-governance-linter.yml` only allowed the 11 stock types (`feat / fix / docs / style / refactor / perf / test / build / ci / chore / revert`), so all 6 pip Dependabot PRs failed:

> `##[error]Unknown release type "deps" found in pull request title "deps(deps): update fastmcp requirement from >=2.0.0 to >=3.3.1..."`

CI-prefixed bumps (`ci:` for github-actions) were already passing.

## Fix

Add `deps` and `deps-dev` to the types allowlist (2 lines).

Both are industry-standard Conventional Commits types for dependency updates (Dependabot, Renovate, and most Conventional-Commits-aligned bots use them).

## Risk + rollback

- **Risk**: Zero. Adding allowed types only relaxes the gate; existing valid types stay valid.
- **Rollback**: `git revert` removes the 2 lines.

## Test plan

- [x] gitleaks staged pre-commit clean
- [ ] Governance pipeline self-check on this PR runs successfully (auto-validates the YAML change)
- [ ] After merge: re-run / re-check the 6 pip Dependabot PRs — all should flip from UNSTABLE → CLEAN

## Refs

- PR #53 / commit `a6a4740` — introduced the dependabot config
- This PR is the corrective follow-up tracked in PR #53's "Follow-ups (out of scope)" section as part of governance baseline tuning

🤖 Auto-orchestrator Tree 1/3 (count=3, --max-iter 10).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
