### PR TITLE
fix(ci): set dependabot `prefix-development` to `deps` (Conventional Commits compat)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,8 +23,13 @@ updates:
     reviewers:
       - "ekson73"
     commit-message:
+      # `deps-dev` was tried first but Conventional Commits parser
+      # (amannn/action-semantic-pull-request) rejects hyphenated types
+      # ("No release type found"). Both prod and dev deps use `deps:` type;
+      # the `(deps-dev)` scope token in the title still distinguishes them
+      # (e.g. "deps(deps-dev): bump pytest from 8.0 to 8.1").
       prefix: "deps"
-      prefix-development: "deps-dev"
+      prefix-development: "deps"
       include: "scope"
     groups:
       python-minor-patch:


### PR DESCRIPTION
## Summary

Auto-orchestrator Tree 1b — unblocks PR #55 (the only Dependabot PR still failing after PR #64 allowlist fix).

PR #55 title format `deps-dev(deps-dev): bump...` triggers a different parser error than the original:

> `##[error]No release type found in pull request title "deps-dev(deps-dev): bump the python-minor-patch group..."`

Root cause: `amannn/action-semantic-pull-request@v6` rejects hyphenated type identifiers as malformed even when they're in the allowlist (parser-level rejection, not allowlist-level).

## Fix

Change `prefix-development: "deps-dev"` → `"deps"`. Dev/prod distinction preserved via the `(deps-dev)` scope token in the title:
- Before: `deps-dev(deps-dev): bump pytest from 8.0 to 8.1`
- After: `deps(deps-dev): bump pytest from 8.0 to 8.1`

Inline comment in `.github/dependabot.yml` explains the rationale so future maintainers don't re-introduce the hyphenated form.

## Test plan

- [x] gitleaks staged scan clean
- [ ] After merge: comment `@dependabot rebase` on PR #55 → expect title to become `deps(deps-dev): ...` → governance-validation passes
- [ ] Future dev-dep bumps from Dependabot will use the corrected prefix

## Risk + rollback

- **Risk**: Zero. Affects only Dependabot's PR-title prefix; no runtime/build behavior touched.
- **Rollback**: `git revert`.

🤖 Auto-orchestrator Tree 1b (follow-up to PR #64).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
