### PR TITLE
refactor(commands): rename /status → /agentic-status to resolve Claude built-in collision (v1.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **DEPRECATION ALIAS**: `commands/status.md` retained for 1 release with deprecation warning + redirect to `/agentic-status`; hard-removed in **v1.6.0**
 - **Sandwich Namespacing pattern** Layer 3 (function-specific filename) — paired with companion PRs:
   - PR-3 manifest extension (`.claude-plugin/plugin.json` `command_namespace` block — Layer 2)
-  - Companion vendor-reserved-words list (`~/.claude/docs/vendor-reserved-words.md` — Layer 4 audit reference)
+  - Companion vendor-reserved-words list (sister-PR [ekson73/vek-dot-claude#54](https://github.com/ekson73/vek-dot-claude/pull/54), merged — Layer 4 audit reference)
   - AGENTS.md §34/§73 refinement (Layer 5 convention/docs)
 - **Unchanged**: `skills/status-map/SKILL.md` already has `-map` qualifier; no collision risk; remains invocation target of `/agentic-status`
-- **Refs**: Plan PR-2 of 5 at `~/.claude/plans/jaunty-riding-knuth.md` · Sister-PR (vendor-words) ekson73/vek-dot-claude#54
+- **Refs**: Sister-PR (vendor-words audit list — Sandwich Namespacing Layer 4) at [ekson73/vek-dot-claude#54](https://github.com/ekson73/vek-dot-claude/pull/54) (merged 2026-05-21)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+#### Command `status` → `agentic-status` (v1.5.1 — naming collision fix)
+
+- **RENAME** `commands/status.md` → `commands/agentic-status.md` to resolve empirical collision with Claude Code built-in `/status` (observed 2026-05-21; built-in surfaces session/model/auth metadata, not agentic-system state)
+- **DEPRECATION ALIAS**: `commands/status.md` retained for 1 release with deprecation warning + redirect to `/agentic-status`; hard-removed in **v1.6.0**
+- **Sandwich Namespacing pattern** Layer 3 (function-specific filename) — paired with companion PRs:
+  - PR-3 manifest extension (`.claude-plugin/plugin.json` `command_namespace` block — Layer 2)
+  - Companion vendor-reserved-words list (`~/.claude/docs/vendor-reserved-words.md` — Layer 4 audit reference)
+  - AGENTS.md §34/§73 refinement (Layer 5 convention/docs)
+- **Unchanged**: `skills/status-map/SKILL.md` already has `-map` qualifier; no collision risk; remains invocation target of `/agentic-status`
+- **Refs**: Plan PR-2 of 5 at `~/.claude/plans/jaunty-riding-knuth.md` · Sister-PR (vendor-words) ekson73/vek-dot-claude#54
+
 ### Added
 
 #### Skill `auto-pilot` v0.1.0 — Autonomous unattended orchestration entry point

--- a/commands/agentic-status.md
+++ b/commands/agentic-status.md
@@ -1,0 +1,65 @@
+---
+name: agentic-status
+description: Display human-readable status of the agentic system (git + agents + sentinel + locks) using Status Map templates. Renamed from `status` (v1.5.1) to avoid collision with Claude Code built-in `/status`.
+---
+
+# /agentic-status Command
+
+Displays human-readable ASCII status visualizations for the current agentic-system session (git + agents + sentinel + locks).
+
+> **Renamed from `/status`** in v1.5.1 to avoid collision with Claude Code built-in `/status` (which shows session/model/auth metadata). The deprecation alias `/status` remains functional for 1 release with warning; will be hard-removed in v1.6.0.
+
+## Usage
+
+```
+/agentic-status [template]
+```
+
+## Templates
+
+| Template | Description | Absorption Time |
+|----------|-------------|-----------------|
+| (default) | COMPACT - Quick 6-line check | 3-5s |
+| `pulse` | 1-line minimal status | 1-2s |
+| `full` | Complete audit report | 60-120s |
+| `debug` | Error diagnosis view | 15-20s |
+| `pre` | Pre-commit validation | 8-10s |
+| `end` | Session handoff summary | 20-30s |
+
+## Examples
+
+```
+/agentic-status              # COMPACT template (default)
+/agentic-status pulse        # 1-line status
+/agentic-status full         # Full report
+/agentic-status debug        # Debug view for errors
+```
+
+## Output Examples
+
+### PULSE
+```
+[PULSE] ████████░░ 80% | ✓3 ↻1 ⚠0 | 25m | → Continue editing
+```
+
+### COMPACT (default)
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  STATUS MAP | 2026-01-06T12:30 | Session: c614                  │
+├────────────┬────────────────────────────────────────────────────┤
+│ 🟢 GIT     │ main | clean | last: a31b933                       │
+│ 🟢 AGENTS  │ 23 completed | 0 active | 0 blocked                │
+│ 🟢 SENTINEL│ v1.0 | 10 rules | health: 100                      │
+│ 🟢 LOCKS   │ 0 active | 0 stale                                 │
+├────────────┴────────────────────────────────────────────────────┤
+│ NEXT: aguardando instrucao do humano                            │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Semaphore Indicators
+
+| Indicator | Meaning |
+|-----------|---------|
+| 🟢 | OK / Healthy |
+| 🟡 | Warning / Attention |
+| 🔴 | Error / Critical |

--- a/commands/agentic-status.md
+++ b/commands/agentic-status.md
@@ -11,7 +11,7 @@ Displays human-readable ASCII status visualizations for the current agentic-syst
 
 ## Usage
 
-```
+```text
 /agentic-status [template]
 ```
 
@@ -28,7 +28,7 @@ Displays human-readable ASCII status visualizations for the current agentic-syst
 
 ## Examples
 
-```
+```text
 /agentic-status              # COMPACT template (default)
 /agentic-status pulse        # 1-line status
 /agentic-status full         # Full report
@@ -38,12 +38,14 @@ Displays human-readable ASCII status visualizations for the current agentic-syst
 ## Output Examples
 
 ### PULSE
-```
+
+```text
 [PULSE] ████████░░ 80% | ✓3 ↻1 ⚠0 | 25m | → Continue editing
 ```
 
 ### COMPACT (default)
-```
+
+```text
 ┌─────────────────────────────────────────────────────────────────┐
 │  STATUS MAP | 2026-01-06T12:30 | Session: c614                  │
 ├────────────┬────────────────────────────────────────────────────┤

--- a/commands/status.md
+++ b/commands/status.md
@@ -23,7 +23,7 @@ The fix follows the **Sandwich Namespacing 5-layer pattern** documented in:
 
 ## Equivalent invocation (use this instead)
 
-```
+```text
 /agentic-status              # COMPACT template (default) — RECOMMENDED
 /agentic-status pulse        # 1-line status
 /agentic-status full         # Full audit report
@@ -32,10 +32,9 @@ The fix follows the **Sandwich Namespacing 5-layer pattern** documented in:
 /agentic-status end          # Session handoff
 ```
 
-See `/agentic-status` command documentation for full template reference + ASCII output examples.
+See [`/agentic-status` command documentation](./agentic-status.md) for full template reference + ASCII output examples.
 
 ## Refs
 
-- Plan PR-2 of 5: `~/.claude/plans/jaunty-riding-knuth.md`
-- CHANGELOG.md v1.5.1 entry
-- `~/.claude/docs/vendor-reserved-words.md` (origin of Sandwich Namespacing pattern)
+- [CHANGELOG.md](../CHANGELOG.md) — `[Unreleased] §Changed v1.5.1` entry documents rename rationale + Sandwich Namespacing pattern
+- [Sister PR ekson73/vek-dot-claude#54](https://github.com/ekson73/vek-dot-claude/pull/54) — vendor-reserved-words audit list (Layer 4 of Sandwich Namespacing 5-layer pattern)

--- a/commands/status.md
+++ b/commands/status.md
@@ -1,63 +1,41 @@
 ---
 name: status
-description: Display human-readable status of current session using Status Map templates
+description: "[DEPRECATED v1.5.1 → removed v1.6.0] Alias for /agentic-status. Renamed to avoid collision with Claude Code built-in /status."
 ---
 
-# /status Command
+# /status Command — ⚠️ DEPRECATED ALIAS
 
-Displays human-readable ASCII status visualizations for the current session.
+> **⚠️ DEPRECATION NOTICE**
+>
+> This command was renamed to **`/agentic-status`** in v1.5.1 to avoid collision with the Claude Code built-in `/status` (which shows session/model/auth metadata, unrelated to agentic-system status).
+>
+> **Action required**: update muscle-memory + tooling to use `/agentic-status` instead.
+>
+> **Removal**: this alias will be **hard-removed in v1.6.0**. Re-target now to avoid disruption.
 
-## Usage
+## Why the rename?
 
-```
-/status [template]
-```
+Per empirical observation 2026-05-21, the plugin command `/status` collided with Claude Code's built-in `/status`. The runtime resolution was ambiguous (built-in vs plugin), making UX unpredictable.
 
-## Templates
+The fix follows the **Sandwich Namespacing 5-layer pattern** documented in:
+- `~/.claude/docs/vendor-reserved-words.md` v1.0.0 (Layer 2 — vendor-reserved audit)
+- `multi-agent-os/AGENTS.md` §34/§73 refined (Layer 3 — function-specific filename)
 
-| Template | Description | Absorption Time |
-|----------|-------------|-----------------|
-| (default) | COMPACT - Quick 6-line check | 3-5s |
-| `pulse` | 1-line minimal status | 1-2s |
-| `full` | Complete audit report | 60-120s |
-| `debug` | Error diagnosis view | 15-20s |
-| `pre` | Pre-commit validation | 8-10s |
-| `end` | Session handoff summary | 20-30s |
-
-## Examples
+## Equivalent invocation (use this instead)
 
 ```
-/status              # COMPACT template (default)
-/status pulse        # 1-line status
-/status full         # Full report
-/status debug        # Debug view for errors
+/agentic-status              # COMPACT template (default) — RECOMMENDED
+/agentic-status pulse        # 1-line status
+/agentic-status full         # Full audit report
+/agentic-status debug        # Debug view
+/agentic-status pre          # Pre-commit validation
+/agentic-status end          # Session handoff
 ```
 
-## Output Examples
+See `/agentic-status` command documentation for full template reference + ASCII output examples.
 
-### PULSE
-```
-[PULSE] ████████░░ 80% | ✓3 ↻1 ⚠0 | 25m | → Continue editing
-```
+## Refs
 
-### COMPACT (default)
-```
-┌─────────────────────────────────────────────────────────────────┐
-│  STATUS MAP | 2026-01-06T12:30 | Session: c614                  │
-├────────────┬────────────────────────────────────────────────────┤
-│ 🟢 GIT     │ main | clean | last: a31b933                       │
-│ 🟢 AGENTS  │ 23 completed | 0 active | 0 blocked                │
-│ 🟢 SENTINEL│ v1.0 | 10 rules | health: 100                      │
-│ 🟢 LOCKS   │ 0 active | 0 stale                                 │
-├────────────┴────────────────────────────────────────────────────┤
-│ NEXT: aguardando instrucao do humano                            │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-## Semaphore Indicators
-
-| Indicator | Meaning |
-|-----------|---------|
-| 🟢 | OK / Healthy |
-| 🟡 | Warning / Attention |
-| 🔴 | Error / Critical |
+- Plan PR-2 of 5: `~/.claude/plans/jaunty-riding-knuth.md`
+- CHANGELOG.md v1.5.1 entry
+- `~/.claude/docs/vendor-reserved-words.md` (origin of Sandwich Namespacing pattern)


### PR DESCRIPTION
## Summary

Renames `/status` → `/agentic-status` to resolve empirical collision with Claude Code built-in `/status` (which shows session/model/auth metadata, unrelated to agentic-system state).

Preserves backward compatibility via 1-release deprecation alias.

## Why

Empirical observation 2026-05-21: invoking `/status` produced ambiguous runtime resolution between:
- **Claude Code built-in `/status`** (vendor-native) — shows model + auth + session metadata
- **multi-agent-os `commands/status.md`** — wraps `skills/status-map/SKILL.md` for ASCII visualization of agentic state

Operator-reported UX confusion → governance fix needed.

## Architectural pattern

Implements **Sandwich Namespacing 5-layer Layer 3** (function-specific filename) — paired with companion changes:
- ✅ Companion vendor-reserved-words list at [ekson73/vek-dot-claude#54](https://github.com/ekson73/vek-dot-claude/pull/54) (Layer 4 audit reference)
- 🔜 PR-3 manifest extension (Layer 2 — `command_namespace` block in `.claude-plugin/plugin.json`)
- 🔜 AGENTS.md §34/§73 refinement (Layer 5 convention/docs)

## Changes

| File | Action | Notes |
|---|---|---|
| `commands/status.md` → `commands/agentic-status.md` | RENAME + update frontmatter name + body title/usage | Preserves all 6 templates (COMPACT/PULSE/FULL/DEBUG/PRE/END) |
| `commands/status.md` (NEW) | Create as deprecation alias | 1-release TTL; warning banner + redirect to `/agentic-status` |
| `CHANGELOG.md` | Add `[Unreleased] §Changed v1.5.1` entry | Conventional Commits format |
| `skills/status-map/SKILL.md` | **Unchanged** | Already has `-map` qualifier; no collision; remains target of `/agentic-status` |

## Deprecation timeline

- **v1.5.1** (this PR): rename + alias active
- **v1.6.0** (next minor): hard-remove `commands/status.md` alias

Users have 1 minor-version window to update muscle-memory + tooling.

## Test plan

- [x] gitleaks pre-commit: PASS (commit `b0483ee`)
- [x] `bash tests/validate-plugin.sh`: only the 1 pre-existing `plugin.json hooks field` error documented in AGENTS.md line 41; no new errors introduced
- [x] Frontmatter validation: both files have `name` + `description` fields
- [x] Body validation: `/agentic-status` examples use new name consistently
- [x] CHANGELOG entry under `[Unreleased]` with Keep-a-Changelog format
- [ ] (manual post-merge): operator confirms `/agentic-status` invocation resolves correctly
- [ ] (v1.6.0): hard-remove alias

## Risk + rollback

- **Risk**: medium — operator-facing rename; users with `/status` muscle-memory hit deprecation warning
- **Rollback**: `git revert <merge-commit>` (restores `/status` → status-map behavior)
- **Blast-radius**: operator + AI agents that invoke `/status`; alias period gives transition window
- **Compatibility**: `skills/status-map/SKILL.md` invocation contract unchanged; `/agentic-status` invokes it identically

## Plan PR-2 of 5

Per `~/.claude/plans/jaunty-riding-knuth.md` (operator-approved 2026-05-21 via ExitPlanMode):
- ✅ **PR-1** vendor-words list — [ekson73/vek-dot-claude#54](https://github.com/ekson73/vek-dot-claude/pull/54) (independent, parallel-safe)
- ✅ **PR-2** (this PR) — RENAME status → agentic-status
- 🔜 PR-0 — RESEARCH spike (`command_namespace` empirical test)
- 🔜 PR-3 — MANIFEST extension + AGENTS.md §34/§73 refinement
- 🔜 PR-4 — NEW `session-recap` skill + command (cycle-1 dogfood)

## Refs

- Parent plan: `~/.claude/plans/jaunty-riding-knuth.md`
- Memory: `feedback_session_recap_convergence_plan.md`
- `pr-review-protocol.md` v2.1.0 (PDCA + gates G1-G8 + R1-R6)
- `scope-discipline-pre-creation.md` v1.0.2 §Q2.1 (PR-State Inventory applied — worktree off origin/main)
- `anti-theater-grounding-protocol.md` v1.0.0 (8Q REALITY 8/8 PASS)
- AGENTS.md line 41 (known pre-existing validation error)

🤖 Generated with [Claude Code](https://claude.com/claude-code) per `/auto-orchestrator` operator directive 2026-05-21 (post-convergence implementation phase).
