### PR TITLE
feat(governance): Sandwich Namespacing Layer 2 + Layer 4 ref + AGENTS.md §34/§73 refinement (v1.5.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maos",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",
@@ -22,5 +22,23 @@
     "rbad",
     "validation",
     "agent-design"
-  ]
+  ],
+  "command_namespace": {
+    "_comment": "Sandwich Namespacing Layer 2 — manifest-declared namespace prefix for plugin commands. Forward-compat: if host runtime supports `command_namespace` declaration, commands surface as /maos:<name> (preventing cross-plugin collision). If host does not support, fallback to function-specific filename (Layer 3) handles disambiguation. See AGENTS.md §34 and sister-PR ekson73/vek-dot-claude#54 (vendor-reserved-words audit list, Layer 4).",
+    "prefix": "maos",
+    "separator": ":",
+    "prefix_required": true,
+    "fallback": "permit_unprefixed_if_no_collision"
+  },
+  "vendor_reserved_audit": {
+    "_comment": "Sandwich Namespacing Layer 4 reference — list of vendor-native command names plugins should NEVER override at filename level. Authoritative cross-vendor catalog: ekson73/vek-dot-claude:docs/vendor-reserved-words.md v1.0.0 (36+ Claude Code built-ins + Cursor/Copilot/Aider/Gemini/Goose).",
+    "source_of_truth": "https://github.com/ekson73/vek-dot-claude/blob/main/docs/vendor-reserved-words.md",
+    "claude_code_builtins_sample": [
+      "help", "clear", "status", "compact", "cost", "exit", "quit", "resume",
+      "login", "logout", "model", "init", "memory", "context", "review",
+      "permissions", "hooks", "mcp", "agents", "plugin", "config", "ide",
+      "color", "vim", "goal", "loop", "schedule", "enhance", "bug", "doctor",
+      "output-style", "output-styles", "terminal-setup", "upgrade", "install-github-app"
+    ]
+  }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,9 @@ claude --plugin-dir .
 - **Agents**: markdown files with YAML frontmatter in `agents/`
 - **Hook scripts**: bash with `set -euo pipefail`, source `lib/common.sh` and `lib/json-rpc.sh`
 - **Config**: JSON with `_comment` fields for documentation
-- **Naming**: lowercase-hyphenated for skills/commands/agents. No `maos-` prefix on internal artifacts.
+- **Naming**: lowercase-hyphenated for skills/commands/agents. **Sandwich Namespacing 5-layer pattern**:
+  - **For skills/agents**: no `maos-` prefix in filename — Claude Code runtime auto-namespaces via plugin id (e.g., subagents surface as `maos:orchestrator`)
+  - **For commands**: runtime auto-namespace is **empirically unreliable** (verified 2026-05-21: `/status` collided with Claude Code built-in `/status`). Use function-specific filenames (e.g., `agentic-status` not `status`) + declare namespace prefix in `.claude-plugin/plugin.json` `command_namespace` block (Layer 2) + lint against `vendor_reserved_audit.claude_code_builtins` (Layer 4 reference: [ekson73/vek-dot-claude:docs/vendor-reserved-words.md](https://github.com/ekson73/vek-dot-claude/blob/main/docs/vendor-reserved-words.md))
 - **Delegation**: spawning sub-agents goes through `skills/delegate-governance/SKILL.md` (or `plugin-scripts/gaac/delegate.sh init|dna|finalize`) — canonical entry point for the GaaS/GaaC framework
 
 ## Testing Instructions
@@ -70,7 +72,7 @@ Before committing any changes:
 - **GaaS principle**: deterministic hooks > probabilistic prompts
 - **Sentinel**: 10 detection rules, enforcement modes (soft/moderate/strict)
 - **Skills are Agent Skills standard**: compatible with Claude Code, Cursor, Codex, Gemini CLI, Kiro, VS Code, Goose, and 25+ other tools
-- **No `maos-` prefix** on internal skills/commands/agents (namespaced by plugin)
+- **No `maos-` prefix** in filenames for skills+agents (Claude Code runtime auto-namespaces via plugin name `maos`). For commands, runtime auto-namespace is unreliable; prefix declaration lives in `.claude-plugin/plugin.json` `command_namespace` block (Sandwich Namespacing Layer 2), not in filename. Defense-in-depth: vendor-reserved-words lint reference at sister-repo `ekson73/vek-dot-claude:docs/vendor-reserved-words.md` (Layer 4)
 - **Framework Consumption Model**: this repo is source of truth; consumers reference, don't duplicate
 
 ## Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+#### Sandwich Namespacing — `command_namespace` + `vendor_reserved_audit` in plugin.json (v1.5.2)
+
+- **NEW `.claude-plugin/plugin.json` `command_namespace` block** — declarative prefix `maos:` for commands (Layer 2 of Sandwich Namespacing 5-layer pattern). Forward-compat: when Claude Code runtime supports `command_namespace` declaration, commands surface as `/maos:<name>` preventing cross-plugin collision. Until runtime supports, Layer 3 (function-specific filename) handles disambiguation.
+- **NEW `.claude-plugin/plugin.json` `vendor_reserved_audit` block** — Layer 4 reference pointing to canonical vendor-reserved-words list at [ekson73/vek-dot-claude:docs/vendor-reserved-words.md](https://github.com/ekson73/vek-dot-claude/blob/main/docs/vendor-reserved-words.md) (36+ Claude Code built-ins + Cursor/Copilot/Aider/Gemini/Goose).
+- **Origin**: empirical observation 2026-05-21 — `commands/status.md` collided with Claude Code built-in `/status`. Layer 3 fix shipped v1.5.1 (rename to `agentic-status`); Layer 2 + Layer 4 reference shipped here v1.5.2.
+
 ### Changed
+
+#### AGENTS.md §34 + §73 refinement — Sandwich Namespacing rationale split (v1.5.2)
+
+- **REFINED §34 Naming rule**: split into 2 statements — skills+agents (no `maos-` prefix in filename — runtime auto-namespaces) vs commands (use function-specific filenames + manifest `command_namespace` block — runtime auto-namespace empirically unreliable). Cites empirical collision evidence + vendor-reserved-words list.
+- **REFINED §73 Architecture decision**: same split + cross-reference to sister-PR `ekson73/vek-dot-claude#54` (vendor-words list, Sandwich Layer 4).
 
 #### Command `status` → `agentic-status` (v1.5.1 — naming collision fix)
 


### PR DESCRIPTION
## Summary

Completes the Sandwich Namespacing 5-layer governance pattern started in v1.5.1 (PR #80 rename `status`→`agentic-status`).

| Layer | Status |
|---|---|
| Layer 1 (filesystem path) | Pre-existing (`multi-agent-os/commands/`) |
| **Layer 2 (manifest)** | ✅ NEW in this PR — `plugin.json command_namespace` block |
| Layer 3 (function-specific filename) | ✅ Shipped v1.5.1 (PR #80) |
| **Layer 4 (vendor-reserved audit)** | ✅ Referenced in `plugin.json vendor_reserved_audit` block (canonical list at `ekson73/vek-dot-claude:docs/vendor-reserved-words.md` v1.0.0, merged sister-PR #54) |
| **Layer 5 (convention/docs)** | ✅ NEW in this PR — AGENTS.md §34 + §73 refined |

## Changes

| File | Action |
|---|---|
| `.claude-plugin/plugin.json` | ADD `command_namespace` + `vendor_reserved_audit` blocks; BUMP version 1.5.0 → 1.5.2 |
| `AGENTS.md` (§34 + §73) | SPLIT skill/agent rule (runtime auto-prefix works) from command rule (empirically unreliable) |
| `CHANGELOG.md` | Add `[Unreleased]` entries for v1.5.2 (added) + cross-link v1.5.1 (changed) |

## PR-0 RESEARCH collapsed into this PR

The empirical evidence for "Claude Code doesn't auto-prefix commands" was operator's empirical observation 2026-05-21 (`/status` collision). No sandbox needed; v1.5.1 rename PR (PR #80) was the empirical proof. PR-0 task closed via this PR.

## Test plan

- [x] `python3 -m json.tool .claude-plugin/plugin.json` PASS (JSON valid)
- [x] gitleaks pre-commit: PASS (commit `591d0bc`)
- [x] No `maos-` filename prefix introduced (Layer 3 clean)
- [ ] Bot convergence (pending re-review)

## Plan PR-3 of 5

Per `~/.claude/plans/jaunty-riding-knuth.md` (operator-approved):
- ✅ PR-1 vendor-words (merged: ekson73/vek-dot-claude#54 @ b2a82e6)
- ✅ PR-2 rename status→agentic-status (merged: #80 @ b7786d0)
- ✅ PR-0 RESEARCH (collapsed into this PR)
- ✅ **PR-3** (this PR) — Sandwich Layer 2 + 4 + 5
- 🔜 PR-4 — NEW `session-recap` skill + command (next session)
- 🔜 Jira ticket VKS-XXXX cycle-1 dogfood (after PR-4)

🤖 Generated with [Claude Code](https://claude.com/claude-code) per `/auto-orchestrator prossiga` 2026-05-21.