### PR TITLE
docs(contributing): add CONTRIBUTING.md (process workflow + AI disclosure)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ Maintainer-only operations. A release MUST:
 
 If a merged change causes regression in production usage:
 
-1. Revert via `gh pr create` opening a `revert: ` PR against the offending commit (do not `git push --force`).
+1. Revert via `gh pr create` opening a `revert:` PR against the offending commit (do not `git push --force`).
 2. Roll back the marketplace SHA pin if the change shipped to consumers.
 3. Document the incident in `docs/` and open a follow-up to prevent recurrence.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing to Multi-Agent OS
+
+Thanks for your interest in contributing. This file documents the **process** for contributions; the **technical contract** for agents (build/test, conventions, key directories, architecture decisions) lives in [`AGENTS.md`](AGENTS.md) — read it first. This document covers what AGENTS.md does **not**: PR/release/rollback gates and AI-involvement disclosure.
+
+## Contributor Types
+
+| Type | Examples |
+|---|---|
+| Human contributor | Direct edits, design review, manual testing |
+| AI-assisted contributor | Human author who used an AI agent (Copilot, Cursor, Claude Code, Codex, etc.) for parts of the change |
+| AI-generated draft (reviewed) | Change drafted end-to-end by an AI agent and reviewed by a named human before submission |
+
+All three types are welcome. The PR template's **AI Involvement** checkbox is required — disclose honestly.
+
+## Workflow
+
+1. **Open an issue** (or comment on an existing one) describing the change before non-trivial work.
+2. **Branch + worktree**: never commit directly to `main`. Use `git worktree add .worktrees/<slug> -b <type>/<scope>`. The GaaS hook (`plugin-scripts/governance/`) blocks direct-main commits unless `GOVERNANCE_OVERRIDE=1 GOVERNANCE_OVERRIDE_REASON="<rationale>"` is set by the operator.
+3. **Build & test** per [`AGENTS.md` § Build & Test](AGENTS.md#build--test). Pre-commit `gitleaks` is enforced — `--no-verify` is not permitted.
+4. **Conventional Commits** + `Co-Authored-By:` footer for AI involvement (see [`AGENTS.md` § Commit & PR Guidelines](AGENTS.md#commit--pr-guidelines)).
+5. **Open the PR** using the `.github/pull_request_template.md` template. Fill every section — `Summary`, `Type`, `AI Involvement`, `Evidence`, `Risks`, `Rollback`, `Checklist`.
+6. **Bot review convergence** is required before merge — CodeRabbit, Amazon Q Developer, Qodo Merge, gitleaks workflow, and any required CI checks must all be GREEN or resolved. Address `:stop_sign:` / Security / Logic Error severity findings with either a fix-commit or an in-thread rationale.
+7. **Merge gate**: maintainer (or HITL-authorized agent) squash-merges with `--delete-branch`. Self-approve via Comment-Only path when GitHub blocks formal APPROVE on own PRs.
+8. **Post-merge cleanup**: `git worktree remove .worktrees/<slug>` + `git branch -D` + sync local main.
+
+## Reviews
+
+- Reviewers should focus on the contract impact (`AGENTS.md`, `CLAUDE.md`, `plugin.json`, `hooks.json`, protocols) and on whether bot findings were genuinely addressed (not waved away).
+- For substantive guidance on what makes a useful PR review, see `.claude/rules/pr-reviewer-communication.md`.
+
+## Release Gates
+
+Maintainer-only operations. A release MUST:
+
+1. Update `CHANGELOG.md` (Keep a Changelog format, SemVer).
+2. Bump `.claude-plugin/plugin.json` `version`.
+3. Tag the release (`v<version>`) and verify the downstream marketplace entry in [`ekson73/eko-claude-plugins`](https://github.com/ekson73/eko-claude-plugins) SHA-pins the validated commit.
+4. Confirm CI version-sync workflow passes.
+
+## Rollback
+
+If a merged change causes regression in production usage:
+
+1. Revert via `gh pr create` opening a `revert: ` PR against the offending commit (do not `git push --force`).
+2. Roll back the marketplace SHA pin if the change shipped to consumers.
+3. Document the incident in `docs/` and open a follow-up to prevent recurrence.
+
+## Code of Conduct
+
+Be technically rigorous, treat bot and human reviewers with the same respect, and prefer evidence over speculation. Disagreement is welcome; performative review is not.
+
+## Reference
+
+- [`AGENTS.md`](AGENTS.md) — agent contract (build, test, conventions, key dirs, architecture decisions, security)
+- [`CLAUDE.md`](CLAUDE.md) — Claude Code-specific notes and MVV
+- [`SECURITY.md`](SECURITY.md) — vulnerability disclosure
+- [`CHANGELOG.md`](CHANGELOG.md) — release history
+- [`.github/pull_request_template.md`](.github/pull_request_template.md) — PR template (added separately)
+- [`.github/copilot-instructions.md`](.github/copilot-instructions.md) — Copilot pointer to AGENTS.md (added separately)


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md` (~60 lines) closing a real gap detected in Phase-0 governance audit.
- Slim by design — points to `AGENTS.md` as SSOT (DRY per `scope-discipline-pre-creation.md` §Q2). Adds only what AGENTS.md lacks: contributor types, AI-involvement disclosure, release gates, rollback procedure.

## Type

- [x] docs
- [x] governance

## AI Involvement

- [x] AI-generated draft reviewed by human
- Drafted by Claude Opus 4.7 under operator plan `analise-critique-valide-entenda-twinkly-locket`.
- Operator reviewed and approved the plan before execution.

## Runtime Impact

- [x] Claude Code (workflow guidance for contributors)
- [x] Generic agents (PR workflow + AI-disclosure section applies cross-vendor)

## Files

- [x] `CONTRIBUTING.md` (new)

## Evidence

Commands run:
```bash
git worktree add .worktrees/contributing-md -b chore/add-contributing-md
git add CONTRIBUTING.md
gitleaks detect --staged --no-banner    # no leaks
git commit -m "docs(contributing): ..."  # GaaS pre-commit gitleaks PASS
git push -u origin chore/add-contributing-md  # GaaS pre-push naming checks PASS
```

Pre-commit + pre-push hooks GREEN locally.

## Risks

- Low — pure docs addition, no code/config touched. Refers to files that exist (`AGENTS.md`, `CLAUDE.md`, `SECURITY.md`, `CHANGELOG.md`) and two files staged as follow-up PRs (`.github/pull_request_template.md`, `.github/copilot-instructions.md`).

## Rollback

`git revert <merge-sha>` — no schema/runtime impact.

## Checklist

- [x] AGENTS.md is SSOT — CONTRIBUTING.md complements, does not duplicate
- [x] gitleaks clean
- [x] No secrets, no PII, no Vek-specific content (Layer Purity per `layer-precedence-policy.md`)
- [x] Refs to follow-up files (`.github/pull_request_template.md`, `.github/copilot-instructions.md`) clearly marked "added separately"
- [x] Worktree + branch per `pr-review-protocol.md` v2.0.0

## Plan

`~/.claude/plans/analise-critique-valide-entenda-twinkly-locket.md` — Gap G1 of 3 atomic fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
