### PR TITLE
docs(copilot): add .github/copilot-instructions.md as AGENTS.md pointer

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,33 @@
+# GitHub Copilot — Repository Instructions
+
+This file is GitHub Copilot's entry point. **The canonical agent contract is [`AGENTS.md`](../AGENTS.md)** — read that first. This file is a pointer, not a duplicate, in keeping with the DRY principle (`scope-discipline-pre-creation.md` §Q2).
+
+## Read order
+
+1. [`AGENTS.md`](../AGENTS.md) — project overview, build/test, conventions, key directories, architecture decisions, security
+2. [`CONTRIBUTING.md`](../CONTRIBUTING.md) — PR workflow, AI-involvement disclosure, release/rollback gates
+3. [`CLAUDE.md`](../CLAUDE.md) — Claude Code-specific notes (most cross-vendor guidance lives in AGENTS.md)
+4. [`SECURITY.md`](../SECURITY.md) — vulnerability disclosure
+5. `.github/pull_request_template.md` — PR template (mandatory fields)
+
+## Must
+
+- Use a `git worktree` for any edits (`AGENTS.md` § Commit & PR Guidelines). Direct-main commits are blocked by GaaS hook.
+- Run `bash tests/validate-plugin.sh` before committing (`AGENTS.md` § Testing Instructions).
+- Conventional Commits with `Co-Authored-By:` footer when AI assistance is used.
+- Disclose AI involvement honestly in the PR template's `AI Involvement` section.
+
+## Must Not
+
+- Use `--no-verify` to bypass pre-commit hooks (gitleaks is non-negotiable).
+- Commit secrets, tokens, `.env`, or PAT credentials.
+- Edit `.claude-plugin/plugin.json` `version` or `name` without coordinating the downstream marketplace pin in [`ekson73/eko-claude-plugins`](https://github.com/ekson73/eko-claude-plugins).
+- Mass-create governance scaffolding (`.ai/`, ADRs, EVALS yaml, etc.) without Triple-touch evidence (`AGENTS.md` § Architecture Decisions + 3 occurrences of need).
+
+## Code style
+
+See `AGENTS.md` § Code Conventions. Bash hooks use `set -euo pipefail` and source `lib/common.sh` + `lib/json-rpc.sh`. Skills follow the `SKILL.md` subdirectory format (Agent Skills open standard).
+
+## Tests
+
+`AGENTS.md` § Build & Test enumerates the canonical commands. The CI workflows in `.github/workflows/` (`ai-governance-linter`, `converge-tests`, `ontology-validation`, `supply-chain-sentinel`, `version-sync`) run on every PR — local Copilot suggestions should not break them.


### PR DESCRIPTION
## Summary

- Adds `.github/copilot-instructions.md` (~35 lines) as a thin pointer to `AGENTS.md`.
- Orients GitHub Copilot to the canonical read-order (AGENTS.md → CONTRIBUTING.md → CLAUDE.md → SECURITY.md).
- Lifts Must / Must-Not rules from existing governance — no new policy, no duplication.

## Type

- [x] docs
- [x] governance

## AI Involvement

- [x] AI-generated draft reviewed by human
- Drafted by Claude Opus 4.7 under operator plan `analise-critique-valide-entenda-twinkly-locket` (Gap G2 of 3).
- Sequential to PR #82 (CONTRIBUTING.md, Gap G1) — different file, no overlap.

## Runtime Impact

- [x] GitHub Copilot (primary)
- [x] Generic agents (read-order applies to any agent landing in `.github/`)

## Files

- [x] `.github/copilot-instructions.md` (new)

## Evidence

```bash
git worktree add .worktrees/copilot-instructions -b chore/add-copilot-instructions
git add .github/copilot-instructions.md
git commit  # GaaS pre-commit gitleaks PASS
git push -u origin chore/add-copilot-instructions  # GaaS pre-push naming checks PASS
```

## Risks

- Low — pointer doc, no policy change. References two files:
  - `CONTRIBUTING.md` (in flight as PR #82) — link will resolve once PR #82 merges
  - `.github/pull_request_template.md` (Gap G3, follow-up PR) — link resolves on G3 merge

## Rollback

`git revert <merge-sha>` — no schema/runtime impact.

## Checklist

- [x] AGENTS.md is SSOT — copilot-instructions.md complements, does not duplicate
- [x] gitleaks clean (GaaS pre-commit + scan workflow)
- [x] No secrets, no PII, no Vek-specific content (Layer Purity)
- [x] Worktree + branch per `pr-review-protocol.md` v2.0.0
- [x] Pointer-only design per `scope-discipline-pre-creation.md` §Q2 DRY

## Plan

`~/.claude/plans/analise-critique-valide-entenda-twinkly-locket.md` — Gap G2 of 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
