### PR TITLE
docs(pr-template): add .github/pull_request_template.md (governance-aligned)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,80 @@
+## Summary
+
+<!-- 1–3 bullets describing what changed and why. -->
+
+## Type
+
+- [ ] feat (new functionality)
+- [ ] fix (bug fix)
+- [ ] docs
+- [ ] refactor
+- [ ] chore
+- [ ] security
+- [ ] governance
+- [ ] release
+
+## AI Involvement
+
+<!-- Disclose honestly. See CONTRIBUTING.md § Contributor Types. -->
+
+- [ ] Human-authored
+- [ ] AI-assisted (human author used AI tools for parts of the change)
+- [ ] AI-generated draft reviewed by human (named reviewer required)
+
+If AI-assisted or AI-generated, include `Co-Authored-By:` footer(s) in the commit messages.
+
+## Runtime / Surface Impact
+
+<!-- Tick the surfaces this change touches. -->
+
+- [ ] Claude Code (plugin runtime, hooks, agents, commands, skills)
+- [ ] GitHub Copilot (`.github/copilot-instructions.md`)
+- [ ] Generic AI agents (AGENTS.md contract)
+- [ ] Plugin manifest (`.claude-plugin/plugin.json`) — requires downstream marketplace sync
+- [ ] CI / GitHub Actions (`.github/workflows/`)
+- [ ] Security / compliance posture
+
+## Files requiring follow-up governance update
+
+<!-- Tick if this PR materially changes a contract documented elsewhere. -->
+
+- [ ] `README.md`
+- [ ] `AGENTS.md`
+- [ ] `CLAUDE.md`
+- [ ] `CONTRIBUTING.md`
+- [ ] `SECURITY.md`
+- [ ] `CHANGELOG.md`
+- [ ] `.github/CODEOWNERS`
+- [ ] `.claude-plugin/plugin.json`
+- [ ] Downstream marketplace pin (`ekson73/eko-claude-plugins`)
+
+## Evidence
+
+<!-- Show commands run + relevant output. Brief, paste-ready. -->
+
+```bash
+# e.g.
+bash tests/validate-plugin.sh
+```
+
+## Risks
+
+<!-- Be specific. "Low — docs only" is acceptable when accurate. -->
+
+## Rollback
+
+<!-- How to revert if regression detected post-merge. -->
+
+## Checklist
+
+- [ ] Worktree + branch used (no direct-main commits)
+- [ ] Conventional Commits + `Co-Authored-By:` footer if AI involved
+- [ ] gitleaks clean (pre-commit + CI workflow)
+- [ ] Build / tests pass (`tests/validate-plugin.sh` or equivalent)
+- [ ] No secrets, no PII, no Vek-specific content (Layer Purity per `~/.claude/rules/layer-precedence-policy.md`)
+- [ ] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated if contract changed
+- [ ] Version bump + CHANGELOG entry if `.claude-plugin/plugin.json` changed
+
+<!--
+🤖 If this PR was opened by an automated agent, link the plan file or skill that drove it.
+-->


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` (~80 lines) — governance-aligned PR template that auto-populates on `gh pr create` / GitHub UI.
- Mandatory fields: Summary, Type, AI Involvement (3-tier), Runtime/Surface Impact, governance-update list, Evidence, Risks, Rollback, Layer-Purity checklist.

## Type

- [x] docs
- [x] governance

## AI Involvement

- [x] AI-generated draft reviewed by human
- Drafted by Claude Opus 4.7 under operator plan `analise-critique-valide-entenda-twinkly-locket` (Gap G3 of 3).
- Sibling PRs: #82 (CONTRIBUTING.md, G1) + #83 (copilot-instructions.md, G2). Different file, no conflict.

## Runtime Impact

- [x] Generic agents — template applies to every PR opened on this repo
- [x] Governance posture — formalizes the disclosure + evidence contract referenced by CONTRIBUTING.md + AGENTS.md

## Files

- [x] `.github/pull_request_template.md` (new)

## Evidence

```bash
git worktree add .worktrees/pr-template -b chore/add-pr-template
git add .github/pull_request_template.md
git commit  # GaaS pre-commit gitleaks PASS
git push -u origin chore/add-pr-template  # GaaS pre-push naming checks PASS
```

## Risks

- Low — template addition, applies to future PRs only. Does NOT touch existing files.
- Adapted from the operator-supplied audit prompt §15, with private-org-specific fields (redacted field names) **removed** to preserve Layer Purity (`~/.claude/rules/layer-precedence-policy.md` Rule 2 — no private-org content in community repos).

## Rollback

`git revert <merge-sha>` — the next PR after revert will simply have no template (status quo ante).

## Checklist

- [x] AGENTS.md / CONTRIBUTING.md cross-referenced where appropriate
- [x] gitleaks clean
- [x] No secrets, no PII, no private-org-specific content (Layer Purity verified)
- [x] Worktree + branch per `pr-review-protocol.md` v2.0.0
- [x] Template self-aware — its own checklist references Layer Purity rule

## Plan

`~/.claude/plans/analise-critique-valide-entenda-twinkly-locket.md` — Gap G3 of 3 (last in the trio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

