### PR TITLE
feat(skills): add founder-* family converting Anthropic Founder's Playbook (#85)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,7 +21,11 @@
     "forge",
     "rbad",
     "validation",
-    "agent-design"
+    "agent-design",
+    "founder",
+    "startup",
+    "ai-native",
+    "playbook"
   ],
   "command_namespace": {
     "_comment": "Sandwich Namespacing Layer 2 — manifest-declared namespace prefix for plugin commands. Forward-compat: if host runtime supports `command_namespace` declaration, commands surface as /maos:<name> (preventing cross-plugin collision). If host does not support, fallback to function-specific filename (Layer 3) handles disambiguation. See AGENTS.md §34 and sister-PR ekson73/vek-dot-claude#54 (vendor-reserved-words audit list, Layer 4).",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### `founder-*` family — Anthropic Founder's Playbook converted to agentic-tools
+
+- **NEW skills** (Agent Skills standard, vendor-neutral): `founder-playbook` (lifecycle router + `references/product-matrix.md`), `founder-stage-idea`, `founder-stage-mvp`, `founder-stage-launch`, `founder-stage-scale`. Each stage skill carries its goal, exit-criteria gate, failure modes + mitigations, and ready-to-use exercise prompts / emittable templates.
+- **NEW agent**: `founder-coach` — delegatable "founder as orchestrator-of-agents" coaching persona (stage diagnosis + exit-gate review).
+- **NEW command**: `/founder-playbook` — thin wrapper over the router skill.
+- **Origin**: framework adapted (process & methodology, original prose, attributed — no verbatim copy) from Anthropic, *The Founder's Playbook: Building an AI-Native Startup* (2026, https://claude.com/blog/the-founders-playbook). Capability classes are vendor-neutral (conversational-research / agentic-coding / workflow-automation) with Claude (Chat/Code/Cowork) as the reference implementation. Resolves #85.
+
 #### Sandwich Namespacing — `command_namespace` + `vendor_reserved_audit` in plugin.json (v1.5.2)
 
 - **NEW `.claude-plugin/plugin.json` `command_namespace` block** — declarative prefix `maos:` for commands (Layer 2 of Sandwich Namespacing 5-layer pattern). Forward-compat: when Claude Code runtime supports `command_namespace` declaration, commands surface as `/maos:<name>` preventing cross-plugin collision. Until runtime supports, Layer 3 (function-specific filename) handles disambiguation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NEW skills** (Agent Skills standard, vendor-neutral): `founder-playbook` (lifecycle router + `references/product-matrix.md`), `founder-stage-idea`, `founder-stage-mvp`, `founder-stage-launch`, `founder-stage-scale`. Each stage skill carries its goal, exit-criteria gate, failure modes + mitigations, and ready-to-use exercise prompts / emittable templates.
 - **NEW agent**: `founder-coach` — delegatable "founder as orchestrator-of-agents" coaching persona (stage diagnosis + exit-gate review).
 - **NEW command**: `/founder-playbook` — thin wrapper over the router skill.
-- **Origin**: framework adapted (process & methodology, original prose, attributed — no verbatim copy) from Anthropic, *The Founder's Playbook: Building an AI-Native Startup* (2026, https://claude.com/blog/the-founders-playbook). Capability classes are vendor-neutral (conversational-research / agentic-coding / workflow-automation) with Claude (Chat/Code/Cowork) as the reference implementation. Resolves #85.
+- **Origin**: framework adapted (process & methodology, original prose, attributed — no verbatim copy) from Anthropic, *The Founder's Playbook: Building an AI-Native Startup* (2026-05-14, https://claude.com/blog/the-founders-playbook). Capability classes are vendor-neutral (conversational-research / agentic-coding / workflow-automation) with Claude (Chat/Code/Cowork) as the reference implementation. Resolves #85.
 
 #### Sandwich Namespacing — `command_namespace` + `vendor_reserved_audit` in plugin.json (v1.5.2)
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -37,6 +37,7 @@ Agent definitions for the multi-agent-os plugin. These define specialized person
 - `memory-curator` — Audit and maintain persistent memory/knowledge quality
 
 ### Startup Coaching
+
 - `founder-coach` — AI-native startup lifecycle coach; pairs with the `founder-*` skills
 
 ## Agent Naming Convention

--- a/agents/README.md
+++ b/agents/README.md
@@ -14,6 +14,7 @@ Agent definitions for the multi-agent-os plugin. These define specialized person
 | consolidator | `consolidator.md` | Output synthesis |
 | legacy-archaeologist | `legacy-archaeologist.md` | Legacy codebase reverse-engineering |
 | memory-curator | `memory-curator.md` | Knowledge/memory hygiene and curation |
+| founder-coach | `founder-coach.md` | AI-native startup lifecycle coach (stage diagnosis + exit gates) |
 
 ## Agent Categories
 
@@ -34,6 +35,9 @@ Agent definitions for the multi-agent-os plugin. These define specialized person
 
 ### Knowledge Management
 - `memory-curator` — Audit and maintain persistent memory/knowledge quality
+
+### Startup Coaching
+- `founder-coach` — AI-native startup lifecycle coach; pairs with the `founder-*` skills
 
 ## Agent Naming Convention
 

--- a/agents/founder-coach.md
+++ b/agents/founder-coach.md
@@ -1,0 +1,58 @@
+---
+name: founder-coach
+description: AI-native startup coach. Diagnoses a founder's lifecycle stage (Idea/MVP/Launch/Scale), checks exit gates, names the active failure modes, and routes to the founder-stage-* skills. Use for stage diagnosis, "where am I / what next", and exit-gate reviews.
+---
+
+# Founder Coach Agent
+
+## Identity
+
+A vendor-neutral coaching persona for founders building **AI-native startups**. It
+embodies the discipline of *The Founder's Playbook* (see Attribution) and pairs with
+the `founder-playbook` router skill and the four `founder-stage-*` skills.
+
+## Stance
+
+- **The founder is an orchestrator of agents**, not an individual contributor. AI has
+  removed the capital / headcount / technical-skill gates between stages; the scarce
+  input is **judgment about what to build and whether it's working.**
+- **Validation over building.** Easy prototyping inflates the risk of building
+  something nobody needs. Push back when a founder reaches for the build before the
+  evidence justifies it.
+- **Evidence over enthusiasm.** Early energy (friends, investor networks, a
+  front-page post) is not product-market fit.
+- **Vendor-neutral.** Reason in capability classes (conversational-research /
+  agentic-coding / workflow-automation); name a specific tool only as a reference.
+
+## Responsibilities
+
+- **Diagnose the stage** using the `founder-playbook` diagnosis flow; when unsure
+  between two, choose the earlier (cheaper to revisit than the failure it prevents).
+- **Review exit gates** honestly before endorsing a stage transition; advancing early
+  is itself a failure mode.
+- **Name the active failure mode(s)** for the current stage and the concrete mitigation.
+- **Route** to the matching `founder-stage-*` skill and surface its exercise prompts /
+  emittable templates.
+- **Keep a human in the loop** for nuanced calls — interpreting user feedback, and any
+  security/compliance/legal/financial decision (judgment support, never sign-off).
+
+## How to use (delegation)
+
+Spawn via the Task tool with the founder's current context (what they've built, what
+evidence they have, what they're deciding). The coach returns: detected stage +
+rationale, exit-gate checklist with pass/fail, the top failure mode to watch, and the
+next concrete action (usually: load a specific stage skill + run a named exercise).
+
+## Boundaries (when NOT to act autonomously)
+
+- No legal / financial / medical / security sign-off — recommend a qualified human.
+- No fundraising or PMF guarantees — it surfaces evidence and discipline, not promises.
+- Does not write production code itself — it directs the agentic-coding capability and
+  insists on persisted architecture/scope/security context first.
+
+## Attribution
+
+Adapted (process & methodology, original prose) from Anthropic, *The Founder's
+Playbook: Building an AI-Native Startup* (2026) —
+https://claude.com/blog/the-founders-playbook. No text reproduced verbatim;
+encoded for agent use under this repository's MIT license.

--- a/agents/founder-coach.md
+++ b/agents/founder-coach.md
@@ -53,6 +53,6 @@ next concrete action (usually: load a specific stage skill + run a named exercis
 ## Attribution
 
 Adapted (process & methodology, original prose) from Anthropic, *The Founder's
-Playbook: Building an AI-Native Startup* (2026) —
+Playbook: Building an AI-Native Startup* (2026-05-14) —
 https://claude.com/blog/the-founders-playbook. No text reproduced verbatim;
 encoded for agent use under this repository's MIT license.

--- a/commands/README.md
+++ b/commands/README.md
@@ -13,6 +13,7 @@ Slash commands for the multi-agent-os plugin. Commands are auto-discovered by Cl
 | `/status` | `status.md` | Display human-readable status maps |
 | `/worktree` | `worktree.md` | Manage git worktrees |
 | `/delegate` | `delegate.md` | Delegate tasks to sub-agents |
+| `/founder-playbook` | `founder-playbook.md` | Diagnose AI-native startup stage + route to stage skills |
 
 ## Command Categories
 
@@ -26,6 +27,9 @@ Slash commands for the multi-agent-os plugin. Commands are auto-discovered by Cl
 ### Coordination
 - `/worktree` — Git worktree management
 - `/delegate` — Sub-agent task delegation
+
+### Startup Coaching
+- `/founder-playbook` — Diagnose AI-native startup stage; route to `founder-stage-*` skills
 
 ## Command Structure
 

--- a/commands/README.md
+++ b/commands/README.md
@@ -29,6 +29,7 @@ Slash commands for the multi-agent-os plugin. Commands are auto-discovered by Cl
 - `/delegate` — Sub-agent task delegation
 
 ### Startup Coaching
+
 - `/founder-playbook` — Diagnose AI-native startup stage; route to `founder-stage-*` skills
 
 ## Command Structure

--- a/commands/founder-playbook.md
+++ b/commands/founder-playbook.md
@@ -15,7 +15,7 @@ it surfaces as `/maos:founder-playbook`.
 
 ## Usage
 
-```
+```text
 /founder-playbook ["<where I am / what I'm deciding>"]
 ```
 

--- a/commands/founder-playbook.md
+++ b/commands/founder-playbook.md
@@ -1,0 +1,38 @@
+---
+name: founder-playbook
+description: Diagnose your AI-native startup's lifecycle stage (Idea/MVP/Launch/Scale) and route to the matching stage discipline, with exit-gate checks and the vendor-neutral product matrix.
+---
+
+# /founder-playbook Command
+
+Thin wrapper that invokes `skills/founder-playbook/SKILL.md` (the router). The skill
+holds all logic — stage diagnosis, exit gates, failure modes, and routing to the four
+`founder-stage-*` skills; this file is the command surface only.
+
+`founder-playbook` is a function-specific command name (not a vendor-reserved word per
+`.claude-plugin/plugin.json` `vendor_reserved_audit`); under namespace-aware runtimes
+it surfaces as `/maos:founder-playbook`.
+
+## Usage
+
+```
+/founder-playbook ["<where I am / what I'm deciding>"]
+```
+
+With no argument, it runs the stage-diagnosis flow interactively. With a short context
+string, it diagnoses the stage directly and routes you to the right stage skill.
+
+## What it does
+
+1. Runs the **stage-diagnosis flow** (Idea → MVP → Launch → Scale).
+2. Reports the detected stage + the **exit gate** for it (pass/fail).
+3. Names the **signature failure mode** to watch and routes you to the matching
+   `founder-stage-*` skill (with its exercise prompts / emittable templates).
+
+## Related
+
+- Skills: `founder-playbook` (router), `founder-stage-idea`, `founder-stage-mvp`,
+  `founder-stage-launch`, `founder-stage-scale`.
+- Agent: `founder-coach` (delegatable coaching persona via the Task tool).
+
+See `skills/founder-playbook/SKILL.md` for the full framework and attribution.

--- a/skills/README.md
+++ b/skills/README.md
@@ -49,6 +49,7 @@ This folder contains reusable Agent Skills for the Multi-Agent OS framework. Ski
 - `find-docs` — Up-to-date library documentation and code examples via Context7 CLI
 
 ### Founder / Startup Skills
+
 - `founder-playbook` — Lifecycle router: diagnose stage, check exit gates, route
 - `founder-stage-idea` — Validate the problem before building
 - `founder-stage-mvp` — Product-market-fit evidence; tech-debt / scope / security discipline

--- a/skills/README.md
+++ b/skills/README.md
@@ -18,6 +18,11 @@ This folder contains reusable Agent Skills for the Multi-Agent OS framework. Ski
 | `ttl-policy` | `ttl-policy/SKILL.md` | Manage content freshness policies |
 | `find-docs` | `find-docs/SKILL.md` | Library documentation lookup via Context7 |
 | `response-compression` | `response-compression/SKILL.md` | Output verbosity control with role-based profiles (none/lite/full/ultra) |
+| `founder-playbook` | `founder-playbook/SKILL.md` | AI-native startup lifecycle router — diagnose stage + route to stage skills |
+| `founder-stage-idea` | `founder-stage-idea/SKILL.md` | Idea stage — validate the problem before building |
+| `founder-stage-mvp` | `founder-stage-mvp/SKILL.md` | MVP stage — product-market-fit evidence without compounding tech debt |
+| `founder-stage-launch` | `founder-stage-launch/SKILL.md` | Launch stage — repeatable growth; remove the founder bottleneck |
+| `founder-stage-scale` | `founder-stage-scale/SKILL.md` | Scale stage — systematic growth + defensible moat |
 
 ## Skill Categories
 
@@ -42,6 +47,13 @@ This folder contains reusable Agent Skills for the Multi-Agent OS framework. Ski
 
 ### Developer Tools
 - `find-docs` — Up-to-date library documentation and code examples via Context7 CLI
+
+### Founder / Startup Skills
+- `founder-playbook` — Lifecycle router: diagnose stage, check exit gates, route
+- `founder-stage-idea` — Validate the problem before building
+- `founder-stage-mvp` — Product-market-fit evidence; tech-debt / scope / security discipline
+- `founder-stage-launch` — Repeatable growth engine; remove the founder bottleneck
+- `founder-stage-scale` — Systematic growth + defensible moat + GTM
 
 ## Directory Structure
 

--- a/skills/founder-playbook/SKILL.md
+++ b/skills/founder-playbook/SKILL.md
@@ -68,7 +68,8 @@ Ask the founder these, in order — stop at the first "no":
    - No → **Launch stage** → load `founder-stage-launch`.
 4. **Are you building systematic growth + a defensible moat, with the company
    sustainable even when you step back from day-to-day?**
-   - Otherwise → **Scale stage** → load `founder-stage-scale`.
+   - **No** (you cleared 1–3 but aren't there yet) → you're early in **Scale** → load `founder-stage-scale`.
+   - **Yes** → you're maturing through **Scale** toward the threshold exit (profitability / IPO / acquisition); `founder-stage-scale` still applies — re-check its exit gate.
 
 > A founder can be mid-stage. If unsure between two, pick the **earlier** one — the
 > earlier discipline is cheaper to revisit than the failure mode it prevents.
@@ -112,6 +113,6 @@ the framework holds for any AAIF-compatible toolset.
 ## Attribution
 
 Framework adapted (process & methodology, original prose) from Anthropic,
-*The Founder's Playbook: Building an AI-Native Startup* (2026) —
+*The Founder's Playbook: Building an AI-Native Startup* (2026-05-14) —
 https://claude.com/blog/the-founders-playbook. No text is reproduced verbatim;
 this skill encodes the framework for agent use under the repository's MIT license.

--- a/skills/founder-playbook/SKILL.md
+++ b/skills/founder-playbook/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: founder-playbook
+version: "1.0.0"
+description: |
+  Diagnose where an AI-native startup is in its lifecycle (Idea → MVP → Launch →
+  Scale) and route to the right stage discipline. Provides the four-stage map,
+  per-stage goals/exit-criteria/failure-modes, and a vendor-neutral product matrix
+  (conversational-research / agentic-coding / workflow-automation, with Claude
+  Chat/Code/Cowork as reference). Use when a founder asks "where am I", "what
+  should I focus on now", "am I ready to move to the next stage", "how do AI-native
+  startups work", or wants an overview of the whole journey. For deep work inside a
+  single stage, this skill hands off to founder-stage-idea / -mvp / -launch / -scale.
+allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
+---
+
+# Founder Playbook — AI-Native Startup Lifecycle (router)
+
+A stage-gated coach for building an AI-native startup. This skill **locates** a
+founder on the lifecycle and routes to the matching stage discipline. It encodes
+the *process and judgment* from Anthropic's *The Founder's Playbook: Building an
+AI-Native Startup* (see Attribution), generalized to be vendor-neutral.
+
+## The core reframe
+
+In an AI-native startup the founder shifts from **individual contributor** to
+**orchestrator of agents** — specialized AI assistants that research, write and
+run code, and automate operations. AI has removed the three classic gates between
+stages: **capital, headcount, and technical skill**. The scarce resource is no
+longer building — it's **judgment about what to build and whether it's working.**
+
+## When to use this skill
+
+- "I have an idea — where do I start?" / "where am I in the journey?"
+- "Am I ready to move from MVP to Launch?" (exit-gate check)
+- "What should I focus on / what's the biggest risk right now?"
+- You want the whole-lifecycle overview or the tool-per-stage matrix.
+
+## When NOT to use it
+
+- You already know your stage and want to do the work → go straight to the stage
+  skill (`founder-stage-idea` | `-mvp` | `-launch` | `-scale`).
+- You need legal/financial/medical/security sign-off → this is judgment **support**,
+  not a substitute for a qualified human reviewer. Keep a human in the loop for
+  nuanced calls (interpreting user feedback, security on auth/secrets/data, compliance).
+- It's not a fundraising deck generator or a guarantee of product-market fit.
+
+## The four-stage map
+
+| Stage | Goal (one line) | Exit gate (one line) | Signature failure mode |
+|---|---|---|---|
+| **Idea** | Validate a real problem before building | Problem-solution fit: 3 honest "yes" | Mistaking *building* for *validating* |
+| **MVP** | Turn a validated problem into a used product | Genuine product-market-fit evidence | Compounding agentic tech debt; false PMF |
+| **Launch** | Make growth repeatable; build the company | Channel-driven growth + ops without founder | The founder becomes the bottleneck |
+| **Scale** | Systematic growth + a defensible moat | Threshold: profitability / IPO-ready / acquire | Can't delegate the operating layer |
+
+## Stage diagnosis flow
+
+Ask the founder these, in order — stop at the first "no":
+
+1. **Do you have qualitative evidence (from real conversations, not surveys) that a
+   specific group has this problem and that your solution addresses it?**
+   - No → **Idea stage** → load `founder-stage-idea`.
+2. **Do real users return to / pay for / refer the product (evidence of PMF, e.g.
+   Sean Ellis ≥40% "very disappointed"; effort starts to *pull* not *push*)?**
+   - No → **MVP stage** → load `founder-stage-mvp`.
+3. **Is growth repeatable through known channels (CAC·LTV·payback you can defend)
+   AND do operations run without you personally in every loop?**
+   - No → **Launch stage** → load `founder-stage-launch`.
+4. **Are you building systematic growth + a defensible moat, with the company
+   sustainable even when you step back from day-to-day?**
+   - Otherwise → **Scale stage** → load `founder-stage-scale`.
+
+> A founder can be mid-stage. If unsure between two, pick the **earlier** one — the
+> earlier discipline is cheaper to revisit than the failure mode it prevents.
+
+## Product matrix (vendor-neutral)
+
+Three capability classes power the lean startup; see
+[references/product-matrix.md](references/product-matrix.md) for the per-stage
+mapping. Claude (Chat / Code / Cowork) is the canonical reference implementation;
+the framework holds for any AAIF-compatible toolset.
+
+| Capability class | What it is | Reference tool |
+|---|---|---|
+| Conversational research | On-call expert: research, drafting, strategy partner | Claude (Chat) |
+| Agentic coding | The always-available engineer: generate/test/debug/refactor | Claude Code |
+| Workflow automation | The on-demand ops team: recurring tasks + integrations | Claude Cowork |
+
+## Cross-stage anti-patterns (watch at every stage)
+
+- **Speed as the only variable** — AI removes natural bottlenecks, so velocity is
+  guaranteed; *judgment* is the scarce input. Easy prototyping inflates the risk of
+  building something nobody needs.
+- **Skipping persistent context** — without written specs/architecture/decisions
+  (e.g., a `CLAUDE.md`/context file), each session re-derives foundations and drifts.
+- **Treating early energy as proof** — launch spikes from friends, investor networks,
+  or a front-page post don't predict week-6/week-12 retention.
+- **Vendor lock-in** — keep the capability classes provider-agnostic so a single
+  vendor outage or pricing change can't paralyze the company.
+- **Founder as permanent bottleneck** — the job is to design the systems that do the
+  work, not to keep doing all the work.
+
+## How to drive the family
+
+1. Run the **diagnosis flow** → name the stage.
+2. Load the matching **stage skill** for goal + exit-criteria checklist + failure
+   modes + ready-to-use exercise prompts.
+3. Re-check the **exit gate** before advancing; advancing early is its own failure mode.
+4. For an interactive coach persona (delegatable via the Task tool), use the
+   `founder-coach` agent. To invoke this router explicitly, run `/founder-playbook`.
+
+## Attribution
+
+Framework adapted (process & methodology, original prose) from Anthropic,
+*The Founder's Playbook: Building an AI-Native Startup* (2026) —
+https://claude.com/blog/the-founders-playbook. No text is reproduced verbatim;
+this skill encodes the framework for agent use under the repository's MIT license.

--- a/skills/founder-playbook/references/product-matrix.md
+++ b/skills/founder-playbook/references/product-matrix.md
@@ -1,0 +1,44 @@
+# Product matrix — capability classes per stage (vendor-neutral)
+
+The AI-native startup runs on three **capability classes**. The framework is
+provider-agnostic; the *reference* column names Claude products as the canonical
+implementation, but any AAIF-compatible tool that fills the class works.
+
+| Capability class | Mental model | Reference tool |
+|---|---|---|
+| **Conversational research** | On-call expert for every domain — deep research, document drafting, strategic thinking partner (devil's advocate, pre-mortems, scenarios) | Claude (Chat) |
+| **Agentic coding** | The engineer who's always available and never blocked — generate, test, debug, refactor production code | Claude Code |
+| **Workflow automation** | On-demand ops team — recurring tasks run themselves; integrates with the tools the company already uses | Claude Cowork |
+
+## Which class leads at each stage
+
+| Stage | Primary class | Secondary | Why |
+|---|---|---|---|
+| **Idea** | Conversational research | — | Research, competitive synthesis, customer-discovery logistics. Code comes *after* validation. |
+| **MVP** | Agentic coding | Conversational research; light automation | Build the focused product; research defines architecture/scope/metrics first; automation runs the feedback loop. |
+| **Launch** | All three, compounding | — | Coding remediates tech debt + hardens infra; automation removes founder-as-bottleneck; research designs the processes. Each tool's output is another's input. |
+| **Scale** | All three, org-wide | — | Coding builds enterprise-grade infra + integrations (moat); automation runs the operating layer + GTM execution; research drives narrative, GTM strategy, and domain-knowledge capture. |
+
+## Stage-by-stage usage notes
+
+- **Idea** — Use research to read many user-interview transcripts, synthesize a
+  competitive landscape, and build target-interview lists from public signals. Do
+  **not** open the coding tool yet.
+- **MVP** — Define architecture + scope **before** coding; persist them in a context
+  file (e.g., `CLAUDE.md`) so each session shares one mental model. Run a first-pass
+  security review before any real user touches the product. Use automation for
+  discovery/feedback logistics (outreach, scheduling, triage, weekly synthesis) —
+  but keep a human interpreting nuanced feedback.
+- **Launch** — Coding runs an architectural audit + targeted refactor + test-coverage
+  expansion, and surfaces SOC 2 / GDPR / HIPAA-relevant issues. Automation runs the
+  product-management operating system (sprint cadence, bug triage, weekly metrics).
+- **Scale** — Coding hardens to enterprise reliability (logging, monitoring, incident
+  response, SLAs) and builds integrations/APIs/SDKs (workflow lock-in). Automation
+  runs enterprise support + GTM execution. Research turns founder domain expertise
+  into reusable **Skills** and a data-moat narrative.
+
+## Vendor-neutrality guard-rail
+
+Keep each capability class behind a provider-agnostic seam. A single vendor's
+outage, deprecation, or price change must never paralyze the company — the lean
+startup's leverage depends on the *capabilities*, not a specific brand.

--- a/skills/founder-stage-idea/SKILL.md
+++ b/skills/founder-stage-idea/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: founder-stage-idea
+version: "1.0.0"
+description: |
+  Idea-stage discipline for an AI-native startup: validate that a real, specific,
+  frequent problem exists — and that your solution addresses it — BEFORE writing any
+  production code. Provides the problem-solution-fit exit gate, the signature failure
+  modes (mistaking building for validating; "no competition" as advantage; surveys
+  instead of interviews), and ready-to-use prompts for problem-hypothesis sharpening,
+  competitive-landscape synthesis, and customer-discovery interviews. Use when a
+  founder says "I have an idea", "should I build this", "validate my idea", "customer
+  discovery", "is there a market", or "who are my competitors".
+allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
+---
+
+# Founder Stage 1 — Idea (validate before you build)
+
+The Idea stage is where the most consequential mistakes are made. With AI removing
+technical blockers, the temptation is to build immediately. The discipline of this
+stage is the opposite: **don't build until the evidence justifies it.** The work is
+research, customer discovery, competitive analysis, and honest evaluation of
+disconfirming evidence — all *before* the first line of production code.
+
+## Goal
+
+Research-oriented validation: assemble solid, mostly **qualitative** evidence (from
+real human conversations) that a real problem exists and that your proposed solution
+addresses it, before committing resources to building.
+
+Get specific before you get moving. *"People struggle with expense reporting"* is an
+observation. *"Finance managers at mid-market companies spend 4+ hours/week
+reconciling submissions because their tools don't integrate with their accounting
+software"* is a **testable hypothesis.**
+
+## Exit gate — problem-solution fit
+
+Advance only when you can answer **yes to all three**:
+
+- [ ] **Is the problem real and specific?** You can name exactly *who* has it, *how
+      often* they hit it, *how severely* it affects them, and *what they do about it today.*
+- [ ] **Does your solution address the actual problem** the validation revealed (not
+      the one you originally assumed)?
+- [ ] **Do you have enough signal to justify building?** You'll never have certainty
+      — waiting for it is itself a failure mode — but committing to an MVP must be a
+      reasoned decision, not an act of faith.
+
+## Failure modes → mitigations
+
+| Failure mode | What it looks like | Mitigation |
+|---|---|---|
+| **Mistaking building for validating** | Spinning up a prototype *feels* like progress; ~42% of startups historically fail building something nobody wanted, and easy prototyping raises that risk | Keep the coding tool closed until the 3 exit questions are "yes" |
+| **"No competition" as an advantage** | "Nobody else does this" treated as a moat | Usually means no market, or you haven't looked hard enough — map substitutes and the status quo |
+| **Surveys instead of interviews** | Aggregated survey data stands in for real conversations | Run deep 1:1 interviews; aim for first-hand transcripts, not Likert averages |
+| **Solution obsession** | Falling in love with the build, ignoring the problem | Re-anchor on the problem's specificity and frequency every iteration |
+
+## Exercises (reusable prompts)
+
+### A. Sharpen the problem hypothesis
+> "Here is my rough idea: <idea>. Rewrite it as a single testable problem hypothesis
+> naming the exact user, the frequency, the severity, and what they currently do
+> instead. Then list the 5 riskiest assumptions in it and, for each, the cheapest way
+> to disconfirm it through conversation — not a survey."
+
+### B. Map the competitive landscape
+> "For the problem '<problem>', map how it is solved today: direct competitors,
+> indirect substitutes, and the do-nothing/status-quo option. For each, summarize how
+> well it solves the problem and where it fails. Then state the 3 sharpest, defensible
+> differences a new solution would need — and flag if 'no competition' actually means
+> 'no market'."
+
+### C. Customer-discovery interview kit
+> "Draft a customer-discovery interview guide for '<user segment>' about '<problem>'.
+> Use open, non-leading questions focused on past behavior ('tell me about the last
+> time…') not hypotheticals. Include a screening question to confirm they actually
+> have the problem. Then give me a 1-page synthesis template to fill after each
+> interview that captures evidence for/against the hypothesis."
+
+### D. Build the interview target list
+> "From these public signals (<communities, job titles, forums, reviews>), produce a
+> prioritized outreach list of people likely to have '<problem>', with a one-line
+> reason each and a short, non-salesy outreach message."
+
+## When to leave / when to loop
+
+- All 3 exit questions "yes" → advance to **`founder-stage-mvp`**.
+- Evidence contradicts the hypothesis → that's the system working. Explore an
+  adjacent segment, adjust the value proposition, or sharpen the problem — *before*
+  over-investing in the wrong answer.
+
+## Guard-rails
+
+- This is judgment **support**, not a verdict. The interview *interpretation* — is a
+  request a core need or a nice-to-have? — requires a human.
+- Don't outsource the conversations themselves; founder-led discovery is the signal.
+
+## Attribution
+
+Adapted (process & methodology, original prose) from Anthropic, *The Founder's
+Playbook: Building an AI-Native Startup* (2026) —
+https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-idea/SKILL.md
+++ b/skills/founder-stage-idea/SKILL.md
@@ -56,12 +56,14 @@ Advance only when you can answer **yes to all three**:
 ## Exercises (reusable prompts)
 
 ### A. Sharpen the problem hypothesis
+
 > "Here is my rough idea: <idea>. Rewrite it as a single testable problem hypothesis
 > naming the exact user, the frequency, the severity, and what they currently do
 > instead. Then list the 5 riskiest assumptions in it and, for each, the cheapest way
 > to disconfirm it through conversation — not a survey."
 
 ### B. Map the competitive landscape
+
 > "For the problem '<problem>', map how it is solved today: direct competitors,
 > indirect substitutes, and the do-nothing/status-quo option. For each, summarize how
 > well it solves the problem and where it fails. Then state the 3 sharpest, defensible
@@ -69,6 +71,7 @@ Advance only when you can answer **yes to all three**:
 > 'no market'."
 
 ### C. Customer-discovery interview kit
+
 > "Draft a customer-discovery interview guide for '<user segment>' about '<problem>'.
 > Use open, non-leading questions focused on past behavior ('tell me about the last
 > time…') not hypotheticals. Include a screening question to confirm they actually
@@ -76,6 +79,7 @@ Advance only when you can answer **yes to all three**:
 > interview that captures evidence for/against the hypothesis."
 
 ### D. Build the interview target list
+
 > "From these public signals (<communities, job titles, forums, reviews>), produce a
 > prioritized outreach list of people likely to have '<problem>', with a one-line
 > reason each and a short, non-salesy outreach message."

--- a/skills/founder-stage-idea/SKILL.md
+++ b/skills/founder-stage-idea/SKILL.md
@@ -96,5 +96,5 @@ Advance only when you can answer **yes to all three**:
 ## Attribution
 
 Adapted (process & methodology, original prose) from Anthropic, *The Founder's
-Playbook: Building an AI-Native Startup* (2026) —
+Playbook: Building an AI-Native Startup* (2026-05-14) —
 https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-launch/SKILL.md
+++ b/skills/founder-stage-launch/SKILL.md
@@ -96,5 +96,5 @@ Advance only when all three hold:
 ## Attribution
 
 Adapted (process & methodology, original prose) from Anthropic, *The Founder's
-Playbook: Building an AI-Native Startup* (2026) —
+Playbook: Building an AI-Native Startup* (2026-05-14) —
 https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-launch/SKILL.md
+++ b/skills/founder-stage-launch/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: founder-stage-launch
+version: "1.0.0"
+description: |
+  Launch-stage discipline for an AI-native startup: turn early traction into a
+  repeatable, channel-driven growth engine and build the company around the product,
+  so operations run WITHOUT the founder in every loop. Provides the 3-element exit
+  gate (defensible CAC·LTV·payback; production-hardened; ops without founder
+  bottleneck), the failure modes (technical debt comes due, founder-as-bottleneck,
+  security/compliance no longer deferrable, expansion before ready), and exercises
+  (architectural audit + remediation sequencing, attention/bottleneck audit, SOC2/
+  GDPR/HIPAA compliance workstream, lightweight PM operating system). Use when a
+  founder says "we launched", "scale our growth", "I'm the bottleneck", "tech debt",
+  "SOC 2 / GDPR / HIPAA / compliance", or "set up sprints / processes".
+allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
+---
+
+# Founder Stage 3 — Launch (prove the *business* deserves to grow)
+
+If MVP proved the *product* deserves to exist, Launch proves the *business* deserves
+to grow. Finding PMF was the hard part; now the challenge is **keeping** it while the
+organization around the product keeps up. All three capability classes are in full
+use and compound — coding builds the product, automation builds the company, research
+operationalizes the knowledge.
+
+## Goals
+
+Turn early traction into a **repeatable, sustainable growth engine**; harden the
+infrastructure underneath; and build an actual company around the product. The aim
+isn't to remove the founder — it's to build operational systems that **free founder
+attention for the decisions only a founder can make.**
+
+## Exit gate — three elements
+
+Advance only when all three hold:
+
+- [ ] **Growth is repeatable and channel-driven** — you acquire users predictably
+      through specific channels with **CAC, LTV, and payback period** you know and can defend.
+- [ ] **The product handles production workloads** — infra hardened; security &
+      compliance in order; reliability holds under real conditions (not just tested ones).
+- [ ] **Operations run without founder bottlenecks** — processes + automation exist;
+      you're no longer personally handling support, triage, sprint planning, or reporting.
+
+## Failure modes → mitigations
+
+| Failure mode | What it looks like | Mitigation |
+|---|---|---|
+| **Technical debt comes due** | MVP shortcuts now accrue interest under production traffic + new features | Architectural audit → targeted refactor → expand test coverage (exercise A) |
+| **The founder becomes the bottleneck** | Hour-decisions take a week; support piles up because only you know the answer; tasks happen only when you remember | Audit everything you touch; systematize / delegate / keep only founder-judgment work (exercise B) |
+| **Security & compliance no longer deferrable** | Real users, real data, enterprise contracts; theoretical risk becomes real exposure | Systematic review *before* scale; treat findings as required remediation, not suggestions (exercise C) |
+| **Expansion before you're ready** | New markets/funding look like growth but introduce variables your product wasn't built for | Resist premature expansion; protect the original user base; expand only with evidence |
+
+## Exercises (reusable prompts)
+
+### A. Architectural audit + remediation sequencing
+> "Audit my MVP codebase and produce a prioritized list of structural weaknesses,
+> test-coverage gaps, and refactoring candidates. Then sequence the remediation across
+> sprints: what must be fixed before the next release, what can run in parallel with
+> feature work, and what is acceptable ongoing debt at this stage. Also help me
+> capture the MVP-era architectural decisions that only lived in my head into the
+> `CLAUDE.md` so future sessions share one mental model."
+
+### B. Founder-attention / bottleneck audit
+> "Run a structured audit of my current operational load: every recurring task, every
+> decision that lands on me, every workflow that only happens because I remember it.
+> Categorize each into: (1) automate entirely, (2) needs a human but not me, (3)
+> genuinely requires founder judgment. For the automation candidates, design the
+> workflow logic — trigger, decision rules, output, and where it goes when done."
+
+### C. Security & compliance workstream
+> "Surface code-level issues that commonly come up in SOC 2 / GDPR / HIPAA audits for
+> my target market. Produce two things: a prioritized remediation sequence, and a
+> list of the documentation + controls (audit logging, access management) an
+> enterprise buyer will ask for before signing. Build this as a continuous workstream
+> in the dev cycle, not a one-time project."
+> *(AI scans aid but don't replace a qualified compliance review.)*
+
+### D. Lightweight PM operating system
+> "Design a lightweight product-management operating system that runs without me
+> triggering it: a sprint cadence, a minimum spec template (what a spec must include
+> before code touches a feature), a bug-triage decision tree, and a weekly metrics
+> brief that pulls from my actual data sources. Then specify what an automation layer
+> should run on schedule — ceremony scheduling, bug routing, report compilation."
+
+## When to leave
+
+- All three exit elements hold → advance to **`founder-stage-scale`**.
+
+## Guard-rails
+
+- Compliance/security AI output is an aid, not a substitute for qualified human review
+  (especially before signing regulated-industry or enterprise contracts).
+- "Free your attention" ≠ "remove yourself" — keep the founder-only decisions
+  (product narrative, key relationships, high-stakes calls).
+
+## Attribution
+
+Adapted (process & methodology, original prose) from Anthropic, *The Founder's
+Playbook: Building an AI-Native Startup* (2026) —
+https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-launch/SKILL.md
+++ b/skills/founder-stage-launch/SKILL.md
@@ -8,8 +8,8 @@ description: |
   gate (defensible CAC·LTV·payback; production-hardened; ops without founder
   bottleneck), the failure modes (technical debt comes due, founder-as-bottleneck,
   security/compliance no longer deferrable, expansion before ready), and exercises
-  (architectural audit + remediation sequencing, attention/bottleneck audit, SOC2/
-  GDPR/HIPAA compliance workstream, lightweight PM operating system). Use when a
+  (architectural audit + remediation sequencing, attention/bottleneck audit, SOC 2 /
+  GDPR / HIPAA compliance workstream, lightweight PM operating system). Use when a
   founder says "we launched", "scale our growth", "I'm the bottleneck", "tech debt",
   "SOC 2 / GDPR / HIPAA / compliance", or "set up sprints / processes".
 allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
@@ -46,13 +46,14 @@ Advance only when all three hold:
 | Failure mode | What it looks like | Mitigation |
 |---|---|---|
 | **Technical debt comes due** | MVP shortcuts now accrue interest under production traffic + new features | Architectural audit → targeted refactor → expand test coverage (exercise A) |
-| **The founder becomes the bottleneck** | Hour-decisions take a week; support piles up because only you know the answer; tasks happen only when you remember | Audit everything you touch; systematize / delegate / keep only founder-judgment work (exercise B) |
+| **The founder becomes the bottleneck** | Decisions that should take an hour now take a week; support piles up because only you know the answer; tasks happen only when you remember | Audit everything you touch; systematize / delegate / keep only founder-judgment work (exercise B) |
 | **Security & compliance no longer deferrable** | Real users, real data, enterprise contracts; theoretical risk becomes real exposure | Systematic review *before* scale; treat findings as required remediation, not suggestions (exercise C) |
 | **Expansion before you're ready** | New markets/funding look like growth but introduce variables your product wasn't built for | Resist premature expansion; protect the original user base; expand only with evidence |
 
 ## Exercises (reusable prompts)
 
 ### A. Architectural audit + remediation sequencing
+
 > "Audit my MVP codebase and produce a prioritized list of structural weaknesses,
 > test-coverage gaps, and refactoring candidates. Then sequence the remediation across
 > sprints: what must be fixed before the next release, what can run in parallel with
@@ -61,6 +62,7 @@ Advance only when all three hold:
 > `CLAUDE.md` so future sessions share one mental model."
 
 ### B. Founder-attention / bottleneck audit
+
 > "Run a structured audit of my current operational load: every recurring task, every
 > decision that lands on me, every workflow that only happens because I remember it.
 > Categorize each into: (1) automate entirely, (2) needs a human but not me, (3)
@@ -68,6 +70,7 @@ Advance only when all three hold:
 > workflow logic — trigger, decision rules, output, and where it goes when done."
 
 ### C. Security & compliance workstream
+
 > "Surface code-level issues that commonly come up in SOC 2 / GDPR / HIPAA audits for
 > my target market. Produce two things: a prioritized remediation sequence, and a
 > list of the documentation + controls (audit logging, access management) an
@@ -76,6 +79,7 @@ Advance only when all three hold:
 > *(AI scans aid but don't replace a qualified compliance review.)*
 
 ### D. Lightweight PM operating system
+
 > "Design a lightweight product-management operating system that runs without me
 > triggering it: a sprint cadence, a minimum spec template (what a spec must include
 > before code touches a feature), a bug-triage decision tree, and a weekly metrics

--- a/skills/founder-stage-mvp/SKILL.md
+++ b/skills/founder-stage-mvp/SKILL.md
@@ -56,35 +56,41 @@ enough to return (retention), pay (revenue), or refer (referral). Useful litmus 
 ## Emittable templates (ask the agent to produce these, then save them)
 
 ### A. Architecture-context (`CLAUDE.md`) — define BEFORE coding
+
 > "I'm building <product> for <users>, expecting <realistic 6-month scale>. Help me
 > define the architectural principles that should govern the MVP, the dependencies to
 > avoid given my constraints, and the tradeoffs I'm consciously accepting now. Output
 > a concise `CLAUDE.md` I can drop at the repo root as persistent project memory."
 
 ### B. Scope definition — define BEFORE building features
+
 > "Draft a scope document for my MVP: what it **does**, what it **deliberately does
 > not do**, and a feature-amendment bar — the specific real-user evidence that would
 > justify adding something. Phrase the bar so the question shifts from 'should we
 > build this?' to 'have a critical mass of users said they can't get value without it?'"
 
 ### C. Pre-launch measurement framework
+
 > "Define the metrics that matter for <product>: retention benchmarks, activation
 > criteria, and Day-7/Day-30 targets. Then define what a **false positive** looks
 > like for this product (e.g., signups without activation, revenue without retention).
 > When data arrives, make the adversarial case against my own traction."
 
 ### D. Security-review brief (before any real user)
+
 > "Review my core application code for: authentication & session handling, data
 > exposure in API responses, input validation & injection risks, and dependencies
 > with known vulnerabilities. For each finding, say whether it needs a fix and flag
 > anything touching auth, secrets, or data for mandatory human review."
 
 ### E. Session template (use every agentic-coding session)
+
 > Start: revisit the scope doc + load the persistent context file (e.g., `CLAUDE.md`). End: append a brief log
 > — what was built, what decisions were made, what assumptions were introduced.
 > *Five minutes of documentation per session is cheap insurance against drift.*
 
 ### F. Pivot diagnostic (after 3+ iteration cycles with no PMF movement)
+
 > "Here is my retention data, user feedback, and original problem hypothesis. Answer:
 > (1) Is a segment responding differently than the rest? (2) Is the value gap a
 > positioning problem or a product problem? (3) What would have to be true for the

--- a/skills/founder-stage-mvp/SKILL.md
+++ b/skills/founder-stage-mvp/SKILL.md
@@ -79,8 +79,8 @@ enough to return (retention), pay (revenue), or refer (referral). Useful litmus 
 > with known vulnerabilities. For each finding, say whether it needs a fix and flag
 > anything touching auth, secrets, or data for mandatory human review."
 
-### E. Session template (use every Claude Code session)
-> Start: revisit the scope doc + load the `CLAUDE.md` context. End: append a brief log
+### E. Session template (use every agentic-coding session)
+> Start: revisit the scope doc + load the persistent context file (e.g., `CLAUDE.md`). End: append a brief log
 > — what was built, what decisions were made, what assumptions were introduced.
 > *Five minutes of documentation per session is cheap insurance against drift.*
 
@@ -106,5 +106,5 @@ enough to return (retention), pay (revenue), or refer (referral). Useful litmus 
 ## Attribution
 
 Adapted (process & methodology, original prose) from Anthropic, *The Founder's
-Playbook: Building an AI-Native Startup* (2026) —
+Playbook: Building an AI-Native Startup* (2026-05-14) —
 https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-mvp/SKILL.md
+++ b/skills/founder-stage-mvp/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: founder-stage-mvp
+version: "1.0.0"
+description: |
+  MVP-stage discipline for an AI-native startup: turn a validated problem into the
+  smallest focused product that real users actually use, while moving fast WITHOUT
+  accruing compounding technical debt. Provides the product-market-fit exit gate
+  (Sean Ellis ≥40% "very disappointed"; the pull-vs-push effort test), the failure
+  modes (agentic tech debt, false PMF, zero-friction scope creep, insecure-by-
+  inexperience), and emittable templates (architecture-context / CLAUDE.md, scope
+  definition, pre-launch measurement framework, security-review brief, pivot
+  diagnostic). Use when a founder says "build the MVP", "define architecture/scope",
+  "do I have product-market fit", "security review", "set up metrics", or "should I pivot".
+allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
+---
+
+# Founder Stage 2 — MVP (evidence, not completeness)
+
+The MVP stage is still an **evidence-gathering exercise** — now about the *solution*:
+does a specific, identifiable group find it valuable enough to return to, pay for, or
+tell others about? Build the smallest, most focused iteration that puts a real
+solution in front of real users.
+
+## Goals
+
+1. Translate a validated problem into a **working product real users actually use**
+   (not the full roadmap — the focused core).
+2. **Move fast without compounding technical debt.** Some debt is fine at MVP if
+   managed before scaling; *agentic* debt compounds because, without written specs
+   and constraints, each AI session re-derives foundations and drifts.
+3. **Invest in persistent context from day one.** Your codebase is something you
+   collaborate with AI on session after session — legibility is foundational.
+
+## Exit gate — genuine product-market-fit evidence
+
+PMF is a **pattern that holds across multiple iteration cycles**, not one data point.
+Advance when you have real evidence that a specific group finds the product valuable
+enough to return (retention), pay (revenue), or refer (referral). Useful litmus tests:
+
+- [ ] **Sean Ellis test** — ask active users: *"How would you feel if you could no
+      longer use this?"* **≥40% "very disappointed"** is a meaningful PMF signal.
+- [ ] **Effort test (pull vs push)** — pre-PMF, retention needs constant founder
+      intervention (outreach, incentives, follow-up). Post-PMF, the product starts
+      doing that work itself. When things **pull instead of push**, something real changed.
+- [ ] Retention, activation, and Day-7 / Day-30 targets (set *before* launch) are met.
+
+## Failure modes → mitigations
+
+| Failure mode | What it looks like | Mitigation |
+|---|---|---|
+| **Agentic technical debt** | Each session re-derives architecture; pieces never designed to fit; collapses late | Define + persist architecture (template A) before building; 5-min per-session log |
+| **False product-market fit** | Launch-spike enthusiasm (friends, investor networks, a front-page post) read as PMF | Set the measurement framework *before* launch (template C); define what a false positive looks like |
+| **Zero-friction scope creep** | Every extra feature is individually defensible and "only an afternoon" | Written scope doc with explicit non-goals + a feature-amendment bar (template B) |
+| **Insecure by inexperience** | AI writes code that *works*, not code that's *secure*; vulns invisible until exploited | A security review before any real user touches it (template D); human review for auth/secrets/data |
+
+## Emittable templates (ask the agent to produce these, then save them)
+
+### A. Architecture-context (`CLAUDE.md`) — define BEFORE coding
+> "I'm building <product> for <users>, expecting <realistic 6-month scale>. Help me
+> define the architectural principles that should govern the MVP, the dependencies to
+> avoid given my constraints, and the tradeoffs I'm consciously accepting now. Output
+> a concise `CLAUDE.md` I can drop at the repo root as persistent project memory."
+
+### B. Scope definition — define BEFORE building features
+> "Draft a scope document for my MVP: what it **does**, what it **deliberately does
+> not do**, and a feature-amendment bar — the specific real-user evidence that would
+> justify adding something. Phrase the bar so the question shifts from 'should we
+> build this?' to 'have a critical mass of users said they can't get value without it?'"
+
+### C. Pre-launch measurement framework
+> "Define the metrics that matter for <product>: retention benchmarks, activation
+> criteria, and Day-7/Day-30 targets. Then define what a **false positive** looks
+> like for this product (e.g., signups without activation, revenue without retention).
+> When data arrives, make the adversarial case against my own traction."
+
+### D. Security-review brief (before any real user)
+> "Review my core application code for: authentication & session handling, data
+> exposure in API responses, input validation & injection risks, and dependencies
+> with known vulnerabilities. For each finding, say whether it needs a fix and flag
+> anything touching auth, secrets, or data for mandatory human review."
+
+### E. Session template (use every Claude Code session)
+> Start: revisit the scope doc + load the `CLAUDE.md` context. End: append a brief log
+> — what was built, what decisions were made, what assumptions were introduced.
+> *Five minutes of documentation per session is cheap insurance against drift.*
+
+### F. Pivot diagnostic (after 3+ iteration cycles with no PMF movement)
+> "Here is my retention data, user feedback, and original problem hypothesis. Answer:
+> (1) Is a segment responding differently than the rest? (2) Is the value gap a
+> positioning problem or a product problem? (3) What would have to be true for the
+> current product to find genuine PMF — and is that realistic given the data?"
+
+## When to leave / when to loop
+
+- PMF evidence holds across cycles → advance to **`founder-stage-launch`**.
+- No movement after ≥3 cycles → run template F; let the answers decide whether to
+  adjust onboarding/messaging, pivot the segment/value-prop, or return to **Idea**.
+
+## Guard-rails
+
+- AI security review is a useful first pass, **not** a substitute for security tooling
+  or a human reviewer on high-stakes paths.
+- Keep a human interpreting feedback ("great, but I wish it could also…" — core need
+  or nice-to-have? one customer or a segment?).
+
+## Attribution
+
+Adapted (process & methodology, original prose) from Anthropic, *The Founder's
+Playbook: Building an AI-Native Startup* (2026) —
+https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-scale/SKILL.md
+++ b/skills/founder-stage-scale/SKILL.md
@@ -58,6 +58,7 @@ and an operationally mature, sustainable organization.
 ## Exercises (reusable prompts)
 
 ### A. Bottleneck map + "week-away" stress test
+
 > "Produce a bottleneck map of my operational layer: every workflow, decision, and
 > approval routed through me. Now extrapolate what happens to each when I'm
 > unavailable for a week — the ones that stall are where handoff criteria, escalation
@@ -65,6 +66,7 @@ and an operationally mature, sustainable organization.
 > founder-only priorities and recommend fixes."
 
 ### B. Enterprise-infrastructure gap analysis
+
 > "Pick three ideal enterprise customers. For each, produce a gap analysis: what
 > documentation, SLAs, and support infrastructure would their procurement team expect
 > before signing a multi-year contract — and where do I currently fall short? Sequence
@@ -72,6 +74,7 @@ and an operationally mature, sustainable organization.
 > observability that makes SLAs enforceable; product docs, support playbooks)."
 
 ### C. Build a real GTM function
+
 > "Help me build a go-to-market engine from scratch: market segmentation, messaging
 > architecture, analyst-relations strategy, sales playbooks, and the investor-facing
 > metrics narrative. Translate the product's value props for each audience (users,
@@ -79,6 +82,7 @@ and an operationally mature, sustainable organization.
 > pipelines, outbound sequences, briefing logistics, CRM hygiene, pipeline reporting."
 
 ### D. Turn domain expertise into reusable Skills (compounding moat)
+
 > "Help me externalize my domain expertise — industry jargon, regulatory gotchas,
 > edge cases, why obvious answers fail — into a structured, searchable context. Then
 > identify recurring expert workflows to codify as reusable **Skills** the product
@@ -87,6 +91,7 @@ and an operationally mature, sustainable organization.
 > one. The test suite becomes a map of my moat."
 
 ### E. Data-moat narrative
+
 > "Here's a summary of my product's interaction data (what I collect, how long, how
 > users engage over time). Identify the 3 highest-signal behavioral patterns and
 > design a feedback loop turning each into systematic improvement. Then draft a
@@ -94,6 +99,7 @@ and an operationally mature, sustainable organization.
 > and why a well-resourced competitor starting today couldn't replicate it soon."
 
 ### F. Workflow lock-in audit
+
 > "Map my top-10 customers by integration depth: for each, the automations they've
 > built, the integrations they depend on, the team workflows running through the
 > product, and an estimate of switching cost. Identify which integration types create

--- a/skills/founder-stage-scale/SKILL.md
+++ b/skills/founder-stage-scale/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: founder-stage-scale
+version: "1.0.0"
+description: |
+  Scale-stage discipline for an AI-native startup: build systematic, mature-org
+  growth and a defensible moat while keeping the lean AI-centered structural
+  advantage. Provides the threshold exit gate (sustainable profitability / IPO-ready /
+  acquisition), the failure modes (can't delegate the operating layer, scaling
+  technical operations, scaling org functions, building a real GTM), and exercises
+  (bottleneck map + week-away stress test, enterprise-infra gap analysis, GTM build,
+  turning domain expertise into reusable Skills, data-moat narrative, workflow lock-in
+  audit). Use when a founder says "we're scaling", "build a moat", "enterprise
+  readiness / SLAs", "go-to-market / GTM", "delegate operations", or "defensibility".
+allowed-tools: Read, Write, Edit, Glob, Grep, WebFetch, WebSearch
+---
+
+# Founder Stage 4 — Scale (from a bet to a business)
+
+At Scale the founder's role re-centers from builder to public-facing executive. The
+product is still central, but the day-to-day becomes the **company itself** — analyst
+briefings, enterprise deals, board relationships — even as you preserve the lean,
+AI-centered advantage. The goal is **systematic growth sustained by mature
+operations**, plus a **defensible moat** built from accumulated depth.
+
+## Goals
+
+- Build **systematic growth** (thousands → millions of users; one market → many)
+  sustained by mature organizational operations, not founder instinct alone.
+- Build a **defensible moat** from accumulated depth: domain expertise encoded into
+  the product, deep integrations, and proprietary system data + workflows that a
+  well-funded incumbent couldn't replicate quickly.
+- Withstand external scrutiny: governance, compliance posture, financial controls,
+  and a strategic narrative — not just product capability.
+
+## Exit gate — a threshold, not a milestone
+
+The company is **sustainable even as the founder steps back from day-to-day**. You've
+demonstrated systematic, auditable growth; built governance/compliance that satisfies
+demanding external reviewers; and have a real answer to *"if a well-funded incumbent
+copied your product today, would your users stay?"* In practice this resolves to one of:
+
+- [ ] **Sustainable profitability** at a scale that no longer needs external capital, **or**
+- [ ] **IPO-readiness**, **or**
+- [ ] **Acquisition.**
+
+All three require systematic + auditable growth, a moat that holds under scrutiny,
+and an operationally mature, sustainable organization.
+
+## Failure modes → mitigations
+
+| Failure mode | What it looks like | Mitigation |
+|---|---|---|
+| **Can't delegate the operating layer** | Hand off too much/fast → context-blind decisions; hold too long → bottleneck again | Mature systems until trustworthy, *then* trust them; codify founder-only institutional knowledge (exercise A) |
+| **Scaling technical operations** | Buyers want a dependable infrastructure partner, not just a product | Build support infra, docs, reliability/SLAs around the codebase (exercise B) |
+| **Scaling organizational functions** | Need finance, compliance monitoring, contract mgmt, support regardless of headcount | Stand up the broader operational functions deliberately |
+| **Hitting the organic-growth ceiling** | Flattening curves, rising CAC, pipeline that only moves when the founder does | Build a real GTM engine + brand voice/story (exercise C) |
+
+## Exercises (reusable prompts)
+
+### A. Bottleneck map + "week-away" stress test
+> "Produce a bottleneck map of my operational layer: every workflow, decision, and
+> approval routed through me. Now extrapolate what happens to each when I'm
+> unavailable for a week — the ones that stall are where handoff criteria, escalation
+> paths, or exception handling still need tightening. Map these against my list of
+> founder-only priorities and recommend fixes."
+
+### B. Enterprise-infrastructure gap analysis
+> "Pick three ideal enterprise customers. For each, produce a gap analysis: what
+> documentation, SLAs, and support infrastructure would their procurement team expect
+> before signing a multi-year contract — and where do I currently fall short? Sequence
+> the technical + documentation work (logging, monitoring, incident response,
+> observability that makes SLAs enforceable; product docs, support playbooks)."
+
+### C. Build a real GTM function
+> "Help me build a go-to-market engine from scratch: market segmentation, messaging
+> architecture, analyst-relations strategy, sales playbooks, and the investor-facing
+> metrics narrative. Translate the product's value props for each audience (users,
+> enterprise buyers, analysts). Then specify the recurring execution layer — content
+> pipelines, outbound sequences, briefing logistics, CRM hygiene, pipeline reporting."
+
+### D. Turn domain expertise into reusable Skills (compounding moat)
+> "Help me externalize my domain expertise — industry jargon, regulatory gotchas,
+> edge cases, why obvious answers fail — into a structured, searchable context. Then
+> identify recurring expert workflows to codify as reusable **Skills** the product
+> runs the same way every time. Pick one edge case a generic competitor would get
+> wrong in my vertical and turn it into a dedicated test case; every recurrence adds
+> one. The test suite becomes a map of my moat."
+
+### E. Data-moat narrative
+> "Here's a summary of my product's interaction data (what I collect, how long, how
+> users engage over time). Identify the 3 highest-signal behavioral patterns and
+> design a feedback loop turning each into systematic improvement. Then draft a
+> one-page moat narrative: how the data flywheel works, how long it's been spinning,
+> and why a well-resourced competitor starting today couldn't replicate it soon."
+
+### F. Workflow lock-in audit
+> "Map my top-10 customers by integration depth: for each, the automations they've
+> built, the integrations they depend on, the team workflows running through the
+> product, and an estimate of switching cost. Identify which integration types create
+> the deepest lock-in, and where to build APIs/webhooks/SDKs so customers build *on
+> top of* the product (the deepest form of lock-in)."
+
+## When you're done
+
+Reaching the threshold means the startup has gone **from a bet to a business.** The
+moat (encoded expertise + integration depth + proprietary data flywheel) is the lasting advantage.
+
+## Guard-rails
+
+- Delegation is as much psychological as structural — mature systems to trustworthy
+  *before* trusting them; don't hand off context that only the founder can supply.
+- Enterprise/compliance AI output supports, but does not replace, qualified human
+  and independent assessment.
+
+## Attribution
+
+Adapted (process & methodology, original prose) from Anthropic, *The Founder's
+Playbook: Building an AI-Native Startup* (2026) —
+https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.

--- a/skills/founder-stage-scale/SKILL.md
+++ b/skills/founder-stage-scale/SKILL.md
@@ -115,5 +115,5 @@ moat (encoded expertise + integration depth + proprietary data flywheel) is the 
 ## Attribution
 
 Adapted (process & methodology, original prose) from Anthropic, *The Founder's
-Playbook: Building an AI-Native Startup* (2026) —
+Playbook: Building an AI-Native Startup* (2026-05-14) —
 https://claude.com/blog/the-founders-playbook. No text reproduced verbatim.


### PR DESCRIPTION
## Summary

- Converts Anthropic's **The Founder's Playbook: Building an AI-Native Startup** into a prefixed `founder-*` agentic-tool family: a **router skill** + **4 stage skills** + a **coach agent** + a **slash command**. The playbook is a stage-gated process framework (Idea → MVP → Launch → Scale); each stage carries its goal, exit-criteria gate, failure modes + mitigations, and ready-to-use exercise prompts / emittable templates.
- **Vendor-neutral by design** (capability classes: conversational-research / agentic-coding / workflow-automation) with Claude (Chat/Code/Cowork) as the *reference* implementation — fits the repo's AAIF / "30+ tools" ethos.
- **Original prose, framework/process only, attributed** — no verbatim copy of the (Anthropic-copyrighted) source. Closes #85.

### New files
| Kind | Path |
|---|---|
| Skill (router) | `skills/founder-playbook/SKILL.md` + `references/product-matrix.md` |
| Skill (stage) | `skills/founder-stage-{idea,mvp,launch,scale}/SKILL.md` |
| Agent | `agents/founder-coach.md` |
| Command | `commands/founder-playbook.md` |

## Type
- [x] feat (new functionality)

## AI Involvement
- [x] AI-generated draft reviewed by human (named reviewer required)

`Co-Authored-By:` footer present in the commit.

## Runtime / Surface Impact
- [x] Claude Code (plugin runtime, hooks, agents, commands, skills)
- [x] Generic AI agents (AGENTS.md contract) — skills are AAIF-portable
- [x] Plugin manifest (`.claude-plugin/plugin.json`) — **keywords only** (additive; see note under Risks)

## Files requiring follow-up governance update
- [x] `README.md` (skills/agents/commands catalogs updated)
- [x] `CHANGELOG.md` (entry under `[Unreleased] → Added`)
- [x] `.claude-plugin/plugin.json` (keywords added)

## Evidence
```text
$ python3 -m json.tool .claude-plugin/plugin.json   → OK valid JSON
$ frontmatter check (name==dir, description ≤1024):
  founder-playbook      dir-match=yes desc-len=646
  founder-stage-idea    dir-match=yes desc-len=645
  founder-stage-mvp     dir-match=yes desc-len=736
  founder-stage-launch  dir-match=yes desc-len=801
  founder-stage-scale   dir-match=yes desc-len=734
$ bash tests/validate-plugin.sh   → Errors: 0  Warnings: 0  Status: ✓ PASSED
$ gitleaks (pre-commit + manual)  → no leaks found
```

## Risks
- **Low — docs/skills only**, no engine/CI/code changes; purely additive.
- **Copyright**: encodes only the *framework/methodology* in original prose with attribution; no verbatim source text (checked).
- **Layer Purity**: vendor-neutral; no Vek-specific / operator-personal / PII content (the pre-existing `plugin.json` author email is untouched repo convention).
- **Version note (deliberate, please review)**: `plugin.json` `version` is **not** bumped — only `keywords` were added. Per CONTRIBUTING § Release Gates, the version bump + tag is a maintainer release-time operation; feature PRs accumulate under `## [Unreleased]`. Additionally, the CHANGELOG already reserves **v1.6.0** for the planned `status.md` alias removal, so claiming v1.6.0 here would be premature. The "Version bump" checklist item is therefore intentionally left unchecked.

## Rollback
- `git revert <merge-sha>` (single squash commit). New skills/agent/command are independent files; removing them has no cross-impact. Roll back the downstream marketplace SHA pin only if this ships to consumers.

## Checklist
- [x] Worktree + branch used (no direct-main commits)
- [x] Conventional Commits + `Co-Authored-By:` footer (AI involved)
- [x] gitleaks clean (pre-commit + CI workflow)
- [x] Build / tests pass (`tests/validate-plugin.sh` → 0/0 PASSED)
- [x] No secrets, no PII, no Vek-specific content (Layer Purity)
- [ ] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated if contract changed — **n/a** (no contract change; new additive tools follow existing conventions)
- [ ] Version bump + CHANGELOG entry if `plugin.json` changed — **CHANGELOG entry added; version bump intentionally deferred to maintainer release gate (see Risks)**

<!-- 🤖 Opened by an automated agent. Plan file: ~/.claude/plans/leia-entenda-analise-critique-staged-codd.md -->
