### PR TITLE
docs(branching): GitHub Flow (Class B) model in AGENTS.md SSOT + ADR-004

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,3 +31,7 @@ See `AGENTS.md` § Code Conventions. Bash hooks use `set -euo pipefail` and sour
 ## Tests
 
 `AGENTS.md` § Build & Test enumerates the canonical commands. The CI workflows in `.github/workflows/` (`ai-governance-linter`, `converge-tests`, `ontology-validation`, `supply-chain-sentinel`, `version-sync`) run on every PR — local Copilot suggestions should not break them.
+
+## Branching & Release
+
+Model = **GitHub Flow (Class B — library/marketplace)**. SSOT = [`AGENTS.md`](../AGENTS.md) §"Branching & Release Model" (+ `docs/adrs/ADR-004`). Never create environment branches here; never commit to `main` directly; PR → squash → delete-branch. Consumer source-pin = float per ADR-003.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,3 +81,12 @@ Before committing any changes:
 - Never use `--no-verify` to bypass hooks
 - Never push --force to protected branches
 - Treat hook scripts as security-critical (they have elevated permissions)
+
+## Branching & Release Model — GitHub Flow (Class B: library/marketplace)
+
+> This repo is **CONSUMED** by other repos/users — it does **not** deploy to environments. Model = **GitHub Flow + SemVer**. See [`docs/adrs/ADR-004-github-flow-branching.md`](./docs/adrs/ADR-004-github-flow-branching.md).
+
+- **Trunk**: `main` is always releasable. **No environment branches** (no `homolog`/`ppe`/`prd` here — those exist only in Class A *deployed apps* like `vek-sales`/`vek-list`).
+- **Work**: branch `feature/<id>-slug` · `fix/<id>-slug` · `hotfix/<id>-slug` · `docs/` · `chore/` off `main` → PR → **squash-merge** → **delete branch**.
+- **Agents MUST**: never commit to `main` directly · always open a PR · never create env-branches here · treat tagging/release as a human/operator gate.
+- **Versioning & consumer source-pin**: governed by the companion **ADR-003** (`version-ssot-float`) + Jira — source `ref = main` during MVP (TTL'd). Do **not** re-decide it here.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- **docs(branching)**: documented GitHub Flow (Class B) model in `AGENTS.md` (SSOT) + `ADR-004`; added GEMINI.md / Copilot pointers; README badge. Companion to ADR-003 (source float).
+
 ### Added
 
 #### `founder-*` family — Anthropic Founder's Playbook converted to agentic-tools

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,3 +351,7 @@ Entry points: skill `delegate-governance` (discoverable) + CLI `plugin-scripts/g
 
 *Multi-Agent OS v1.5.2 | Plugin for Claude Code*
 *Analysis by: Claude-Analyst-c614-plugin | 2026-01-08T21:30:00-03:00*
+
+## Branching & Release Model
+
+**GitHub Flow (Class B — library/marketplace).** Canonical SSOT: [`AGENTS.md`](./AGENTS.md) §"Branching & Release Model" + `docs/adrs/ADR-004-github-flow-branching.md`. No environment branches here; source-pin = float per ADR-003.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,5 @@
+# GEMINI.md — pointer to AGENTS.md (AAIF SSOT)
+
+This repo's agent instructions are **vendor-neutral** and live in **[`AGENTS.md`](./AGENTS.md)** (AAIF single source of truth). Gemini: read `AGENTS.md` first.
+
+**Branching/release model**: **GitHub Flow (Class B — library/marketplace)** — see `AGENTS.md` §"Branching & Release Model" + [`docs/adrs/ADR-004-github-flow-branching.md`](./docs/adrs/ADR-004-github-flow-branching.md). Never create environment branches here; never commit to `main` directly; PR → squash → delete-branch.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet)](https://claude.ai/code)
 [![Version](https://img.shields.io/badge/Version-1.5.2-blue)](https://github.com/ekson73/multi-agent-os)
 [![Sentinel](https://img.shields.io/badge/Sentinel-Protocol-green)](https://github.com/ekson73/multi-agent-os/tree/main/sentinel)
+[![Branching: GitHub Flow](https://img.shields.io/badge/branching-GitHub%20Flow%20(Class%20B)-0a7bbb)](./AGENTS.md)
 
 A comprehensive Claude Code plugin for orchestrating AI agents in software development workflows.
 

--- a/docs/adrs/ADR-004-github-flow-branching.md
+++ b/docs/adrs/ADR-004-github-flow-branching.md
@@ -1,0 +1,36 @@
+# ADR-004: GitHub Flow branching model (Class B — library/marketplace)
+
+- **Status**: Accepted
+- **Date**: 2026-05-26
+- **Deciders**: Operator (DevSecOps / AI-eng), via HITL directive
+- **Scope**: This repo (Class B: **consumed, not deployed**). **Companion to ADR-003** (`version-ssot-float`): ADR-003 governs how *consumers* pin sources; **this ADR governs how *maintainers/agents* branch.**
+
+## Context
+
+Vek repos split into two classes:
+
+- **Class A — apps that DEPLOY** (`vek-sales`, `vek-list`, new ai-driven apps): GitLab-Flow-Lite + environment branches (`main` / `homolog` / `prod`) + canary ring.
+- **Class B — libraries/marketplaces that are CONSUMED** (this repo): there is **no environment to deploy to**, so environment branches are meaningless.
+
+This repo already had branch-naming (`CLAUDE.md`) and a PR/merge workflow (`CONTRIBUTING.md`), but **no NAMED branching model in the agent-facing SSOT (`AGENTS.md`)** — causing ambiguity for humans and agents moving across repos.
+
+## Decision
+
+Adopt **GitHub Flow + SemVer** for this Class-B repo:
+
+1. Single trunk `main`, always releasable.
+2. Short-lived `feature/<id>-slug` · `fix/<id>-slug` · `hotfix/<id>-slug` · `docs/` · `chore/` branches → PR → **squash-merge** → **delete branch**.
+3. **No environment branches** (`homolog`/`ppe`/`prd` do not exist here — they belong to Class A deployed apps only).
+4. **Versioning + consumer source-pin are governed by the companion ADR-003 (float, version SSOT in `plugin.json`, TTL'd)** — explicitly **not** re-decided here.
+5. Agents MUST: never commit to `main` directly · always open a PR · never create env-branches here · treat tagging/release as a human/operator gate.
+
+## Consequences
+
+- **Positive**: one named model across all Class-B repos → zero human/agent confusion; `AGENTS.md` becomes the discoverable SSOT.
+- **Negative (mitigated)**: one more ADR to maintain — kept short and as a *companion* that references ADR-003 rather than duplicating it.
+
+## References
+
+- **Companion**: `ADR-003-version-ssot-float.md` (source/version strategy) + Jira ticket
+- `AGENTS.md` §"Branching & Release Model"
+- Class A counterpart: `vek-sales` / `vek-list` GitLab-Flow-Lite (deployed apps)


### PR DESCRIPTION
**[PR-as-Enhancement-Prompt]**

## Context
This repo is **Class B** (library/marketplace — *consumed, not deployed*). It already had branch-naming (`CLAUDE.md`) + a PR/merge workflow (`CONTRIBUTING.md`) and the **source-float** decision (`ADR-003-version-ssot-float`), but **no NAMED branching model in `AGENTS.md`** (the AAIF SSOT agents read). This caused cross-repo ambiguity for humans + agents (e.g. confusion vs Class-A apps that DO use `homolog`/`prod` env-branches).

## Objectives
- Name the model explicitly: **GitHub Flow + SemVer (Class B)** in `AGENTS.md` (SSOT).
- Add a short **companion** ADR-004 that references ADR-003 (does **not** re-decide source-pin/float).
- Provide non-AAIF vendor pointers (`GEMINI.md`, Copilot) → `AGENTS.md`.
- README badge + CHANGELOG entry.

## Acceptance
- [x] `AGENTS.md` §"Branching & Release Model" present (no env-branches; PR→squash→delete; agent MUSTs).
- [x] `docs/adrs/ADR-004-github-flow-branching.md` is a **companion** to ADR-003 (no conflict; references it + Jira).
- [x] `GEMINI.md` + `.github/copilot-instructions.md` point to `AGENTS.md`.
- [x] README badge + CHANGELOG entry.
- [x] gitleaks clean; docs-only diff.

## Cross-links
- Companion: `docs/adrs/ADR-003-version-ssot-float.md` (source/version strategy) + Jira ticket.
- Class A counterpart: a private corporate product/a private corporate product GitLab-Flow-Lite (deployed apps, env-branches).
- Sibling rollout: eko-claude-plugins · a private corporate-layer toolkit · a private plugin marketplace (same Class-B package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

