### PR TITLE
feat(skills): add quiesce — session-quiescence agentic-tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### `quiesce` — session-quiescence agentic-tool (compose /goal + pluggable driver)
+
+- **NEW skill** `skills/quiesce/SKILL.md` + **NEW command** `/quiesce` — thin preset that drives the current session to QUIESCENCE (no open ticket/gap/fix/failure/PR, every PR green + answered, agentic convergence) by composing the native `/goal` condition-loop with a pluggable inner driver (default `auto-pilot`, in-repo; `--driver=auto-orchestrator` for the operator's user-scope stack). PDCA-converges open PRs and auto-files tracking tickets for out-of-radar gaps.
+- **Override flags**: `--scope`, `--condition`, `--driver`, `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`, `--autonomy-threshold`, `--max-pdca`.
+- **DRY/SSOT**: reimplements nothing — sibling to `auto-pilot` (single-goal delegation kernel); reuses STOP-marker grammar + Sentinel bounds + worktree-policy. Resolves VKS-2030.
+
 #### `founder-*` family — Anthropic Founder's Playbook converted to agentic-tools
 
 - **NEW skills** (Agent Skills standard, vendor-neutral): `founder-playbook` (lifecycle router + `references/product-matrix.md`), `founder-stage-idea`, `founder-stage-mvp`, `founder-stage-launch`, `founder-stage-scale`. Each stage skill carries its goal, exit-criteria gate, failure modes + mitigations, and ready-to-use exercise prompts / emittable templates.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **NEW skill** `skills/quiesce/SKILL.md` + **NEW command** `/quiesce` — thin preset that drives the current session to QUIESCENCE (no open ticket/gap/fix/failure/PR, every PR green + answered, agentic convergence) by composing the native `/goal` condition-loop with a pluggable inner driver (default `auto-pilot`, in-repo; `--driver=auto-orchestrator` for the operator's user-scope stack). PDCA-converges open PRs and auto-files tracking tickets for out-of-radar gaps.
 - **Override flags**: `--scope`, `--condition`, `--driver`, `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`, `--autonomy-threshold`, `--max-pdca`.
-- **DRY/SSOT**: reimplements nothing — sibling to `auto-pilot` (single-goal delegation kernel); reuses STOP-marker grammar + Sentinel bounds + worktree-policy. Resolves VKS-2030.
+- **DRY/SSOT**: reimplements nothing — sibling to `auto-pilot` (single-goal delegation kernel); reuses STOP-marker grammar + Sentinel bounds + worktree-policy.
 
 #### `founder-*` family — Anthropic Founder's Playbook converted to agentic-tools
 

--- a/commands/quiesce.md
+++ b/commands/quiesce.md
@@ -1,0 +1,68 @@
+---
+name: quiesce
+description: Drive the current session to QUIESCENCE — no open ticket/gap/fix/failure/PR, every PR green + answered, agentic convergence — by composing the native /goal condition-loop with a pluggable inner driver (default auto-pilot). Override-friendly.
+---
+
+# /quiesce Command
+
+Thin wrapper that invokes `skills/quiesce/SKILL.md`. The skill holds all logic
+(quiescence predicate, `/goal` + inner-driver composition, PDCA-converge, auto
+ticket filing, STOP-marker grammar, bounds). This file is the command surface only.
+
+## Usage
+
+```
+/quiesce ["<instructions>"] [--scope=…] [--condition=…] [--driver=…] \
+         [--auto-merge=…] [--auto-merge-reason="…"] [--auto-fix=…] [--self-fix=…] \
+         [--autonomy-threshold=…] [--max-pdca=…]
+```
+
+All flags are optional — invoking bare `/quiesce` uses the defaults below.
+
+## Flags
+
+| Flag | Default | Allowed values |
+|---|---|---|
+| `"<instructions>"` (positional) | empty | extra free-text appended to the driver action |
+| `--scope` | `this.session` | `this.session`, `repo`, `branch`, `ticket:<id>`, `pr:<n>` |
+| `--condition` | *(quiescence predicate)* | any override termination predicate string |
+| `--driver` | `auto-pilot` | `auto-pilot`, `auto-orchestrator`, `<custom>` |
+| `--auto-merge` | `authorized` | `authorized`, `hold`, `off` |
+| `--auto-merge-reason` | *(operator invocation)* | non-empty string; required when `--auto-merge=authorized` |
+| `--auto-fix` | `enabled` | `enabled`, `disabled` |
+| `--self-fix` | `enabled` | `enabled`, `disabled` |
+| `--autonomy-threshold` | `0.85` | `0.0`–`1.0` (maps to auto-pilot band L1/L2/L3) |
+| `--max-pdca` | `6` | integer — per-PR PDCA iteration cap |
+
+See `skills/quiesce/SKILL.md` § Override parameters and § Quiescence predicate for
+the meaning of each value.
+
+## Examples
+
+```
+/quiesce
+/quiesce "prioritize the auth PRs first"
+/quiesce --scope=pr:42 --auto-merge=hold
+/quiesce --condition='NOT open PR AND every PR green' --max-pdca=3
+/quiesce --driver=auto-orchestrator --auto-merge=authorized --auto-merge-reason="nightly convergence"
+```
+
+## Workflow (delegates to the skill)
+
+1. Resolve flags → defaults unless overridden.
+2. Emit `/goal --goal-aware --scope=<scope> --condition='<predicate>'` (outer loop).
+3. Each iteration runs the inner `<driver>` (default `auto-pilot`) which PDCA-converges
+   open PRs and files tracking tickets for out-of-radar items.
+4. Emit exactly ONE `<!--ORCH-STATUS: … -->` STOP marker per turn for the `/goal` evaluator.
+5. Terminate when the quiescence predicate holds.
+
+## Anti-loop / autonomy bounds
+
+Inherited from the skill — `--max-pdca` cap (6), depth ≤ 2, Sentinel HIGH auto-blocks,
+6-attempt escalation, HUMAN_DOMAIN + non-negotiable guardrails always halt → HITL.
+See `skills/quiesce/SKILL.md` § Anti-loop invariants and § Auto-merge.
+
+## Related
+
+`skills/quiesce/SKILL.md` (logic) · `skills/auto-pilot/SKILL.md` (default driver, sibling) ·
+`skills/converge/SKILL.md` (used inside PDCA) · `commands/auto-pilot.md`.

--- a/commands/quiesce.md
+++ b/commands/quiesce.md
@@ -11,7 +11,7 @@ ticket filing, STOP-marker grammar, bounds). This file is the command surface on
 
 ## Usage
 
-```
+```text
 /quiesce ["<instructions>"] [--scope=…] [--condition=…] [--driver=…] \
          [--auto-merge=…] [--auto-merge-reason="…"] [--auto-fix=…] [--self-fix=…] \
          [--autonomy-threshold=…] [--max-pdca=…]
@@ -34,12 +34,12 @@ All flags are optional — invoking bare `/quiesce` uses the defaults below.
 | `--autonomy-threshold` | `0.85` | `0.0`–`1.0` (maps to auto-pilot band L1/L2/L3) |
 | `--max-pdca` | `6` | integer — per-PR PDCA iteration cap |
 
-See `skills/quiesce/SKILL.md` § Override parameters and § Quiescence predicate for
-the meaning of each value.
+See `skills/quiesce/SKILL.md` (Override parameters + Quiescence predicate) for
+the meaning of each value, and the Composition section for how resolved flags flow to the driver.
 
 ## Examples
 
-```
+```text
 /quiesce
 /quiesce "prioritize the auth PRs first"
 /quiesce --scope=pr:42 --auto-merge=hold
@@ -49,18 +49,18 @@ the meaning of each value.
 
 ## Workflow (delegates to the skill)
 
-1. Resolve flags → defaults unless overridden.
+1. Resolve flags -> defaults unless overridden.
 2. Emit `/goal --goal-aware --scope=<scope> --condition='<predicate>'` (outer loop).
-3. Each iteration runs the inner `<driver>` (default `auto-pilot`) which PDCA-converges
-   open PRs and files tracking tickets for out-of-radar items.
-4. Emit exactly ONE `<!--ORCH-STATUS: … -->` STOP marker per turn for the `/goal` evaluator.
+3. Each iteration runs the inner `<driver>` (default `auto-pilot`), passing the resolved
+   control flags, which PDCA-converges open PRs and files tracking tickets for out-of-radar items.
+4. Emit exactly ONE `<!--ORCH-STATUS: ... -->` STOP marker per turn for the `/goal` evaluator.
 5. Terminate when the quiescence predicate holds.
 
 ## Anti-loop / autonomy bounds
 
-Inherited from the skill — `--max-pdca` cap (6), depth ≤ 2, Sentinel HIGH auto-blocks,
-6-attempt escalation, HUMAN_DOMAIN + non-negotiable guardrails always halt → HITL.
-See `skills/quiesce/SKILL.md` § Anti-loop invariants and § Auto-merge.
+Inherited from the skill — `--max-pdca` cap (6), depth <= 2, Sentinel HIGH auto-blocks,
+6-attempt escalation, HUMAN_DOMAIN + non-negotiable guardrails always halt -> HITL.
+See `skills/quiesce/SKILL.md` (Protocol Rules + Auto-merge).
 
 ## Related
 

--- a/skills/quiesce/SKILL.md
+++ b/skills/quiesce/SKILL.md
@@ -60,7 +60,7 @@ Canonical invocations that should activate this skill:
 ## Quiescence predicate (default `--condition`)
 
 ```text
-QUIESCENCE := NOT(open TICKET or GAP or pending FIX or FAILURE or open PR)
+QUIESCENCE := NOT(unaddressed in-scope TICKET or GAP or pending FIX or FAILURE or open PR)
               AND every PR green (all required checks pass)
               AND every PR comment answered
               AND agentic convergence reached
@@ -69,6 +69,11 @@ QUIESCENCE := NOT(open TICKET or GAP or pending FIX or FAILURE or open PR)
 Agentic convergence = all bot reviewers + CI (e.g. CodeRabbit, Amazon Q, Qodo,
 gitleaks) GREEN or resolved — see `CONTRIBUTING.md` (Bot review convergence) and
 `.claude/rules/pr-reviewer-communication.md`.
+
+> **Non-blocking tickets**: a tracking ticket filed for an out-of-radar / out-of-scope /
+> deferred item does NOT block quiescence — capturing-and-deferring IS the resolution
+> (Boy-Scout "don't lose it"). Only *unaddressed in-scope* obligations keep the loop
+> open; otherwise filing tickets would make QUIESCENCE unreachable.
 
 ## How it works
 
@@ -93,16 +98,16 @@ operator invokes /quiesce
 
 ## Composition (the wiring it emits)
 
-All resolved flags are passed through to `<driver>` (NOT dropped) — the driver
-honors `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`,
-`--autonomy-threshold`, and `--max-pdca`:
+The resolved control flags are applied **per-driver** (translated for `auto-pilot`,
+native for `auto-orchestrator`) — never silently dropped. `auto-pilot`'s own surface
+is only `--mode`/`--band`/`--max-depth`, so its controls are translated (see table):
 
 ```text
 /goal --goal-aware --scope=<scope> --condition='<condition>' --action:{
-  <driver> --auto-merge=<auto-merge> --auto-merge-reason="<reason>"
-           --auto-fix=<auto-fix> --self-fix=<self-fix>
-           --autonomy-threshold=<thr> --max-pdca=<n>
-    "<instructions>; PDCA-loop each OPEN PR of <scope> as a converge-prompt;
+  <driver-invocation>      # resolved per the table below (flags translated, not dropped)
+    "<instructions>; honor: auto-merge=<auto-merge> (reason "<reason>"),
+     auto-fix=<auto-fix>, self-fix=<self-fix>, max-pdca=<n>;
+     PDCA-loop each OPEN PR of <scope> as a converge-prompt;
      for any out-of-radar item (gap/pending/failure/warning/error) file a
      tracking ticket (per CONTRIBUTING.md) + cross-link; keep created tickets updated."
 }
@@ -112,8 +117,8 @@ honors `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`,
 
 | `--driver` | Resolves to | How resolved flags are applied |
 |---|---|---|
-| `auto-pilot` (default) | `skills/auto-pilot/SKILL.md` | `--autonomy-threshold` -> `--band` (>=0.85 L3, >=0.65 L2, else L1); `--auto-merge`/`--max-pdca` honored in its PDCA + merge gate; in-repo (portable) |
-| `auto-orchestrator` | user-scope `/auto-orchestrator --goal-aware` | flags passed as native `--auto-merge`/`--auto-fix`/`--self-fix` args; only if installed |
+| `auto-pilot` (default) | `/auto-pilot "<goal+controls>" --band=<L1\|L2\|L3>` | auto-pilot's surface is `--mode`/`--band`/`--max-depth` only, so `--autonomy-threshold` -> `--band` (>=0.85 L3, >=0.65 L2, else L1) and `--auto-merge`/`--auto-fix`/`--self-fix`/`--max-pdca` are carried in the goal text (honored by its PDCA + merge gate). In-repo (portable). |
+| `auto-orchestrator` | `/auto-orchestrator --goal-aware --scope=... --auto-merge=... --auto-fix=... --self-fix=... --autonomy-threshold=...` | controls passed as native flags; only if installed |
 | `<custom>` | any host orchestrator the operator names | operator maps the flags |
 
 > The operator's original `/goal ... /auto-orchestrator ...` pattern is reproduced
@@ -199,9 +204,11 @@ queue across turns (amnesic-safe; delegates the merge contract to GitHub).
 
 ## Validation
 
-- Frontmatter `name: quiesce`; `commands/quiesce.md` exists with matching frontmatter.
-- Skill file < 12288 bytes (Goldilocks ceiling — mirrors `auto-pilot`/`auto-shard`).
-- `tests/validate-plugin.sh` enforces frontmatter + size checks.
+- `tests/validate-plugin.sh` enforces (generically, for all skills): `skills/quiesce/`
+  contains `SKILL.md` with valid frontmatter.
+- Skill file kept < 12288 bytes — a Goldilocks *guideline* mirrored from `auto-pilot`
+  (the script hard-codes that ceiling only for `auto-pilot`, not as a quiesce-specific gate).
+- `commands/quiesce.md` carries matching `name: quiesce` frontmatter.
 - Satisfies the 10-item checklist in `skills/skill-writer/SKILL.md`.
 
 ## Related

--- a/skills/quiesce/SKILL.md
+++ b/skills/quiesce/SKILL.md
@@ -1,0 +1,201 @@
+---
+name: quiesce
+version: "0.1.0"
+description: |
+  Drive the current work session to QUIESCENCE — a steady state with no pending
+  work: no open ticket/gap/fix/failure/PR, every PR green, every PR comment
+  answered, agentic convergence reached. Thin preset that composes the native
+  /goal outer condition-loop with a pluggable inner driver (default auto-pilot);
+  PDCA-converges the session's open PRs and auto-files tracking tickets for
+  out-of-radar gaps. Reimplements nothing — sibling to auto-pilot (which
+  decomposes ONE goal). Accepts override flags: --scope, --condition, --driver,
+  --auto-merge, --auto-fix, --self-fix, --autonomy-threshold, --max-pdca.
+  Use when the operator wants the session left clean/green/converged with nothing
+  pending: "quiesce", "drive this session to green", "converge all open PRs",
+  "zero-open loop", "leave nothing pending", "sessao limpa/convergente".
+  Triggers: "quiesce", "session quiescence", "drive to green", "converge open PRs",
+  "zero-open", "clean session loop".
+allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
+---
+
+# Quiesce
+
+Thin **session-quiescence** preset. `quiesce` does not re-implement
+orchestration, delegation, convergence, or anomaly detection — it composes the
+native `/goal` condition-loop with a pluggable inner driver. Every behavior
+below lands on a primitive that already exists in this repo (or a host built-in).
+
+## When to use
+
+- The operator wants the session driven to a clean/green/converged steady state.
+- One or more open PRs of this session need PDCA convergence before merge.
+- Out-of-radar items (gaps/failures/warnings) should be captured as tickets, not lost.
+- A long unattended run where per-step approval would dominate wall-clock.
+
+## When **not** to use
+
+- Single-shot edit / single-file fix / typo — disproportionate ceremony.
+- Read-only Q&A — answer directly.
+- ONE specific goal needs decompose+delegate across agents -> use `auto-pilot`.
+- Destructive ops (force-push protected, drop prod) — always HITL.
+- Goal not yet stable / operator still exploring — wait for stability.
+
+## Quiescence predicate (default `--condition`)
+
+```
+QUIESCENCE := NOT(open TICKET or GAP or pending FIX or FAILURE or open PR)
+              AND every PR green (all required checks pass)
+              AND every PR comment answered
+              AND agentic convergence reached
+```
+
+Agentic convergence = all bot reviewers + CI (e.g. CodeRabbit, Amazon Q, Qodo,
+gitleaks) GREEN or resolved — see `CONTRIBUTING.md` (Bot review convergence) and
+`.claude/rules/pr-reviewer-communication.md`.
+
+## How it works
+
+```
+operator invokes /quiesce
+        |
+        v
+  resolve flags -> defaults unless overridden
+        |
+        v
+/goal --goal-aware --scope=<scope> --condition='<predicate>'   (OUTER loop — host built-in)
+        |  each iteration v
+        v
+<inner driver: default skills/auto-pilot>                      (INNER work driver)
+        |-- PDCA-loop each OPEN PR of <scope> (steelman -> critique -> fix -> re-review)
+        |-- out-of-radar item -> file a tracking ticket (per CONTRIBUTING tracker) + cross-link
+        \-- emit exactly ONE STOP marker as the last line of the turn
+        |
+        v
+  /goal Stop-hook evaluator reads the marker -> CONTINUE or terminate at QUIESCENCE
+```
+
+## Composition (the wiring it emits)
+
+```
+/goal --goal-aware --scope=<scope> --condition='<condition>' --action:{
+  <driver>
+    "<instructions>; PDCA-loop each OPEN PR of <scope> as a converge-prompt;
+     for any out-of-radar item (gap/pending/failure/warning/error) file a
+     tracking ticket (per CONTRIBUTING.md) + cross-link; keep created tickets updated."
+}
+```
+
+`<driver>` resolves from `--driver`:
+
+| `--driver` | Resolves to | Portability |
+|---|---|---|
+| `auto-pilot` (default) | `skills/auto-pilot/SKILL.md`, `--band` derived from `--autonomy-threshold` | in-repo — works for every consumer |
+| `auto-orchestrator` | user-scope `/auto-orchestrator --goal-aware --scope=... --auto-merge=... --auto-fix=... --self-fix=...` | only if the operator has it installed |
+| `<custom>` | any host orchestrator the operator names | operator-supplied |
+
+> The operator's original `/goal ... /auto-orchestrator ...` pattern is reproduced
+> exactly via `--driver=auto-orchestrator`. The default stays in-repo for portability.
+
+## Override parameters
+
+| Flag | Default | Allowed / Notes |
+|---|---|---|
+| `"<instructions>"` (positional) | empty | extra free-text appended to the driver action |
+| `--scope` | `this.session` | `this.session` \| `repo` \| `branch` \| `ticket:<id>` \| `pr:<n>` |
+| `--condition` | *(quiescence predicate above)* | override the termination predicate string |
+| `--driver` | `auto-pilot` | `auto-pilot` \| `auto-orchestrator` \| `<custom>` |
+| `--auto-merge` | `authorized` | `authorized` \| `hold` \| `off` |
+| `--auto-merge-reason` | *(operator invocation)* | required-non-empty when `authorized`; invoking `/quiesce --auto-merge=authorized` IS the authorization |
+| `--auto-fix` | `enabled` | `enabled` \| `disabled` |
+| `--self-fix` | `enabled` | `enabled` \| `disabled` |
+| `--autonomy-threshold` | `0.85` (HIGH) | `0.0`-`1.0` — maps to auto-pilot band (>=0.85->L3, >=0.65->L2, else L1) |
+| `--max-pdca` | `6` | int — per-PR PDCA iteration cap |
+
+## STOP-marker grammar (paired with `--goal-aware`, not re-authored)
+
+Emit exactly ONE terminal marker as the last line of each turn. The HTML-comment
+prefix is low-collision; the `/goal` Stop-hook evaluator reads it:
+
+```
+<!--ORCH-STATUS: STOP-DONE -->     quiescence reached — nothing pending
+<!--ORCH-STATUS: STOP-HITL -->     HITL escalation required (also prepend above any action block)
+<!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (subagent / network / rate-limit)
+<!--ORCH-STATUS: CONTINUE -->      iteration done; work remains; evaluator decides next turn
+```
+
+## Relationship to siblings
+
+| Tool | Scope | Drives |
+|---|---|---|
+| `quiesce` (this) | the SESSION | termination predicate over ALL open items -> steady state |
+| `auto-pilot` | ONE operator goal | decompose -> select -> spawn -> converge |
+| `converge` | N proposals | 5-act merge (invoked inside PDCA when a PR has competing proposals) |
+
+`quiesce` MAY invoke `auto-pilot` for sub-goals; it never re-implements delegation,
+convergence, or anomaly detection.
+
+## Auto-merge
+
+`--auto-merge=authorized` lets the driver queue GitHub native auto-merge **only**
+when all gates pass (mergeable + green + all-comments-answered + agentic convergence
++ autonomy >= `--autonomy-threshold` + non-empty reason) and no refusal applies
+(target is a protected deploy branch, CI/infra files touched, native auto-merge
+disabled on the repo, or operator cancel). Otherwise use `hold` (operator merges)
+or `off`. Always `--squash --delete-branch`. Fire-and-forget — no local merge
+queue across turns (amnesic-safe; delegates the merge contract to GitHub).
+
+## Anti-loop invariants / bounds
+
+- `--max-pdca` (default 6) caps per-PR PDCA iterations; diminishing returns -> escalate.
+- Delegation depth <= 2; Sentinel HIGH auto-blocks (`sentinel/config.json` authoritative).
+- 6-attempt escalation rule (different approach each attempt).
+- HUMAN_DOMAIN + non-negotiable guardrails (secrets/PII, force-push protected,
+  prod/irreversible, cross-org) ALWAYS halt the loop -> HITL.
+
+## DNA Geracional (inherited by every spawned agent)
+
+- **Dogfood**: validate the loop on its own artifacts before declaring done.
+- **Persist-over-fail**: write-ahead-checkpoint each obligation (task/ticket/note)
+  BEFORE executing, so a mid-session collapse is recoverable.
+- **DRY / KISS / YAGNI / SSOT** — compose primitives, never duplicate them.
+- **No self-destructive decisions** — nothing that boomerangs on a future session.
+- **Boy-Scout** — leave every repo cleaner than found: no stale branches/worktrees,
+  no loose ends, no unanswered comments.
+
+## Examples
+
+```
+/quiesce
+/quiesce "prioritize the auth PRs first"
+/quiesce --scope=pr:42 --auto-merge=hold
+/quiesce --condition='NOT open PR AND every PR green' --max-pdca=3
+/quiesce --driver=auto-orchestrator --auto-merge=authorized --auto-merge-reason="nightly convergence"
+```
+
+## Validation
+
+- Frontmatter `name: quiesce`; `commands/quiesce.md` exists with matching frontmatter.
+- Skill file < 12288 bytes (Goldilocks ceiling — mirrors `auto-pilot`/`auto-shard`).
+- `tests/validate-plugin.sh` enforces frontmatter + size checks.
+- Satisfies the 10-item checklist in `skills/skill-writer/SKILL.md`.
+
+## Related
+
+- `commands/quiesce.md` — operator-facing command surface
+- `skills/auto-pilot/SKILL.md` — single-goal delegation kernel (default driver, sibling)
+- `skills/converge/SKILL.md` — 5-act proposal merge (used inside PDCA)
+- `skills/worktree-policy/SKILL.md` — write discipline every iteration honors
+- `skills/status-map/SKILL.md` — status reporting templates
+- `sentinel/config.json` + `sentinel/detection_rules.md` — anomaly thresholds
+- `CONTRIBUTING.md` — PR convergence + tracker conventions
+- `agents/orchestrator.md` — master coordinator persona
+
+## Versioning
+
+- v0.1.0 (initial) — quiescence predicate; `/goal` + pluggable-driver composition
+  (default `auto-pilot`); override flags incl. `--driver`; PDCA-converge open PRs +
+  auto-file tracking tickets; STOP-marker grammar reuse; depth/PDCA bounds; DNA Geracional.
+
+## License
+
+MIT (matches multi-agent-os repo `LICENSE`).

--- a/skills/quiesce/SKILL.md
+++ b/skills/quiesce/SKILL.md
@@ -9,7 +9,7 @@ description: |
   PDCA-converges the session's open PRs and auto-files tracking tickets for
   out-of-radar gaps. Reimplements nothing — sibling to auto-pilot (which
   decomposes ONE goal). Accepts override flags: --scope, --condition, --driver,
-  --auto-merge, --auto-fix, --self-fix, --autonomy-threshold, --max-pdca.
+  --auto-merge[-reason], --auto-fix, --self-fix, --autonomy-threshold, --max-pdca.
   Use when the operator wants the session left clean/green/converged with nothing
   pending: "quiesce", "drive this session to green", "converge all open PRs",
   "zero-open loop", "leave nothing pending", "sessao limpa/convergente".
@@ -24,6 +24,14 @@ Thin **session-quiescence** preset. `quiesce` does not re-implement
 orchestration, delegation, convergence, or anomaly detection — it composes the
 native `/goal` condition-loop with a pluggable inner driver. Every behavior
 below lands on a primitive that already exists in this repo (or a host built-in).
+
+## Purpose
+
+Drive the current work session to a QUIESCENT steady state — no open
+ticket/gap/fix/failure/PR, every PR green and answered, agentic convergence
+reached — by wrapping the native `/goal` condition-loop around a pluggable inner
+work driver, and codifying the operator's recurring "converge the whole session"
+invocation as one reusable, override-friendly, token-economic command.
 
 ## When to use
 
@@ -40,9 +48,18 @@ below lands on a primitive that already exists in this repo (or a host built-in)
 - Destructive ops (force-push protected, drop prod) — always HITL.
 - Goal not yet stable / operator still exploring — wait for stability.
 
+## Trigger Phrases
+
+Canonical invocations that should activate this skill:
+
+- "quiesce" / "/quiesce"
+- "session quiescence" / "drive this session to green" / "sessao limpa/convergente"
+- "converge all open PRs" / "converge open PRs"
+- "zero-open loop" / "leave nothing pending" / "clean session loop"
+
 ## Quiescence predicate (default `--condition`)
 
-```
+```text
 QUIESCENCE := NOT(open TICKET or GAP or pending FIX or FAILURE or open PR)
               AND every PR green (all required checks pass)
               AND every PR comment answered
@@ -55,7 +72,7 @@ gitleaks) GREEN or resolved — see `CONTRIBUTING.md` (Bot review convergence) a
 
 ## How it works
 
-```
+```text
 operator invokes /quiesce
         |
         v
@@ -76,9 +93,15 @@ operator invokes /quiesce
 
 ## Composition (the wiring it emits)
 
-```
+All resolved flags are passed through to `<driver>` (NOT dropped) — the driver
+honors `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`,
+`--autonomy-threshold`, and `--max-pdca`:
+
+```text
 /goal --goal-aware --scope=<scope> --condition='<condition>' --action:{
-  <driver>
+  <driver> --auto-merge=<auto-merge> --auto-merge-reason="<reason>"
+           --auto-fix=<auto-fix> --self-fix=<self-fix>
+           --autonomy-threshold=<thr> --max-pdca=<n>
     "<instructions>; PDCA-loop each OPEN PR of <scope> as a converge-prompt;
      for any out-of-radar item (gap/pending/failure/warning/error) file a
      tracking ticket (per CONTRIBUTING.md) + cross-link; keep created tickets updated."
@@ -87,11 +110,11 @@ operator invokes /quiesce
 
 `<driver>` resolves from `--driver`:
 
-| `--driver` | Resolves to | Portability |
+| `--driver` | Resolves to | How resolved flags are applied |
 |---|---|---|
-| `auto-pilot` (default) | `skills/auto-pilot/SKILL.md`, `--band` derived from `--autonomy-threshold` | in-repo — works for every consumer |
-| `auto-orchestrator` | user-scope `/auto-orchestrator --goal-aware --scope=... --auto-merge=... --auto-fix=... --self-fix=...` | only if the operator has it installed |
-| `<custom>` | any host orchestrator the operator names | operator-supplied |
+| `auto-pilot` (default) | `skills/auto-pilot/SKILL.md` | `--autonomy-threshold` -> `--band` (>=0.85 L3, >=0.65 L2, else L1); `--auto-merge`/`--max-pdca` honored in its PDCA + merge gate; in-repo (portable) |
+| `auto-orchestrator` | user-scope `/auto-orchestrator --goal-aware` | flags passed as native `--auto-merge`/`--auto-fix`/`--self-fix` args; only if installed |
+| `<custom>` | any host orchestrator the operator names | operator maps the flags |
 
 > The operator's original `/goal ... /auto-orchestrator ...` pattern is reproduced
 > exactly via `--driver=auto-orchestrator`. The default stays in-repo for portability.
@@ -116,7 +139,7 @@ operator invokes /quiesce
 Emit exactly ONE terminal marker as the last line of each turn. The HTML-comment
 prefix is low-collision; the `/goal` Stop-hook evaluator reads it:
 
-```
+```text
 <!--ORCH-STATUS: STOP-DONE -->     quiescence reached — nothing pending
 <!--ORCH-STATUS: STOP-HITL -->     HITL escalation required (also prepend above any action block)
 <!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (subagent / network / rate-limit)
@@ -144,11 +167,13 @@ disabled on the repo, or operator cancel). Otherwise use `hold` (operator merges
 or `off`. Always `--squash --delete-branch`. Fire-and-forget — no local merge
 queue across turns (amnesic-safe; delegates the merge contract to GitHub).
 
-## Anti-loop invariants / bounds
+## Protocol Rules (anti-loop invariants + bounds)
 
 - `--max-pdca` (default 6) caps per-PR PDCA iterations; diminishing returns -> escalate.
+- Worktree discipline always on (`skills/worktree-policy/SKILL.md`); never commit to main.
 - Delegation depth <= 2; Sentinel HIGH auto-blocks (`sentinel/config.json` authoritative).
 - 6-attempt escalation rule (different approach each attempt).
+- Exactly ONE STOP marker per turn (the `/goal` evaluator contract).
 - HUMAN_DOMAIN + non-negotiable guardrails (secrets/PII, force-push protected,
   prod/irreversible, cross-org) ALWAYS halt the loop -> HITL.
 
@@ -164,7 +189,7 @@ queue across turns (amnesic-safe; delegates the merge contract to GitHub).
 
 ## Examples
 
-```
+```text
 /quiesce
 /quiesce "prioritize the auth PRs first"
 /quiesce --scope=pr:42 --auto-merge=hold


### PR DESCRIPTION
## Summary

- Adds **`quiesce`** — a session-quiescence agentic-tool: `commands/quiesce.md` (surface) + `skills/quiesce/SKILL.md` (logic).
- Drives the current session to **QUIESCENCE** (no open ticket/gap/fix/failure/PR · every PR green + answered · agentic convergence) by composing the native `/goal` condition-loop with a **pluggable inner driver** (default `auto-pilot`).
- Override-friendly (`--scope` · `--condition` · `--driver` · `--auto-merge` · `--auto-merge-reason` · `--auto-fix` · `--self-fix` · `--autonomy-threshold` · `--max-pdca`). DRY sibling to `auto-pilot` — reimplements nothing.
- Post-review fixes (commit `db96f6c`): frontmatter flag list now includes `--auto-merge[-reason]`; composition block passes all resolved control flags into `<driver>` with a per-driver application table; fenced code blocks labelled with `text`; explicit `Purpose` / `Trigger Phrases` / `Protocol Rules` sections added to `SKILL.md`.

## Type

- [x] feat (new functionality)

## AI Involvement

- [x] AI-generated draft reviewed by human (reviewer: **@ekson73**)

`Co-Authored-By:` footers present on all commits.

## Runtime / Surface Impact

- [x] Claude Code (plugin runtime — commands, skills)

Plugin manifest (`plugin.json`) is **not** touched — `quiesce` is auto-discovered. Version bump deferred to a release PR per `CONTRIBUTING.md` § Release Gates (additive command+skill).

## Files requiring follow-up governance update

- [x] `CHANGELOG.md` (entry added under `[Unreleased] → Added`)

## Evidence

```bash
$ bash tests/validate-plugin.sh
  ✓ skills/quiesce/SKILL.md exists
  ✓ quiesce.md has frontmatter
  Errors: 0   Warnings: 0   Status: ✓ PASSED

$ gitleaks protect --staged --no-banner
  no leaks found

$ wc -c skills/quiesce/SKILL.md
  10768   # < 12288 Goldilocks ceiling; 0 unlabeled fence openers
```

**skill-writer 10-item checklist**: all pass — lowercase name; description &lt; 1024 chars with what + "Use when"; valid YAML; step-by-step (How it works / Composition / Workflow); 5 concrete examples; deps + `allowed-tools` documented; forward-slash paths; `Triggers:` for activation.

## Risks

**Low** — additive plugin artifacts (1 command + 1 skill + CHANGELOG); no behavior change to existing tools. `quiesce` composes existing primitives (`/goal`, `auto-pilot`) and reimplements no orchestration/delegation/convergence. The one real risk is **ecosystem overlap with `auto-pilot`** — mitigated by an explicit *sibling, not competitor* framing + cross-ref in `skills/quiesce/SKILL.md` § Relationship to siblings (auto-pilot = decompose ONE goal; quiesce = drive the SESSION to a termination predicate). Default `--driver=auto-pilot` keeps the artifact **portable** (no hard dependency on any user-scope `/auto-orchestrator`).

## Rollback

`git revert` the relevant commits (no force-push). No marketplace pin shipped yet. Deleting `commands/quiesce.md` + `skills/quiesce/` + the CHANGELOG bullet fully reverts.

## Checklist

- [x] Worktree + branch used (no direct-main commits)
- [x] Conventional Commits + `Co-Authored-By:` footer
- [x] gitleaks clean (pre-commit + staged scan)
- [x] Build / tests pass (`tests/validate-plugin.sh` — 0 errors)
- [x] No secrets, no PII, no Vek-specific content (Layer Purity — CHANGELOG kept tracker-ref-free)
- [x] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated if contract changed (N/A — no contract change)
- [x] Version bump + CHANGELOG entry if `plugin.json` changed (plugin.json unchanged; CHANGELOG entry added)