### PR TITLE
feat(session-fission): on-demand non-destructive tangled-session splitter (MVP v0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NEW skill** `skills/quiesce/SKILL.md` + **NEW command** `/quiesce` — thin preset that drives the current session to QUIESCENCE (no open ticket/gap/fix/failure/PR, every PR green + answered, agentic convergence) by composing the native `/goal` condition-loop with a pluggable inner driver (default `auto-pilot`, in-repo; `--driver=auto-orchestrator` for the operator's user-scope stack). PDCA-converges open PRs and auto-files tracking tickets for out-of-radar gaps.
 - **Override flags**: `--scope`, `--condition`, `--driver`, `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`, `--autonomy-threshold`, `--max-pdca`.
 - **DRY/SSOT**: reimplements nothing — sibling to `auto-pilot` (single-goal delegation kernel); reuses STOP-marker grammar + Sentinel bounds + worktree-policy.
+#### `session-fission` — on-demand, non-destructive tangled-session splitter (v1.6.0, MVP v0.1.0)
+
+- **NEW skill** `skills/session-fission/SKILL.md` — splits one tangled Claude session (an N-Tree of atomic contexts collapsed into a single linear transcript) into clean, focused, atomic-context sessions via **non-destructive distill-and-reseed**. Relieves context bloat, cognitive overhead, and token exhaustion. The source session is **archived, never mutated or deleted** (recoverable via native `/resume`).
+- **NEW command** `commands/session-fission.md` — `/maos:session-fission [transcript.jsonl] [--apply]` (dry-run by default).
+- **NEW scripts** `plugin-scripts/session-fission/` — `inventory.sh` (READ-ONLY transcript → atomic-context N-Tree JSON), `snapshot.sh` (backup + manifest + gitleaks = rollback anchor, idempotent by SHA), `seed.sh` (Ticket-as-Prompt seed scaffold per cluster; agent fills the distilled context).
+- **NEW spec** `docs/specs/session-fission-spec.md` — feasibility verdict, option analysis (A/B + C/D/E), algorithm, data shapes, safety contract.
+- **Feasibility (validated vs `code.claude.com/docs/en/sessions` + on-disk transcript schema)**: native `/branch`/`--fork-session` *copy* the whole conversation (don't relieve bloat); surgical mid-message trimming is unsafe (append-only `parentUuid` DAG + paired `tool_use`/`tool_result` ⇒ unresumable). Fission fills the gap: distill each atomic context into a light seed and reseed, preserving the original.
+- **Safety**: read-only on source; snapshot before any archive; idempotent; rollback via `/resume` + retained backup. Layer-pure (generic; backup/seed dirs env-configurable; no operator-specific content).
+- **Deferred**: v2 automated spawn + CPT `topology.md` emission + rollback command; v3 sentinel anomaly rule + statusmap template + morning-briefing/auto-orchestrator deep wiring.
 
 #### `founder-*` family — Anthropic Founder's Playbook converted to agentic-tools
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NEW skill** `skills/quiesce/SKILL.md` + **NEW command** `/quiesce` — thin preset that drives the current session to QUIESCENCE (no open ticket/gap/fix/failure/PR, every PR green + answered, agentic convergence) by composing the native `/goal` condition-loop with a pluggable inner driver (default `auto-pilot`, in-repo; `--driver=auto-orchestrator` for the operator's user-scope stack). PDCA-converges open PRs and auto-files tracking tickets for out-of-radar gaps.
 - **Override flags**: `--scope`, `--condition`, `--driver`, `--auto-merge`, `--auto-merge-reason`, `--auto-fix`, `--self-fix`, `--autonomy-threshold`, `--max-pdca`.
 - **DRY/SSOT**: reimplements nothing — sibling to `auto-pilot` (single-goal delegation kernel); reuses STOP-marker grammar + Sentinel bounds + worktree-policy.
+
 #### `session-fission` — on-demand, non-destructive tangled-session splitter (v1.6.0, MVP v0.1.0)
 
 - **NEW skill** `skills/session-fission/SKILL.md` — splits one tangled Claude session (an N-Tree of atomic contexts collapsed into a single linear transcript) into clean, focused, atomic-context sessions via **non-destructive distill-and-reseed**. Relieves context bloat, cognitive overhead, and token exhaustion. The source session is **archived, never mutated or deleted** (recoverable via native `/resume`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **NEW spec** `docs/specs/session-fission-spec.md` — feasibility verdict, option analysis (A/B + C/D/E), algorithm, data shapes, safety contract.
 - **Feasibility (validated vs `code.claude.com/docs/en/sessions` + on-disk transcript schema)**: native `/branch`/`--fork-session` *copy* the whole conversation (don't relieve bloat); surgical mid-message trimming is unsafe (append-only `parentUuid` DAG + paired `tool_use`/`tool_result` ⇒ unresumable). Fission fills the gap: distill each atomic context into a light seed and reseed, preserving the original.
 - **Safety**: read-only on source; snapshot before any archive; idempotent; rollback via `/resume` + retained backup. Layer-pure (generic; backup/seed dirs env-configurable; no operator-specific content).
-- **Deferred**: v2 automated spawn + CPT `topology.md` emission + rollback command; v3 sentinel anomaly rule + statusmap template + morning-briefing/auto-orchestrator deep wiring.
+- **Deferred**: v2 automated spawn + CPT `topology.md` emission + rollback command; v3 sentinel anomaly rule + status-map template + morning-briefing/auto-orchestrator deep wiring.
 
 #### `founder-*` family — Anthropic Founder's Playbook converted to agentic-tools
 

--- a/commands/session-fission.md
+++ b/commands/session-fission.md
@@ -9,7 +9,7 @@ description: On-demand, non-destructive splitter for a tangled Claude session â€
 
 ## Usage
 
-```
+```text
 /maos:session-fission [transcript.jsonl] [--apply]
 ```
 

--- a/commands/session-fission.md
+++ b/commands/session-fission.md
@@ -1,0 +1,42 @@
+---
+name: session-fission
+description: On-demand, non-destructive splitter for a tangled Claude session — inventories the N-Tree of atomic contexts, snapshots the transcript, and reseeds clean focused sessions. Original is archived, never mutated or deleted.
+---
+
+# /session-fission Command
+
+> Surfaces as `/maos:session-fission` under the plugin namespace (see `.claude-plugin/plugin.json` `command_namespace`).
+
+## Usage
+
+```
+/maos:session-fission [transcript.jsonl] [--apply]
+```
+
+| Arg / flag | Meaning |
+|---|---|
+| `[transcript.jsonl]` | Optional explicit transcript path. Omit to auto-detect the most-recent session in the current project dir. |
+| `--apply` | Run the safe write steps (snapshot + emit seed scaffolds). **Default is dry-run** (inventory + N-Tree proposal only). |
+
+## What it does
+
+This command invokes the **`session-fission` skill**. Follow that skill's 6-step protocol:
+
+1. **Inventory** (read-only) — `plugin-scripts/session-fission/inventory.sh` proposes an atomic-context N-Tree.
+2. **Classify** the N-Tree (sequential / recursive / independent / parallel) and confirm with the user.
+3. **Snapshot** (`--apply`) — `plugin-scripts/session-fission/snapshot.sh` backs up the source + manifest + gitleaks (rollback anchor).
+4. **Distill** each cluster into a clean Ticket-as-Prompt seed (`seed.sh` scaffolds; the agent fills the distilled context).
+5. **Reseed** focused sessions (ccpanes/`launch_task`, `claude -n`, or native `/branch`+`/compact`); archive the original (never delete).
+6. **Topology + briefing** — emit the resulting N-Tree + per-seed pointers (CPT Compass-navigable).
+
+## Safety
+
+- Read-only on the source transcript; never trims/deletes it (surgical mid-delete is unsafe — see skill).
+- Snapshot precedes any archive op; rollback = native `/resume <original>` + retained backup.
+- Idempotent; dry-run by default.
+
+## See also
+
+- Skill: `skills/session-fission/SKILL.md`
+- Spec: `docs/specs/session-fission-spec.md`
+- Cowork Process Topology Protocol (Compass navigation of the resulting N-Tree)

--- a/docs/specs/session-fission-spec.md
+++ b/docs/specs/session-fission-spec.md
@@ -44,7 +44,7 @@ Chosen = C (algorithm) + E (execution) + D (where cheaper); archive-not-delete f
 
 ## 5. Data shapes
 
-- `inventory.sh` → `{status, schema, source, read_only, total_lines, cluster_count, clusters[{id,label,branch,cwd,msg_count,first_ts,last_ts}], relations[{from,to,rel}]}`
+- `inventory.sh` → `{status, schema, source, read_only, total_lines, cluster_count, gap_seconds, clusters[{id,label,branch,cwd,msg_count,has_sidechain,first_ts,last_ts}], relations[{from,to,rel}], note}`
 - `snapshot.sh` → `{status, snapshot_path, manifest_path, source_sha256, gitleaks, sanitized_utc}` + `*.manifest.yaml`
 - `seed.sh` → `{status, cluster_id, seed_path}` + a `<cluster_id>.md` Ticket-as-Prompt scaffold (17-field skeleton, agent-filled)
 

--- a/docs/specs/session-fission-spec.md
+++ b/docs/specs/session-fission-spec.md
@@ -1,0 +1,75 @@
+# session-fission — Specification (MVP v0.1.0)
+
+> Status: MVP (non-destructive) · Author: Claude Opus 4.7 · Date: 2026-05-27
+> Skill: `skills/session-fission/SKILL.md` · Command: `commands/session-fission.md` · Scripts: `plugin-scripts/session-fission/`
+> Related: `docs/feature-request-session-api.md`, `docs/adrs/ADR-001-session-identity.md`, `docs/session-identifiers-research.md`
+
+## 1. Problem
+
+A single Claude Code session interleaves unrelated work (Task-A → Task-B → MCP-fix Task-B2 → boss's Task-C → skill-fix Task-D) into one linear transcript. The result: context bloat, cognitive overhead, token exhaustion, unfinished work, and backlog spillover. We want an **on-demand**, **non-destructive** way to split that tangle into clean, atomic-context sessions.
+
+## 2. Feasibility (validated)
+
+Validated against `code.claude.com/docs/en/sessions` + direct inspection of a live transcript on disk.
+
+| Capability | Native | Note |
+|---|---|---|
+| Resume `--continue`/`--resume`/`--from-pr`/`/resume` | ✅ | picker groups forks under root |
+| Whole-session fork (`/branch`, `--fork-session`) | ✅ | **copies** the whole conversation (new `.jsonl`, `forkedFrom.sessionId`) — not a topic split |
+| `/rewind`, `/clear`, `/compact [instructions]`, `/context`, `/export` | ✅ | `/compact` is lossy; `/clear` total |
+| Subagent context isolation (Task tool) | ✅ | separate window, returns summary |
+| Surgical mid-message delete / topic-grouped split into N sessions | ❌ | transcript = append-only `parentUuid` DAG with paired `tool_use`/`tool_result`; middle-delete ⇒ unresumable |
+| `CLAUDE_SESSION_ID` env var | ❌ | per `docs/feature-request-session-api.md`; use transcript-path UUID / statusline `session_id` |
+
+**Conclusion:** the only safe mechanism is **non-destructive distill-and-reseed**. Native forking copies the bloat; surgical trimming corrupts. Fission distills each atomic context into a light seed and reseeds, preserving the original.
+
+## 3. Option analysis
+
+- **A (delete original after split):** partial — keep *archive*, reject *delete* (breaks rollback).
+- **B (surgical in-place trim):** REJECTED — unsafe/unsupported (DAG + tool pairing).
+- **C (snapshot→distill→reseed):** ✅ core algorithm — non-destructive, idempotent.
+- **D (native `/branch` + scoped `/compact`):** ✅ cheaper reseed path where distillation isn't worth it (lossy).
+- **E (reuse `ccpanes-fork-session` + `context-save`):** ✅ execution substrate — don't build a new spawner.
+
+Chosen = C (algorithm) + E (execution) + D (where cheaper); archive-not-delete from A; never B.
+
+## 4. Algorithm (6 steps)
+
+1. **Inventory** (read-only): `inventory.sh` → JSON N-Tree of atomic-context clusters keyed by branch/cwd + time-gap.
+2. **Classify**: tag relations (sequential `→` / recursive `↻` / independent `∥` / parallel `‖`); confirm with operator.
+3. **Snapshot** (before any write): `snapshot.sh` → backup copy + manifest + gitleaks (rollback anchor).
+4. **Distill** (agent cognition): per cluster, write a Ticket-as-Prompt seed carrying ONLY that atomic context; `seed.sh` emits the scaffold.
+5. **Reseed**: hand each seed to a fresh focused session (Option E/D); archive original (never delete).
+6. **Topology + briefing**: emit N-Tree (Mermaid + per-seed pointers) for CPT Compass navigation; end-of-action briefing.
+
+## 5. Data shapes
+
+- `inventory.sh` → `{status, schema, source, read_only, total_lines, cluster_count, clusters[{id,label,branch,cwd,msg_count,first_ts,last_ts}], relations[{from,to,rel}]}`
+- `snapshot.sh` → `{status, snapshot_path, manifest_path, source_sha256, gitleaks, sanitized_utc}` + `*.manifest.yaml`
+- `seed.sh` → `{status, cluster_id, seed_path}` + a `<cluster_id>.md` Ticket-as-Prompt scaffold (17-field skeleton, agent-filled)
+
+## 6. Safety contract
+
+- Read-only on source transcript (all 3 scripts). Reseeds are additive. Out-of-scope sessions untouched.
+- Snapshot precedes any archive op. Rollback = `/resume <original>` + retained backup.
+- Idempotent: same input → same clustering; `snapshot.sh` skips duplicate SHA; seeds overwrite-safe.
+- gitleaks scrub on snapshot before finalize.
+
+## 7. Layer purity
+
+This tool is generic (community layer). No operator-personal names; backup/seed dirs configurable via env (`SESSION_FISSION_SNAPSHOT_DIR`, `SESSION_FISSION_SEED_DIR`); defaults use `$HOME`/`./`. Vek-specific wiring (Jira/walkthrough/ASH-lite) lives in `vek-ai-toolkit`, not here.
+
+## 8. Scope
+
+**In (v0.1.0 MVP):** skill, command, `inventory.sh`, `snapshot.sh`, `seed.sh`, this spec. No destructive ops; reseed is operator-guided (Option D/E).
+
+**Deferred:** v2 automated spawn + CPT `topology.md`/`INDEX.yaml` emission + rollback command; v3 sentinel anomaly rule + statusmap template + morning-briefing/auto-orchestrator deep wiring.
+
+**Out:** in-place trimming (B); reliance on `CLAUDE_SESSION_ID`; long-term retention past the native 30-day `cleanupPeriodDays` (snapshots live outside that lifecycle).
+
+## 9. Verification
+
+1. `bash tests/validate-plugin.sh` passes.
+2. Dry-run `inventory.sh` on a real session → review N-Tree; `shasum` source before/after identical (non-interference).
+3. `snapshot.sh` → backup exists + gitleaks reported; `/resume <original>` recovers untouched original (rollback).
+4. A reseeded session carries only its atomic context (context ≪ original) — bloat relief.

--- a/plugin-scripts/session-fission/inventory.sh
+++ b/plugin-scripts/session-fission/inventory.sh
@@ -35,6 +35,10 @@ fi
 # =============================================================================
 # ANALYZE (python3 — robust JSONL parse; emits JSON; no message bodies, labels only)
 # =============================================================================
+if ! command -v python3 >/dev/null 2>&1; then
+  printf '{"status":"error","error":"python3 not found","hint":"inventory.sh requires python3 for robust JSONL parsing; install python3 and retry"}\n'
+  exit 1
+fi
 python3 - "$TRANSCRIPT" "$GAP_SECONDS" <<'PY'
 import sys, json, datetime
 
@@ -88,14 +92,15 @@ with open(path, "r", encoding="utf-8", errors="replace") as fh:
 events.sort(key=lambda e: (e["ts"] is None, e["ts"] or 0))
 
 clusters = []
-def label_from(seg):
+def label_from(seg, branch, idx):
+    # SAFETY CONTRACT: labels must NOT embed raw message text — that would leak
+    # transcript content (potentially secrets) into stdout/logs, contradicting the
+    # "no message bodies, labels only" guarantee. Use the explicit `slug` (operator-set,
+    # already safe) when present; otherwise a content-free branch+segment label.
     for e in seg:
         if e["slug"]:
             return e["slug"][:80]
-    for e in seg:
-        if e["role"] == "user" and e["text"].strip():
-            return " ".join(e["text"].split())[:80]
-    return "(unlabeled)"
+    return f"{branch} · segment {idx}"
 
 # Cluster by branch, then split on time-gaps inside the same branch.
 by_branch = {}
@@ -114,12 +119,14 @@ for branch, seg in by_branch.items():
         cur.append(e); prev = e["ts"] if e["ts"] else prev
     if cur:
         sub.append(cur)
+    seg_idx = 0
     for s in sub:
         cid += 1
+        seg_idx += 1
         ts_vals = [e["ts"] for e in s if e["ts"]]
         clusters.append({
             "id": f"c{cid:02d}",
-            "label": label_from(s),
+            "label": label_from(s, branch, seg_idx),
             "branch": branch,
             "cwd": (s[0]["cwd"] if s else ""),
             "msg_count": len(s),
@@ -128,10 +135,15 @@ for branch, seg in by_branch.items():
             "last_ts": (datetime.datetime.fromtimestamp(max(ts_vals), datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")) if ts_vals else None,
         })
 
-# Relation hints: same branch consecutive => sequential; different branch => independent.
+# Relation hints are time-ordered, NOT branch-grouped order: clusters were appended
+# grouped by branch, so we must re-sort by first_ts before deriving sequential/independent
+# hints — otherwise interleaved-branch work yields misleading relations.
+def _cluster_start(c):
+    return c["first_ts"] or "9999"  # ISO strings sort lexicographically; None last
+ordered = sorted(clusters, key=_cluster_start)
 relations = []
-for i in range(1, len(clusters)):
-    a, b = clusters[i-1], clusters[i]
+for i in range(1, len(ordered)):
+    a, b = ordered[i-1], ordered[i]
     rel = "sequential" if a["branch"] == b["branch"] else "independent"
     relations.append({"from": a["id"], "to": b["id"], "rel": rel})
 

--- a/plugin-scripts/session-fission/inventory.sh
+++ b/plugin-scripts/session-fission/inventory.sh
@@ -27,6 +27,12 @@ CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 TRANSCRIPT="${1:-}"
 TARGET_CWD="${SF_CWD:-$PWD}"
 GAP_SECONDS="${SF_GAP_SECONDS:-1800}"   # time-gap (s) that suggests a topic boundary within a branch
+# Validate before it reaches the embedded python int() — a bad SF_GAP_SECONDS would
+# otherwise crash with a non-JSON ValueError traceback, breaking the JSON contract.
+if ! printf '%s' "$GAP_SECONDS" | grep -qE '^[0-9]+$'; then
+  printf '{"status":"error","error":"SF_GAP_SECONDS must be a non-negative integer (got: %s)"}\n' "$(json_escape "$GAP_SECONDS")"
+  exit 1
+fi
 
 if [ -z "$TRANSCRIPT" ]; then
   # Claude Code encodes the cwd into the project dir name by replacing '/' and '.' with '-'.

--- a/plugin-scripts/session-fission/inventory.sh
+++ b/plugin-scripts/session-fission/inventory.sh
@@ -10,6 +10,16 @@
 
 set -euo pipefail
 
+# JSON-escape a string for safe interpolation into the bash-emitted error envelopes.
+# (The python3 analysis block below emits JSON via json.dumps, which is already safe;
+# this helper only guards the pre-python3 error paths where a path is interpolated.)
+json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}; s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}; s=${s//$'\r'/\\r}; s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
 # =============================================================================
 # RESOLVE TRANSCRIPT (read-only)
 # =============================================================================
@@ -28,7 +38,7 @@ if [ -z "$TRANSCRIPT" ]; then
 fi
 
 if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
-  printf '{"status":"error","error":"transcript not found","hint":"pass a path arg, or run inside a project dir that has sessions under %s/projects/<encoded-cwd>/"}\n' "$CONFIG_DIR"
+  printf '{"status":"error","error":"transcript not found","hint":"pass a path arg, or run inside a project dir that has sessions under %s/projects/<encoded-cwd>/"}\n' "$(json_escape "$CONFIG_DIR")"
   exit 1
 fi
 
@@ -114,9 +124,9 @@ for branch, seg in by_branch.items():
     prev = None
     sub = []
     for e in seg:
-        if prev is not None and e["ts"] and prev and (e["ts"] - prev) > gap:
+        if prev is not None and e["ts"] is not None and (e["ts"] - prev) > gap:
             sub.append(cur); cur = []
-        cur.append(e); prev = e["ts"] if e["ts"] else prev
+        cur.append(e); prev = e["ts"] if e["ts"] is not None else prev
     if cur:
         sub.append(cur)
     seg_idx = 0

--- a/plugin-scripts/session-fission/inventory.sh
+++ b/plugin-scripts/session-fission/inventory.sh
@@ -62,18 +62,6 @@ def parse_ts(s):
     except Exception:
         return None
 
-def first_text(msg):
-    if not isinstance(msg, dict):
-        return ""
-    c = msg.get("content")
-    if isinstance(c, str):
-        return c
-    if isinstance(c, list):
-        for part in c:
-            if isinstance(part, dict) and part.get("type") == "text":
-                return part.get("text", "") or ""
-    return ""
-
 events = []
 total = 0
 with open(path, "r", encoding="utf-8", errors="replace") as fh:
@@ -95,7 +83,6 @@ with open(path, "r", encoding="utf-8", errors="replace") as fh:
             "slug": d.get("slug") or "",
             "sidechain": bool(d.get("isSidechain")),
             "role": d.get("type"),
-            "text": first_text(d.get("message") or {}),
         })
 
 # order by timestamp when available (stable otherwise)

--- a/plugin-scripts/session-fission/inventory.sh
+++ b/plugin-scripts/session-fission/inventory.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# /**
+#  * session-fission · inventory.sh
+#  * @context MAOS plugin script — READ-ONLY transcript analysis for the session-fission skill.
+#  * @reason Parse a Claude Code session transcript (.jsonl) into a proposed N-Tree of atomic
+#  *         contexts (keyed by project/branch/cwd + time-gap) so a tangled session can be split.
+#  * @impact Emits JSON only. Never writes to, mutates, or deletes the source transcript.
+#  * @version 0.1.0
+#  */
+
+set -euo pipefail
+
+# =============================================================================
+# RESOLVE TRANSCRIPT (read-only)
+# =============================================================================
+CONFIG_DIR="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+TRANSCRIPT="${1:-}"
+TARGET_CWD="${SF_CWD:-$PWD}"
+GAP_SECONDS="${SF_GAP_SECONDS:-1800}"   # time-gap (s) that suggests a topic boundary within a branch
+
+if [ -z "$TRANSCRIPT" ]; then
+  # Claude Code encodes the cwd into the project dir name by replacing '/' and '.' with '-'.
+  enc="$(printf '%s' "$TARGET_CWD" | tr '/.' '--')"
+  proj="$CONFIG_DIR/projects/$enc"
+  if [ -d "$proj" ]; then
+    TRANSCRIPT="$(ls -t "$proj"/*.jsonl 2>/dev/null | head -1 || true)"
+  fi
+fi
+
+if [ -z "$TRANSCRIPT" ] || [ ! -f "$TRANSCRIPT" ]; then
+  printf '{"status":"error","error":"transcript not found","hint":"pass a path arg, or run inside a project dir that has sessions under %s/projects/<encoded-cwd>/"}\n' "$CONFIG_DIR"
+  exit 1
+fi
+
+# =============================================================================
+# ANALYZE (python3 — robust JSONL parse; emits JSON; no message bodies, labels only)
+# =============================================================================
+python3 - "$TRANSCRIPT" "$GAP_SECONDS" <<'PY'
+import sys, json, datetime
+
+path, gap = sys.argv[1], int(sys.argv[2])
+
+def parse_ts(s):
+    if not s:
+        return None
+    try:
+        return datetime.datetime.fromisoformat(s.replace("Z", "+00:00")).timestamp()
+    except Exception:
+        return None
+
+def first_text(msg):
+    if not isinstance(msg, dict):
+        return ""
+    c = msg.get("content")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        for part in c:
+            if isinstance(part, dict) and part.get("type") == "text":
+                return part.get("text", "") or ""
+    return ""
+
+events = []
+total = 0
+with open(path, "r", encoding="utf-8", errors="replace") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        total += 1
+        try:
+            d = json.loads(line)
+        except Exception:
+            continue
+        if d.get("type") not in ("user", "assistant"):
+            continue
+        events.append({
+            "ts": parse_ts(d.get("timestamp")),
+            "branch": d.get("gitBranch") or "no-branch",
+            "cwd": d.get("cwd") or "",
+            "slug": d.get("slug") or "",
+            "sidechain": bool(d.get("isSidechain")),
+            "role": d.get("type"),
+            "text": first_text(d.get("message") or {}),
+        })
+
+# order by timestamp when available (stable otherwise)
+events.sort(key=lambda e: (e["ts"] is None, e["ts"] or 0))
+
+clusters = []
+def label_from(seg):
+    for e in seg:
+        if e["slug"]:
+            return e["slug"][:80]
+    for e in seg:
+        if e["role"] == "user" and e["text"].strip():
+            return " ".join(e["text"].split())[:80]
+    return "(unlabeled)"
+
+# Cluster by branch, then split on time-gaps inside the same branch.
+by_branch = {}
+for e in events:
+    by_branch.setdefault(e["branch"], []).append(e)
+
+cid = 0
+for branch, seg in by_branch.items():
+    seg.sort(key=lambda e: (e["ts"] is None, e["ts"] or 0))
+    cur = []
+    prev = None
+    sub = []
+    for e in seg:
+        if prev is not None and e["ts"] and prev and (e["ts"] - prev) > gap:
+            sub.append(cur); cur = []
+        cur.append(e); prev = e["ts"] if e["ts"] else prev
+    if cur:
+        sub.append(cur)
+    for s in sub:
+        cid += 1
+        ts_vals = [e["ts"] for e in s if e["ts"]]
+        clusters.append({
+            "id": f"c{cid:02d}",
+            "label": label_from(s),
+            "branch": branch,
+            "cwd": (s[0]["cwd"] if s else ""),
+            "msg_count": len(s),
+            "has_sidechain": any(e["sidechain"] for e in s),
+            "first_ts": (datetime.datetime.fromtimestamp(min(ts_vals), datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")) if ts_vals else None,
+            "last_ts": (datetime.datetime.fromtimestamp(max(ts_vals), datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")) if ts_vals else None,
+        })
+
+# Relation hints: same branch consecutive => sequential; different branch => independent.
+relations = []
+for i in range(1, len(clusters)):
+    a, b = clusters[i-1], clusters[i]
+    rel = "sequential" if a["branch"] == b["branch"] else "independent"
+    relations.append({"from": a["id"], "to": b["id"], "rel": rel})
+
+out = {
+    "status": "ok",
+    "schema": "session-fission/inventory/0.1.0",
+    "source": path,
+    "read_only": True,
+    "total_lines": total,
+    "cluster_count": len(clusters),
+    "gap_seconds": gap,
+    "clusters": clusters,
+    "relations": relations,
+    "note": "Heuristic proposal — confirm/adjust with the operator before snapshot/reseed. Auto-detected transcript = most-recent (no CLAUDE_SESSION_ID env var exists).",
+}
+print(json.dumps(out, indent=2))
+PY

--- a/plugin-scripts/session-fission/seed.sh
+++ b/plugin-scripts/session-fission/seed.sh
@@ -10,12 +10,29 @@
 
 set -euo pipefail
 
+# JSON-escape a string for safe interpolation into the stdout envelope.
+json_escape() {
+  local s=$1
+  s=${s//\\/\\\\}; s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}; s=${s//$'\r'/\\r}; s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
 CLUSTER_ID="${1:?usage: seed.sh <cluster_id> [label] [seed_dir]}"
 LABEL="${2:-$CLUSTER_ID}"
 SEED_DIR="${3:-${SESSION_FISSION_SEED_DIR:-./.session-fission/seeds}}"
-mkdir -p "$SEED_DIR"
 
-SEED="$SEED_DIR/${CLUSTER_ID}.md"
+# Path-traversal guard: CLUSTER_ID becomes a filename — strip everything but
+# [A-Za-z0-9._-] and any leading dots, so values like '../x' or 'a/b' cannot
+# escape SEED_DIR or overwrite arbitrary files.
+SAFE_ID="$(printf '%s' "$CLUSTER_ID" | tr -cd 'A-Za-z0-9._-' | sed 's/^\.*//')"
+if [ -z "$SAFE_ID" ]; then
+  printf '{"status":"error","error":"cluster_id has no filesystem-safe characters: %s"}\n' "$(json_escape "$CLUSTER_ID")"
+  exit 1
+fi
+
+mkdir -p "$SEED_DIR"
+SEED="$SEED_DIR/${SAFE_ID}.md"
 NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 cat > "$SEED" <<MD
@@ -57,4 +74,4 @@ TODO — sequential → / recursive ↻ / independent ∥ / parallel ‖ (relati
 MD
 
 printf '{"status":"ok","cluster_id":"%s","label":"%s","seed_path":"%s","next":"fill the TODOs with distilled context, then reseed (ccpanes/launch_task | claude -n | /branch+/compact)"}\n' \
-  "$CLUSTER_ID" "$LABEL" "$SEED"
+  "$(json_escape "$SAFE_ID")" "$(json_escape "$LABEL")" "$(json_escape "$SEED")"

--- a/plugin-scripts/session-fission/seed.sh
+++ b/plugin-scripts/session-fission/seed.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# /**
+#  * session-fission · seed.sh
+#  * @context MAOS plugin script — emits a Ticket-as-Prompt seed SCAFFOLD for one atomic context.
+#  * @reason Deterministic scaffold only. The AGENT (per the session-fission skill) fills the
+#  *         distilled context — the cognitive step a script cannot do. Keeps the seed LIGHT.
+#  * @impact Writes a markdown seed file under the seed dir. Touches no session transcript.
+#  * @version 0.1.0
+#  */
+
+set -euo pipefail
+
+CLUSTER_ID="${1:?usage: seed.sh <cluster_id> [label] [seed_dir]}"
+LABEL="${2:-$CLUSTER_ID}"
+SEED_DIR="${3:-${SESSION_FISSION_SEED_DIR:-./.session-fission/seeds}}"
+mkdir -p "$SEED_DIR"
+
+SEED="$SEED_DIR/${CLUSTER_ID}.md"
+NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+cat > "$SEED" <<MD
+# Seed — ${LABEL}
+
+> session-fission atomic-context seed · cluster: \`${CLUSTER_ID}\` · generated: ${NOW_UTC}
+> FILL every TODO with the DISTILLED context for THIS atomic task only. A fresh amnesic agent
+> must be able to resume with ZERO prior context. Keep it minimal-sufficient (light nucleus).
+
+## Context
+TODO — state of the world preceding this task (what exists, what was decided, where we are).
+
+## Objective
+TODO — the single measurable outcome for this atomic context.
+
+## Tasks / subtasks / steps
+- [ ] TODO
+
+## Files touched
+- TODO (paths)
+
+## Decisions made
+- TODO
+
+## Open question / next step
+TODO — exactly what to do next.
+
+## Acceptance criteria
+- [ ] TODO
+
+## Cross-links (traceability)
+- ticket/backlog: TODO
+- branch: TODO
+- worktree: TODO
+- origin session (archived, recoverable via /resume): TODO
+
+## Relation in N-Tree
+TODO — sequential → / recursive ↻ / independent ∥ / parallel ‖ (relative to sibling seeds)
+MD
+
+printf '{"status":"ok","cluster_id":"%s","label":"%s","seed_path":"%s","next":"fill the TODOs with distilled context, then reseed (ccpanes/launch_task | claude -n | /branch+/compact)"}\n' \
+  "$CLUSTER_ID" "$LABEL" "$SEED"

--- a/plugin-scripts/session-fission/seed.sh
+++ b/plugin-scripts/session-fission/seed.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 # JSON-escape a string for safe interpolation into the stdout envelope.
 json_escape() {
-  local s=$1
+  local s="$1"
   s=${s//\\/\\\\}; s=${s//\"/\\\"}
   s=${s//$'\n'/\\n}; s=${s//$'\r'/\\r}; s=${s//$'\t'/\\t}
   printf '%s' "$s"

--- a/plugin-scripts/session-fission/snapshot.sh
+++ b/plugin-scripts/session-fission/snapshot.sh
@@ -23,18 +23,25 @@ TS="$(date -u +%Y%m%dT%H%M%SZ)"
 SANITIZED_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 BASE="$(basename "$TRANSCRIPT" .jsonl)"
 
-# Portable SHA-256 (macOS shasum / Linux sha256sum)
+# Portable SHA-256 (macOS shasum / Linux sha256sum / python3 hashlib fallback).
+# The python3 fallback keeps SHA-based idempotency working on minimal systems that
+# ship neither shasum nor sha256sum — without it, idempotency silently breaks and
+# snapshots grow unbounded.
 if command -v shasum >/dev/null 2>&1; then
   SHA="$(shasum -a 256 "$TRANSCRIPT" | cut -d' ' -f1)"
 elif command -v sha256sum >/dev/null 2>&1; then
   SHA="$(sha256sum "$TRANSCRIPT" | cut -d' ' -f1)"
+elif command -v python3 >/dev/null 2>&1; then
+  SHA="$(python3 -c 'import hashlib,sys; print(hashlib.sha256(open(sys.argv[1],"rb").read()).hexdigest())' "$TRANSCRIPT")"
 else
   SHA="unavailable"
 fi
 
 # Idempotent: if a manifest already records this SHA, reuse it (skip duplicate copy).
+# Guard: only use SHA in the grep pattern when it is a clean 64-char hex digest
+# (defense against any non-digest value reaching the pattern).
 EXISTING=""
-if [ "$SHA" != "unavailable" ]; then
+if printf '%s' "$SHA" | grep -qE '^[0-9a-f]{64}$'; then
   EXISTING="$(grep -l "source_sha256: \"$SHA\"" "$BACKUP_DIR"/*.manifest.yaml 2>/dev/null | head -1 || true)"
 fi
 if [ -n "$EXISTING" ]; then

--- a/plugin-scripts/session-fission/snapshot.sh
+++ b/plugin-scripts/session-fission/snapshot.sh
@@ -24,7 +24,11 @@ json_escape() {
 # stay valid YAML (parallel guarantee to json_escape for the stdout envelopes).
 yaml_sq() { local s="$1"; s=${s//\'/\'\'}; printf "'%s'" "$s"; }
 
-TRANSCRIPT="${1:?usage: snapshot.sh <transcript.jsonl> [backup_dir]}"
+TRANSCRIPT="${1:-}"
+if [ -z "$TRANSCRIPT" ]; then
+  printf '{"status":"error","error":"usage: snapshot.sh <transcript.jsonl> [backup_dir]"}\n'
+  exit 1
+fi
 if [ ! -f "$TRANSCRIPT" ]; then
   printf '{"status":"error","error":"transcript not found: %s"}\n' "$(json_escape "$TRANSCRIPT")"
   exit 1
@@ -61,10 +65,15 @@ shopt -u nullglob
 if [ "${#_manifests[@]}" -gt 0 ] && printf '%s' "$SHA" | grep -qE '^[0-9a-f]{64}$'; then
   EXISTING="$(grep -l "source_sha256: \"$SHA\"" "${_manifests[@]}" 2>/dev/null | head -1 || true)"
 fi
-if [ -n "$EXISTING" ]; then
+# Only reuse when the snapshot file ITSELF still exists — a stale manifest whose
+# .jsonl was deleted must NOT report a phantom reuse; fall through to re-create.
+if [ -n "$EXISTING" ] && [ -f "${EXISTING%.manifest.yaml}" ]; then
   SNAP="${EXISTING%.manifest.yaml}"
-  printf '{"status":"ok","idempotent":true,"snapshot_path":"%s","manifest_path":"%s","source_sha256":"%s","note":"identical SHA already snapshotted — reused"}\n' \
-    "$(json_escape "$SNAP")" "$(json_escape "$EXISTING")" "$SHA"
+  # Mirror the cache-miss envelope's key set (gitleaks + sanitized_utc) so callers
+  # parse a stable schema regardless of cache hit/miss; values come from the manifest.
+  EX_UTC="$(sed -n 's/^sanitized_utc: "\(.*\)"$/\1/p' "$EXISTING" | head -1)"
+  printf '{"status":"ok","idempotent":true,"snapshot_path":"%s","manifest_path":"%s","source_sha256":"%s","gitleaks":"cached","sanitized_utc":"%s","note":"identical SHA already snapshotted — reused"}\n' \
+    "$(json_escape "$SNAP")" "$(json_escape "$EXISTING")" "$SHA" "$(json_escape "$EX_UTC")"
   exit 0
 fi
 
@@ -75,13 +84,17 @@ MANIFEST="$SNAP.manifest.yaml"
 cp -p "$TRANSCRIPT" "$SNAP"
 
 # gitleaks scrub (best-effort; reported, not enforced here).
+# Distinguish tool errors from real findings: gitleaks exits 0=clean, 1=leaks,
+# anything else=tool error (do NOT misreport an error as "findings"). `detect
+# --source` kept for broad version compat (newer `dir` subcommand breaks older installs).
 GL="skipped"
 if command -v gitleaks >/dev/null 2>&1; then
-  if gitleaks detect --no-git --source "$SNAP" >/dev/null 2>&1; then
-    GL="clean"
-  else
-    GL="findings"
-  fi
+  gitleaks detect --no-git --source "$SNAP" >/dev/null 2>&1
+  case $? in
+    0) GL="clean" ;;
+    1) GL="findings" ;;
+    *) GL="scan-error" ;;
+  esac
 fi
 
 SOURCE_Y="$(yaml_sq "$TRANSCRIPT")"

--- a/plugin-scripts/session-fission/snapshot.sh
+++ b/plugin-scripts/session-fission/snapshot.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# /**
+#  * session-fission · snapshot.sh
+#  * @context MAOS plugin script — the rollback anchor for the session-fission skill.
+#  * @reason Copy the source transcript to a backup dir + write a manifest + run gitleaks,
+#  *         BEFORE any archive/reseed op. The source is read-only; this only copies OUT.
+#  * @impact Writes a snapshot + manifest under the backup dir. Never touches the source.
+#  * @version 0.1.0
+#  */
+
+set -euo pipefail
+
+TRANSCRIPT="${1:?usage: snapshot.sh <transcript.jsonl> [backup_dir]}"
+if [ ! -f "$TRANSCRIPT" ]; then
+  printf '{"status":"error","error":"transcript not found: %s"}\n' "$TRANSCRIPT"
+  exit 1
+fi
+
+BACKUP_DIR="${2:-${SESSION_FISSION_SNAPSHOT_DIR:-$HOME/.claude/session-fission/snapshots}}"
+mkdir -p "$BACKUP_DIR"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+SANITIZED_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+BASE="$(basename "$TRANSCRIPT" .jsonl)"
+
+# Portable SHA-256 (macOS shasum / Linux sha256sum)
+if command -v shasum >/dev/null 2>&1; then
+  SHA="$(shasum -a 256 "$TRANSCRIPT" | cut -d' ' -f1)"
+elif command -v sha256sum >/dev/null 2>&1; then
+  SHA="$(sha256sum "$TRANSCRIPT" | cut -d' ' -f1)"
+else
+  SHA="unavailable"
+fi
+
+# Idempotent: if a manifest already records this SHA, reuse it (skip duplicate copy).
+EXISTING=""
+if [ "$SHA" != "unavailable" ]; then
+  EXISTING="$(grep -l "source_sha256: \"$SHA\"" "$BACKUP_DIR"/*.manifest.yaml 2>/dev/null | head -1 || true)"
+fi
+if [ -n "$EXISTING" ]; then
+  SNAP="${EXISTING%.manifest.yaml}"
+  printf '{"status":"ok","idempotent":true,"snapshot_path":"%s","manifest_path":"%s","source_sha256":"%s","note":"identical SHA already snapshotted — reused"}\n' \
+    "$SNAP" "$EXISTING" "$SHA"
+  exit 0
+fi
+
+SNAP="$BACKUP_DIR/${BASE}-${TS}.jsonl"
+MANIFEST="$SNAP.manifest.yaml"
+
+# Read-only copy of the source OUT to the backup dir (-p preserves mtime/perms).
+cp -p "$TRANSCRIPT" "$SNAP"
+
+# gitleaks scrub (best-effort; reported, not enforced here).
+GL="skipped"
+if command -v gitleaks >/dev/null 2>&1; then
+  if gitleaks detect --no-git --source "$SNAP" >/dev/null 2>&1; then
+    GL="clean"
+  else
+    GL="findings"
+  fi
+fi
+
+cat > "$MANIFEST" <<YAML
+# session-fission snapshot manifest
+schema: "session-fission/manifest/0.1.0"
+source_path: "$TRANSCRIPT"
+source_sha256: "$SHA"
+snapshot_path: "$SNAP"
+snapshot_utc: "$SANITIZED_UTC"
+sanitized_utc: "$SANITIZED_UTC"
+gitleaks: "$GL"
+lifecycle_state: "snapshotted"
+rollback: "source never mutated; resume original via /resume; this copy is the backup anchor"
+YAML
+
+printf '{"status":"ok","idempotent":false,"snapshot_path":"%s","manifest_path":"%s","source_sha256":"%s","gitleaks":"%s","sanitized_utc":"%s"}\n' \
+  "$SNAP" "$MANIFEST" "$SHA" "$GL" "$SANITIZED_UTC"

--- a/plugin-scripts/session-fission/snapshot.sh
+++ b/plugin-scripts/session-fission/snapshot.sh
@@ -10,6 +10,15 @@
 
 set -euo pipefail
 
+# JSON-escape a string for safe interpolation into the stdout envelopes
+# (paths can legally contain quotes, backslashes, spaces, or newlines).
+json_escape() {
+  local s="$1"
+  s=${s//\\/\\\\}; s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}; s=${s//$'\r'/\\r}; s=${s//$'\t'/\\t}
+  printf '%s' "$s"
+}
+
 TRANSCRIPT="${1:?usage: snapshot.sh <transcript.jsonl> [backup_dir]}"
 if [ ! -f "$TRANSCRIPT" ]; then
   printf '{"status":"error","error":"transcript not found: %s"}\n' "$TRANSCRIPT"
@@ -41,13 +50,16 @@ fi
 # Guard: only use SHA in the grep pattern when it is a clean 64-char hex digest
 # (defense against any non-digest value reaching the pattern).
 EXISTING=""
-if printf '%s' "$SHA" | grep -qE '^[0-9a-f]{64}$'; then
-  EXISTING="$(grep -l "source_sha256: \"$SHA\"" "$BACKUP_DIR"/*.manifest.yaml 2>/dev/null | head -1 || true)"
+shopt -s nullglob
+_manifests=( "$BACKUP_DIR"/*.manifest.yaml )
+shopt -u nullglob
+if [ "${#_manifests[@]}" -gt 0 ] && printf '%s' "$SHA" | grep -qE '^[0-9a-f]{64}$'; then
+  EXISTING="$(grep -l "source_sha256: \"$SHA\"" "${_manifests[@]}" 2>/dev/null | head -1 || true)"
 fi
 if [ -n "$EXISTING" ]; then
   SNAP="${EXISTING%.manifest.yaml}"
   printf '{"status":"ok","idempotent":true,"snapshot_path":"%s","manifest_path":"%s","source_sha256":"%s","note":"identical SHA already snapshotted — reused"}\n' \
-    "$SNAP" "$EXISTING" "$SHA"
+    "$(json_escape "$SNAP")" "$(json_escape "$EXISTING")" "$SHA"
   exit 0
 fi
 
@@ -81,4 +93,4 @@ rollback: "source never mutated; resume original via /resume; this copy is the b
 YAML
 
 printf '{"status":"ok","idempotent":false,"snapshot_path":"%s","manifest_path":"%s","source_sha256":"%s","gitleaks":"%s","sanitized_utc":"%s"}\n' \
-  "$SNAP" "$MANIFEST" "$SHA" "$GL" "$SANITIZED_UTC"
+  "$(json_escape "$SNAP")" "$(json_escape "$MANIFEST")" "$SHA" "$GL" "$SANITIZED_UTC"

--- a/plugin-scripts/session-fission/snapshot.sh
+++ b/plugin-scripts/session-fission/snapshot.sh
@@ -21,7 +21,7 @@ json_escape() {
 
 TRANSCRIPT="${1:?usage: snapshot.sh <transcript.jsonl> [backup_dir]}"
 if [ ! -f "$TRANSCRIPT" ]; then
-  printf '{"status":"error","error":"transcript not found: %s"}\n' "$TRANSCRIPT"
+  printf '{"status":"error","error":"transcript not found: %s"}\n' "$(json_escape "$TRANSCRIPT")"
   exit 1
 fi
 

--- a/plugin-scripts/session-fission/snapshot.sh
+++ b/plugin-scripts/session-fission/snapshot.sh
@@ -19,6 +19,11 @@ json_escape() {
   printf '%s' "$s"
 }
 
+# YAML single-quoted scalar escape for the manifest: wrap in single quotes and
+# double any internal single quote, so paths with quotes/colons/backslashes/spaces
+# stay valid YAML (parallel guarantee to json_escape for the stdout envelopes).
+yaml_sq() { local s="$1"; s=${s//\'/\'\'}; printf "'%s'" "$s"; }
+
 TRANSCRIPT="${1:?usage: snapshot.sh <transcript.jsonl> [backup_dir]}"
 if [ ! -f "$TRANSCRIPT" ]; then
   printf '{"status":"error","error":"transcript not found: %s"}\n' "$(json_escape "$TRANSCRIPT")"
@@ -79,12 +84,14 @@ if command -v gitleaks >/dev/null 2>&1; then
   fi
 fi
 
+SOURCE_Y="$(yaml_sq "$TRANSCRIPT")"
+SNAP_Y="$(yaml_sq "$SNAP")"
 cat > "$MANIFEST" <<YAML
 # session-fission snapshot manifest
 schema: "session-fission/manifest/0.1.0"
-source_path: "$TRANSCRIPT"
+source_path: $SOURCE_Y
 source_sha256: "$SHA"
-snapshot_path: "$SNAP"
+snapshot_path: $SNAP_Y
 snapshot_utc: "$SANITIZED_UTC"
 sanitized_utc: "$SANITIZED_UTC"
 gitleaks: "$GL"

--- a/skills/session-fission/SKILL.md
+++ b/skills/session-fission/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: session-fission
+description: On-demand splitter for a tangled Claude session. Non-destructively inventories the current session's N-Tree of atomic contexts (project / ticket / task / worktree / branch), snapshots the transcript, distills each atomic context into a clean self-contained seed, and reseeds fresh focused sessions — relieving context bloat, cognitive overhead, and token exhaustion. NEVER mutates or deletes the source session. Trigger when the user says "split this session", "session fission", "this session is tangled", "encavalei assuntos", "untangle my session", "too much context in one session", "spin this off into its own session".
+version: 0.1.0
+---
+
+# Session Fission Skill
+
+## Purpose
+
+A single Claude session often tangles unrelated work into one linear transcript: Task-A needs Task-B, Task-B needs an MCP fix (Task-B2), the boss injects Task-C, a bug forces a Task-D skill fix. By day's end the session is an **N-Tree forest collapsed into one timeline** — huge context, cognitive overhead, token exhaustion, and unfinished work spilling into backlog.
+
+`session-fission` splits that tangled "heavy nucleus" into multiple **light, stable, atomic-context sessions** — *non-destructively*. It inventories the tangle, snapshots it safely, distills each atomic context into a clean seed, and reseeds focused sessions. The original is **archived, never mutated or deleted** (fully recoverable via native `/resume`).
+
+## When to Use
+
+- A session has drifted across 2+ unrelated tasks/projects/branches and feels heavy.
+- `/context` shows high usage and you want to shed bloat per-topic instead of `/clear` (total) or `/compact` (lossy).
+- You want each remaining thread to continue in its own focused session.
+- End-of-day: convert one exhausted tangled session into a clean N-Tree of resumable seeds for tomorrow.
+
+## Trigger Phrases
+
+`split this session` · `session fission` · `fission this` · `this session is tangled` · `untangle my session` · `encavalei assuntos` · `dividir esta sessão` · `too much context` · `spin this off`
+
+## Feasibility note — why fission ≠ native `/branch`
+
+Native Claude Code session ops (validated against `code.claude.com/docs/en/sessions`):
+
+- `/branch`, `claude --resume <id> --fork-session` **copy the WHOLE conversation** (new `.jsonl` with `forkedFrom.sessionId`, grouped under root). A fork still carries the full tangle — it does **not** relieve bloat.
+- There is **no supported way to surgically delete middle messages** or split one session into N topic-grouped sessions. The transcript is an append-only `parentUuid` DAG with paired `tool_use`/`tool_result`; cutting migrated messages would orphan parent pointers and break tool-call pairing → an **unresumable** transcript.
+
+So fission's value = **distill-and-reseed per atomic context** (the gap no native command fills), with the original preserved.
+
+## Protocol (6 steps)
+
+1. **Inventory (read-only).** Run `inventory.sh` to parse the current transcript and propose an N-Tree of atomic-context clusters keyed by `{project, branch, cwd, ticket, task, time-gap}`. Review/adjust the clustering with the user — this is a *proposal*, not a verdict.
+2. **Classify into N-Tree.** Tag each cluster + relation: sequential `→`, recursive `↻`, independent `∥`, parallel `‖`.
+3. **Snapshot (safety gate — BEFORE any file op).** Run `snapshot.sh` to copy the source `.jsonl` to a backup dir + write a manifest + `gitleaks` scrub. This is the rollback anchor. The source is read-only throughout.
+4. **Distill per node (the cognitive step — YOU do this, not the script).** For each cluster, read its slice of the transcript and write a clean, self-contained seed: a Ticket-as-Prompt that carries ONLY that atomic context (goal, state, files, decisions, next step). `seed.sh` emits the scaffold; you fill it with the distilled context. This is what relieves bloat — the seed is small.
+5. **Reseed / spawn.** Hand each seed to a fresh focused session (see Reseed paths below). Mark the original archived/superseded — do NOT delete it.
+6. **Topology + handoff.** Summarize the resulting N-Tree (Mermaid + per-seed pointers) so the user can navigate "forward / sideways / down / up-to-root" (CPT Compass). Emit an end-of-action briefing.
+
+## Safety guarantees (requirements ↔ mechanism)
+
+| Requirement | Mechanism |
+|---|---|
+| on-demand | this skill + `/maos:session-fission` command |
+| non-interfering | scripts are **read-only on the source transcript**; reseeds are additive; out-of-scope sessions untouched |
+| snapshot before manipulating files | step 3 `snapshot.sh` copies source + manifest + gitleaks **before** any archive |
+| rollback | source never mutated; backup retained; native `/resume <original>` always recovers |
+| idempotent | re-running yields the same clustering; `snapshot.sh` skips duplicate SHA; seed files overwrite-safe |
+
+## Commands (helper scripts — deterministic mechanics)
+
+```bash
+# 1. Inventory current (or given) transcript → atomic-context N-Tree (JSON, read-only)
+bash ${CLAUDE_PLUGIN_ROOT}/plugin-scripts/session-fission/inventory.sh [transcript.jsonl]
+
+# 2. Snapshot the source transcript (rollback anchor) BEFORE any archive op
+bash ${CLAUDE_PLUGIN_ROOT}/plugin-scripts/session-fission/snapshot.sh <transcript.jsonl> [backup_dir]
+
+# 3. Emit a Ticket-as-Prompt seed scaffold for one cluster (you then fill the distilled context)
+bash ${CLAUDE_PLUGIN_ROOT}/plugin-scripts/session-fission/seed.sh <cluster_id> [label] [seed_dir]
+```
+
+Transcript auto-detect: with no arg, `inventory.sh` picks the most-recent `.jsonl` in `${CLAUDE_CONFIG_DIR:-$HOME/.claude}/projects/<encoded-cwd>/` (Claude Code exposes no `CLAUDE_SESSION_ID` env var, so auto-detect = most-recent; pass the path explicitly to be exact).
+
+## Distillation guidance (the cognitive step)
+
+For each cluster, the seed must let a fresh amnesic agent resume with ZERO prior context. Fill the scaffold's fields: **context** (state of the world), **objective**, **tasks/subtasks/steps**, **files touched**, **decisions made**, **open question / next step**, **acceptance criteria**, **cross-links** (ticket, branch, worktree). Keep it minimal-sufficient — the whole point is a *light* nucleus.
+
+## Reseed paths
+
+- **Option E (reuse — preferred):** hand the seed to `ccpanes-fork-session` / `launch_task` (new instance), or `claude -n <name>` seeded from the seed file (`Read the seed at <path> and execute it`). Use `context-save` for the snapshot substrate if available.
+- **Option D (native primitives):** `/branch <name>` per atomic context, then `/compact <retain only Task-X>` to shed the rest. Cheaper but `/compact` is lossy; use when full distillation isn't worth it.
+- **Never Option B:** do not attempt to trim/delete the migrated messages from the live transcript — unsafe and unsupported.
+
+## Integration (CPT + ecosystem)
+
+- **CPT** (`cowork-process-topology-protocol`): the N-Tree + per-seed pointers ARE a CPT topology; emit `topology.md` + `manifest.yaml` so morning-briefing/auto-orchestrator can navigate via the Compass `--scope` API.
+- **morning-briefing:** the resulting seeds surface as next-action / in-flight items.
+- **auto-orchestrator:** may invoke `/maos:session-fission` as a pre-step before working a backlog.
+- **(v3 roadmap):** sentinel anomaly rule "session exceeds N atomic contexts ⇒ recommend fission" + statusmap dashboard node.
+
+## Anti-patterns
+
+- ❌ Deleting the original session (Option A delete) — archive-not-delete; deletion breaks rollback.
+- ❌ Surgically trimming the live transcript (Option B) — produces an unresumable session.
+- ❌ Reseeding with the full tangle copied in — defeats the purpose; the seed must be the distilled atomic context only.
+- ❌ Skipping the snapshot before archiving — snapshot is the rollback anchor; never skip.
+- ❌ Treating `inventory.sh` clustering as authoritative — it's a heuristic proposal; confirm with the user.
+
+## Examples
+
+```
+/maos:session-fission                 # dry-run: inventory current session, propose N-Tree
+/maos:session-fission --apply         # inventory + snapshot + emit seed scaffolds for confirmed clusters
+/maos:session-fission ~/.claude/projects/<enc>/<uuid>.jsonl   # explicit transcript
+```
+
+---
+
+*Part of multi-agent-os · session-fission v0.1.0 (MVP, non-destructive) · pairs with Cowork Process Topology Protocol*

--- a/skills/session-fission/SKILL.md
+++ b/skills/session-fission/SKILL.md
@@ -34,7 +34,7 @@ So fission's value = **distill-and-reseed per atomic context** (the gap no nativ
 
 ## Protocol (6 steps)
 
-1. **Inventory (read-only).** Run `inventory.sh` to parse the current transcript and propose an N-Tree of atomic-context clusters keyed by `{project, branch, cwd, ticket, task, time-gap}`. Review/adjust the clustering with the user — this is a *proposal*, not a verdict.
+1. **Inventory (read-only).** Run `inventory.sh` to parse the current transcript and propose an N-Tree of atomic-context clusters. The MVP heuristic clusters by `{git-branch, time-gap}` (a topic boundary is inferred from `SF_GAP_SECONDS`, default 1800s, within a branch) and records `cwd` per cluster; richer `{project, ticket, task}` keying is deferred to v2. Review/adjust the clustering with the user — this is a *proposal*, not a verdict.
 2. **Classify into N-Tree.** Tag each cluster + relation: sequential `→`, recursive `↻`, independent `∥`, parallel `‖`.
 3. **Snapshot (safety gate — BEFORE any file op).** Run `snapshot.sh` to copy the source `.jsonl` to a backup dir + write a manifest + `gitleaks` scrub. This is the rollback anchor. The source is read-only throughout.
 4. **Distill per node (the cognitive step — YOU do this, not the script).** For each cluster, read its slice of the transcript and write a clean, self-contained seed: a Ticket-as-Prompt that carries ONLY that atomic context (goal, state, files, decisions, next step). `seed.sh` emits the scaffold; you fill it with the distilled context. This is what relieves bloat — the seed is small.

--- a/skills/session-fission/SKILL.md
+++ b/skills/session-fission/SKILL.md
@@ -93,7 +93,7 @@ For each cluster, the seed must let a fresh amnesic agent resume with ZERO prior
 
 ## Examples
 
-```
+```text
 /maos:session-fission                 # dry-run: inventory current session, propose N-Tree
 /maos:session-fission --apply         # inventory + snapshot + emit seed scaffolds for confirmed clusters
 /maos:session-fission ~/.claude/projects/<enc>/<uuid>.jsonl   # explicit transcript


### PR DESCRIPTION
## Summary

- Adds **`session-fission`** MVP (skill + command + scripts + spec) for on-demand, non-destructive splitting of tangled Claude sessions via distill-and-reseed.
- Incorporates post-review hardening fixes: safe `CLUSTER_ID` filename handling, JSON-escaped script output, python3 availability guard, content-free labeling, chronology-correct relation hints, and robust SHA fallback for snapshot idempotency.
- Aligns docs to implementation details (MVP clustering heuristic) and keeps plugin release updates (`.claude-plugin/plugin.json` 1.6.0 + `CHANGELOG.md`).

## Type

- [x] feat (new functionality)
- [x] fix (bug fix)
- [x] docs
- [ ] refactor
- [ ] chore
- [x] security
- [ ] governance
- [ ] release

## AI Involvement

- [ ] Human-authored
- [ ] AI-assisted (human author used AI tools for parts of the change)
- [x] AI-generated draft reviewed by human (named reviewer required)

If AI-assisted or AI-generated, include `Co-Authored-By:` footer(s) in the commit messages.

## Runtime / Surface Impact

- [x] Claude Code (plugin runtime, hooks, agents, commands, skills)
- [ ] GitHub Copilot (`.github/copilot-instructions.md`)
- [ ] Generic AI agents (AGENTS.md contract)
- [x] Plugin manifest (`.claude-plugin/plugin.json`) — requires downstream marketplace sync
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [x] Security / compliance posture

## Files requiring follow-up governance update

- [ ] `README.md`
- [ ] `AGENTS.md`
- [ ] `CLAUDE.md`
- [ ] `CONTRIBUTING.md`
- [ ] `SECURITY.md`
- [x] `CHANGELOG.md`
- [ ] `.github/CODEOWNERS`
- [x] `.claude-plugin/plugin.json`
- [x] Downstream marketplace pin (`ekson73/eko-claude-plugins`)

## Evidence

```bash
bash tests/validate-plugin.sh
# PASSED (Errors: 0, Warnings: 0)

bash -n plugin-scripts/session-fission/inventory.sh \
  plugin-scripts/session-fission/snapshot.sh \
  plugin-scripts/session-fission/seed.sh
# clean

python3 -m py_compile plugin-scripts/session-fission/inventory.sh
# compile OK (embedded Python blocks)

gitleaks detect --no-git --source .
# clean

# Smoke checks performed:
# - seed.sh path traversal attempt -> sanitized safe filename
# - seed.sh JSON output -> valid escaping for special chars
# - inventory.sh labels -> no message-body fallback leakage
# - snapshot.sh -> idempotent duplicate detection by SHA
```

## Risks

Low. Changes are scoped to session-fission MVP and primarily harden safety/output correctness:
- source transcript remains non-destructively handled;
- security-sensitive paths and JSON output are now sanitized/escaped;
- heuristic clustering remains operator-confirmed before reseed.

## Rollback

Revert this PR with a `revert:` PR if needed.  
No source-session mutation occurs, so original sessions remain recoverable via native `/resume`.  
Snapshots are additive and removable from `SESSION_FISSION_SNAPSHOT_DIR`.

## Checklist

- [x] Worktree + branch used (no direct-main commits)
- [x] Conventional Commits + `Co-Authored-By:` footer if AI involved
- [x] gitleaks clean (pre-commit + CI workflow)
- [x] Build / tests pass (`tests/validate-plugin.sh` or equivalent)
- [x] No secrets, no PII, no Vek-specific content (Layer Purity per `~/.claude/rules/layer-precedence-policy.md`)
- [x] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated if contract changed
- [x] Version bump + CHANGELOG entry if `.claude-plugin/plugin.json` changed

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>