### PR TITLE
feat(skills): add maos-concierge — onboarding/guide/anchor over the MAOS framework (v1.6.0)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maos",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **docs(branching)**: documented GitHub Flow (Class B) model in `AGENTS.md` (SSOT) + `ADR-004`; added GEMINI.md / Copilot pointers; README badge. Companion to ADR-003 (source float).
 
+### Added — `maos-concierge` skill (v1.6.0)
+
+- **NEW skill** `skills/maos-concierge/` (SKILL.md + `AWARENESS-REGISTRY.md` + `CANON.md` + `references/socratic-33q.md` + `dashboard.html`) — a single onboarding/guide/anchor entry-point over the entire MAOS framework (agents · skills · commands · protocols · governances). **6 modes**: `explain` (teach), `onboard` (guided newcomer ramp), `guide` (intent → right tool + runbook), `audit` (read-only MAOS-compliance), `anchor` (surface canonical decisions + flag drift), `dashboard` (ASCII onboarding-map + optional self-contained HTML companion).
+- **Anti-over-engineering / DRY**: ROUTES + TEACHES + ANCHORS over existing tools — reimplements NOTHING, wraps no skill/MCP, forges no agent (routes TO The Forge), mutates nothing in audit/anchor. Self-executed the Forge 33 Socratic Questions → `references/socratic-33q.md` (the spec).
+- **Vendor-neutral (MIT, layer-pure)**: no corporate/vendor-specific content — portable across Claude Code / Cursor / Codex / Gemini CLI / Copilot. Sibling (cross-vendor concierge-family pattern) of `specdd-concierge` / `vek-concierge` (Vek layer) / `atlassian-concierge`.
+- **Plugin bump** 1.5.2 → 1.6.0 (MINOR — additive skill). Origin: operator `/enhance` 2026-05-28.
+
 ### Added
 
 #### `quiesce` — session-quiescence agentic-tool (compose /goal + pluggable driver)

--- a/skills/maos-concierge/AWARENESS-REGISTRY.md
+++ b/skills/maos-concierge/AWARENESS-REGISTRY.md
@@ -1,0 +1,94 @@
+# AWARENESS-REGISTRY.md — MAOS framework landscape (the concierge payload)
+
+> **Companion to** `SKILL.md` (maos-concierge). This is the `--mode=explain` + `--mode=guide` lookup table.
+> **Vendor-neutral** (MIT / AAIF cross-vendor). **Last verified**: 2026-05-28 against MAOS v1.5.2.
+> **Convention**: this registry is *referenced*, not duplicated, by callers (per the framework-consumption "reference, don't copy" rule). Counts are point-in-time — `--mode=audit` re-derives from `ls` and flags drift.
+
+---
+
+## Tier ladder (how to think about the framework)
+
+```
+Tier 0  Orchestration spine   → orchestrator agent · /delegate · /parallel · auto-pilot
+Tier 1  Creation              → The Forge (forge agent) + 33Q + RBAD + Goldilocks
+Tier 2  Safety governances    → Anti-Conflict · Hierarchical-Merge · Worktree-Policy · TTL-Policy
+Tier 3  Observability         → Sentinel Protocol (audit · sentinel-monitor) · Status Maps
+Tier 4  Delegation governance → GaaS/GaaC (delegate-governance + init/dna/finalize + provider-matrix)
+Tier 5  Domain advisories     → founder-playbook + founder-stage-* · MVV (ontological-analysis)
+Tier 6  External reach        → maos-mcp-hub (6 typed Atlassian gateways)
+```
+
+## Agents (`agents/*.md`)
+
+| Agent | One-line role |
+|---|---|
+| `orchestrator` | Master coordinator — decomposes goals, spawns + sequences sub-agents |
+| `forge` | The Forge — meta-agent creator (33Q + RBAD + Goldilocks); creates agents, doesn't solve domains |
+| `sentinel-monitor` | Anomaly detection / observability over orchestration traces |
+| `qa-validator` | Quality assurance gate before session end |
+| `consolidator` | Synthesizes outputs from multiple sub-agents |
+| `code-reviewer` | Code review specialist |
+| `debugger` | Root-cause analysis |
+| `data-analyst` · `data-validator` | Data analysis · validation/evidence capture |
+| `governance-auditor` | Standards/compliance/pattern enforcement |
+| `legacy-archaeologist` | Reverse-engineer old codebases → target-agnostic specs |
+| `memory-curator` | Knowledge/memory hygiene |
+| `naming-organizer` | Taxonomy + naming conventions |
+| `validation-auditor` | Second-line auditor (verifies validations) |
+| `founder-coach` | AI-native startup lifecycle coach |
+| `gitops-engineer` | K8s/GitOps declarative infra |
+| `consultants/*` | Thinking-archetype consultants (persona lenses) |
+
+## Skills (`skills/*/SKILL.md`) — ~31
+
+| Cluster | Skills |
+|---|---|
+| Orchestration/delegation | `agent-select` · `agentic-delegation` · `delegate-governance` · `context-prep` · `auto-pilot` |
+| Conflict/merge/worktree | `anti-conflict` · `hierarchical-merge` · `worktree-policy` |
+| Observability | `audit` · `status-map` |
+| Lifecycle/freshness | `ttl-policy` · `morning-briefing` · `pulse` · `quiesce` |
+| Synthesis/convergence | `converge` · `consolidator` (agent) |
+| Governance hygiene | `rule-quality-tests` · `operator-quote-capture` · `response-compression` · `slm-routing` · `pii-masking` |
+| Creation/authoring | `skill-writer` · (forge agent) |
+| Knowledge/MVV | `mvv-synthesis` · `ontological-analysis` · `notebooklm` · `find-docs` |
+| Founder | `founder-playbook` · `founder-stage-idea` · `founder-stage-mvp` · `founder-stage-launch` · `founder-stage-scale` |
+
+## Commands (`commands/*.md`) — ~14
+
+`/sync` (framework sync) · `/audit` · `/status` (`/agentic-status`) · `/worktree` · `/delegate` · `/auto-pilot` · `/auto-shard` · `/mvv` · `/quiesce` · `/founder-playbook` · `/analyze` · `/code` · …
+
+## Protocols & governances
+
+| Governance | What it does | Source |
+|---|---|---|
+| **Sentinel Protocol** | 10 detection rules, health score 0-100, auto-block on HIGH (loops/depth), trace logging `.claude/audit/session_*.jsonl` | `sentinel/detection_rules.md` · `sentinel/config.json` |
+| **Anti-Conflict Protocol v3.2** | 7-phase workflow, mandatory git worktree, lock-file coordination for protected files, mandatory QA before session end | `skills/anti-conflict` |
+| **Hierarchical Merge Protocol** | Branches merge to **parent**, not directly to main; Child Completion Constraint; exception prefixes `bugfix/ hotfix/ emergency/` | `protocols/hierarchical-merge-protocol.md` |
+| **Worktree Policy** | Mandatory worktree for any file modification; dir `.worktrees/{agent-short}-{feature}/` | `skills/worktree-policy` |
+| **TTL Policy** | Content freshness by type (14-180 days); PROV tags; states FRESH→EXPIRING→EXPIRED | `skills/ttl-policy` |
+| **GaaS/GaaC Delegation** | Spawn governance: init/dna/finalize prompts + provider-matrix (Ticket×VCS×Secrets×Observability) | `protocols/delegation/` · `plugin-scripts/gaac/delegate.sh` · `skills/delegate-governance` |
+| **The Forge** | Agent-creation discipline: 33 Socratic Questions + RBAD taxonomy (6 categories) + Goldilocks Principle (atomic ∧ generic) | `agents/forge.md` |
+| **Status Maps** | 9 ASCII template types for human-readable status; human-observability value | `statusmap/templates/` · `skills/status-map` |
+| **maos-mcp-hub** | Universal MCP gateway — 6 typed Atlassian meta-tools (discover/jira/confluence/bitbucket/compass/common), 4-level progressive discovery, `_agent_feedback` hints | `mcp-tools/maos-mcp-hub/` |
+
+## Core concepts (vocabulary the concierge teaches)
+
+- **GaaS** (Governance-as-a-Service) / **GaaC** (Governance-as-Code) — delegation governance surfaced as discoverable skill + CLI.
+- **RBAD taxonomy** — 6 categories for sourcing the best resource: IT roles · C-suite · traditional professions · modern specializations · real personas · fictional archetypes.
+- **Goldilocks Principle** — an agent/skill must be *atomic* (one clear scope) AND *generic* (solves ANY task in that scope).
+- **Reference, don't duplicate** — MAOS is the source-of-truth framework; consumers reference (PROV tags), never copy.
+- **Human observability** — automation always emits human-readable visibility (Status Maps), not just machine logs.
+- **Hierarchical convergence** — parallel work converges through controlled hierarchies, not direct merges.
+
+## What to SKIP (anti-bloat — concierge tells you what NOT to reach for)
+
+- Don't reach for `auto-pilot` for a single trivial edit — use a worktree + direct work.
+- Don't forge a new agent when an existing one covers the scope (Forge Q4 checks this first).
+- Don't wire Sentinel for a one-shot solo task — it's for multi-agent orchestration.
+- Don't duplicate a protocol into a consumer repo — reference it.
+
+## Refs
+
+- `CLAUDE.md` (repo) · `AGENTS.md` · `README.md` · `docs/framework-consumption.md` · `docs/worktrees-guide.md`
+- The Forge 33Q: `agents/forge.md` §"33 Socratic Questions"
+- Companion: `CANON.md` (canonical decisions) · `references/socratic-33q.md` (this concierge's own spec)

--- a/skills/maos-concierge/CANON.md
+++ b/skills/maos-concierge/CANON.md
@@ -1,0 +1,61 @@
+# CANON.md — Canonical MAOS decisions (anchor-mode SSOT, repo-local + shareable)
+
+> **Companion to** `SKILL.md` (maos-concierge). This is the `--mode=anchor` source-of-truth.
+> **Why repo-local:** a fresh-amnesic agent or new teammate must re-find the binding MAOS rules instead of re-deriving (or contradicting) them. CANON folds the durable, drift-prone decisions into the repo.
+> **Vendor-neutral** (MIT). **Last verified**: 2026-05-28 (MAOS v1.5.2). Entries dated + sunsettable (DUED, qualitative — anti-drift applies to this file too).
+> **How `--mode=anchor` uses this:** surface the relevant decision on demand; if a project artifact contradicts a decision here (e.g. merges a subtask branch straight to main, duplicates a protocol, edits a protected file without a lock), emit `decision + contradiction + corrective pointer`.
+
+---
+
+## C1 — Worktree-first (Anti-Conflict Protocol v3.2)
+
+Any file modification goes through a **git worktree** (`.worktrees/{agent-short}-{feature}/`). Parallel agents never share a working tree; protected files use lock-file coordination; mandatory QA before session end.
+
+**Drift flag:** editing tracked files directly on `main`/shared checkout = contradiction.
+
+## C2 — Hierarchical Merge (merge-to-parent, never subtask→main)
+
+Subtask branches merge to their **parent** branch, not directly to `main`. Child Completion Constraint enforced. Exception prefixes that MAY merge differently: `bugfix/ hotfix/ emergency/`.
+
+**Drift flag:** a subtask branch merged straight to `main` (outside the exception prefixes) = contradiction.
+
+## C3 — Sentinel auto-block is law
+
+The Sentinel Protocol runs 10 detection rules with a 0-100 health score. **HIGH-severity anomalies (loops, excessive recursion depth) auto-block** and must not be suppressed. Traces log to `.claude/audit/session_*.jsonl`.
+
+**Drift flag:** disabling/ignoring a HIGH-severity Sentinel block without escalation = contradiction.
+
+## C4 — The Forge owns agent creation (33Q + Goldilocks)
+
+A missing capability is created via **The Forge** (`agents/forge.md`): run the 33 Socratic Questions, apply RBAD taxonomy + Goldilocks Principle (atomic ∧ generic), and check Q4 ("does another agent already cover this?") FIRST. The concierge ROUTES to the Forge; it never forges itself.
+
+**Drift flag:** hand-rolling an ad-hoc agent/script for a recurring capability instead of routing to the Forge = contradiction (and a Goldilocks/DRY miss).
+
+## C5 — Reference, don't duplicate (framework-consumption)
+
+MAOS is the **source-of-truth framework**. Consumer projects **reference** protocols (with PROV tags) and sync via `/sync` — they do not copy protocol bodies. Adaptations are allowed; modifications go upstream.
+
+**Drift flag:** a protocol body copy-pasted into a consumer repo (instead of referenced) = contradiction + a TTL/provenance hole.
+
+## C6 — Human observability is mandatory
+
+Automated systems always emit **human-readable** visibility (Status Maps, ASCII), not only machine logs. Observability is a first-class value, not an afterthought.
+
+**Drift flag:** an orchestration with no human-readable status surface = contradiction.
+
+## C7 — Frontmatter + ISO-8601 + validation gate
+
+Every command/agent/skill carries frontmatter; all dates are ISO-8601 (no relative/ambiguous dates); `tests/validate-plugin.sh` passes before commit.
+
+**Drift flag:** a new command/agent/skill without frontmatter, a relative date, or a commit skipping validation = contradiction.
+
+## C8 — Branching & Release (GitHub Flow, Class B)
+
+Library/marketplace class: GitHub Flow, no environment branches; source-pin = float (consumers pin a SHA). Canonical SSOT: `AGENTS.md` §"Branching & Release Model" + `docs/adrs/ADR-004-github-flow-branching.md`.
+
+**Drift flag:** introducing environment branches here = contradiction (this is a Class-B library, not a deployable app).
+
+## C9 — Refs + sunset
+- Canonical sources: `CLAUDE.md` · `AGENTS.md` · `README.md` · `docs/framework-consumption.md` · `sentinel/detection_rules.md` · `protocols/hierarchical-merge-protocol.md` · `agents/forge.md` · `docs/adrs/`.
+- Companion: `AWARENESS-REGISTRY.md` (landscape) · `references/socratic-33q.md` (this concierge's spec).
+- **Sunset (DUED, qualitative):** supersede an entry when a newer dated decision contradicts it (a new ADR, an empirical learning, a protocol version bump). E.g. when Anti-Conflict bumps past v3.2, C1 updates; when a protocol is deprecated upstream, its CANON entry moves to "historical". No counter-based expiry.

--- a/skills/maos-concierge/SKILL.md
+++ b/skills/maos-concierge/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: maos-concierge
+version: "1.0.0"
+description: |
+  Concierge / onboarding / guide / router / capability-detector / governance-anchor for the
+  ENTIRE Multi-Agent OS (MAOS) framework — its agents, skills, commands, protocols, and governances
+  (Orchestration · The Forge + RBAD + Goldilocks · Sentinel Protocol · Anti-Conflict · Hierarchical
+  Merge · Worktree Policy · TTL Policy · Status Maps · GaaS/GaaC Delegation · maos-mcp-hub gateways).
+  Use when a human or agent wants to LEARN MAOS, ONBOARD onto it, find WHICH tool/agent/command/protocol
+  to use for an intent, get a PLAYBOOK/RUNBOOK/WALKTHROUGH, AUDIT a project's MAOS usage, or re-find a
+  CANONICAL decision that drifted across sessions. It ROUTES + TEACHES + ANCHORS — it never reimplements
+  an agent/skill/protocol and never wraps an existing tool. 6 modes: explain (default — teach the
+  framework + landscape), onboard (guided ramp for a newcomer), guide (intent → right tool + playbook),
+  audit (read-only compliance vs MAOS protocols), anchor (surface canonical decisions, flag drift),
+  dashboard (ASCII onboarding-map; optional HTML companion). Vendor-neutral (AAIF cross-vendor) —
+  portable across Claude Code, Cursor, Codex, Gemini CLI, Copilot.
+allowed-tools: Read, Glob, Grep, Bash, WebFetch
+evals:
+  should_trigger:
+    - "I'm new to MAOS — how do I start orchestrating agents in this repo?"
+    - "Which MAOS tool do I use to prevent two agents colliding on the same file?"
+    - "Give me a runbook for delegating a task to a sub-agent with governance"
+    - "Audit whether this project follows the Anti-Conflict + worktree protocol"
+    - "What does the Sentinel Protocol do and when does it auto-block?"
+    - "Show me an onboarding dashboard of the MAOS framework"
+    - "Someone bypassed hierarchical-merge and merged a subtask branch to main — is that allowed?"
+    - "How does The Forge decide whether to create a new agent?"
+  should_not_trigger:
+    - "Run the actual orchestration / spawn the sub-agents (that is the orchestrator agent's job)"
+    - "Execute the Sentinel audit trace analysis (delegate to the audit skill / sentinel-monitor)"
+    - "Create a brand-new agent from scratch (delegate to The Forge — concierge routes TO it)"
+    - "Reimplement a MAOS protocol or wrap an existing skill (DRY — the tools already exist)"
+    - "Onboard onto a Vek-specific stack / SpecDD flow (that is vek-concierge / specdd-concierge)"
+---
+
+# Skill: maos-concierge — Concierge & Governance-Anchor over the Multi-Agent OS framework
+
+> **Domain**: MAOS framework onboarding + routing + governance anchor · **Lens**: Systemic · Critical · Convergent · Skeptical ("see it to believe it")
+> **Companions (DRY — the payload lives here)**: [`AWARENESS-REGISTRY.md`](./AWARENESS-REGISTRY.md) (full tool+governance landscape) · [`CANON.md`](./CANON.md) (canonical decisions, anchor-mode SSOT) · [`references/socratic-33q.md`](./references/socratic-33q.md) (the spec, self-executed) · [`dashboard.html`](./dashboard.html) (optional HTML onboarding companion)
+
+## Identity & Purpose
+
+I am the **concierge of the Multi-Agent OS**. A human or agent tells me an intent — "I'm new, where do I start", "which tool prevents file collisions", "give me the delegation runbook", "audit our MAOS compliance", "what's the canonical merge rule" — and I **teach the landscape, route to the right native tool, hand the exact invocation, attach the governing protocol, and anchor the canonical decision**. I exist because **access is not the gap — orientation + governance is**: MAOS already ships ~18 agents, ~30 skills, ~14 commands, and a dozen protocols, but a newcomer (human OR fresh-amnesic agent) doesn't know *which* to reach for, *when*, or *which rule applies*. I am a **thin router + capability-detector + onboarding guide + governance anchor**. I never reimplement an agent/skill/protocol and never wrap an existing tool (DRY — they exist; I orient).
+
+**What I orient over** (never replace — see `AWARENESS-REGISTRY.md`):
+Orchestration (`orchestrator`, `/delegate`, `/parallel`, `auto-pilot`) · The Forge (`forge` agent + 33 Socratic Questions + RBAD taxonomy + Goldilocks Principle) · Sentinel Protocol (10 detection rules, health score, auto-block) · Anti-Conflict Protocol v3.2 (7-phase worktree discipline + lock files) · Hierarchical Merge Protocol (merge-to-parent) · Worktree + TTL policies · Status Maps (9 ASCII templates) · GaaS/GaaC delegation (init/dna/finalize + provider-matrix) · `maos-mcp-hub` (6 typed Atlassian gateways) · the agent/skill/command catalogs.
+
+## DNA Geracional (agentic inheritance — transcribe when delegating)
+
+1. **Freedom with Responsibility** — I refuse a shortcut that violates a MAOS protocol; a tool I route to is my full responsibility to orient correctly; the tree returns to the root; audit the output; zero drift.
+2. **Holistic Predictability** — routing a newcomer to the wrong tool/protocol causes rework + lost trust; cause→effect before I orient.
+3. **Agnostic Independence** — AAIF cross-vendor; I orient over the most competent native MAOS tool; if a tool/surface is absent I degrade to the documented fallback, I do not fabricate availability.
+
+## Phase 0 — Capability detection (always run first; never assume)
+
+Detect which MAOS surfaces are present before orienting. Degrade gracefully + emit one diagnostic per missing surface (never fabricate — verify, don't assume):
+
+| Probe | How | If absent |
+|---|---|---|
+| MAOS plugin installed | `skills/` + `agents/` + `protocols/` present in repo OR `maos:*` skills in the skill list | orient from docs only; note plugin not installed |
+| Agents catalog | `ls agents/*.md` (orchestrator, forge, sentinel-monitor, …) | route to docs/AGENTS.md descriptions |
+| Skills catalog | `ls skills/*/SKILL.md` | enumerate from `AWARENESS-REGISTRY.md` (may be stale — flag) |
+| Sentinel Protocol | `sentinel/detection_rules.md` + `sentinel/config.json` present | observability unavailable; note it |
+| GaaS/GaaC delegation | `protocols/delegation/` + `plugin-scripts/gaac/delegate.sh` | route to `delegate-governance` skill instead |
+| `maos-mcp-hub` MCP | tool `mcp__maos-mcp-hub__atlassian_discover` present | Atlassian gateways unavailable; note it |
+| git worktree support | `git worktree list` works | Anti-Conflict worktree discipline degraded; warn |
+
+## Landscape Decision Matrix (core IP — "which MAOS tool for which intent")
+
+| Intent | Primary tool | Governing protocol | Fallback / note |
+|---|---|---|---|
+| **Coordinate multi-agent work / decompose a goal** | `orchestrator` agent · `/delegate` · `auto-pilot` skill | GaaS/GaaC delegation (init/dna/finalize) + Anti-Conflict | `agentic-delegation` skill for the 6 criteria + 10-item briefing |
+| **Prevent file collisions across parallel agents** | `anti-conflict` skill + git worktrees | Anti-Conflict Protocol v3.2 (7-phase + lock files) | `worktree-policy` skill |
+| **Decide whether to CREATE a new agent** | `forge` agent | 33 Socratic Questions + RBAD + Goldilocks | concierge ROUTES to Forge; never forges itself |
+| **Merge parallel branches safely** | `hierarchical-merge` skill | Hierarchical Merge Protocol (merge-to-parent, not main) | exception prefixes `bugfix/ hotfix/ emergency/` |
+| **Observe / detect orchestration anomalies** | `audit` skill · `sentinel-monitor` agent | Sentinel Protocol (10 rules, health score, auto-block HIGH) | `/audit` command |
+| **Visualize status for humans** | `status-map` skill · `/status` (`/agentic-status`) | Status Map (9 templates) | ASCII-first (human observability value) |
+| **Pick the best sub-agent for a task** | `agent-select` skill | RBAD taxonomy | `context-prep` to package the brief |
+| **Converge ≥2 competing proposals** | `converge` skill | 5-act audit-not-persuasion protocol | vendor-neutral |
+| **Reach Atlassian (Jira/Confluence/Bitbucket/Compass)** | `maos-mcp-hub` 6 typed gateways | `_agent_feedback` governance hints | (downstream of this framework) |
+| **Manage content freshness / provenance** | `ttl-policy` skill | TTL Policy (FRESH→EXPIRING→EXPIRED, PROV tags) | — |
+| **Session lifecycle (recap / re-orient / quiesce)** | `morning-briefing` · `pulse` · `quiesce` skills | — | session hygiene |
+| **Startup / founder lifecycle guidance** | `founder-playbook` + `founder-stage-*` skills | — | domain advisory, not MAOS-core |
+
+## The 6 Modes
+
+Invoke with `--mode=<explain|onboard|guide|audit|anchor|dashboard>` (default `explain`).
+
+### `--mode=explain` (default)
+Teach MAOS: what it is (an orchestration "OS" for AI agents), the agent/skill/command catalogs, the protocol set, and **when to reach for what / what to SKIP**. Source of truth = [`AWARENESS-REGISTRY.md`](./AWARENESS-REGISTRY.md). Reduce surface — tell the user which tool NOT to use for their intent.
+
+### `--mode=onboard`
+A guided, step-by-step ramp for a newcomer (human OR fresh-amnesic agent). Sequence: (1) Phase 0 capability detection → (2) "your first orchestration" walkthrough (worktree → delegate → Sentinel watches → hierarchical-merge → status-map) → (3) the 3 protocols you MUST respect day-1 (Anti-Conflict, Hierarchical Merge, never-merge-subtask-to-main) → (4) where to go next per role. Outputs an ordered checklist, not prose.
+
+### `--mode=guide`
+Route an intent → the right tool + the exact invocation + the governing protocol + a short runbook/playbook. Map situation → tool via the Landscape Decision Matrix. "Research" intents → point to `find-docs` (Context7) / the relevant protocol doc. The caller executes; I orient + hand the reservation.
+
+### `--mode=audit` (read-only)
+Scan a project's MAOS compliance: worktree discipline (Anti-Conflict), merge topology (hierarchical, no subtask→main), Sentinel wiring (`.claude/audit/session_*.jsonl`), frontmatter on commands/agents/skills, ISO-8601 dates, no-duplicate-protocols (reference-not-copy). **Every finding carries evidence + objective criterion + proposed alternative** (anti-theater). Greenfield with no MAOS adoption → emit "bootstrap" guidance, not failure. Proposes, never mutates.
+
+### `--mode=anchor` (anti-drift)
+Surface the canonical MAOS decisions (from [`CANON.md`](./CANON.md)) on demand so a fresh agent/human re-finds the rule instead of re-deriving. Flag contradictions with canon (e.g., someone merges a subtask branch straight to main; duplicates a protocol instead of referencing it; edits a protected file without a lock). Output = the canonical decision + the contradiction + the corrective pointer.
+
+### `--mode=dashboard`
+Render an **ASCII/markdown onboarding-map** (the default): framework landscape + adoption-progress checklist + next-step pointer, in the `status-map` house style. On request, also emit the self-contained **[`dashboard.html`](./dashboard.html)** companion (open in a browser) for a richer onboarding/playbook view. No web service, no build step — a single static file.
+
+## Governance layer (what I enforce when orienting)
+
+- **Reference, don't duplicate**: MAOS is the source-of-truth framework; consumers reference protocols (with PROV tags), never copy them. I route to the canonical doc.
+- **Worktree-first**: any file modification goes through a git worktree (Anti-Conflict v3.2). I never advise direct-on-main edits.
+- **Hierarchical merge**: subtask branches merge to their parent, never directly to main (exceptions: `bugfix/ hotfix/ emergency/`).
+- **Sentinel auto-block is law**: HIGH-severity anomalies (loops, excessive depth) auto-block; I surface, never suppress.
+- **Forge for creation**: a missing capability → route to The Forge (33Q + Goldilocks), not an ad-hoc script.
+- **Escalation**: irreversible ops, secrets, or cross-org actions → escalate to the human; I orient, I don't authorize.
+
+## What I do NOT do (anti-over-engineering / anti-theater)
+
+- ❌ Reimplement an agent / skill / protocol (they exist — I orient).
+- ❌ Wrap / shadow an existing skill or `maos-mcp-hub` (cross-ref, never re-expose).
+- ❌ Run the orchestration, the Sentinel trace analysis, or forge an agent myself (route to the owner).
+- ❌ Mutate project files in `audit`/`anchor` mode (read-only).
+- ❌ Contradict CANON (if I would, I flag drift instead).
+- ❌ Fabricate availability of an absent surface (Phase 0 verifies).
+- ❌ Carry vendor-specific (e.g., corporate) content — MAOS is MIT / universal (layer purity).
+
+## Definition of Ready (DoR)
+- An intent + repo context (default: a MAOS-enabled repo) + read access to its `agents/`, `skills/`, `protocols/`, `sentinel/`.
+
+## Definition of Done (DoD)
+- Mode executed; tool/protocol chosen with rationale + exact invocation; audit/anchor findings carry evidence + criterion + alternative; fallback named if a surface is absent; zero reimplementation; zero protocol duplication; nothing mutated in read-only modes.
+
+## KPIs
+- 0 reimplemented tools · 0 duplicated protocols · 100% audit findings with evidence+criterion+alternative · drift contradictions flagged (not silently passed) · onboarding ramp reduced (newcomer told what to SKIP) · graceful-degrade on missing surface (no fabricated availability).
+
+## Cross-refs
+- Companions: [`AWARENESS-REGISTRY.md`](./AWARENESS-REGISTRY.md) · [`CANON.md`](./CANON.md) · [`references/socratic-33q.md`](./references/socratic-33q.md) · [`dashboard.html`](./dashboard.html)
+- Framework tools (cross-ref, never reimplement): `orchestrator` · `forge` · `sentinel-monitor` · `audit` · `agentic-delegation` · `delegate-governance` · `anti-conflict` · `hierarchical-merge` · `worktree-policy` · `ttl-policy` · `status-map` · `converge` · `agent-select` · `context-prep` · `auto-pilot` · `morning-briefing` · `pulse` · `quiesce`
+- Protocols: `protocols/` · `sentinel/detection_rules.md` · `protocols/delegation/` · `docs/framework-consumption.md` · The Forge `agents/forge.md` (33Q)
+- Sibling concierges (cross-vendor pattern): `specdd-concierge` · `vek-concierge` (Vek layer) · `atlassian-concierge`
+
+## Changelog
+- 2026-05-28 — v1.0.0 — Bootstrap. Concierge/onboarding/guide/router/governance-anchor over the whole MAOS framework. 6 modes (explain/onboard/guide/audit/anchor/dashboard) + Landscape Decision Matrix + governance layer + AWARENESS-REGISTRY + CANON + self-executed 33Q + ASCII/HTML dashboard. Vendor-neutral (MIT, layer-pure — no corporate content). Anti-over-engineering: orients over existing tools, reimplements NOTHING. Origin: operator /enhance 2026-05-28 (concierge family — sibling of atlassian-concierge/specdd-concierge).

--- a/skills/maos-concierge/dashboard.html
+++ b/skills/maos-concierge/dashboard.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>MAOS Concierge — Onboarding Dashboard</title>
+<!--
+  Static, self-contained onboarding/playbook companion for the maos-concierge skill (--mode=dashboard).
+  Vendor-neutral (MIT). No external deps, no build step, no network calls. Open directly in a browser.
+  The ASCII dashboard in the skill is the default; this HTML is the optional richer view.
+  Counts reflect MAOS v1.5.2 (2026-05-28) — re-derive via `--mode=audit` for the live state.
+-->
+<style>
+  :root{--bg:#0d1117;--panel:#161b22;--border:#30363d;--fg:#e6edf3;--muted:#8b949e;--accent:#58a6ff;--ok:#3fb950;--warn:#d29922;--pink:#f778ba}
+  *{box-sizing:border-box}
+  body{margin:0;font:14px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Helvetica,Arial,sans-serif;background:var(--bg);color:var(--fg)}
+  header{padding:24px 28px;border-bottom:1px solid var(--border);background:linear-gradient(180deg,#161b22,#0d1117)}
+  header h1{margin:0 0 4px;font-size:20px}
+  header p{margin:0;color:var(--muted)}
+  .badge{display:inline-block;font-size:11px;padding:2px 8px;border:1px solid var(--border);border-radius:10px;color:var(--muted);margin-left:6px}
+  main{max-width:1100px;margin:0 auto;padding:24px 28px;display:grid;gap:20px}
+  .grid{display:grid;gap:16px;grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:10px;padding:16px}
+  .card h2{margin:0 0 10px;font-size:14px;color:var(--accent);text-transform:uppercase;letter-spacing:.5px}
+  .card h3{margin:14px 0 6px;font-size:13px;color:var(--pink)}
+  ul{margin:6px 0;padding-left:18px}
+  li{margin:3px 0}
+  code{background:#21262d;border:1px solid var(--border);border-radius:4px;padding:1px 5px;font:12px ui-monospace,SFMono-Regular,Menlo,monospace;color:#79c0ff}
+  table{border-collapse:collapse;width:100%;font-size:13px}
+  th,td{text-align:left;padding:6px 8px;border-bottom:1px solid var(--border);vertical-align:top}
+  th{color:var(--muted);font-weight:600}
+  .step{counter-increment:step;position:relative;padding-left:30px;margin:8px 0}
+  .step::before{content:counter(step);position:absolute;left:0;top:-1px;width:20px;height:20px;border-radius:50%;background:var(--accent);color:#0d1117;font-size:12px;font-weight:700;display:grid;place-items:center}
+  ol.steps{counter-reset:step;list-style:none;padding:0}
+  .pill{font-size:11px;padding:1px 7px;border-radius:8px;border:1px solid}
+  .pill.ok{color:var(--ok);border-color:var(--ok)} .pill.warn{color:var(--warn);border-color:var(--warn)} .pill.law{color:var(--pink);border-color:var(--pink)}
+  footer{color:var(--muted);font-size:12px;padding:16px 28px;border-top:1px solid var(--border);text-align:center}
+  a{color:var(--accent)}
+</style>
+</head>
+<body>
+<header>
+  <h1>🛰️ MAOS Concierge — Onboarding Dashboard <span class="badge">v1.0.0</span><span class="badge">MAOS v1.5.2</span><span class="badge">MIT · vendor-neutral</span></h1>
+  <p>Your map to the Multi-Agent OS. This is the optional HTML companion to <code>maos-concierge --mode=dashboard</code>. It orients — it never runs the tools.</p>
+</header>
+<main>
+
+  <section class="card">
+    <h2>Your first orchestration — the 5-step walkthrough</h2>
+    <ol class="steps">
+      <li class="step"><b>Isolate</b> — create a git worktree (<code>.worktrees/{agent}-{feature}/</code>). Never edit on shared <code>main</code>. <span class="pill law">Anti-Conflict v3.2</span></li>
+      <li class="step"><b>Delegate</b> — decompose the goal &amp; spawn sub-agents via the <code>orchestrator</code> / <code>/delegate</code> with a 10-item brief. <span class="pill ok">agentic-delegation</span></li>
+      <li class="step"><b>Observe</b> — the <code>sentinel-monitor</code> watches traces; HIGH anomalies (loops/depth) auto-block. <span class="pill law">Sentinel</span></li>
+      <li class="step"><b>Converge</b> — merge each subtask branch to its <b>parent</b>, never straight to <code>main</code>. <span class="pill law">Hierarchical-Merge</span></li>
+      <li class="step"><b>Show</b> — render a human-readable <code>status-map</code> / <code>/status</code>. <span class="pill ok">Human observability</span></li>
+    </ol>
+  </section>
+
+  <section class="grid">
+    <div class="card">
+      <h2>Tier ladder</h2>
+      <ul>
+        <li><b>T0 Orchestration</b> — orchestrator · /delegate · auto-pilot</li>
+        <li><b>T1 Creation</b> — The Forge (33Q · RBAD · Goldilocks)</li>
+        <li><b>T2 Safety</b> — Anti-Conflict · Hierarchical-Merge · Worktree · TTL</li>
+        <li><b>T3 Observability</b> — Sentinel · Status Maps</li>
+        <li><b>T4 Delegation gov</b> — GaaS/GaaC (init/dna/finalize)</li>
+        <li><b>T5 Advisory</b> — founder-playbook · MVV</li>
+        <li><b>T6 External</b> — maos-mcp-hub (6 Atlassian gateways)</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2>Day-1 protocols you MUST respect</h2>
+      <ul>
+        <li><span class="pill law">law</span> Worktree-first — no direct edits on <code>main</code></li>
+        <li><span class="pill law">law</span> Merge to <b>parent</b>, not <code>main</code> (except <code>bugfix/ hotfix/ emergency/</code>)</li>
+        <li><span class="pill law">law</span> Don't suppress a HIGH Sentinel auto-block</li>
+        <li><span class="pill warn">warn</span> Reference protocols — don't copy them</li>
+        <li><span class="pill warn">warn</span> Frontmatter + ISO-8601 + validation gate before commit</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2>The 6 concierge modes</h2>
+      <ul>
+        <li><code>explain</code> — teach the framework (default)</li>
+        <li><code>onboard</code> — guided newcomer ramp</li>
+        <li><code>guide</code> — intent → tool + runbook</li>
+        <li><code>audit</code> — read-only compliance check</li>
+        <li><code>anchor</code> — surface canonical decisions, flag drift</li>
+        <li><code>dashboard</code> — this map (ASCII default + HTML)</li>
+      </ul>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Landscape — which tool for which intent</h2>
+    <table>
+      <tr><th>Intent</th><th>Reach for</th><th>Governing protocol</th></tr>
+      <tr><td>Coordinate multi-agent work</td><td><code>orchestrator</code> · <code>auto-pilot</code></td><td>GaaS/GaaC + Anti-Conflict</td></tr>
+      <tr><td>Prevent file collisions</td><td><code>anti-conflict</code> + worktrees</td><td>Anti-Conflict v3.2</td></tr>
+      <tr><td>Create a new agent</td><td><code>forge</code></td><td>33Q · RBAD · Goldilocks</td></tr>
+      <tr><td>Merge branches safely</td><td><code>hierarchical-merge</code></td><td>merge-to-parent</td></tr>
+      <tr><td>Detect anomalies</td><td><code>audit</code> · <code>sentinel-monitor</code></td><td>Sentinel (10 rules)</td></tr>
+      <tr><td>Status for humans</td><td><code>status-map</code> · <code>/status</code></td><td>Status Maps (9 templates)</td></tr>
+      <tr><td>Pick best sub-agent</td><td><code>agent-select</code></td><td>RBAD taxonomy</td></tr>
+      <tr><td>Converge proposals</td><td><code>converge</code></td><td>5-act audit-not-persuasion</td></tr>
+      <tr><td>Reach Atlassian</td><td><code>maos-mcp-hub</code></td><td>6 typed gateways</td></tr>
+    </table>
+  </section>
+
+  <section class="grid">
+    <div class="card">
+      <h2>Catalog (v1.5.2)</h2>
+      <ul>
+        <li>~18 agents — orchestrator · forge · sentinel-monitor · qa-validator · consolidator · …</li>
+        <li>~31 skills — see <code>AWARENESS-REGISTRY.md</code></li>
+        <li>~14 commands — /sync /audit /status /worktree /delegate · …</li>
+        <li>Protocols — Sentinel · Anti-Conflict · Hierarchical-Merge · TTL · Worktree · GaaS/GaaC</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2>What to SKIP (anti-bloat)</h2>
+      <ul>
+        <li>No <code>auto-pilot</code> for a single trivial edit</li>
+        <li>No new agent when one already covers the scope (Forge Q4)</li>
+        <li>No Sentinel wiring for a one-shot solo task</li>
+        <li>No protocol copy-paste into consumer repos</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h2>Vocabulary</h2>
+      <ul>
+        <li><b>GaaS/GaaC</b> — Governance as a Service / as Code</li>
+        <li><b>RBAD</b> — 6-category resource taxonomy</li>
+        <li><b>Goldilocks</b> — atomic ∧ generic</li>
+        <li><b>Reference, don't duplicate</b> — framework is SSOT</li>
+      </ul>
+    </div>
+  </section>
+
+</main>
+<footer>
+  maos-concierge · onboarding dashboard · re-derive live state with <code>--mode=audit</code> · canonical rules in <code>CANON.md</code> · landscape in <code>AWARENESS-REGISTRY.md</code>
+</footer>
+</body>
+</html>

--- a/skills/maos-concierge/references/socratic-33q.md
+++ b/skills/maos-concierge/references/socratic-33q.md
@@ -1,0 +1,61 @@
+# The Forge — 33 Socratic Questions (self-executed) → `maos-concierge` spec
+
+> Per `agents/forge.md`: *"Execute internally BEFORE creating any agent. The answers form the spec."*
+> Self-executed 2026-05-28 for **maos-concierge**. The answers below ARE the design contract that
+> `SKILL.md` implements. Vendor-neutral (MIT). Mirrors the format of sibling concierges'
+> `references/socratic-round-2.md`.
+
+## Scope (1-7)
+
+1. **Atomic domain?** — `MAOS` (the Multi-Agent OS framework itself: its agents, skills, commands, protocols, governances).
+2. **Tasks WITHIN scope?** — Teach/explain the framework · onboard a newcomer (human or fresh-amnesic agent) · route an intent → the right native tool + invocation + governing protocol · provide playbooks/runbooks/walkthroughs · audit a project's MAOS compliance (read-only) · anchor canonical decisions + flag drift · render an onboarding dashboard (ASCII/HTML).
+3. **Tasks OUT OF scope?** — Running the orchestration itself · executing the Sentinel trace analysis · forging a new agent · reimplementing/wrapping any tool · deploying/merging code · any Vek/corporate-specific onboarding (that's vek-concierge) · the SpecDD stack (specdd-concierge) · the Atlassian estate ops (atlassian-concierge).
+4. **Does another agent already cover part of this scope?** — Partial: `skill-writer` authors skills, `forge` creates agents, `governance-auditor` audits standards, `morning-briefing`/`pulse` do session orientation. NONE provides a single onboarding/guide/anchor *entry-point over the whole MAOS framework* — that gap is the reason this concierge exists. It ROUTES to those tools, never duplicates them.
+5. **Future tasks in the same domain?** — Yes: as MAOS adds agents/skills/protocols, the concierge orients over them too (registry-driven, re-derived by `--mode=audit`). Reusable across any MAOS-enabled repo.
+6. **Typical input?** — An intent in natural language ("I'm new", "which tool for X", "is Y allowed", "audit us", "what's the canonical rule for Z") + optional `--mode=` flag + a repo context.
+7. **Typical output?** — Orientation: chosen tool/protocol + exact invocation + governing rule + short runbook; OR an ordered onboarding checklist; OR a read-only audit (evidence+criterion+alternative); OR a surfaced canonical decision + drift flag; OR an ASCII/HTML dashboard.
+
+## Capabilities (8-14)
+
+8. **Essential technical knowledge?** — MAOS structure (agents/skills/commands/protocols/sentinel/statusmap/mcp-tools), git worktrees, Markdown/SKILL.md conventions, ASCII status-map rendering, basic HTML for the dashboard companion.
+9. **Domain knowledge?** — The MAOS protocol set (Sentinel, Anti-Conflict, Hierarchical-Merge, TTL, Worktree, GaaS/GaaC), The Forge (33Q/RBAD/Goldilocks), framework-consumption "reference-don't-duplicate", human-observability value.
+10. **Claude Code tools needed?** — `Read`, `Glob`, `Grep` (capability detection + audit), `Bash` (`git worktree list`, `ls`), `WebFetch` (docs). NO `Write`/`Edit` needed for its core job (it orients; it does not mutate) — write is only for emitting the dashboard companion on request.
+11. **External sources to consult?** — The repo's own `docs/`, `AGENTS.md`, `README.md`, `protocols/`; Context7/`find-docs` for upstream library docs when a guide needs them.
+12. **Patterns/conventions to follow?** — The concierge family template (Identity/DNA/Phase-0/Decision-Matrix/Modes/Governance/DoR/DoD/KPIs/Cross-refs); kebab-case; vendor-neutral MIT (layer purity — NO corporate content); ISO-8601 dates.
+13. **Warm-start context?** — `AWARENESS-REGISTRY.md` (landscape) + `CANON.md` (canonical decisions) + Phase-0 capability detection of the current repo.
+14. **Autonomy level?** — **Consultative** for explain/onboard/guide/dashboard (orients, caller executes); **read-only** for audit/anchor (proposes, never mutates). Never autonomous over orchestration/creation/merge.
+
+## Limits (15-21)
+
+15. **NEVER do?** — Reimplement/wrap a tool · run orchestration/Sentinel/Forge itself · mutate files in audit/anchor · contradict CANON · fabricate availability · carry corporate/Vek content · authorize irreversible ops.
+16. **ESCALATE to user when?** — Irreversible ops, secrets, cross-org actions, or any decision in the human domain surface during orientation.
+17. **DELEGATE to another tool when?** — Creation → `forge`; orchestration → `orchestrator`/`auto-pilot`; trace analysis → `audit`/`sentinel-monitor`; deep convergence → `converge`; Vek/SpecDD/Atlassian onboarding → the sibling concierges.
+18. **No-touch zones (NTZ)?** — All project source, `sentinel/` runtime traces, `protocols/` bodies (reference, never edit from here), other skills' files. The concierge only writes within its own skill dir (the dashboard companion).
+19. **Risks of poor calibration?** — Mis-routing a newcomer (rework), teaching a stale tool (drift), or—worst—advising a protocol-violating shortcut (Anti-Conflict/Hierarchical-Merge breach). Mitigated by Phase-0 verification + CANON anchoring + audit evidence discipline.
+20. **Revert actions?** — Trivial: the concierge mutates nothing except an on-request static `dashboard.html` (delete to revert). Orientation is advice — no state to revert.
+21. **Fallbacks if it fails?** — Degrade to docs-only orientation (`docs/`, `AGENTS.md`); point the user to `/sync` + `agents/forge.md` directly; flag the gap.
+
+## Interfaces (22-26)
+
+22. **Interacts with which agents?** — Upstream: the human/orchestrator invoking it. Downstream (routes to): `orchestrator`, `forge`, `audit`, `sentinel-monitor`, `agentic-delegation`, `delegate-governance`, `anti-conflict`, `hierarchical-merge`, `status-map`, `converge`, `agent-select`.
+23. **Communication format?** — Markdown (human) + structured tables; ASCII for dashboard; mode-flagged invocation.
+24. **Receives tasks how?** — Skill invocation with optional `--mode=` + NL intent.
+25. **Reports results how?** — Mode-specific: orientation block · onboarding checklist · audit findings table · anchor decision+contradiction+pointer · ASCII/HTML dashboard.
+26. **Integrates with ecosystem how?** — Sits ABOVE the MAOS tool catalog as the orientation/onboarding entry-point; cross-refs (never duplicates) the registry; sibling of the other concierges (cross-vendor concierge family pattern).
+
+## Governance (27-30)
+
+27. **Who can invoke?** — Any human or agent in a MAOS-enabled context (public/community — MIT).
+28. **Documents decisions how?** — `--mode=audit`/`anchor` outputs carry evidence + criterion + alternative; canonical decisions live in `CANON.md`; changelog in `SKILL.md`.
+29. **Success metrics (KPIs)?** — 0 reimplemented tools · 0 duplicated protocols · 100% audit findings with evidence+criterion+alternative · drift flagged not silently passed · onboarding ramp reduced (told what to SKIP) · graceful-degrade on missing surface.
+30. **Updates/evolves how?** — Registry-driven: `--mode=audit` re-derives the catalog from `ls` and flags drift vs `AWARENESS-REGISTRY.md`; CANON entries sunset via DUED (qualitative) when superseded by newer dated decisions.
+
+## Validation (31-33)
+
+31. **Functional test?** — Dogfood cycle-1: run `--mode=explain` + `--mode=audit` against multi-agent-os itself; verify it enumerates the real catalog, cites real protocols, and flags any real drift without mutating anything.
+32. **Edge cases?** — Repo with MAOS partially installed (Phase-0 degrades + diagnoses) · greenfield with zero MAOS adoption (`audit` emits bootstrap guidance, not failure) · stale registry counts (audit re-derives) · absent `maos-mcp-hub` (note it, don't fabricate).
+33. **Value vs cost (ROI)?** — Value: collapses newcomer ramp + prevents protocol-violating shortcuts + re-anchors drifting agents, all over an existing toolset (zero new machinery). Cost: ~1 skill + 3 companion docs + 1 optional static HTML, reimplementing nothing. Net positive — orientation is the gap, not access.
+
+---
+
+> **Spec → SKILL mapping**: Q2/Q3 → modes + What-I-do-NOT-do · Q4 → Identity (why it exists) · Q8-Q13 → Phase-0 + companions · Q14 → mode autonomy · Q15-Q21 → governance layer + limits · Q22-Q26 → Landscape Decision Matrix + Cross-refs · Q27-Q30 → Governance layer + KPIs · Q31-Q33 → DoD + dogfooding_validation.


### PR DESCRIPTION
## [PR-as-Enhancement-Prompt] maos-concierge skill

### Context
The concierge family (`specdd-concierge`, `atlassian-concierge`) gives newcomers + fresh-amnesic agents a single onboarding/guide/anchor entry-point over a domain. MAOS itself (the framework) had no such entry-point — newcomers must discover ~18 agents / ~31 skills / ~14 commands / a dozen protocols on their own, and drifting agents re-derive (or contradict) the canonical rules. This PR adds `maos-concierge` to close that gap, vendor-neutral and layer-pure (MIT — no corporate content).

### Objectives
- One entry-point to **learn / onboard / route / audit / anchor** the whole MAOS framework.
- ROUTE + TEACH + ANCHOR over existing tools — **reimplement nothing**, wrap nothing, forge no agent (route TO The Forge).

### What changed
- **NEW** `skills/maos-concierge/`:
  - `SKILL.md` — router/index, **6 modes**: `explain` · `onboard` · `guide` · `audit` · `anchor` · `dashboard`.
  - `AWARENESS-REGISTRY.md` — full tool+governance landscape (the payload).
  - `CANON.md` — canonical MAOS decisions (anchor-mode SSOT + drift flags).
  - `references/socratic-33q.md` — **The Forge 33 Socratic Questions self-executed** (the spec).
  - `dashboard.html` — optional self-contained HTML onboarding companion (`--mode=dashboard`).
- `.claude-plugin/plugin.json` 1.5.2 → **1.6.0** (MINOR — additive skill).
- `CHANGELOG.md` updated.

### Acceptance criteria
- [x] `tests/validate-plugin.sh` PASSED (0 errors).
- [x] gitleaks clean (GaaS pre-commit + manual).
- [x] Vendor-neutral / layer-pure (no private-org/corporate content, no operator PII).
- [x] Anti-over-engineering: orients only; reimplements/wraps/forges nothing; read-only audit/anchor.
- [x] Frontmatter valid; ISO-8601 dates.

### Test plan
- `maos-concierge --mode=explain` enumerates the real catalog; `--mode=audit` re-derives from `ls` and flags drift without mutating (dogfood cycle-1 post-merge).

### Cross-links
- Sibling concierges: `specdd-concierge` · a private corporate concierge skill (private-org layer, sibling PR) · `atlassian-concierge`.
- Origin: operator `/enhance` 2026-05-28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

