### PR TITLE
feat(dogfood-ledger): canonical dogfood-cycle counter (Phase 1 — primitive)

### DIFF
--- a/bin/dogfood-mark
+++ b/bin/dogfood-mark
@@ -172,7 +172,7 @@ while ! mkdir "$LOCK_DIR" 2>/dev/null; do
       continue
     fi
   fi
-  i=$((i + 1)); [ "$i" -ge 50 ] && { echo "could not acquire ledger lock (held >5s; if a process was SIGKILLed mid-write, remove $LOCK_DIR)" >&2; exit 2; }
+  i=$((i + 1)); [ "$i" -ge 50 ] && { printf 'could not acquire ledger lock (held >5s; if a process was SIGKILLed mid-write, remove %s)\n' "$LOCK_DIR" >&2; exit 2; }
   sleep 0.1
 done
 trap 'rm -f "$LOCK_DIR/ts" 2>/dev/null; rmdir "$LOCK_DIR" 2>/dev/null || true' INT TERM EXIT

--- a/bin/dogfood-mark
+++ b/bin/dogfood-mark
@@ -57,17 +57,21 @@ TOOL=""; CYCLE=""; STATUS="in-progress"; RATIFIED="false"
 SID="${CLAUDE_CODE_SESSION_ID:-}"; PROJECT=""; VENDOR=""; NOTE=""; DRYRUN=0
 EVID_RAW=""
 
+# Guard a value-taking flag: ensure a value follows before `shift 2` (else set -e would
+# abort on a short `shift` without a clear usage error). Call as: need_val --flag "$#".
+need_val() { [ "$2" -ge 2 ] || { echo "$1 requires a value" >&2; exit 1; }; }
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --help|-h) usage ;;
-    --status) STATUS="${2:-}"; shift 2 ;;
+    --status) need_val --status "$#"; STATUS="$2"; shift 2 ;;
     --ratified) RATIFIED="true"; shift ;;
-    --evidence) EVID_RAW="${EVID_RAW}${2:-}
+    --evidence) need_val --evidence "$#"; EVID_RAW="${EVID_RAW}$2
 "; shift 2 ;;
-    --session) SID="${2:-}"; shift 2 ;;
-    --project) PROJECT="${2:-}"; shift 2 ;;
-    --vendor) VENDOR="${2:-}"; shift 2 ;;
-    --note) NOTE="${2:-}"; shift 2 ;;
+    --session) need_val --session "$#"; SID="$2"; shift 2 ;;
+    --project) need_val --project "$#"; PROJECT="$2"; shift 2 ;;
+    --vendor) need_val --vendor "$#"; VENDOR="$2"; shift 2 ;;
+    --note) need_val --note "$#"; NOTE="$2"; shift 2 ;;
     --dry-run) DRYRUN=1; shift ;;
     -*) echo "Unknown option: $1" >&2; exit 1 ;;
     *)
@@ -154,15 +158,21 @@ LOCK_DIR="$LEDGER_DIR/.lock-dogfood"
 STALE_SECS=30
 i=0
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+  # Stale-lock reclaim: a writer killed by an uncatchable SIGKILL leaves the lock behind.
+  # Read its epoch marker (numeric-guarded against empty/corrupt); if older than STALE_SECS,
+  # reclaim ATOMICALLY via `mv` — rename is POSIX-atomic, so only ONE concurrent process wins
+  # the rename (the losers get ENOENT), eliminating the check-then-remove TOCTOU. The winner
+  # discards the moved dir; everyone re-races mkdir so exactly one holder remains.
   if [ -f "$LOCK_DIR/ts" ]; then
-    age=$(( $(date +%s 2>/dev/null || echo 0) - $(cat "$LOCK_DIR/ts" 2>/dev/null || echo 0) ))
-    if [ "$age" -gt "$STALE_SECS" ]; then
-      rm -f "$LOCK_DIR/ts" 2>/dev/null || true
-      rmdir "$LOCK_DIR" 2>/dev/null || true
+    lock_ts=$(cat "$LOCK_DIR/ts" 2>/dev/null || echo 0); case "$lock_ts" in ''|*[!0-9]*) lock_ts=0 ;; esac
+    now=$(date +%s 2>/dev/null || echo 0);              case "$now"     in ''|*[!0-9]*) now=0 ;; esac
+    if [ "$((now - lock_ts))" -gt "$STALE_SECS" ]; then
+      dead="$LOCK_DIR.stale.$$"
+      if mv "$LOCK_DIR" "$dead" 2>/dev/null; then rm -rf "$dead" 2>/dev/null || true; fi
       continue
     fi
   fi
-  i=$((i + 1)); [ "$i" -ge 50 ] && { echo "could not acquire ledger lock (held >5s)" >&2; exit 2; }
+  i=$((i + 1)); [ "$i" -ge 50 ] && { echo "could not acquire ledger lock (held >5s; if a process was SIGKILLed mid-write, remove $LOCK_DIR)" >&2; exit 2; }
   sleep 0.1
 done
 trap 'rm -f "$LOCK_DIR/ts" 2>/dev/null; rmdir "$LOCK_DIR" 2>/dev/null || true' INT TERM EXIT

--- a/bin/dogfood-mark
+++ b/bin/dogfood-mark
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# MAOS — Dogfood-Cycle Ledger · mark (capture / writer)
+# Function: append ONE dogfood-cycle event to the user-scope canonical ledger
+#   ${DOGFOOD_LEDGER_DIR:-~/.claude/audit}/dogfood-cycles.jsonl — making the
+#   dogfooding-mandate "≥2 real cycles before promotion" gate STRUCTURED and
+#   jq-countable (via `dogfood-tally`) instead of fragmented changelog prose.
+# Anti-theater: a `complete` cycle REQUIRES --ratified AND >=1 --evidence (no
+#   evidence => refuse). `abandoned` never counts toward the gate.
+# Idempotent: an identical event (tool,cycle_id,status,ratified) is a no-op.
+#   Status transitions (in-progress -> complete) append a NEW event; `dogfood-tally`
+#   reduces by (tool,cycle_id) to the latest-by-ts status (append-only history).
+# Portability: AAIF cross-vendor — POSIX Bash 3.2 + jq only; no associative arrays,
+#   no ${var^^}; atomic append via mkdir-lock (POSIX). Claude Code / Cursor /
+#   Copilot / Codex / Gemini.
+# No organization-specific content — promotion-eligible per Layer Purity.
+# Exit codes ([C06]): 0 success (incl. idempotent no-op) · 1 usage/validation · 2 setup.
+set -euo pipefail
+
+LEDGER_DIR="${DOGFOOD_LEDGER_DIR:-$HOME/.claude/audit}"
+LEDGER="$LEDGER_DIR/dogfood-cycles.jsonl"
+
+usage() {
+  cat <<EOF
+MAOS dogfood-cycle mark — record ONE dogfood-cycle event for the >=2-cycle gate.
+
+Usage:
+  $(basename "$0") <tool> <cycle_id> [options]
+
+Required positionals:
+  <tool>       agentic-tool slug, e.g. debate-converge   ([A-Za-z0-9._-])
+  <cycle_id>   cycle id within that tool, e.g. 001        ([A-Za-z0-9._-])
+
+Options:
+  --status VAL       complete | in-progress | abandoned   (default: in-progress)
+  --ratified         mark the cycle as ratified (REQUIRED for --status complete)
+  --evidence REF     evidence the cycle is real (repeatable; REQUIRED for complete),
+                     e.g. github:ekson73/multi-agent-os/pull/97 · session:<sid> · path:...
+  --session SID      session id   (default: \$CLAUDE_CODE_SESSION_ID)
+  --project NAME     project slug (default: basename of git toplevel / PWD)
+  --vendor NAME      ai-vendor    (default: auto-detect; else "unknown")
+  --note "<text>"    short note (<=240 chars)
+  --dry-run          print the event JSON, do NOT append
+  --help
+
+Examples:
+  $(basename "$0") debate-converge 001 --status in-progress \\
+    --evidence session:da7015 --note "language-cascade run, round 3 pending"
+  $(basename "$0") debate-converge 001 --status complete --ratified \\
+    --evidence github:ekson73/multi-agent-os/pull/97 --evidence session:da7015
+EOF
+  exit 0
+}
+
+[ $# -eq 0 ] && usage
+
+TOOL=""; CYCLE=""; STATUS="in-progress"; RATIFIED="false"
+SID="${CLAUDE_CODE_SESSION_ID:-}"; PROJECT=""; VENDOR=""; NOTE=""; DRYRUN=0
+EVID_RAW=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h) usage ;;
+    --status) STATUS="${2:-}"; shift 2 ;;
+    --ratified) RATIFIED="true"; shift ;;
+    --evidence) EVID_RAW="${EVID_RAW}${2:-}
+"; shift 2 ;;
+    --session) SID="${2:-}"; shift 2 ;;
+    --project) PROJECT="${2:-}"; shift 2 ;;
+    --vendor) VENDOR="${2:-}"; shift 2 ;;
+    --note) NOTE="${2:-}"; shift 2 ;;
+    --dry-run) DRYRUN=1; shift ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *)
+      if [ -z "$TOOL" ]; then TOOL="$1"
+      elif [ -z "$CYCLE" ]; then CYCLE="$1"
+      else echo "Unexpected arg: $1" >&2; exit 1
+      fi
+      shift ;;
+  esac
+done
+
+[ -n "$TOOL" ]  || { echo "<tool> is required" >&2; exit 1; }
+[ -n "$CYCLE" ] || { echo "<cycle_id> is required" >&2; exit 1; }
+case "$TOOL"   in *[!a-zA-Z0-9._-]*) echo "Invalid <tool>: $TOOL" >&2; exit 1 ;; esac
+case "$CYCLE"  in *[!a-zA-Z0-9._-]*) echo "Invalid <cycle_id>: $CYCLE" >&2; exit 1 ;; esac
+case "$STATUS" in complete|in-progress|abandoned) ;; *) echo "--status must be complete|in-progress|abandoned" >&2; exit 1 ;; esac
+if [ -n "$SID" ]; then case "$SID" in *[!a-zA-Z0-9-]*) echo "Invalid --session: $SID" >&2; exit 1 ;; esac; fi
+
+# Build evidence[] (drop blank lines).
+EVID_JSON=$(printf '%s' "$EVID_RAW" | jq -R -s 'split("\n") | map(select(length>0))')
+EVID_N=$(printf '%s' "$EVID_JSON" | jq 'length')
+
+# Anti-theater gate: complete REQUIRES ratified + >=1 evidence.
+if [ "$STATUS" = "complete" ]; then
+  [ "$RATIFIED" = "true" ] || { echo "refuse: --status complete requires --ratified (anti-theater)" >&2; exit 1; }
+  [ "$EVID_N" -ge 1 ]      || { echo "refuse: --status complete requires >=1 --evidence (anti-theater)" >&2; exit 1; }
+fi
+
+# Defaults: project + vendor.
+[ -n "$PROJECT" ] || PROJECT=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")")
+if [ -z "$VENDOR" ]; then
+  if   [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] || [ -n "${CLAUDECODE:-}" ]; then VENDOR="claude-code"
+  elif [ -n "${CURSOR_SESSION_ID:-}" ]     || [ -n "${CURSOR:-}" ];      then VENDOR="cursor"
+  elif [ -n "${GITHUB_COPILOT_SESSION:-}" ];                            then VENDOR="copilot"
+  else VENDOR="unknown"; fi
+fi
+
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+EVENT=$(jq -nc \
+  --arg tool "$TOOL" --arg cycle "$CYCLE" --arg status "$STATUS" \
+  --argjson ratified "$RATIFIED" --argjson evidence "$EVID_JSON" \
+  --arg session "$SID" --arg project "$PROJECT" --arg vendor "$VENDOR" \
+  --arg note "$NOTE" --arg ts "$TS" \
+  '{
+     tool:$tool, cycle_id:$cycle, status:$status, ratified:$ratified,
+     evidence:$evidence,
+     session:(if $session=="" then null else $session end),
+     project:$project, vendor:$vendor,
+     note:(if $note=="" then null else ($note[0:240]) end), ts:$ts
+   } | with_entries(select(.value != null))')
+
+if [ "$DRYRUN" = "1" ]; then
+  printf '%s\n' "$EVENT"
+  exit 0
+fi
+
+mkdir -p "$LEDGER_DIR"
+touch "$LEDGER"
+
+# Idempotency: skip if an identical (tool,cycle_id,status,ratified) event already present.
+if jq -se --arg t "$TOOL" --arg c "$CYCLE" --arg s "$STATUS" --argjson r "$RATIFIED" \
+     'any(.[]; .tool==$t and .cycle_id==$c and .status==$s and .ratified==$r)' \
+     "$LEDGER" 2>/dev/null | grep -q '^true$'; then
+  printf 'dogfood-mark: no-op (idempotent) — %s/%s already %s\n' "$TOOL" "$CYCLE" "$STATUS" >&2
+  exit 0
+fi
+
+# Atomic append under mkdir-lock (POSIX-atomic).
+LOCK_DIR="$LEDGER_DIR/.lock-dogfood"
+i=0
+while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+  i=$((i + 1)); [ "$i" -ge 50 ] && { echo "could not acquire ledger lock" >&2; exit 2; }
+  sleep 0.1
+done
+trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+printf '%s\n' "$EVENT" >> "$LEDGER"
+
+RAT_TAG=""; [ "$RATIFIED" = "true" ] && RAT_TAG=" ratified"
+printf 'dogfood-mark: %s/%s -> %s%s (ledger: %s)\n' "$TOOL" "$CYCLE" "$STATUS" "$RAT_TAG" "${LEDGER/#$HOME/~}" >&2

--- a/bin/dogfood-mark
+++ b/bin/dogfood-mark
@@ -105,7 +105,8 @@ if [ -z "$VENDOR" ]; then
   else VENDOR="unknown"; fi
 fi
 
-TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || { echo "dogfood-mark: failed to generate timestamp (date error)" >&2; exit 2; }
+[ -n "$TS" ] || { echo "dogfood-mark: empty timestamp from date" >&2; exit 2; }
 
 EVENT=$(jq -nc \
   --arg tool "$TOOL" --arg cycle "$CYCLE" --arg status "$STATUS" \
@@ -128,22 +129,52 @@ fi
 mkdir -p "$LEDGER_DIR"
 touch "$LEDGER"
 
-# Idempotency: skip if an identical (tool,cycle_id,status,ratified) event already present.
-if jq -se --arg t "$TOOL" --arg c "$CYCLE" --arg s "$STATUS" --argjson r "$RATIFIED" \
-     'any(.[]; .tool==$t and .cycle_id==$c and .status==$s and .ratified==$r)' \
-     "$LEDGER" 2>/dev/null | grep -q '^true$'; then
+# Resilient identity check: tolerate malformed/partial JSONL lines (a truncated trailing
+# line from an interrupted write, a disk error, or a manual edit) by skipping them via
+# `fromjson? // empty`, instead of crashing under set -e. Returns success if an identical
+# (tool,cycle_id,status,ratified) event already exists. Each stage emits a single line, so
+# no SIGPIPE/pipefail race with grep -q.
+already_present() {
+  jq -R 'fromjson? // empty' "$LEDGER" 2>/dev/null \
+    | jq -se --arg t "$TOOL" --arg c "$CYCLE" --arg s "$STATUS" --argjson r "$RATIFIED" \
+        'any(.[]; .tool==$t and .cycle_id==$c and .status==$s and .ratified==$r)' \
+        2>/dev/null | grep -q '^true$'
+}
+
+# Fast no-op path (advisory only — the authoritative check runs inside the lock below).
+if already_present; then
   printf 'dogfood-mark: no-op (idempotent) — %s/%s already %s\n' "$TOOL" "$CYCLE" "$STATUS" >&2
   exit 0
 fi
 
-# Atomic append under mkdir-lock (POSIX-atomic).
+# Atomic append under mkdir-lock (POSIX-atomic). The trap releases on catchable signals
+# (INT/TERM/EXIT); the epoch-marker stale-lock reclaim guards against a writer killed by an
+# uncatchable SIGKILL while holding the lock (otherwise future writers would hang then fail).
 LOCK_DIR="$LEDGER_DIR/.lock-dogfood"
+STALE_SECS=30
 i=0
 while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-  i=$((i + 1)); [ "$i" -ge 50 ] && { echo "could not acquire ledger lock" >&2; exit 2; }
+  if [ -f "$LOCK_DIR/ts" ]; then
+    age=$(( $(date +%s 2>/dev/null || echo 0) - $(cat "$LOCK_DIR/ts" 2>/dev/null || echo 0) ))
+    if [ "$age" -gt "$STALE_SECS" ]; then
+      rm -f "$LOCK_DIR/ts" 2>/dev/null || true
+      rmdir "$LOCK_DIR" 2>/dev/null || true
+      continue
+    fi
+  fi
+  i=$((i + 1)); [ "$i" -ge 50 ] && { echo "could not acquire ledger lock (held >5s)" >&2; exit 2; }
   sleep 0.1
 done
-trap 'rmdir "$LOCK_DIR" 2>/dev/null || true' EXIT
+trap 'rm -f "$LOCK_DIR/ts" 2>/dev/null; rmdir "$LOCK_DIR" 2>/dev/null || true' INT TERM EXIT
+date +%s > "$LOCK_DIR/ts" 2>/dev/null || true
+
+# Authoritative idempotency re-check INSIDE the lock — closes the TOCTOU window where two
+# concurrent writers both pass the pre-lock check and both append the same event.
+if already_present; then
+  printf 'dogfood-mark: no-op (idempotent, race-checked) — %s/%s already %s\n' "$TOOL" "$CYCLE" "$STATUS" >&2
+  exit 0
+fi
+
 printf '%s\n' "$EVENT" >> "$LEDGER"
 
 RAT_TAG=""; [ "$RATIFIED" = "true" ] && RAT_TAG=" ratified"

--- a/bin/dogfood-mark
+++ b/bin/dogfood-mark
@@ -57,21 +57,25 @@ TOOL=""; CYCLE=""; STATUS="in-progress"; RATIFIED="false"
 SID="${CLAUDE_CODE_SESSION_ID:-}"; PROJECT=""; VENDOR=""; NOTE=""; DRYRUN=0
 EVID_RAW=""
 
-# Guard a value-taking flag: ensure a value follows before `shift 2` (else set -e would
-# abort on a short `shift` without a clear usage error). Call as: need_val --flag "$#".
-need_val() { [ "$2" -ge 2 ] || { echo "$1 requires a value" >&2; exit 1; }; }
+# Guard a value-taking flag: ensure a real value follows before `shift 2` (else set -e
+# would abort on a short `shift` without a clear usage error, OR a following option could
+# be silently consumed as the value). Call as: need_val --flag "$#" "$2".
+need_val() {
+  [ "$2" -ge 2 ] || { echo "$1 requires a value" >&2; exit 1; }
+  case "$3" in -?*) echo "$1 requires a value (got option '$3')" >&2; exit 1 ;; esac
+}
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --help|-h) usage ;;
-    --status) need_val --status "$#"; STATUS="$2"; shift 2 ;;
+    --status) need_val --status "$#" "${2:-}"; STATUS="$2"; shift 2 ;;
     --ratified) RATIFIED="true"; shift ;;
-    --evidence) need_val --evidence "$#"; EVID_RAW="${EVID_RAW}$2
+    --evidence) need_val --evidence "$#" "${2:-}"; EVID_RAW="${EVID_RAW}$2
 "; shift 2 ;;
-    --session) need_val --session "$#"; SID="$2"; shift 2 ;;
-    --project) need_val --project "$#"; PROJECT="$2"; shift 2 ;;
-    --vendor) need_val --vendor "$#"; VENDOR="$2"; shift 2 ;;
-    --note) need_val --note "$#"; NOTE="$2"; shift 2 ;;
+    --session) need_val --session "$#" "${2:-}"; SID="$2"; shift 2 ;;
+    --project) need_val --project "$#" "${2:-}"; PROJECT="$2"; shift 2 ;;
+    --vendor) need_val --vendor "$#" "${2:-}"; VENDOR="$2"; shift 2 ;;
+    --note) need_val --note "$#" "${2:-}"; NOTE="$2"; shift 2 ;;
     --dry-run) DRYRUN=1; shift ;;
     -*) echo "Unknown option: $1" >&2; exit 1 ;;
     *)

--- a/bin/dogfood-tally
+++ b/bin/dogfood-tally
@@ -31,12 +31,16 @@ EOF
   exit 0
 }
 
+# Guard a value-taking flag before `shift 2` (else set -e aborts on a short shift without a
+# clear usage error). Call as: need_val --flag "$#".
+need_val() { [ "$2" -ge 2 ] || { echo "$1 requires a value" >&2; exit 1; }; }
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --help|-h) usage ;;
     --json) FORMAT="json"; shift ;;
     --table) FORMAT="table"; shift ;;
-    --gate) GATE="${2:-2}"; shift 2 ;;
+    --gate) need_val --gate "$#"; GATE="$2"; shift 2 ;;
     -*) echo "Unknown option: $1" >&2; exit 1 ;;
     *) [ -z "$TOOL" ] && TOOL="$1" || { echo "Unexpected arg: $1" >&2; exit 1; }; shift ;;
   esac

--- a/bin/dogfood-tally
+++ b/bin/dogfood-tally
@@ -50,11 +50,30 @@ if [ ! -f "$LEDGER" ]; then
   exit 2
 fi
 
+# Resilient parse: skip malformed/partial JSONL lines (truncated trailing line from an
+# interrupted write, disk error, or manual edit) via `fromjson? // empty` instead of crashing
+# under set -e. Emit a stderr diagnostic when any line is skipped (auditability).
+TOTAL_LINES=$(grep -c '' "$LEDGER" 2>/dev/null || echo 0)
+VALID=$(jq -R 'fromjson? // empty' "$LEDGER" 2>/dev/null | jq -sc '.' 2>/dev/null) || {
+  echo "dogfood-tally: failed to parse ledger (jq error) — verify ${LEDGER/#$HOME/~}" >&2
+  exit 2
+}
+VALID_N=$(printf '%s' "$VALID" | jq 'length' 2>/dev/null || echo 0)
+if [ "$TOTAL_LINES" -gt 0 ] && [ "$VALID_N" -lt "$TOTAL_LINES" ]; then
+  echo "dogfood-tally: skipped $((TOTAL_LINES - VALID_N)) malformed line(s) in ${LEDGER/#$HOME/~}" >&2
+fi
+
 # Reduce: latest event per (tool,cycle_id) -> group by tool -> count by status.
-REDUCED=$(jq -s '
-  map(select(.tool and .cycle_id and .ts))
-  | group_by(.tool + " " + .cycle_id)
-  | map(max_by(.ts))
+# jq group_by sorts internally, so append-order interleaving is handled correctly. The __idx
+# tie-breaker makes "latest" deterministic when timestamps tie at second-granularity — the
+# later-appended line (chronologically last) wins. Array group-key [.tool,.cycle_id] avoids
+# any string-concat ambiguity.
+REDUCED=$(printf '%s' "$VALID" | jq '
+  to_entries
+  | map(.value + {__idx: .key})
+  | map(select(.tool and .cycle_id and .ts))
+  | group_by([.tool, .cycle_id])
+  | map(max_by([.ts, .__idx]))
   | group_by(.tool)
   | map({
       tool: .[0].tool,
@@ -64,7 +83,7 @@ REDUCED=$(jq -s '
       cycles: (map({cycle_id, status, ratified, evidence:(.evidence // []), ts}))
     })
   | sort_by(.tool)
-' "$LEDGER")
+')
 
 if [ -n "$TOOL" ]; then
   REDUCED=$(printf '%s' "$REDUCED" | jq --arg t "$TOOL" 'map(select(.tool==$t))')

--- a/bin/dogfood-tally
+++ b/bin/dogfood-tally
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# MAOS — Dogfood-Cycle Ledger · tally (report / count) — THE COUNTING AUTHORITY.
+# Reads ${DOGFOOD_LEDGER_DIR:-~/.claude/audit}/dogfood-cycles.jsonl, reduces the
+# append-only event log by (tool,cycle_id) to the latest-by-ts status, and counts
+# COMPLETE (ratified) vs IN-PROGRESS vs ABANDONED per agentic-tool. Gate: a tool is
+# promotion-eligible when COMPLETE >= N (default 2 = dogfooding-mandate; override --gate).
+# REPLACES changelog-prose cycle counting (anti-theater: jq-countable, durable, auditable).
+# Portability: AAIF cross-vendor — POSIX Bash 3.2 + jq only. Read-only (never writes — SRP).
+# No organization-specific content — promotion-eligible per Layer Purity.
+# Exit codes ([C06]): 0 success (incl. empty) · 1 usage · 2 setup (no ledger).
+set -euo pipefail
+
+LEDGER_DIR="${DOGFOOD_LEDGER_DIR:-$HOME/.claude/audit}"
+LEDGER="$LEDGER_DIR/dogfood-cycles.jsonl"
+
+GATE=2; FORMAT="table"; TOOL=""
+usage() {
+  cat <<EOF
+MAOS dogfood-cycle tally — count real dogfood cycles per agentic-tool (the gate authority).
+
+Usage:
+  $(basename "$0") [<tool>] [--json|--table] [--gate N]
+
+Args:
+  <tool>     restrict to one tool slug (optional)
+  --json     machine-readable output (adds .eligible per tool)
+  --table    human table (default)
+  --gate N   promotion threshold (default 2 = dogfooding-mandate >=2)
+  --help
+EOF
+  exit 0
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --help|-h) usage ;;
+    --json) FORMAT="json"; shift ;;
+    --table) FORMAT="table"; shift ;;
+    --gate) GATE="${2:-2}"; shift 2 ;;
+    -*) echo "Unknown option: $1" >&2; exit 1 ;;
+    *) [ -z "$TOOL" ] && TOOL="$1" || { echo "Unexpected arg: $1" >&2; exit 1; }; shift ;;
+  esac
+done
+case "$GATE" in *[!0-9]*|"") echo "--gate must be an integer" >&2; exit 1 ;; esac
+if [ -n "$TOOL" ]; then case "$TOOL" in *[!a-zA-Z0-9._-]*) echo "Invalid <tool>: $TOOL" >&2; exit 1 ;; esac; fi
+
+if [ ! -f "$LEDGER" ]; then
+  echo "No dogfood-cycle ledger yet at ${LEDGER/#$HOME/~} — run dogfood-mark first." >&2
+  [ "$FORMAT" = "json" ] && echo '[]'
+  exit 2
+fi
+
+# Reduce: latest event per (tool,cycle_id) -> group by tool -> count by status.
+REDUCED=$(jq -s '
+  map(select(.tool and .cycle_id and .ts))
+  | group_by(.tool + " " + .cycle_id)
+  | map(max_by(.ts))
+  | group_by(.tool)
+  | map({
+      tool: .[0].tool,
+      complete:    (map(select(.status=="complete" and .ratified==true)) | length),
+      in_progress: (map(select(.status=="in-progress")) | length),
+      abandoned:   (map(select(.status=="abandoned")) | length),
+      cycles: (map({cycle_id, status, ratified, evidence:(.evidence // []), ts}))
+    })
+  | sort_by(.tool)
+' "$LEDGER")
+
+if [ -n "$TOOL" ]; then
+  REDUCED=$(printf '%s' "$REDUCED" | jq --arg t "$TOOL" 'map(select(.tool==$t))')
+fi
+
+if [ "$FORMAT" = "json" ]; then
+  printf '%s' "$REDUCED" | jq --argjson gate "$GATE" 'map(. + {gate:$gate, eligible:(.complete >= $gate)})'
+  exit 0
+fi
+
+TABLE=$(printf '%s' "$REDUCED" | jq -r --argjson gate "$GATE" '
+  if length == 0 then "(no cycles recorded)"
+  else
+    (["TOOL","COMPLETE","IN-PROGRESS","ABANDONED","GATE>=\($gate)"] | @tsv),
+    (.[] | [ .tool,
+             (.complete|tostring), (.in_progress|tostring), (.abandoned|tostring),
+             (if .complete >= $gate then "ELIGIBLE" else "NOT(\(.complete)/\($gate))" end)
+           ] | @tsv)
+  end
+')
+printf '%s\n' "$TABLE" | column -t -s "$(printf '\t')" 2>/dev/null || printf '%s\n' "$TABLE"

--- a/docs/adrs/ADR-005-dogfood-cycle-ledger.md
+++ b/docs/adrs/ADR-005-dogfood-cycle-ledger.md
@@ -1,0 +1,43 @@
+# ADR-005: Canonical Dogfood-Cycle Ledger (structured ≥2-cycle gate, replacing changelog prose)
+
+- **Status**: Accepted
+- **Date**: 2026-05-30
+- **Deciders**: Operator (DevSecOps / AI-eng), via HITL directive ("multi-agent-os primeiro" + "tudo, incl. portabilidade+promoção")
+- **Scope**: MAOS (community, MIT, AAIF cross-vendor). Companion to the dogfooding-mandate / ADR-017 R6 (the gate this ADR makes measurable).
+
+## Context
+
+The dogfooding-mandate requires **≥2 real cycles before promoting** any agentic-tool. That gate is cited across the ecosystem (ADR-017 R6, auto-pilot MASTER-PLAN, GIT-PR-AS-DEBATE-PROMPT, per-skill changelogs) **but the cycle count lives only as changelog prose** — not countable, not auditable, not durable. The operator flagged this directly: *"o cycle-count nem estava funcionando e já tive várias execuções em outras sessões"* — the cycles **already happened**, they were never **counted**. A gate without a measurement mechanism is theater.
+
+Two existing observability systems are nearby but neither counts cycles: **ASH** (per-session walkthrough journal, lives in a product repo) and **Sentinel Protocol** (MAOS metrics/anomaly). A per-skill island ledger (a `DOGFOOD-LEDGER.md` created earlier) would fragment the count (anti-DRY/SSOT).
+
+## Decision
+
+Create a **single canonical dogfood-cycle counting primitive in MAOS** (the canonical agentic-OS, owner of the dogfooding-mandate):
+
+1. **Event** — append-only JSONL `{tool, cycle_id, status, ratified, evidence[], session, project, vendor, note, ts}`.
+2. **Ledger** — user-scope `${DOGFOOD_LEDGER_DIR:-~/.claude/audit}/dogfood-cycles.jsonl` (sees every project/session/vendor — **portability**).
+3. **`bin/dogfood-mark`** (writer) + **`bin/dogfood-tally`** (read-only counting authority) — AAIF bash 3.2, jq-only, Layer-Purity-clean, cloned from ASH `ash-decide`/`ash-decisions` patterns.
+4. **Anti-theater gate** — a cycle counts as COMPLETE only with `ratified==true` + ≥1 `evidence`. Promotion-eligible when `COMPLETE ≥ 2`.
+5. **Backfill** — `--backfill` re-derives **real historical cycles from evidence** (resolving the chicken-and-egg: the gate is met by history, not by waiting, and never by inflation).
+6. **Consumers, not duplicators** — ASH (`--dogfood-cycles`) + Sentinel read this ledger; per-skill island ledgers migrate here.
+
+## Alternatives rejected
+
+- **Per-skill island ledger** (one `DOGFOOD-LEDGER.md` per tool) — fragments the count → re-creates the theater (anti-DRY/SSOT). Migrated into this primitive instead.
+- **Keep changelog-prose counting** — the status quo; unmeasurable (the problem).
+- **Land in the product repo where the session-harness happens to live** — couples a cross-project governance primitive to a single MVP-scoped product repo. Cycle-maturity is canonical governance → belongs in MAOS.
+- **A new database / graph** — over-engineering (YAGNI). Append-only JSONL + 2 small CLIs suffice; graph/inter-relation stays delegated to CPT + `gsd-graphify`.
+
+## Consequences
+
+- **Positive**: the ≥2 gate becomes structured, `jq`-countable, durable, cross-vendor, backfillable; one SSOT kills the fragmentation; amnesic agents can answer "how mature is tool X?" deterministically.
+- **Negative (mitigated)**: the ledger is local-only (LGPD 5y retention = open gap, deferred to a separate ADR — flagged, not over-promised); a new primitive to maintain (kept minimal — 2 CLIs + 1 spec).
+- **Self-application (dogfood)**: this primitive's **own** cycles are tracked in itself; its promotion to a canonical Layer-1 is gated by its own backfilled ≥2 — honest, not asserted.
+
+## References
+
+- Spec: [`docs/dogfood-cycle-ledger-spec.md`](../dogfood-cycle-ledger-spec.md)
+- Gate it measures: dogfooding-mandate / ADR-017 R6
+- Templates reused: ASH `bin/ash-decide` + `bin/ash-decisions` + `ash-stop-fallback.sh`
+- Consumers (planned): ASH `ash-walkthrough --dogfood-cycles` · Sentinel `audit/session_index.json`

--- a/docs/dogfood-cycle-ledger-spec.md
+++ b/docs/dogfood-cycle-ledger-spec.md
@@ -44,7 +44,7 @@ One JSON object per line in the ledger. Fields:
 
 | tool | role | guarantees |
 |---|---|---|
-| **`bin/dogfood-mark <tool> <cycle_id> [--status …] [--ratified] [--evidence …]`** | capture/writer | idempotent (no dup of identical event) · atomic append (mkdir-lock) · **anti-theater**: `complete` REQUIRES `--ratified` + ≥1 `--evidence` else refuse (exit 1) · `--dry-run` · `--backfill` (§6) |
+| **`bin/dogfood-mark <tool> <cycle_id> [--status …] [--ratified] [--evidence …]`** | capture/writer | idempotent (no dup of identical event) · atomic append (mkdir-lock) · **anti-theater**: `complete` REQUIRES `--ratified` + ≥1 `--evidence` else refuse (exit 1) · `--dry-run` · `--backfill` (§6 — **Phase 2, planned; not yet implemented**) |
 | **`bin/dogfood-tally [<tool>] [--json\|--table] [--gate N]`** | report/count — **the counting authority** | read-only (SRP) · reduces latest-per-cycle · renders gate verdict per tool |
 
 Exit codes ([C06]): `0` success · `1` usage/validation · `2` setup.

--- a/docs/dogfood-cycle-ledger-spec.md
+++ b/docs/dogfood-cycle-ledger-spec.md
@@ -1,0 +1,77 @@
+# Dogfood-Cycle Ledger — Spec (canonical SSOT for the ≥2-cycle gate)
+
+> **Status**: Accepted · **Version**: 1.0.0 · **Date**: 2026-05-30 · **Scope**: MAOS (community, MIT, AAIF cross-vendor)
+> **ADR**: [`ADR-005-dogfood-cycle-ledger.md`](./adrs/ADR-005-dogfood-cycle-ledger.md)
+
+## 1. Problem (why this exists)
+
+The **dogfooding-mandate** requires that a new agentic-tool (agent / skill / command / policy) be exercised in **≥2 real cycles before promotion** (project-scope → user-scope → toolkit → multi-agent-os). That gate is referenced everywhere (ADR-017 R6, auto-pilot MASTER-PLAN, GIT-PR-AS-DEBATE-PROMPT, per-skill changelogs) **but the count is recorded only as changelog prose** (`"cycles_completed: N"`, `"Onda N: validou Z"`). Prose is **not countable, not auditable, not durable** — an amnesic agent cannot answer *"how many real cycles does tool X have?"*. A gate with no measurement mechanism is **governance theater**.
+
+This spec defines the single, structured, `jq`-countable **SSOT** for dogfood-cycle counting.
+
+## 2. The event (append-only JSONL)
+
+One JSON object per line in the ledger. Fields:
+
+| field | type | required | meaning |
+|---|---|---|---|
+| `tool` | string (slug `[A-Za-z0-9._-]`) | yes | agentic-tool the cycle belongs to, e.g. `debate-converge` |
+| `cycle_id` | string (slug) | yes | cycle id within that tool, e.g. `001` |
+| `status` | `complete` \| `in-progress` \| `abandoned` | yes | current state of the cycle |
+| `ratified` | bool | yes | the cycle reached a ratified terminal state |
+| `evidence` | string[] | yes (≥1 for `complete`) | real evidence refs — `github:owner/repo/pull/N` · `session:<sid>` · `path:...` · `jira:KEY` |
+| `session` | string | sparse | session id that produced/advanced the cycle |
+| `project` | string | yes | project slug where it ran |
+| `vendor` | string | yes | ai-vendor (`claude-code` \| `cursor` \| `copilot` \| `unknown`) |
+| `note` | string (≤240) | sparse | short human note |
+| `ts` | ISO-8601 UTC | yes | event timestamp |
+
+**Append-only history**: a status transition (`in-progress` → `complete`) is a **new event**, never an in-place edit. The tally reduces by `(tool, cycle_id)` to the **latest-by-`ts`** event — so the cycle's *current* state is the last event, and the full history is preserved for audit.
+
+## 3. Ledger location (portability)
+
+`${DOGFOOD_LEDGER_DIR:-~/.claude/audit}/dogfood-cycles.jsonl` — **user-scope** so it sees cycles from **any project / session / vendor** (a user-scope tool like `debate-converge` runs everywhere). Does NOT touch the sibling `governance_*.jsonl` files. Override via `DOGFOOD_LEDGER_DIR` (tests, CI, multi-tenant).
+
+> **Limitation (honest)**: `~/.claude/audit/` is local-only / not version-controlled → "permanent" is bounded by the machine. LGPD-grade long-term retention (5y) needs an out-of-band sink — **open gap**, deferred to a separate ADR. Do not over-promise durability.
+
+## 4. Count semantics + the gate
+
+- A cycle counts as **COMPLETE** only when its latest event is `status==complete` **and** `ratified==true`. "Rounds happened" ≠ complete; a tool defines its own ratification signal (e.g. `debate-converge` = END-handshake unanimous `RATIFIED`).
+- `abandoned` never counts.
+- **Promotion-eligible** when `COMPLETE ≥ gate` (default `2`; override `--gate N`).
+
+## 5. Tooling (AAIF bash, POSIX 3.2, jq-only, Layer-Purity-clean)
+
+| tool | role | guarantees |
+|---|---|---|
+| **`bin/dogfood-mark <tool> <cycle_id> [--status …] [--ratified] [--evidence …]`** | capture/writer | idempotent (no dup of identical event) · atomic append (mkdir-lock) · **anti-theater**: `complete` REQUIRES `--ratified` + ≥1 `--evidence` else refuse (exit 1) · `--dry-run` · `--backfill` (§6) |
+| **`bin/dogfood-tally [<tool>] [--json\|--table] [--gate N]`** | report/count — **the counting authority** | read-only (SRP) · reduces latest-per-cycle · renders gate verdict per tool |
+
+Exit codes ([C06]): `0` success · `1` usage/validation · `2` setup.
+
+## 6. Backfill (resolves the chicken-and-egg)
+
+Cycles **already happened** across past sessions — they were simply never counted. The `--backfill` mode re-derives them from **real evidence** (ASH journals with `cycles_completed`/`dogfood`; tool changelogs; transcripts; prior per-skill ledgers), one event per detected cycle, each carrying its `evidence` ref. **Anti-hallucination**: no evidence ⇒ not counted. This makes the ≥2 gate satisfiable by **history**, not by waiting on the future — and never by inflation.
+
+> **Status: Phase 2 — `--backfill` automation is NOT yet implemented.** Until it lands, historical cycles are recorded via direct evidence-based `dogfood-mark` calls (each with `--evidence`). The contract above is the design the automated scanner will follow.
+
+## 7. Anti-patterns (do NOT)
+
+- ❌ Two SSOTs — a per-skill island ledger AND this one (re-creates the fragmentation we are killing). Per-skill ledgers MIGRATE here; tools query via `dogfood-tally`.
+- ❌ Counting `complete` without `ratified`+`evidence` (theater).
+- ❌ Inflating the count via fabricated/evidence-less backfill.
+- ❌ Drawing graphs/inter-relation here — delegated to CPT §9 Compass API + `gsd-graphify` (this ledger emits link-fields, it does not visualize).
+- ❌ Writing from `dogfood-tally` (read-only; writes go through `dogfood-mark`).
+
+## 8. Refs
+
+- ADR-005 (this primitive) · dogfooding-mandate / ADR-017 R6 (the ≥2 gate it measures)
+- Consumers (planned): ASH `bin/ash-walkthrough --dogfood-cycles` (reads this ledger) · Sentinel `audit/session_index.json`
+- Templates reused: ASH `bin/ash-decide` (capture) + `bin/ash-decisions` (report) + `ash-stop-fallback.sh` (atomic append+lock)
+- Cross-link slug: `[[dogfood-cycle-ledger]]`
+
+## 9. Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0.0 | 2026-05-30 | Bootstrap — canonical dogfood-cycle counting primitive. Event schema + user-scope ledger + `dogfood-mark`/`dogfood-tally` + anti-theater gate + backfill contract. Replaces changelog-prose counting. |

--- a/docs/dogfood-cycle-ledger-spec.md
+++ b/docs/dogfood-cycle-ledger-spec.md
@@ -44,7 +44,7 @@ One JSON object per line in the ledger. Fields:
 
 | tool | role | guarantees |
 |---|---|---|
-| **`bin/dogfood-mark <tool> <cycle_id> [--status …] [--ratified] [--evidence …]`** | capture/writer | idempotent (no dup of identical event) · atomic append (mkdir-lock) · **anti-theater**: `complete` REQUIRES `--ratified` + ≥1 `--evidence` else refuse (exit 1) · `--dry-run` · `--backfill` (§6 — **Phase 2, planned; not yet implemented**) |
+| **`bin/dogfood-mark <tool> <cycle_id> [--status …] [--ratified] [--evidence …]`** | capture/writer | idempotent (no dup of identical event) · atomic append (mkdir-lock) · **anti-theater**: `complete` REQUIRES `--ratified` + ≥1 `--evidence` else refuse (exit 1) · `--dry-run` (`--backfill` is Phase 2 — see §6, not yet implemented) |
 | **`bin/dogfood-tally [<tool>] [--json\|--table] [--gate N]`** | report/count — **the counting authority** | read-only (SRP) · reduces latest-per-cycle · renders gate verdict per tool |
 
 Exit codes ([C06]): `0` success · `1` usage/validation · `2` setup.

--- a/skills/dogfood-ledger/SKILL.md
+++ b/skills/dogfood-ledger/SKILL.md
@@ -11,11 +11,13 @@ author: MAOS Community
 > The engine is vendor-neutral bash (works in Cursor / Copilot / Codex / Gemini too).
 > **Spec**: `docs/dogfood-cycle-ledger-spec.md` · **ADR**: `docs/adrs/ADR-005-dogfood-cycle-ledger.md`
 
-## Why
+## Purpose
 
-The dogfooding-mandate gates promotion on **≥2 real cycles**, but the count was only changelog prose — unmeasurable = theater. This skill makes it real: one user-scope, append-only, `jq`-countable ledger at `~/.claude/audit/dogfood-cycles.jsonl`, fed by any session/project/vendor.
+The dogfooding-mandate gates promotion on **≥2 real cycles**, but the count was only changelog prose — unmeasurable = theater. This skill makes it real: one user-scope, append-only, `jq`-countable ledger at `~/.claude/audit/dogfood-cycles.jsonl`, fed by any session/project/vendor. `bin/dogfood-mark` is the writer; `bin/dogfood-tally` is the read-only counting authority.
 
-## Use
+## When to Use
+
+Use when you need to record or count dogfood cycles for the ≥2-cycle promotion gate.
 
 **Count cycles for a tool (the gate authority):**
 ```bash
@@ -41,7 +43,14 @@ bin/dogfood-mark --backfill                  # (planned) register them (evidence
 ```
 Until `--backfill` lands, record historical cycles with direct evidence-based `dogfood-mark` calls.
 
-## Rules (binding)
+## Trigger Phrases
+
+- "how many dogfood cycles does X have"
+- "mark this cycle complete" / "mark cycle in-progress"
+- "is X promotion-eligible" / "did X meet the ≥2-cycle gate"
+- "count cycles" / "tally dogfood cycles"
+
+## Protocol Rules
 
 - A cycle is **COMPLETE** only with `ratified==true` + ≥1 evidence ref. "Rounds happened" ≠ complete.
 - The ledger is the **single SSOT** — do NOT keep per-skill island counters (they migrate here).

--- a/skills/dogfood-ledger/SKILL.md
+++ b/skills/dogfood-ledger/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: dogfood-ledger
+description: Count real dogfood cycles per agentic-tool (the ≥2-cycle promotion gate authority). Use to mark a dogfood cycle (in-progress / complete+ratified+evidence) or to tally how many real cycles a tool has before promotion. Replaces changelog-prose cycle counting with a structured, jq-countable, auditable ledger. Triggers - "how many dogfood cycles does X have", "mark this cycle complete", "is X promotion-eligible", "count cycles".
+version: 1.0.0
+author: MAOS Community
+---
+
+# dogfood-ledger
+
+> Thin ergonomic wrapper over the AAIF bash CLIs `bin/dogfood-mark` + `bin/dogfood-tally`.
+> The engine is vendor-neutral bash (works in Cursor / Copilot / Codex / Gemini too).
+> **Spec**: `docs/dogfood-cycle-ledger-spec.md` · **ADR**: `docs/adrs/ADR-005-dogfood-cycle-ledger.md`
+
+## Why
+
+The dogfooding-mandate gates promotion on **≥2 real cycles**, but the count was only changelog prose — unmeasurable = theater. This skill makes it real: one user-scope, append-only, `jq`-countable ledger at `~/.claude/audit/dogfood-cycles.jsonl`, fed by any session/project/vendor.
+
+## Use
+
+**Count cycles for a tool (the gate authority):**
+```bash
+bin/dogfood-tally debate-converge          # table: COMPLETE / IN-PROGRESS / ABANDONED + gate verdict
+bin/dogfood-tally                           # all tools
+bin/dogfood-tally debate-converge --json    # machine-readable (+ .eligible)
+```
+
+**Mark a cycle:**
+```bash
+# open / advance (in-progress)
+bin/dogfood-mark debate-converge 001 --status in-progress --evidence session:<sid>
+
+# close it (COMPLETE requires --ratified AND >=1 --evidence — anti-theater)
+bin/dogfood-mark debate-converge 001 --status complete --ratified \
+  --evidence github:ekson73/multi-agent-os/pull/97 --evidence session:<sid>
+```
+
+**Backfill real historical cycles** (cycles that already happened, never counted) — **Phase 2, planned (not yet implemented)**:
+```bash
+bin/dogfood-mark --backfill --dry-run       # (planned) show detected cycles + evidence
+bin/dogfood-mark --backfill                  # (planned) register them (evidence-based, anti-hallucination)
+```
+Until `--backfill` lands, record historical cycles with direct evidence-based `dogfood-mark` calls.
+
+## Rules (binding)
+
+- A cycle is **COMPLETE** only with `ratified==true` + ≥1 evidence ref. "Rounds happened" ≠ complete.
+- The ledger is the **single SSOT** — do NOT keep per-skill island counters (they migrate here).
+- `dogfood-tally` is read-only; all writes go through `dogfood-mark`.
+- Local-only ledger → LGPD long-term retention is an out-of-band gap (do not over-promise permanence).
+
+## Composition
+
+- **ASH** `bin/ash-walkthrough --dogfood-cycles` (vkl) reads this same ledger (consumer, not a 2nd SSOT).
+- **CPT** §9 Compass API + `gsd-graphify` consume the link-fields for inter-relation/graph (this skill does not visualize).


### PR DESCRIPTION
## [PR-as-Documentation-Prompt] Canonical Dogfood-Cycle Ledger — Phase 1 (primitive)

### Context
The dogfooding-mandate gates promotion on **≥2 real cycles**, but the count lived only as **changelog prose** across the ecosystem (ADR-017 R6, auto-pilot MASTER-PLAN, GIT-PR-AS-DEBATE, per-skill changelogs) — *unmeasurable = theater*. The operator flagged it directly: cycles **already happened across many sessions**, they were just never **counted**. This PR adds the structured, `jq`-countable, AAIF SSOT for dogfood-cycle counting, and lands it in MAOS (the canonical agentic-OS that owns the mandate) rather than any product repo.

### What's in this PR (Phase 1)
- **`bin/dogfood-mark`** — append-only writer. Idempotent (no dup of identical event), atomic `mkdir`-lock, **anti-theater gate** (`complete` REQUIRES `--ratified` + ≥1 `--evidence`, else refuse), `--dry-run`. Cloned from ASH `ash-decide` + `ash-stop-fallback`.
- **`bin/dogfood-tally`** — read-only **counting authority** (SRP). Reduces the event log by `(tool,cycle_id)` to latest-by-`ts`, counts COMPLETE/IN-PROGRESS/ABANDONED per tool, renders the gate verdict. Cloned from ASH `ash-decisions` + `ash-walkthrough` aggregator.
- **`docs/dogfood-cycle-ledger-spec.md`** + **`docs/adrs/ADR-005`** — spec + decision (alternatives rejected: per-skill island ledger / changelog-prose / product-repo / new-DB).
- **`skills/dogfood-ledger/SKILL.md`** — thin ergonomic wrapper (engine is vendor-neutral bash → Cursor/Copilot/Codex/Gemini too).

Ledger = user-scope `~/.claude/audit/dogfood-cycles.jsonl` (sees every project/session/vendor — portability). AAIF bash 3.2, jq-only, Layer-Purity clean.

### Acceptance / verification
- ✅ **11/11 sandbox tests pass under bash 3.2.57** (mark · idempotent no-op · anti-theater refuse ×2 exit 1 · in-progress→complete transition · dry-run · reduce-latest dedup · gate ELIGIBLE/NOT · slug-validation · empty-ledger exit 2).
- ✅ gitleaks clean · Layer-Purity clean (zero product-repo strings).
- ✅ **Recursive dogfood**: this mechanism's own cycle (`dogfood-ledger/001`) + the in-flight `debate-converge/001` are recorded in the real ledger with evidence — the counter is non-empty.

### Deliberately deferred (honest, documented — NOT in this PR)
- **Phase 2**: `--backfill` automation (scan transcripts/changelogs/ASH-journals for historical cycles, evidence-based) — spec/skill mark it `Phase 2 — planned`; until then, cycles are recorded via direct evidence-based `dogfood-mark` calls.
- **Phase 3**: portability install-script (PATH-accessible cross-project) · ASH `ash-walkthrough --dogfood-cycles` consumer · Sentinel `session_index` integration · migrate per-skill `DOGFOOD-LEDGER.md` → this SSOT.

### Out of scope
Graph/inter-relation (delegated to CPT §9 + `gsd-graphify`) · LGPD 5y out-of-band retention sink (separate ADR; `~/.claude/audit/` is local-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
