### PR TITLE
feat(maos-mcp-hub): Jira Agile Sprint + Version CRUD (VKS-2080 Fase 2)

### DIFF
--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -256,7 +256,7 @@ gateways/                          ← Meta-tool gateway layer
 │   └── actions.py                 ← Domain catalog builder
 ├── jira/
 │   ├── gateway.py
-│   └── actions.py                 ← 27 actions across 10 resources
+│   └── actions.py                 ← 27 actions across 12 resources
 ├── confluence/
 │   ├── gateway.py
 │   └── actions.py                 ← 12 actions across 4 resources

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -155,7 +155,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-Restart Claude Desktop. You'll see the **6 `atlassian_*` gateway tools** (discover, jira, confluence, bitbucket, compass, common) covering 99 actions total (v2.2.0, VKS-1853).
+Restart Claude Desktop. You'll see the **6 `atlassian_*` gateway tools** (discover, jira, confluence, bitbucket, compass, common) covering 104 actions total (v2.3.0, VKS-2080).
 
 ### 6. Run tests (pilot D65)
 
@@ -181,12 +181,12 @@ With 55 Bitbucket tools and Jira/Confluence/Compass on the roadmap, the flat nam
 
 ### Solution: 6 Typed Gateways
 
-The Meta-Tools Gateway collapses **99 actions** (v2.2.0) into **6 MCP tools**. Five domain gateways accept a uniform `{resource?, operation?, params?}` input; `atlassian_discover` is parameterless:
+The Meta-Tools Gateway collapses **104 actions** (v2.3.0) into **6 MCP tools**. Five domain gateways accept a uniform `{resource?, operation?, params?}` input; `atlassian_discover` is parameterless:
 
 | Gateway | Tool Name | Actions | Purpose |
 |---------|-----------|---------|---------|
 | **Discover** | `atlassian_discover` | -- | Catalog of all domains and action counts |
-| **Jira** | `atlassian_jira` | 22 | Issues, boards, sprints, estimation, comments, worklogs, links, search |
+| **Jira** | `atlassian_jira` | 27 | Issues, boards, sprints (list/create/update), versions (create/release), estimation, comments, worklogs, links, search |
 | **Confluence** | `atlassian_confluence` | 12 | Pages, comments, spaces, search (CQL) |
 | **Bitbucket** | `atlassian_bitbucket` | 55 | Pipelines, PRs (incl. add/reply comment, update description — VKS-1853), branches, deployments, tests, caches |
 | **Compass** | `atlassian_compass` | 6 | Service registry, components, relationships, custom fields |
@@ -256,7 +256,7 @@ gateways/                          ← Meta-tool gateway layer
 │   └── actions.py                 ← Domain catalog builder
 ├── jira/
 │   ├── gateway.py
-│   └── actions.py                 ← 22 actions across 10 resources
+│   └── actions.py                 ← 27 actions across 10 resources
 ├── confluence/
 │   ├── gateway.py
 │   └── actions.py                 ← 12 actions across 4 resources
@@ -318,7 +318,7 @@ hub is considered ready when these lines appear:
 ```text
 ======================================================================
 ✅ MAOS MCP Hub Ready!
-   Gateways: 6 (99 actions)
+   Gateways: 6 (104 actions)
    Total MCP tools: 6
 ======================================================================
 ```

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -1,5 +1,5 @@
 """
-Jira gateway actions — 27 actions across 10 resources.
+Jira gateway actions — 27 actions across 12 resources.
 
 Wraps existing JiraClient methods + servers/jira/tools.py functions.
 """

--- a/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/actions.py
@@ -1,5 +1,5 @@
 """
-Jira gateway actions — 22 actions across 8 resources.
+Jira gateway actions — 27 actions across 10 resources.
 
 Wraps existing JiraClient methods + servers/jira/tools.py functions.
 """
@@ -343,6 +343,61 @@ async def estimate_story_points(issue_key: str, board_id: int, dry_run: bool = T
     return result
 
 
+# --- Sprints & Versions (VKS-2080 Fase 2) ---
+
+async def get_sprints(board_id: int, state: str = "") -> dict:
+    """List sprints on a board, optionally filtered by state."""
+    client = get_client()
+    sprints = await client.get_sprints(board_id, state)
+    return {"sprints": sprints}
+
+
+async def create_sprint(
+    board_id: int,
+    name: str,
+    start_date: str = "",
+    end_date: str = "",
+    goal: str = "",
+) -> dict:
+    """Create a sprint on a Scrum board."""
+    client = get_client()
+    return await client.create_sprint(board_id, name, start_date, end_date, goal)
+
+
+async def update_sprint(
+    sprint_id: int,
+    name: str = "",
+    state: str = "",
+    start_date: str = "",
+    end_date: str = "",
+    goal: str = "",
+) -> dict:
+    """Partially update a sprint (only provided fields change)."""
+    client = get_client()
+    return await client.update_sprint(sprint_id, name, state, start_date, end_date, goal)
+
+
+async def create_version(
+    project_id: int,
+    name: str,
+    description: str = "",
+    start_date: str = "",
+    release_date: str = "",
+    released: bool = False,
+) -> dict:
+    """Create a project version (release)."""
+    client = get_client()
+    return await client.create_version(
+        project_id, name, description, start_date, release_date, released
+    )
+
+
+async def release_version(version_id: str, release_date: str = "") -> dict:
+    """Mark a project version as released."""
+    client = get_client()
+    return await client.release_version(version_id, release_date)
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -380,7 +435,7 @@ def _walk_adf(node: Any, parts: list[str]) -> None:
 # ---------------------------------------------------------------------------
 
 def build_router() -> MetaToolRouter:
-    """Build the Jira meta-tool router with 22 actions."""
+    """Build the Jira meta-tool router with 27 actions."""
     router = MetaToolRouter(
         tool_name=GATEWAY_INFO["tool_name"],
         governance=["Jira operations follow DARCI-Expanded governance"],
@@ -425,6 +480,17 @@ def build_router() -> MetaToolRouter:
                     description="Calculate story points from observable data (deterministic formula)",
                     governance=["Formula: volume signals × type_multiplier → Fibonacci snap"],
                     next_steps=["Se dry_run=True, chame com dry_run=False para aplicar"])
+
+    # Sprints (VKS-2080 Fase 2)
+    router.register("sprint", "list", get_sprints, description="List sprints on a board (filter by state)")
+    router.register("sprint", "create", create_sprint, description="Create a sprint on a Scrum board",
+                    next_steps=["Mova issues para o sprint", "Ative com sprint.update state=active"])
+    router.register("sprint", "update", update_sprint,
+                    description="Partially update a sprint (name/state/dates/goal — POST partial, never resets unspecified fields)")
+
+    # Versions / Releases (VKS-2080 Fase 2)
+    router.register("version", "create", create_version, description="Create a project version (release)")
+    router.register("version", "release", release_version, description="Mark a project version as released")
 
     # Projects & Metadata
     router.register("project", "list", get_visible_projects, description="List visible projects")

--- a/mcp-tools/maos-mcp-hub/gateways/jira/gateway.py
+++ b/mcp-tools/maos-mcp-hub/gateways/jira/gateway.py
@@ -4,7 +4,7 @@ GATEWAY_INFO = {
     "name": "jira",
     "tool_name": "atlassian_jira",
     "display_name": "Jira Cloud — Issues, Boards, Search, Estimation",
-    "version": "2.0.0",
+    "version": "2.1.0",
     "description": (
         "Manage Jira Cloud issues, boards, sprints, comments, worklogs, "
         "links, and story point estimation. "

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -132,7 +132,7 @@ except ImportError:
 # ============================================================================
 
 HUB_NAME = "maos-mcp-hub"
-HUB_VERSION = "2.2.0"  # VKS-1853: +3 pull_request ops + params standardization
+HUB_VERSION = "2.3.0"  # VKS-2080: +5 Jira Agile ops (sprint list/create/update, version create/release)
 SERVERS_DIR = Path(__file__).parent / "servers"
 
 

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -5,15 +5,15 @@ Protocol: MCP 1.0 (JSON-RPC 2.0)
 Transport: STDIO (stdin/stdout)
 
 Since v1.7 (VKS-1694 Phase 2), this hub exposes exactly 6 typed `atlassian_*`
-meta-tool gateways. v2.2 (VKS-1853) adds 3 pull_request interaction ops →
-99 actions total.
+meta-tool gateways. v2.2 (VKS-1853) added 3 pull_request interaction ops;
+v2.3 (VKS-2080) adds 5 Jira Agile sprint/version ops → 104 actions total.
 
 Architecture:
     hub.py
         ↓ (explicit registration of 6 gateways)
     gateways/
     ├── discover/   → atlassian_discover   (catalog)
-    ├── jira/       → atlassian_jira       (22 actions)
+    ├── jira/       → atlassian_jira       (27 actions)
     ├── confluence/ → atlassian_confluence (12 actions)
     ├── bitbucket/  → atlassian_bitbucket  (55 actions, VKS-1853 v2.2)
     ├── compass/    → atlassian_compass    (6 actions)
@@ -240,7 +240,7 @@ mcp = FastMCP(
     name=HUB_NAME,
     instructions=(
         f"MAOS MCP Hub v{HUB_VERSION} — Atlassian meta-tools gateway. "
-        "Exposes 6 typed `atlassian_*` gateways (99 actions total) with "
+        "Exposes 6 typed `atlassian_*` gateways (104 actions total) with "
         "4-level progressive discovery and governance feedback. "
         "Legacy flat namespace (bitbucket_*, jira_*) was removed in v1.7."
     ),
@@ -265,7 +265,7 @@ if not discovered_servers:
 
 
 # ============================================================================
-# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 99 actions)
+# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 104 actions)
 # ============================================================================
 #
 # Note (VKS-1694, v1.7):

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -445,6 +445,13 @@ class JiraClient:
         if goal:
             body["goal"] = goal
 
+        if not body:
+            raise ValueError(
+                "update_sprint requires at least one field to update "
+                "(name, state, start_date, end_date, or goal) — "
+                "an empty update is rejected by the Agile API with a 400."
+            )
+
         return await request_json(
             method="POST",
             url=f"{self.agile_url}/sprint/{sprint_id}",

--- a/mcp-tools/maos-mcp-hub/lib/jira/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/jira/client.py
@@ -335,6 +335,204 @@ class JiraClient:
         )
 
     # ========================================================================
+    # Agile API — Sprints (VKS-2080 Fase 2)
+    # ========================================================================
+
+    async def get_sprints(self, board_id: int, state: str = "") -> list:
+        """
+        List sprints on a board, optionally filtered by state.
+
+        Args:
+            board_id: Board ID (Scrum board; from get_boards).
+            state: Optional comma-separated filter — "future", "active", "closed".
+
+        Returns:
+            list: Sprint objects [{id, name, state, startDate, endDate, ...}]
+        """
+        params = {}
+        if state:
+            params["state"] = state
+
+        result = await request_json(
+            method="GET",
+            url=f"{self.agile_url}/board/{board_id}/sprint",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            params=params,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+        return result.get("values", [])
+
+    async def create_sprint(
+        self,
+        board_id: int,
+        name: str,
+        start_date: str = "",
+        end_date: str = "",
+        goal: str = "",
+    ) -> dict:
+        """
+        Create a sprint on a Scrum board.
+
+        Args:
+            board_id: Origin board ID (must be a Scrum board).
+            name: Sprint name.
+            start_date: Optional ISO-8601 start (e.g. "2026-06-02T00:00:00.000Z").
+            end_date: Optional ISO-8601 end.
+            goal: Optional sprint goal.
+
+        Returns:
+            dict: Created sprint object {id, name, state, ...}
+        """
+        body: dict = {"originBoardId": board_id, "name": name}
+        if start_date:
+            body["startDate"] = start_date
+        if end_date:
+            body["endDate"] = end_date
+        if goal:
+            body["goal"] = goal
+
+        return await request_json(
+            method="POST",
+            url=f"{self.agile_url}/sprint",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=body,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # POST create — avoid duplicate sprints on retry
+        )
+
+    async def update_sprint(
+        self,
+        sprint_id: int,
+        name: str = "",
+        state: str = "",
+        start_date: str = "",
+        end_date: str = "",
+        goal: str = "",
+    ) -> dict:
+        """
+        Partially update a sprint (only provided fields change).
+
+        Uses Agile API ``POST /sprint/{id}`` (partial update) rather than PUT
+        (full replace) — safer for agentic use: unspecified fields are preserved,
+        never reset.
+
+        Args:
+            sprint_id: Sprint ID.
+            name: New name (optional).
+            state: New state — "future" | "active" | "closed" (optional).
+            start_date: ISO-8601 start (optional).
+            end_date: ISO-8601 end (optional).
+            goal: Sprint goal (optional).
+
+        Returns:
+            dict: Updated sprint object.
+        """
+        body: dict = {}
+        if name:
+            body["name"] = name
+        if state:
+            body["state"] = state
+        if start_date:
+            body["startDate"] = start_date
+        if end_date:
+            body["endDate"] = end_date
+        if goal:
+            body["goal"] = goal
+
+        return await request_json(
+            method="POST",
+            url=f"{self.agile_url}/sprint/{sprint_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=body,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # mutation — no auto-retry
+        )
+
+    # ========================================================================
+    # Versions API (VKS-2080 Fase 2)
+    # ========================================================================
+
+    async def create_version(
+        self,
+        project_id: int,
+        name: str,
+        description: str = "",
+        start_date: str = "",
+        release_date: str = "",
+        released: bool = False,
+    ) -> dict:
+        """
+        Create a project version (release).
+
+        Args:
+            project_id: Numeric project ID (e.g. 10309 for VKS; from board location).
+            name: Version name (e.g. "1.6.0").
+            description: Optional description.
+            start_date: Optional ISO date "YYYY-MM-DD".
+            release_date: Optional ISO date "YYYY-MM-DD".
+            released: Whether the version is already released (default False).
+
+        Returns:
+            dict: Created version object {id, name, released, ...}
+        """
+        body: dict = {"projectId": project_id, "name": name, "released": released}
+        if description:
+            body["description"] = description
+        if start_date:
+            body["startDate"] = start_date
+        if release_date:
+            body["releaseDate"] = release_date
+
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/version",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=body,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # POST create — avoid duplicate versions on retry
+        )
+
+    async def release_version(self, version_id: str, release_date: str = "") -> dict:
+        """
+        Mark a project version as released.
+
+        Args:
+            version_id: Version ID.
+            release_date: Optional ISO date "YYYY-MM-DD" (Jira defaults server-side
+                          if omitted).
+
+        Returns:
+            dict: Updated version object {id, name, released: true, ...}
+        """
+        body: dict = {"released": True}
+        if release_date:
+            body["releaseDate"] = release_date
+
+        return await request_json(
+            method="PUT",
+            url=f"{self.base_url}/version/{version_id}",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            json=body,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+            max_retries=0,  # mutation — no auto-retry
+        )
+
+    # ========================================================================
     # Issues CRUD — create, edit, transition, search
     # ========================================================================
 

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
@@ -49,12 +49,12 @@ def test_discover_action_counts(monkeypatch):
     async def run():
         result = await discover()
         d = result["domains"]
-        assert d["jira"]["actions"] == 22
+        assert d["jira"]["actions"] == 27  # VKS-2080: +5 Sprint+Version CRUD
         assert d["confluence"]["actions"] == 12
         assert d["bitbucket"]["actions"] == 55  # VKS-1853: +3 PR ops
         assert d["compass"]["actions"] == 6
         assert d["common"]["actions"] == 4
-        assert result["total_actions"] == 99  # VKS-1853: 96 + 3
+        assert result["total_actions"] == 104  # VKS-2080: 99 + 5
 
     asyncio.run(run())
 
@@ -128,7 +128,7 @@ def test_common_router_action_count(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Cross-gateway: total action count = 99 (VKS-1853: 96 + 3)
+# Cross-gateway: total action count = 104 (VKS-2080: 99 + 5)
 # ---------------------------------------------------------------------------
 
 def test_total_action_count_across_all_gateways(monkeypatch):
@@ -146,4 +146,4 @@ def test_total_action_count_across_all_gateways(monkeypatch):
         + comp_router().action_count
         + common_router().action_count
     )
-    assert total == 99, f"Expected 99 total actions (VKS-1853: 96 + 3), got {total}"
+    assert total == 104, f"Expected 104 total actions (VKS-2080: 99 + 5), got {total}"

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_jira.py
@@ -1,4 +1,4 @@
-"""Tests for Jira gateway — 22 actions via meta-tool pattern."""
+"""Tests for Jira gateway — 27 actions via meta-tool pattern."""
 
 import asyncio
 
@@ -291,7 +291,7 @@ def test_estimate_story_points_complex_issue(monkeypatch):
 def test_jira_router_action_count(monkeypatch):
     _setup_env(monkeypatch)
     router = build_router()
-    assert router.action_count == 22
+    assert router.action_count == 27
 
 
 def test_jira_router_tool_name(monkeypatch):

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
@@ -63,13 +63,15 @@ def test_hub_exposes_exactly_six_mcp_tools():
 
 
 def test_hub_registers_six_atlassian_gateways():
-    """All 6 atlassian_* gateways must be registered with 99 actions total.
+    """All 6 atlassian_* gateways must be registered with 104 actions total.
 
     VKS-1853 (2026-04-23): +3 pull_request ops (add_comment,
-    update_description, reply_to_comment) bring total from 96 to 99.
+    update_description, reply_to_comment) brought total from 96 to 99.
+    VKS-2080 (2026-06-01): +5 Jira Agile ops (sprint list/create/update,
+    version create/release) bring total from 99 to 104.
     """
     log = _run_hub()
-    assert "6 gateways registered (99 actions)" in log, log
+    assert "6 gateways registered (104 actions)" in log, log
 
 
 def test_hub_does_not_register_flat_bitbucket_tools():

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -310,7 +310,7 @@ def test_get_sprints_with_state_filter(monkeypatch):
     async def run() -> None:
         client = JiraClient()
         with respx.mock(assert_all_called=True) as router:
-            router.get(f"{AGILE_BASE}/board/59/sprint").mock(
+            route = router.get(f"{AGILE_BASE}/board/59/sprint").mock(
                 return_value=httpx.Response(
                     200,
                     json={"values": [{"id": 7, "name": "Sprint 1", "state": "active"}]},
@@ -321,6 +321,8 @@ def test_get_sprints_with_state_filter(monkeypatch):
             assert len(sprints) == 1
             assert sprints[0]["id"] == 7
             assert sprints[0]["state"] == "active"
+            # state filter is actually forwarded as a query param
+            assert "state=active" in str(route.calls.last.request.url)
 
     asyncio.run(run())
 

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -293,3 +293,150 @@ def test_get_estimation_maps_404_to_not_found(monkeypatch):
             assert exc.status_code == 404
 
     asyncio.run(run())
+
+
+# ---------------------------------------------------------------------------
+# Agile — Sprints & Versions (VKS-2080 Fase 2)
+# ---------------------------------------------------------------------------
+
+API3_BASE = "https://api.atlassian.com/ex/jira/023bcd49-f455-4451-a096-c50c42c811d7/rest/api/3"
+
+
+def test_get_sprints_with_state_filter(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(f"{AGILE_BASE}/board/59/sprint").mock(
+                return_value=httpx.Response(
+                    200,
+                    json={"values": [{"id": 7, "name": "Sprint 1", "state": "active"}]},
+                )
+            )
+
+            sprints = await client.get_sprints(59, state="active")
+            assert len(sprints) == 1
+            assert sprints[0]["id"] == 7
+            assert sprints[0]["state"] == "active"
+
+    asyncio.run(run())
+
+
+def test_get_sprints_no_filter(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            router.get(f"{AGILE_BASE}/board/59/sprint").mock(
+                return_value=httpx.Response(200, json={"values": []})
+            )
+
+            sprints = await client.get_sprints(59)
+            assert sprints == []
+
+    asyncio.run(run())
+
+
+def test_create_sprint_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(f"{AGILE_BASE}/sprint").mock(
+                return_value=httpx.Response(
+                    201, json={"id": 99, "name": "Sprint 2026-06", "state": "future"}
+                )
+            )
+
+            result = await client.create_sprint(59, "Sprint 2026-06", goal="ship v2.1")
+            assert result["id"] == 99
+            assert result["state"] == "future"
+            # body carries originBoardId + name + goal (no blank dates)
+            import json as _json
+            sent = _json.loads(route.calls.last.request.content)
+            assert sent == {"originBoardId": 59, "name": "Sprint 2026-06", "goal": "ship v2.1"}
+
+    asyncio.run(run())
+
+
+def test_update_sprint_partial(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(f"{AGILE_BASE}/sprint/99").mock(
+                return_value=httpx.Response(200, json={"id": 99, "state": "active"})
+            )
+
+            result = await client.update_sprint(99, state="active")
+            assert result["state"] == "active"
+            # partial update — only the provided field is sent
+            import json as _json
+            sent = _json.loads(route.calls.last.request.content)
+            assert sent == {"state": "active"}
+
+    asyncio.run(run())
+
+
+def test_create_version_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            route = router.post(f"{API3_BASE}/version").mock(
+                return_value=httpx.Response(
+                    201, json={"id": "10500", "name": "1.6.0", "released": False}
+                )
+            )
+
+            result = await client.create_version(10309, "1.6.0", description="maos v1.6.0")
+            assert result["id"] == "10500"
+            assert result["released"] is False
+            import json as _json
+            sent = _json.loads(route.calls.last.request.content)
+            assert sent == {
+                "projectId": 10309,
+                "name": "1.6.0",
+                "released": False,
+                "description": "maos v1.6.0",
+            }
+
+    asyncio.run(run())
+
+
+def test_release_version_success(monkeypatch):
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with respx.mock(assert_all_called=True) as router:
+            route = router.put(f"{API3_BASE}/version/10500").mock(
+                return_value=httpx.Response(
+                    200, json={"id": "10500", "name": "1.6.0", "released": True}
+                )
+            )
+
+            result = await client.release_version("10500", release_date="2026-06-01")
+            assert result["released"] is True
+            import json as _json
+            sent = _json.loads(route.calls.last.request.content)
+            assert sent == {"released": True, "releaseDate": "2026-06-01"}
+
+    asyncio.run(run())

--- a/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_jira_client.py
@@ -390,6 +390,22 @@ def test_update_sprint_partial(monkeypatch):
     asyncio.run(run())
 
 
+def test_update_sprint_empty_raises(monkeypatch):
+    """All-empty update must raise client-side, never POST an empty {} body
+    (which the Agile API rejects with a confusing 400). Addresses amazon-q
+    :stop_sign: Logic Error on PR #103."""
+    _setup_env(monkeypatch)
+    monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")
+    monkeypatch.delenv("ATLASSIAN_API_TOKEN", raising=False)
+
+    async def run() -> None:
+        client = JiraClient()
+        with pytest.raises(ValueError, match="at least one field"):
+            await client.update_sprint(99)
+
+    asyncio.run(run())
+
+
 def test_create_version_success(monkeypatch):
     _setup_env(monkeypatch)
     monkeypatch.setenv("JIRA_API_TOKEN", "jira-token")


### PR DESCRIPTION
**[PR-as-Enhancement-Prompt]**

## Context
Fase 1 (VKS-1692, **Done**) exposed Jira Agile **Story Points estimation** in the `atlassian_jira` gateway, unblocking AI agents from setting estimates. Fase 2 (this PR, **VKS-2080**) completes the agentic Jira lifecycle by adding **Sprint + Version (release) CRUD** — the remaining P1 gap so agents can manage sprints and releases end-to-end, not just estimate.

## Objectives
Add 5 Jira Agile REST API actions to the jira gateway, mirroring the Fase 1 pattern exactly (async client method → thin gateway action → `router.register` → respx test).

| Action | Endpoint |
|---|---|
| `sprint.list` | `GET /rest/agile/1.0/board/{id}/sprint` |
| `sprint.create` | `POST /rest/agile/1.0/sprint` |
| `sprint.update` | `POST /rest/agile/1.0/sprint/{id}` (partial update) |
| `version.create` | `POST /rest/api/3/version` |
| `version.release` | `PUT /rest/api/3/version/{id}` |

## Design decisions (deviations from the ticket draft, intentional)
- **`sprint.update` uses POST (partial update), not PUT (full replace)** — Agile API `POST /sprint/{id}` only changes provided fields; safer for agentic use (won't silently reset unspecified fields like dates/goal when an agent just flips `state`).
- **All mutations `max_retries=0`** — consistent with the `set_estimation` precedent; avoids duplicate sprints/versions on a retried POST.
- **`create_version` takes numeric `project_id`** (the API's `projectId` field; e.g. 10309 for VKS).

## Acceptance / Test plan
- [x] 6 new respx unit tests with **request-body-shape assertions** (verifies partial-update sends only provided fields; create sends correct payload).
- [x] Full suite **178 passing** (was 172; +6).
- [x] Gateway action-count assertions synced: jira `22 → 27`, cross-gateway total `99 → 104` (`test_gateway_discover`, `test_gateway_jira`, `test_hub_registration`).
- [x] Versions bumped: jira gateway `2.0.0 → 2.1.0`, hub `2.2.0 → 2.3.0`.
- [x] README counts synced. gitleaks clean.

## Risk + rollback
- **Low**: additive (new methods/actions); zero changes to existing action signatures or behavior. No new auth scopes (same Basic Auth as Fase 1).
- **Rollback**: revert the merge commit — gateway returns to 22 actions; no migrations/state.

## Out of scope (noted, not done here)
- Re-mapping the Agentic-Task `Done` status category + enabling Story-Point field on agentic issue types — both are **Jira-admin config** (HUMAN_DOMAIN), tracked in VKS-2080/VKS-1692 comments.
- Pre-existing repo-root `CLAUDE.md` count drift (bitbucket 52 vs 55) — separate cleanup.
- Pre-existing semgrep CWE-706 warning on `hub.py` gateway-loader `importlib` (controlled hardcoded allowlist — false positive; untouched by this PR).

## Cross-links
- Jira: **VKS-2080** (Fase 2, this PR) · **VKS-1692** (Fase 1, Done) · **VKS-2033** (maos release — will consume `version.release`)
- Identity: authored as `ekson73` per multi-identity governance (C19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
