### PR TITLE
fix(governance): preflight peer-session-detect robustness (PR #116 review)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "maos",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — `preflight` cross-session layer robustness (v1.10.1)
+
+- **`peer-session-detect.sh`** — `${HOME:-}` guard so an unset `HOME` under the hook's `set -u` can never trigger an unbound-variable exit (resolves to UNKNOWN instead, preserving the never-blocks contract). Coerce a non-numeric `MAOS_PEER_FRESH_SECS` (e.g. `"90s"`) to the default `90` so it can't break the `-le` arithmetic under `set -e`. (PR #116 review — Copilot + Qodo.)
+- **`skills/preflight/SKILL.md` → v1.1.1** — section heading "The 3 Responsibilities" → "The Responsibilities (R1–R3, + optional R1.5)" to match the 4-row table (Copilot review).
+- **`tests/governance/test-peer-session-detect.sh`** — added a non-numeric `MAOS_PEER_FRESH_SECS` regression assertion.
+
 ### Added — `preflight` cross-session layer: peer-agent awareness (v1.10.0)
 
 - **NEW lib `plugin-scripts/governance/lib/peer-session-detect.sh`** (named by `anima` — `peer-session-detect`/`psd_`, deliberately NOT `git-*` because it is a host-concurrency signal, not a git primitive; `git-safe-sync.sh` explicitly excludes host-specific signals, so they live here, kept separate). The **R1.5** cross-session layer of `preflight`: detects OTHER live agent sessions (peers) writing the **SAME checkout** so the session-start hook can **DEFER R2 (heal/pull)** while a peer is active — closing the gap R1's worktree-locks don't cover (same-cwd/same-branch peers, which `.git/index.lock` only catches at the instant of a write). **Optional + capability-detected + gracefully-degrading**: one ships an agent-session-transcript-mtime backend keyed by the working-tree path (self-excluded, freshness-windowed); when no backend resolves (off-host / dir unresolved) it returns `UNKNOWN` and callers treat that as report-only (**never over-defer** → stays useful on Cursor/Codex/Copilot/Aider). READ-ONLY; **never blocks**. Env seams: `MAOS_PEER_SESSION_DIR` (explicit override / portability seam), `MAOS_PEER_PROJECTS_DIR`, `MAOS_PEER_FRESH_SECS` (default 90), `MAOS_SELF_SESSION_ID`. Functions: `psd_peer_sessions` · `psd_status` (`BUSY_PEERS <n>` | `QUIET` | `UNKNOWN`) · `psd_repo_busy_by_peers`.

--- a/plugin-scripts/governance/lib/peer-session-detect.sh
+++ b/plugin-scripts/governance/lib/peer-session-detect.sh
@@ -77,7 +77,9 @@ psd_session_dir() {
     fi
     # Auto backend: transcripts keyed by this working tree's toplevel abs path.
     top="$(git -C "$repo" rev-parse --show-toplevel 2>/dev/null)" || return 1
-    projects="${MAOS_PEER_PROJECTS_DIR:-$HOME/.claude/projects}"
+    # ${HOME:-} guard: never trip `set -u` if HOME is unset (cron/minimal env) →
+    # unresolved projects dir → return 1 (UNKNOWN), preserving the never-blocks contract.
+    projects="${MAOS_PEER_PROJECTS_DIR:-${HOME:-}/.claude/projects}"
     [ -d "$projects" ] || return 1
     enc="$(_psd_encode_path "$top")"
     dir="$projects/$enc"
@@ -95,6 +97,9 @@ psd_peer_sessions() {
     local repo="${1:-.}" dir fresh own now n=0 f base sid m
     dir="$(psd_session_dir "$repo")" || { printf 'UNKNOWN\n'; return 0; }
     fresh="${MAOS_PEER_FRESH_SECS:-90}"
+    # Coerce to a non-negative integer; a non-numeric value (e.g. "90s") must not
+    # break the `-le` arithmetic under `set -e`. Fall back to the default.
+    case "$fresh" in ''|*[!0-9]*) fresh=90 ;; esac
     own="${MAOS_SELF_SESSION_ID:-${CLAUDE_CODE_SESSION_ID:-}}"
     now="$(date +%s 2>/dev/null || echo 0)"
     [ "$now" -gt 0 ] 2>/dev/null || { printf 'UNKNOWN\n'; return 0; }

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -7,7 +7,7 @@ description: |
   (R2) safely heal the current branch from origin, and (R3) create a git worktree the
   moment you are about to create/update files. Reads whatever governance is present at
   invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories) and adapts.
-version: 1.1.0
+version: 1.1.1
 triggers:
   - preflight
   - run preflight
@@ -18,7 +18,7 @@ triggers:
   - start of session checks
   - prepare a worktree before editing
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -55,7 +55,7 @@ ORIENT (R1) → HEAL (R2) → ISOLATE-ON-MUTATION (R3)
 Each step is SAFE-or-DEFER. Never clobber concurrent work. Never block on a no-op.
 ```
 
-## The 3 Responsibilities
+## The Responsibilities (R1–R3, + optional R1.5)
 
 | # | Responsibility | How (read-only / safe) | Lib |
 |---|---|---|---|

--- a/tests/governance/test-peer-session-detect.sh
+++ b/tests/governance/test-peer-session-detect.sh
@@ -67,6 +67,10 @@ touch -t 200001010000 "$TMP/peer-old.jsonl"   # portable stale mtime (BSD + GNU 
 R="$(psd_peer_sessions .)"
 assert_equals "2" "$R" "psd_peer_sessions: counts 2 fresh peers (self + stale excluded)"
 
+# Robustness: a non-numeric freshness window must NOT crash (coerced to default 90).
+R="$(MAOS_PEER_FRESH_SECS="90s" psd_peer_sessions .)"
+assert_equals "2" "$R" "psd_peer_sessions: non-numeric MAOS_PEER_FRESH_SECS coerced (no crash)"
+
 R="$(psd_status .)"
 assert_equals "BUSY_PEERS 2" "$R" "psd_status: BUSY_PEERS 2"
 


### PR DESCRIPTION
Fix-forward for the Copilot + Qodo review of #116 (already merged).

## Fixed
- **`${HOME:-}` guard** (lib) — unset `HOME` under the hook's `set -u` could trigger an unbound-variable exit, breaking the *never-blocks* contract → now resolves to `UNKNOWN`. (Copilot lib:82 / Qodo)
- **Non-numeric `MAOS_PEER_FRESH_SECS`** (lib) — coerced to default `90` so it can't break the `-le` arithmetic under `set -e`. (Copilot lib:99)
- **SKILL.md heading** — "The 3 Responsibilities" → "The Responsibilities (R1–R3, + optional R1.5)" to match the 4-row table. (Copilot SKILL:64)
- **Regression test** for non-numeric freshness window. (Copilot test)

## Not changed
- Snyk `ERROR` on #116 = integration error, not a finding — this PR adds **zero dependencies** (pure bash), so SCA has nothing to scan.

## Evidence
- unset-`HOME` + non-numeric edges → `UNKNOWN` (no crash, verified) · test **10/10** · governance suite + `validate-plugin` + `check-layer-purity` all green · gitleaks clean.

plugin `1.10.0 → 1.10.1` · skill `1.1.0 → 1.1.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)