### PR TITLE
feat(postflight): scorecard gallery — deterministic 7-model renderer + templates

### DIFF
--- a/bin/scorecard.py
+++ b/bin/scorecard.py
@@ -1,0 +1,469 @@
+#!/usr/bin/env python3
+"""
+postflight scorecard renderer — deterministic end-of-action status cards.
+
+ONE renderer · ONE param schema · 7 layout MODELS. Design contract:
+  - DETERMINISTIC: same params -> same output (no clock unless passed in).
+  - SELF-CALCULATING: auto-derives git/PR facts + the autonomy pulse + bars
+    from numbers, so an AI agent only supplies what cannot be computed.
+  - AI-PARAMETERIZED: the qualitative items (verdict, checklist, notes,
+    confidence, what's-left) arrive as a JSON params blob (file/stdin).
+  - HUMAN-GLANCEABLE: 5-state colour legend (🔴🟡🟠🟢🔵) + bars + tally.
+  - PORTABLE: stdlib only; NO_COLOR / --no-color honoured; emoji carry colour
+    so it renders in any terminal AND in GitHub/markdown.
+
+Usage:
+  scorecard.py --model N [--params FILE|-] [--demo] [--auto-git] [--repo DIR]
+               [--no-color] [--all]
+  echo '<json>' | scorecard.py --model 2
+  scorecard.py --all --demo            # render every model with demo data
+
+Param schema (all keys optional; sane fallbacks):
+  {
+    "session":  {"title","id","date","time","duration"},
+    "verdict":  {"state":"done|warn|blocked|wip", "label":"DONE · green · merged"},
+    "autonomy": {"green":N,"blue":N,"orange":N,"red":N},      # pulse tally
+    "vitals":   [{"label","icon","pct":0-100,"note"}],
+    "checklist":[{"state":"green|blue|orange|yellow|red","label","note","confidence":0-100|null}],
+    "whats_left":[{"state":"done|orange|red|yellow","text"}]
+  }
+"""
+import argparse, json, os, sys, subprocess, datetime, re
+
+# ── 5-state legend (icon · human-word · machine-token · ansi-256) ─────────────
+STATE = {
+    "red":    ("🔴", "not-started", "not_started",  196),
+    "yellow": ("🟡", "in-progress", "in_progress",  226),
+    "orange": ("🟠", "need-HITL",   "need_hitl",    208),
+    "green":  ("🟢", "done-IA",     "done_agentic",  46),
+    "blue":   ("🔵", "done-human",  "done_human",    39),
+}
+ALIAS = {"done": "green", "agentic": "green", "human": "blue", "hitl": "orange",
+         "doing": "yellow", "wip": "yellow", "todo": "red", "blocked": "red",
+         "warn": "orange"}
+VERDICT_ICON = {"done": "✅", "warn": "⚠️", "blocked": "🛑", "wip": "🟡"}
+
+
+def st(key):
+    return STATE.get(ALIAS.get(key, key), STATE["green"])
+
+
+# ── colour + width helpers ────────────────────────────────────────────────────
+COLOR = True
+
+
+def c(text, code=None, bold=False, dim=False):
+    if not COLOR:
+        return text
+    pre = ""
+    if bold:
+        pre += "\033[1m"
+    if dim:
+        pre += "\033[2m"
+    if code is not None:
+        pre += f"\033[38;5;{code}m"
+    return f"{pre}{text}\033[0m" if pre else text
+
+
+_WIDE = re.compile(
+    "[\U0001F000-\U0001FAFF\U00002600-\U000027BF\U00002B00-\U00002BFF✅❌✔✖⚠]"
+)
+
+
+def vlen(s):
+    """visual width: emoji/symbols ~2, variation-selectors 0, else 1."""
+    s = re.sub("\033\\[[0-9;]*m", "", s)  # strip ansi
+    w = 0
+    for ch in s:
+        if ch == "️":
+            continue
+        w += 2 if _WIDE.match(ch) else 1
+    return w
+
+
+def pad(s, width):
+    return s + " " * max(0, width - vlen(s))
+
+
+def bar(pct, width=10, code=46):
+    pct = max(0, min(100, int(round(pct))))
+    fill = int(round(pct / 100 * width))
+    return c("█" * fill, code) + c("▒" * (width - fill), 240)
+
+
+def dot(state):
+    return st(state)[0]
+
+
+def pulse_pct(a):
+    tot = sum(a.get(k, 0) for k in ("green", "blue", "orange", "red"))
+    return (100 * (a.get("green", 0) + a.get("blue", 0)) / tot) if tot else 0
+
+
+def green_pct(a):
+    tot = sum(a.get(k, 0) for k in ("green", "blue", "orange", "red"))
+    return (100 * a.get("green", 0) / tot) if tot else 0
+
+
+# ── deterministic git/PR self-calculation (graceful) ─────────────────────────
+def _run(args, cwd, timeout=6):
+    try:
+        return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
+                              timeout=timeout).stdout.strip()
+    except Exception:
+        return ""
+
+
+def git_facts(repo):
+    g = ["git", "-C", repo]
+    out = {}
+    top = _run(g + ["rev-parse", "--show-toplevel"], repo)
+    if not top:
+        return out
+    out["repo"] = os.path.basename(top)
+    out["branch"] = _run(g + ["rev-parse", "--abbrev-ref", "HEAD"], repo)
+    lr = _run(g + ["rev-list", "--left-right", "--count", "@{u}...HEAD"], repo)
+    if lr and "\t" in lr:
+        b, a = lr.split("\t")[:2]
+        out["behind"], out["ahead"] = int(b or 0), int(a or 0)
+    dirty = _run(g + ["status", "--porcelain"], repo)
+    out["dirty"] = len([x for x in dirty.splitlines() if x.strip()])
+    wl = _run(g + ["worktree", "list"], repo)
+    out["worktrees"] = len(wl.splitlines())
+    out["head"] = _run(g + ["log", "--oneline", "-1"], repo)
+    prs = _run(["gh", "pr", "list", "--state", "open", "--json", "number"], repo)
+    try:
+        out["open_prs"] = len(json.loads(prs)) if prs else 0
+    except Exception:
+        out["open_prs"] = None
+    return out
+
+
+# ── demo params (this session) ───────────────────────────────────────────────
+DEMO = {
+    "session": {"title": "cross-ref end-of-action-* policy ⇄ postflight executable",
+                "id": "49702159", "date": "2026-06-09", "time": "22:07", "duration": "~25min"},
+    "verdict": {"state": "done", "label": "DONE · green · merged"},
+    "autonomy": {"green": 5, "blue": 1, "orange": 0, "red": 0},
+    "vitals": [
+        {"icon": "📦", "label": "Escopo",   "pct": 100, "note": "já existia (PRs #114-#121)"},
+        {"icon": "🎯", "label": "Entregue", "pct": 100, "note": "1/1 remnant (§B-row-3)"},
+        {"icon": "🔀", "label": "PR #138",  "pct": 100, "note": "MERGED · squash · c568d40"},
+        {"icon": "✅", "label": "Checks",   "pct": 100, "note": "gitleaks ✓ · amazon-q ✓"},
+        {"icon": "⚠️", "label": "Risco",    "pct": 10,  "note": "baixo · docs-only · sem deploy"},
+    ],
+    "checklist": [
+        {"state": "green",  "label": "Reuse-verify", "note": "escopo já merged · nada reinventado", "confidence": 97},
+        {"state": "blue",   "label": "Decisão escopo", "note": "build-novo vs confirmar → você (HITL)", "confidence": None},
+        {"state": "green",  "label": "Remnant §B", "note": "cross-ref PATCH (1.1.1 + 1.3.1)", "confidence": 95},
+        {"state": "green",  "label": "PR/merge", "note": "auto-merge sob standing-auth", "confidence": 93},
+        {"state": "green",  "label": "persisted?", "note": "origin/main + ledger + plan", "confidence": 99},
+        {"state": "green",  "label": "boy-scout?", "note": "worktree+branch removidos · MAOS 0/0", "confidence": 99},
+    ],
+    "whats_left": [
+        {"state": "done",   "text": "Nada nesta tarefa — fechada."},
+        {"state": "orange", "text": "(opcional) housekeeping ~/.claude: index.lock stale · 5 worktrees órfãos"},
+    ],
+}
+
+
+def load_params(args):
+    if args.demo:
+        return DEMO
+    raw = ""
+    if args.params == "-":
+        raw = sys.stdin.read()
+    elif args.params:
+        raw = open(args.params, encoding="utf-8").read()
+    if not raw.strip():
+        return DEMO
+    return json.loads(raw)
+
+
+def enrich(d, args):
+    d.setdefault("session", {})
+    if args.auto_git:
+        g = git_facts(args.repo or ".")
+        d["_git"] = g
+    else:
+        d["_git"] = {}
+    d.setdefault("verdict", {"state": "done", "label": "DONE"})
+    d.setdefault("autonomy", {"green": 0, "blue": 0, "orange": 0, "red": 0})
+    d.setdefault("vitals", [])
+    d.setdefault("checklist", [])
+    d.setdefault("whats_left", [])
+    return d
+
+
+# ── shared fragments ─────────────────────────────────────────────────────────
+def legend_line():
+    return "  ".join(f"{i} {w}" for i, w, *_ in (st(k) for k in
+                     ("red", "yellow", "orange", "green", "blue")))
+
+
+def pulse_line(a):
+    seq = (dot("green") * a["green"] + " " + dot("blue") * a["blue"] + " "
+           + dot("orange") * a["orange"] + " " + dot("red") * a["red"]).strip()
+    tot = a["green"] + a["blue"] + a["orange"] + a["red"]
+    tally = f"{a['green']}🟢 · {a['blue']}🔵 · {a['orange']}🟠 · {a['red']}🔴"
+    return seq, tally, tot, green_pct(a)
+
+
+def sess_head(s):
+    t = s.get("title", "session")
+    meta = " · ".join(x for x in (s.get("date"), s.get("time"), s.get("duration")) if x)
+    return t, meta
+
+
+def conf(item):
+    cf = item.get("confidence")
+    return f"{cf}%" if isinstance(cf, (int, float)) else "──"
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 1 — "Cockpit" : rich left-framed card (verdict band · vitals · checklist
+#                       · pulse · what's-left). Best for substantive sessions.
+# ══════════════════════════════════════════════════════════════════════════════
+def model_1(d):
+    s = d["session"]; t, meta = sess_head(s)
+    a = d["autonomy"]; _, _, _, gp = pulse_line(a)
+    vi = VERDICT_ICON.get(d["verdict"].get("state"), "•")
+    L = []
+    L.append(c("┏━━ 🛬 END-OF-ACTION SCORECARD " + "━" * 8, 244))
+    L.append(c("┃ ", 244) + c(t, bold=True))
+    L.append(c("┃ ", 244) + c(meta, dim=True))
+    L.append(c("┣" + "━" * 38, 244))
+    L.append(c("┃ ", 244) + c("VERDICT ", dim=True) + f"{vi} " + c(d["verdict"].get("label", ""), 46, bold=True)
+              + "   " + c("autonomy ", dim=True) + bar(gp, 10) + f" {gp:.0f}%")
+    L.append(c("┃", 244))
+    L.append(c("┃ ", 244) + c("VITALS", 244, bold=True))
+    for v in d["vitals"]:
+        L.append(c("┃  ", 244) + f"{v.get('icon','•')} " + pad(v.get("label", ""), 9)
+                 + bar(v.get("pct", 0), 10) + "  " + c(v.get("note", ""), dim=True))
+    L.append(c("┃", 244))
+    L.append(c("┃ ", 244) + c("CHECKLIST", 244, bold=True))
+    for it in d["checklist"]:
+        L.append(c("┃  ", 244) + f"{dot(it['state'])} " + pad(it.get("label", ""), 16)
+                 + c(pad(it.get("note", ""), 40), dim=True) + c(conf(it), 46))
+    L.append(c("┃", 244))
+    seq, tally, tot, _ = pulse_line(a)
+    L.append(c("┃ ", 244) + c("PULSE ", 244, bold=True) + seq + "   " + c(tally, dim=True))
+    L.append(c("┃", 244))
+    L.append(c("┃ ", 244) + c("WHAT'S LEFT", 244, bold=True))
+    for w in d["whats_left"]:
+        mark = "✔" if w["state"] == "done" else dot(w["state"])
+        L.append(c("┃  ", 244) + f"{mark} " + w.get("text", ""))
+    L.append(c("┗" + "━" * 38, 244))
+    L.append(c("  " + legend_line(), dim=True))
+    return "\n".join(L)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 2 — "Traffic-Light Strip" : ultra-compact, no boxes, one line per item.
+#                       Best for quick sessions / inline / chat.
+# ══════════════════════════════════════════════════════════════════════════════
+def model_2(d):
+    s = d["session"]; t, meta = sess_head(s)
+    a = d["autonomy"]; seq, tally, tot, gp = pulse_line(a)
+    vi = VERDICT_ICON.get(d["verdict"].get("state"), "•")
+    L = [f"{vi} {c(d['verdict'].get('label',''),46,bold=True)}  ·  {c(t,dim=True)}  ·  {c(meta,dim=True)}"]
+    L.append("")
+    for it in d["checklist"]:
+        line = f"{dot(it['state'])} {pad(it.get('label',''),16)} {c('·',240)} {pad(it.get('note',''),42,)}"
+        L.append(line + c(conf(it).rjust(4), 46))
+    L.append("")
+    L.append(f"{c('pulse',244)} {seq}  {bar(gp,10)} {gp:.0f}%  {c(tally,dim=True)}")
+    nxt = next((w["text"] for w in d["whats_left"] if w["state"] != "done"), None)
+    L.append(f"{c('next ',244)}{('✔ nada pendente' if not nxt else dot('orange')+' '+nxt)}")
+    return "\n".join(L)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 3 — "Dashboard / KPI Tiles" : status-page tile grid + compact checklist.
+#                       Best for metric-heavy sessions.
+# ══════════════════════════════════════════════════════════════════════════════
+def _tile(label, value, code, w=17):
+    top = "┌" + "─" * w + "┐"
+    lab = "│ " + pad(c(label, dim=True), w - 1) + "│"
+    val = "│ " + pad(c(value, code, bold=True), w - 1) + "│"
+    bot = "└" + "─" * w + "┘"
+    return [top, lab, val, bot]
+
+
+def model_3(d):
+    s = d["session"]; t, meta = sess_head(s)
+    a = d["autonomy"]; gp = green_pct(a)
+    done = sum(1 for it in d["checklist"] if it["state"] in ("green", "blue"))
+    tiles = [
+        ("VERDICT", d["verdict"].get("label", "").split("·")[0].strip(), 46),
+        ("AUTONOMY", f"{gp:.0f}% green", 46 if gp >= 80 else 208),
+        ("CHECKLIST", f"{done}/{len(d['checklist'])} done", 46),
+        ("OPEN", f"{sum(1 for w in d['whats_left'] if w['state']!='done')} left",
+         46 if all(w["state"] == "done" for w in d["whats_left"]) else 208),
+    ]
+    L = [c(f"🛬 {t}", bold=True), c(meta, dim=True), ""]
+    rows = [tiles[i:i + 2] for i in range(0, len(tiles), 2)]
+    for row in rows:
+        cells = [_tile(lbl, val, cd) for lbl, val, cd in row]
+        for ln in range(4):
+            L.append("  ".join(cell[ln] for cell in cells))
+    L.append("")
+    for it in d["checklist"]:
+        L.append(f"  {dot(it['state'])} {pad(it.get('label',''),14)} {c(it.get('note',''),dim=True)}")
+    return "\n".join(L)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 4 — "Burndown Ledger" : done-vs-remaining bar + numbered item ledger.
+#                       Best for multi-task sessions with a backlog.
+# ══════════════════════════════════════════════════════════════════════════════
+def model_4(d):
+    s = d["session"]; t, meta = sess_head(s)
+    items = d["checklist"]
+    done = sum(1 for it in items if it["state"] in ("green", "blue"))
+    n = len(items) or 1
+    L = [c(f"🛬 {t}", bold=True), c(meta, dim=True), ""]
+    L.append(f"  {c('burndown',244)}  {bar(100*done/n,20)}  {c(f'{done}/{n} done · {n-done} left',bold=True)}")
+    L.append("")
+    for i, it in enumerate(items, 1):
+        L.append(f"  {c(f'[{i:>2}]',240)} {dot(it['state'])} {pad(it.get('label',''),16)}"
+                 f" {c(pad(it.get('note',''),40),dim=True)} {c(conf(it),46)}")
+    rem = [w for w in d["whats_left"] if w["state"] != "done"]
+    L.append("")
+    if rem:
+        L.append(f"  {c('remaining',208,bold=True)}")
+        for w in rem:
+            L.append(f"    {dot(w['state'])} {w['text']}")
+    else:
+        L.append(f"  {c('✔ remaining: none — burned down',46)}")
+    return "\n".join(L)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 5 — "Kanban Lanes" : items bucketed by state (Done/Doing/Need-you/Todo).
+#                       Best when 'what's left' is the headline.
+# ══════════════════════════════════════════════════════════════════════════════
+def model_5(d):
+    s = d["session"]; t, meta = sess_head(s)
+    lanes = [("green", "✅ DONE"), ("yellow", "🟡 DOING"),
+             ("orange", "🟠 NEED-YOU"), ("red", "🔴 TODO")]
+    buckets = {k: [] for k, _ in lanes}
+    for it in d["checklist"]:
+        key = ALIAS.get(it["state"], it["state"])
+        buckets.setdefault("blue" if key == "blue" else key, [])
+        buckets.setdefault(key, []).append(it.get("label", ""))
+    # fold blue(done-human) into DONE lane
+    buckets["green"] = buckets.get("green", []) + buckets.get("blue", [])
+    for w in d["whats_left"]:
+        if w["state"] != "done":
+            buckets.setdefault(ALIAS.get(w["state"], w["state"]), []).append(w["text"])
+    L = [c(f"🛬 {t}", bold=True), c(meta, dim=True), ""]
+    for key, title in lanes:
+        rows = buckets.get(key, [])
+        code = STATE[key][3]
+        L.append(c(f"  {title}  ({len(rows)})", code, bold=True))
+        for r in rows:
+            L.append(f"    {c('•',code)} {r}")
+        if not rows:
+            L.append(c("    —", dim=True))
+    a = d["autonomy"]; _, tally, _, gp = pulse_line(a)
+    L.append("")
+    L.append(f"  {c('pulse',244)} {bar(gp,10)} {gp:.0f}% green  ·  {c(tally,dim=True)}")
+    return "\n".join(L)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 6 — "Telemetry / Machine-First" : key:value + sparkline + JSON-RPC sidecar.
+#                       Best for agent-to-agent consumption (economical register).
+# ══════════════════════════════════════════════════════════════════════════════
+SPARK = "▁▂▃▄▅▆▇█"
+
+
+def model_6(d):
+    s = d["session"]; a = d["autonomy"]; gp = green_pct(a)
+    tot = sum(a.values()) or 1
+    spark = "".join(SPARK[min(7, int(a[k] / tot * 7))] for k in ("red", "orange", "yellow" if "yellow" in a else "blue", "green") if k in a) if a else ""
+    L = [c("# scorecard.telemetry", 244, bold=True)]
+    L.append(f"session.id        = {s.get('id','-')}")
+    L.append(f"session.title     = {s.get('title','-')}")
+    L.append(f"verdict.state     = {d['verdict'].get('state','-')}  {VERDICT_ICON.get(d['verdict'].get('state'),'')}")
+    L.append(f"autonomy.green    = {a['green']}")
+    L.append(f"autonomy.human    = {a['blue']}")
+    L.append(f"autonomy.need_hitl= {a['orange']}")
+    L.append(f"autonomy.pct_green= {gp:.1f}%   {bar(gp,12)}")
+    L.append(f"checklist.done    = {sum(1 for it in d['checklist'] if it['state'] in ('green','blue'))}/{len(d['checklist'])}")
+    L.append(f"open.items        = {sum(1 for w in d['whats_left'] if w['state']!='done')}")
+    g = d.get("_git") or {}
+    if g:  # script-self-calculated facts (zero agent input) — surfaced here
+        L.append(f"git.repo          = {g.get('repo','-')}")
+        L.append(f"git.branch        = {g.get('branch','-')}  (+{g.get('ahead',0)}/-{g.get('behind',0)})")
+        L.append(f"git.dirty         = {g.get('dirty','-')} file(s)")
+        L.append(f"git.open_prs      = {g.get('open_prs','-')}")
+    L.append("")
+    L.append(c("  json-rpc sidecar:", dim=True))
+    payload = {"jsonrpc": "2.0", "method": "session.scorecard", "params": {
+        "verdict": d["verdict"].get("state"),
+        "autonomy": {k: a[k] for k in ("green", "blue", "orange", "red")},
+        "pct_green": round(gp, 1),
+        "checklist": [{"label": it.get("label"), "token": st(it["state"])[2],
+                       "confidence": it.get("confidence")} for it in d["checklist"]],
+        "open": [w["text"] for w in d["whats_left"] if w["state"] != "done"],
+        "git": {k: g.get(k) for k in ("repo", "branch", "ahead", "behind", "dirty", "open_prs")} if g else None,
+    }, "data": {"layer": "community"}}
+    L.append("  " + json.dumps(payload, ensure_ascii=False))
+    return "\n".join(L)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# MODEL 7 — "Executive One-Liner + drilldown" : Minto TL;DR in one line.
+#                       Best for 1-second 'bater o olho'.
+# ══════════════════════════════════════════════════════════════════════════════
+def model_7(d):
+    a = d["autonomy"]; gp = green_pct(a)
+    vi = VERDICT_ICON.get(d["verdict"].get("state"), "•")
+    done = sum(1 for it in d["checklist"] if it["state"] in ("green", "blue"))
+    openn = sum(1 for w in d["whats_left"] if w["state"] != "done")
+    def clip(t, n):
+        return t if len(t) <= n else t[:n - 1] + "…"
+    nxt = next((w["text"] for w in d["whats_left"] if w["state"] != "done"), "—")
+    head = (f"{vi} {c(d['verdict'].get('label','').split('·')[0].strip().upper(),46,bold=True)}"
+            f" · {bar(gp,8)} {gp:.0f}% green"
+            f" · {done}/{len(d['checklist'])} done"
+            f" · {openn} blocker{'s' if openn!=1 else ''}"
+            f" · next: {('—' if openn==0 else clip(nxt,34))}")
+    L = [head]
+    L.append(c(f"  ↳ {d['session'].get('title','')}  ({d['session'].get('duration','')})", dim=True))
+    if openn:
+        L.append(c("  ↳ open: " + " · ".join(clip(w["text"], 42) for w in d["whats_left"] if w["state"] != "done"), 208))
+    return "\n".join(L)
+
+
+MODELS = {1: model_1, 2: model_2, 3: model_3, 4: model_4, 5: model_5, 6: model_6, 7: model_7}
+NAMES = {1: "Cockpit", 2: "Traffic-Light Strip", 3: "Dashboard / KPI Tiles",
+         4: "Burndown Ledger", 5: "Kanban Lanes", 6: "Telemetry / Machine-First",
+         7: "Executive One-Liner"}
+
+
+def main():
+    global COLOR
+    ap = argparse.ArgumentParser(description="postflight scorecard renderer (7 models)")
+    ap.add_argument("--model", type=int, default=1, choices=range(1, 8))
+    ap.add_argument("--params", help="JSON params file, or '-' for stdin")
+    ap.add_argument("--demo", action="store_true", help="use built-in demo params")
+    ap.add_argument("--auto-git", action="store_true", help="self-calculate git/PR facts")
+    ap.add_argument("--repo", help="repo dir for --auto-git (default cwd)")
+    ap.add_argument("--no-color", action="store_true")
+    ap.add_argument("--all", action="store_true", help="render every model")
+    a = ap.parse_args()
+    COLOR = not (a.no_color or os.environ.get("NO_COLOR"))
+    d = enrich(load_params(a), a)
+    if a.all:
+        for m in range(1, 8):
+            print(c(f"\n══════ MODEL {m} — {NAMES[m]} " + "═" * 30, 39, bold=True))
+            print(MODELS[m](d))
+        return
+    print(MODELS[a.model](d))
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/scorecard.py
+++ b/bin/scorecard.py
@@ -111,7 +111,10 @@ def _run(args, cwd, timeout=6):
     try:
         return subprocess.run(args, cwd=cwd, capture_output=True, text=True,
                               timeout=timeout).stdout.strip()
-    except Exception:
+    except (subprocess.SubprocessError, OSError):
+        # narrow: subprocess/OS failures degrade gracefully (deterministic
+        # renderer must not abort on a missing git/gh); programming errors
+        # (AttributeError, etc.) are NOT swallowed so real bugs still surface.
         return ""
 
 
@@ -135,7 +138,7 @@ def git_facts(repo):
     prs = _run(["gh", "pr", "list", "--state", "open", "--json", "number"], repo)
     try:
         out["open_prs"] = len(json.loads(prs)) if prs else 0
-    except Exception:
+    except (json.JSONDecodeError, TypeError):
         out["open_prs"] = None
     return out
 
@@ -181,25 +184,52 @@ def load_params(args):
     if args.params == "-":
         raw = sys.stdin.read()
     elif args.params:
-        raw = open(args.params, encoding="utf-8").read()
+        with open(args.params, encoding="utf-8") as f:
+            raw = f.read()
     if not raw.strip():
         return DEMO
     return json.loads(raw)
 
 
+def _norm_state(x, fallback="yellow"):
+    """Map any (missing/unknown/aliased) state to a known 5-state key."""
+    k = ALIAS.get(x, x)
+    return k if k in STATE else fallback
+
+
+def _as_int(x):
+    """Coerce to a non-negative int; non-numeric/bool/None -> 0 (deterministic)."""
+    return x if isinstance(x, int) and not isinstance(x, bool) and x >= 0 else 0
+
+
 def enrich(d, args):
-    d.setdefault("session", {})
-    if args.auto_git:
-        g = git_facts(args.repo or ".")
-        d["_git"] = g
-    else:
-        d["_git"] = {}
-    d.setdefault("verdict", {"state": "done", "label": "DONE"})
-    d.setdefault("autonomy", {"green": 0, "blue": 0, "orange": 0, "red": 0})
-    d.setdefault("vitals", [])
-    d.setdefault("checklist", [])
-    d.setdefault("whats_left", [])
-    d.setdefault("tickets", [])
+    """Deep-normalize the params blob so EVERY render path is crash-proof on
+    partial/malformed input (the schema's "all keys optional" promise). After
+    enrich, downstream code can index nested keys (a["green"], it["state"],
+    w["state"]) without KeyError — the structure is guaranteed complete."""
+    if not isinstance(d, dict):
+        d = {}
+    if not isinstance(d.get("session"), dict):
+        d["session"] = {}
+    d["_git"] = git_facts(args.repo or ".") if args.auto_git else {}
+    if not isinstance(d.get("verdict"), dict):
+        d["verdict"] = {}
+    d["verdict"].setdefault("state", "done")
+    d["verdict"].setdefault("label", "DONE")
+    a = d.get("autonomy") if isinstance(d.get("autonomy"), dict) else {}
+    d["autonomy"] = {k: _as_int(a.get(k)) for k in ("green", "blue", "orange", "red")}
+    d["vitals"] = [v for v in (d.get("vitals") or []) if isinstance(v, dict)]
+    d["checklist"] = [it for it in (d.get("checklist") or []) if isinstance(it, dict)]
+    for it in d["checklist"]:
+        it["state"] = _norm_state(it.get("state"))
+        it.setdefault("label", "")
+        it.setdefault("note", "")
+    d["whats_left"] = [w for w in (d.get("whats_left") or []) if isinstance(w, dict)]
+    for w in d["whats_left"]:
+        # "done" is a sentinel ("burned down") — preserve it; else normalize.
+        w["state"] = "done" if w.get("state") == "done" else _norm_state(w.get("state"), "red")
+        w.setdefault("text", "")
+    d["tickets"] = [t for t in (d.get("tickets") or []) if isinstance(t, dict)]
     return d
 
 
@@ -384,7 +414,6 @@ def model_5(d):
     buckets = {k: [] for k, _ in lanes}
     for it in d["checklist"]:
         key = ALIAS.get(it["state"], it["state"])
-        buckets.setdefault("blue" if key == "blue" else key, [])
         buckets.setdefault(key, []).append(it.get("label", ""))
     # fold blue(done-human) into DONE lane
     buckets["green"] = buckets.get("green", []) + buckets.get("blue", [])
@@ -419,7 +448,7 @@ SPARK = "▁▂▃▄▅▆▇█"
 def model_6(d):
     s = d["session"]; a = d["autonomy"]; gp = green_pct(a)
     tot = sum(a.values()) or 1
-    spark = "".join(SPARK[min(7, int(a[k] / tot * 7))] for k in ("red", "orange", "yellow" if "yellow" in a else "blue", "green") if k in a) if a else ""
+    spark = "".join(SPARK[min(7, int(a.get(k, 0) / tot * 7))] for k in ("red", "orange", "blue", "green"))
     L = [c("# scorecard.telemetry", 244, bold=True)]
     L.append(f"session.id        = {s.get('id','-')}")
     L.append(f"session.title     = {s.get('title','-')}")
@@ -428,6 +457,7 @@ def model_6(d):
     L.append(f"autonomy.human    = {a['blue']}")
     L.append(f"autonomy.need_hitl= {a['orange']}")
     L.append(f"autonomy.pct_green= {gp:.1f}%   {bar(gp,12)}")
+    L.append(f"autonomy.spark    = {spark}")
     L.append(f"checklist.done    = {sum(1 for it in d['checklist'] if it['state'] in ('green','blue'))}/{len(d['checklist'])}")
     L.append(f"open.items        = {sum(1 for w in d['whats_left'] if w['state']!='done')}")
     g = d.get("_git") or {}

--- a/bin/scorecard.py
+++ b/bin/scorecard.py
@@ -40,7 +40,8 @@ STATE = {
 }
 ALIAS = {"done": "green", "agentic": "green", "human": "blue", "hitl": "orange",
          "doing": "yellow", "wip": "yellow", "todo": "red", "blocked": "red",
-         "warn": "orange"}
+         "warn": "orange", "closed": "green", "open": "yellow", "review": "orange",
+         "in-progress": "yellow", "in_progress": "yellow", "merged": "green"}
 VERDICT_ICON = {"done": "✅", "warn": "⚠️", "blocked": "🛑", "wip": "🟡"}
 
 
@@ -164,6 +165,12 @@ DEMO = {
         {"state": "done",   "text": "Nada nesta tarefa — fechada."},
         {"state": "orange", "text": "(opcional) housekeeping ~/.claude: index.lock stale · 5 worktrees órfãos"},
     ],
+    "tickets": [
+        {"id": "PROJ-204", "status": "closed",      "title": "spec round-2 — as-built fidelity"},
+        {"id": "PROJ-211", "status": "in-progress", "title": "POC: dev branch + protections"},
+        {"id": "PROJ-218", "status": "review",      "title": "add module test oracles"},
+        {"id": "PROJ-220", "status": "open",        "title": "capture infra config in VC"},
+    ],
 }
 
 
@@ -192,6 +199,7 @@ def enrich(d, args):
     d.setdefault("vitals", [])
     d.setdefault("checklist", [])
     d.setdefault("whats_left", [])
+    d.setdefault("tickets", [])
     return d
 
 
@@ -220,6 +228,21 @@ def conf(item):
     return f"{cf}%" if isinstance(cf, (int, float)) else "──"
 
 
+def tk_list(d):
+    return d.get("tickets", []) or []
+
+
+def tk_counts(d):
+    tk = tk_list(d)
+    done = sum(1 for t in tk if ALIAS.get(t.get("status"), t.get("status")) in ("green", "blue"))
+    return done, len(tk)
+
+
+def tk_summary(d):
+    tk = tk_list(d)
+    return "  ".join(f"{dot(t.get('status','green'))} {t.get('id','?')}" for t in tk) if tk else None
+
+
 # ══════════════════════════════════════════════════════════════════════════════
 # MODEL 1 — "Cockpit" : rich left-framed card (verdict band · vitals · checklist
 #                       · pulse · what's-left). Best for substantive sessions.
@@ -245,6 +268,13 @@ def model_1(d):
     for it in d["checklist"]:
         L.append(c("┃  ", 244) + f"{dot(it['state'])} " + pad(it.get("label", ""), 16)
                  + c(pad(it.get("note", ""), 40), dim=True) + c(conf(it), 46))
+    if tk_list(d):
+        L.append(c("┃", 244))
+        dn, tt = tk_counts(d)
+        L.append(c("┃ ", 244) + c(f"TICKETS  ({dn}/{tt} done)", 244, bold=True))
+        for t in tk_list(d):
+            L.append(c("┃  ", 244) + f"{dot(t.get('status','green'))} " + pad(t.get("id", "?"), 12)
+                     + c(t.get("title", ""), dim=True))
     L.append(c("┃", 244))
     seq, tally, tot, _ = pulse_line(a)
     L.append(c("┃ ", 244) + c("PULSE ", 244, bold=True) + seq + "   " + c(tally, dim=True))
@@ -271,6 +301,10 @@ def model_2(d):
     for it in d["checklist"]:
         line = f"{dot(it['state'])} {pad(it.get('label',''),16)} {c('·',240)} {pad(it.get('note',''),42,)}"
         L.append(line + c(conf(it).rjust(4), 46))
+    ts = tk_summary(d)
+    if ts:
+        dn, tt = tk_counts(d)
+        L.append(f"{c('tickets',244)} {ts}   {c(f'({dn}/{tt} done)',dim=True)}")
     L.append("")
     L.append(f"{c('pulse',244)} {seq}  {bar(gp,10)} {gp:.0f}%  {c(tally,dim=True)}")
     nxt = next((w["text"] for w in d["whats_left"] if w["state"] != "done"), None)
@@ -357,6 +391,9 @@ def model_5(d):
     for w in d["whats_left"]:
         if w["state"] != "done":
             buckets.setdefault(ALIAS.get(w["state"], w["state"]), []).append(w["text"])
+    for tk in tk_list(d):
+        key = ALIAS.get(tk.get("status"), tk.get("status", "green"))
+        buckets.setdefault(key, []).append(f"🎫 {tk.get('id','?')} {tk.get('title','')}")
     L = [c(f"🛬 {t}", bold=True), c(meta, dim=True), ""]
     for key, title in lanes:
         rows = buckets.get(key, [])
@@ -399,6 +436,11 @@ def model_6(d):
         L.append(f"git.branch        = {g.get('branch','-')}  (+{g.get('ahead',0)}/-{g.get('behind',0)})")
         L.append(f"git.dirty         = {g.get('dirty','-')} file(s)")
         L.append(f"git.open_prs      = {g.get('open_prs','-')}")
+    if tk_list(d):
+        dn, tt = tk_counts(d)
+        L.append(f"tickets.done      = {dn}/{tt}")
+        for t in tk_list(d):
+            L.append(f"  ticket {t.get('id','?'):<10}= {t.get('status',''):<12} {t.get('title','')}")
     L.append("")
     L.append(c("  json-rpc sidecar:", dim=True))
     payload = {"jsonrpc": "2.0", "method": "session.scorecard", "params": {
@@ -408,6 +450,8 @@ def model_6(d):
         "checklist": [{"label": it.get("label"), "token": st(it["state"])[2],
                        "confidence": it.get("confidence")} for it in d["checklist"]],
         "open": [w["text"] for w in d["whats_left"] if w["state"] != "done"],
+        "tickets": [{"id": t.get("id"), "status": t.get("status"),
+                     "token": st(t.get("status", "green"))[2]} for t in tk_list(d)],
         "git": {k: g.get(k) for k in ("repo", "branch", "ahead", "behind", "dirty", "open_prs")} if g else None,
     }, "data": {"layer": "community"}}
     L.append("  " + json.dumps(payload, ensure_ascii=False))
@@ -426,9 +470,10 @@ def model_7(d):
     def clip(t, n):
         return t if len(t) <= n else t[:n - 1] + "…"
     nxt = next((w["text"] for w in d["whats_left"] if w["state"] != "done"), "—")
+    tkseg = (f" · 🎫 {tk_counts(d)[0]}/{tk_counts(d)[1]}" if tk_list(d) else "")
     head = (f"{vi} {c(d['verdict'].get('label','').split('·')[0].strip().upper(),46,bold=True)}"
             f" · {bar(gp,8)} {gp:.0f}% green"
-            f" · {done}/{len(d['checklist'])} done"
+            f" · {done}/{len(d['checklist'])} done{tkseg}"
             f" · {openn} blocker{'s' if openn!=1 else ''}"
             f" · next: {('—' if openn==0 else clip(nxt,34))}")
     L = [head]

--- a/bin/spawn-continuation.sh
+++ b/bin/spawn-continuation.sh
@@ -49,7 +49,9 @@ Environment guardrails:
   CLAUDE_CODE_SESSION_ID      source session id (idempotency key); falls back to a derived key.
   MAOS_SPAWN_LAUNCHER         force launcher: tmux | cmux | print (default: auto-detect).
 
-Spawns ONE detached session, attachable later:  tmux attach -t <name>   (or via cmux).
+Spawns ONE detached session. Re-enter later with:  claude --resume <uuid>
+(or, while the tmux pane is alive:  tmux attach -t <name>).  Note: --session-id CREATES a
+session (once); to RE-ENTER an existing one use --resume (avoids "session id already in use").
 EOF
   exit "${1:-0}"
 }
@@ -139,16 +141,19 @@ CMD_PRINT="claude --name '${NAME}' --session-id '${UUID}' --append-system-prompt
 # ── G4 launcher capability-detect ────────────────────────────────────────────
 LAUNCHER="${MAOS_SPAWN_LAUNCHER:-auto}"
 if [ "$LAUNCHER" = "auto" ]; then
-  if   command -v cmux >/dev/null 2>&1; then LAUNCHER="cmux"
-  elif command -v tmux >/dev/null 2>&1; then LAUNCHER="tmux"
-  elif command -v claude >/dev/null 2>&1; then LAUNCHER="print"   # claude exists but no detacher → register+print
+  # tmux FIRST: it is the only VERIFIABLE + attachable detached launcher here. cmux has no
+  # documented "run an arbitrary command in a detached pane" primitive (its CLI opens
+  # paths/URLs, not commands), so auto-detect does NOT route to a fake cmux spawn — without
+  # tmux we fall to register+print (honest resume command), never a false "spawned".
+  if   command -v tmux >/dev/null 2>&1; then LAUNCHER="tmux"
+  elif command -v claude >/dev/null 2>&1; then LAUNCHER="print"   # detacher absent/unverifiable → register+print
   else LAUNCHER="none"; fi
 fi
 
 emit_plan() { # status, launched(bool)
   printf '{"status":"%s","name":"%s","session_id":"%s","launcher":"%s","depth":%s,"src_session":"%s","resume_cmd":"%s","attach":"%s"}\n' \
     "$1" "$(json_escape "$NAME")" "$(json_escape "$UUID")" "$(json_escape "$LAUNCHER")" "$DEPTH" \
-    "$(json_escape "$SRC_KEY")" "$(json_escape "$CMD_PRINT")" "$(json_escape "tmux attach -t ${NAME}")"
+    "$(json_escape "$SRC_KEY")" "$(json_escape "$CMD_PRINT")" "$(json_escape "claude --resume ${UUID}")"
 }
 
 # ── --dry-run: print plan, touch nothing ─────────────────────────────────────
@@ -179,7 +184,8 @@ printf '%s\tname=%s\tuuid=%s\tsrc=%s\tlauncher=%s\tspawn=%s\n' \
 if [ "$NO_SPAWN" = "1" ] || [ "$LAUNCHER" = "none" ] || [ "$LAUNCHER" = "print" ]; then
   reason="$([ "$NO_SPAWN" = 1 ] && echo '--no-spawn' || echo "no detached launcher (tmux/cmux) found")"
   echo "🛫 continuation prepared (${reason}). Seed → ${SEED_FILE}" >&2
-  echo "   Resume with:  claude --name '${NAME}' --session-id '${UUID}' --append-system-prompt \"\$(cat '${SEED_FILE}')\"" >&2
+  echo "   Start it:  claude --name '${NAME}' --session-id '${UUID}' --append-system-prompt \"\$(cat '${SEED_FILE}')\"" >&2
+  echo "   Re-enter:  claude --resume '${UUID}'   (after it has been started once)" >&2
   emit_plan "registered"; exit 0
 fi
 
@@ -191,15 +197,18 @@ case "$LAUNCHER" in
     # interactive claude in a detached tmux session, pre-seeded, attachable.
     POSTFLIGHT_SPAWN_DEPTH="$CHILD_DEPTH" tmux new-session -d -s "$NAME" \
       "POSTFLIGHT_SPAWN_DEPTH=$CHILD_DEPTH claude --name '$NAME' --session-id '$UUID' --append-system-prompt \"\$(cat '$SEED_FILE')\"" 2>/dev/null \
-      && { echo "🛫 spawned (tmux): $NAME  — attach: tmux attach -t '$NAME'" >&2; emit_plan "spawned"; exit 0; }
+      && { echo "🛫 spawned (tmux): $NAME" >&2
+           echo "   re-enter:  tmux attach -t '$NAME'   (or, once the pane exits:  claude --resume '$UUID')" >&2
+           emit_plan "spawned"; exit 0; }
     ;;
   cmux)
-    POSTFLIGHT_SPAWN_DEPTH="$CHILD_DEPTH" cmux claude --name "$NAME" --session-id "$UUID" --append-system-prompt "$SEED_RAW" >/dev/null 2>&1 & \
-      { echo "🛫 spawned (cmux): $NAME" >&2; emit_plan "spawned"; exit 0; }
-    ;;
+    # cmux exposes no verified "run an arbitrary detached command" primitive (its CLI opens
+    # paths/URLs, not commands). NEVER fake a spawn — fall through to the honest register+print.
+    : ;;
 esac
 # launcher failed → fall back to registered (never leave the operator stranded)
 rm -f "$MARKER" 2>/dev/null || true   # spawn didn't happen → let a retry through
-echo "🛫 launcher '$LAUNCHER' failed; continuation registered. Resume manually:" >&2
-echo "   claude --name '${NAME}' --session-id '${UUID}' --append-system-prompt \"\$(cat '${SEED_FILE}')\"" >&2
+echo "🛫 launcher '$LAUNCHER' failed; continuation registered. Start manually:" >&2
+echo "   Start it:  claude --name '${NAME}' --session-id '${UUID}' --append-system-prompt \"\$(cat '${SEED_FILE}')\"" >&2
+echo "   Re-enter:  claude --resume '${UUID}'   (after it has been started once)" >&2
 emit_plan "registered"; exit 0

--- a/skills/postflight/scorecards/GALLERY.md
+++ b/skills/postflight/scorecards/GALLERY.md
@@ -1,0 +1,88 @@
+# Postflight Scorecard Gallery — 7 end-of-action status-card models
+
+> Candidate **output formats** for `postflight` P3 HANDOFF (and the `end-of-action-briefing`
+> §4.1 visual legend). One deterministic renderer · one param schema · 7 layout models.
+> Renderer: `bin/scorecard.py`. Render any model: `bin/scorecard.py --model N --demo`.
+
+## Design contract (all 7 share it)
+
+- **Deterministic** — same params → same output (no clock unless passed in).
+- **Self-calculating** — the script derives *every* bar, %, count, tally, sparkline,
+  burndown, and (with `--auto-git`) the git/PR facts. The AI agent supplies only atoms
+  it cannot compute (verdict, per-item state/label/note/confidence, what's-left).
+- **AI-parameterized** — atoms arrive as a JSON params blob (`--params FILE|-`); see
+  `sample-params.json`.
+- **Human-glanceable** — 5-state colour legend 🔴🟡🟠🟢🔵 (icon + word + machine-token;
+  never colour-alone) + the autonomy pulse (% green = the all-green compass).
+- **Portable** — stdlib only · `NO_COLOR`/`--no-color` honoured · emoji carry colour so it
+  renders in any terminal AND in GitHub/markdown.
+
+## Param schema (atoms the agent supplies)
+
+```json
+{
+  "session":  {"title": "...", "id": "...", "date": "2026-06-09", "time": "22:07", "duration": "~25min"},
+  "verdict":  {"state": "done|warn|blocked|wip", "label": "DONE · green · merged"},
+  "autonomy": {"green": 5, "blue": 1, "orange": 0, "red": 0},
+  "vitals":   [{"icon": "📦", "label": "Escopo", "pct": 100, "note": "..."}],
+  "checklist":[{"state": "green|blue|orange|yellow|red", "label": "...", "note": "...", "confidence": 97}],
+  "whats_left":[{"state": "done|orange|red|yellow", "text": "..."}]
+}
+```
+`state` aliases: `done→green · human→blue · hitl→orange · doing/wip→yellow · todo/blocked→red`.
+
+## The 7 models (run `--model N --demo` to see each rendered)
+
+| # | Name | Essence | Best for |
+|---|---|---|---|
+| **1** | **Cockpit** | rich left-framed card: verdict band · vitals bars · checklist · pulse · what's-left · legend | substantive sessions (the full debrief) |
+| **2** | **Traffic-Light Strip** | no boxes; one colour-dot line per item + pulse + next | quick sessions · inline · chat (fast clean glance) |
+| **3** | **Dashboard / KPI Tiles** | a grid of boxed KPI tiles (verdict/autonomy/checklist/open) + compact list | metric-heavy sessions (status-page feel) |
+| **4** | **Burndown Ledger** | done-vs-remaining bar + numbered item ledger + remaining block | multi-task sessions with a backlog |
+| **5** | **Kanban Lanes** | items bucketed by state (Done/Doing/Need-you/Todo) | when "what's left" is the headline |
+| **6** | **Telemetry / Machine-First** | `key=value` + git facts + sparkline + **JSON-RPC sidecar** | agent-to-agent handoff (economical register) |
+| **7** | **Executive One-Liner** | Minto TL;DR in ONE line + 2-line drilldown | 1-second "bater o olho" |
+
+## Scoring (1–100, transparent rubric — AI-recomputable)
+
+Weights (Σ=100): **Glance-speed 25** · **AI-calculability 20** · **Density/Coverage 20** ·
+**Determinism 15** · **Clean/low-noise 12** · **Portability 8**.
+
+| Model | Glance · 25 | AICalc · 20 | Dens/Cov · 20 | Determ · 15 | Clean · 12 | Port · 8 | **TOTAL** |
+|---|---|---|---|---|---|---|---|
+| 2 · Traffic-Light Strip | 23 | 18 | 16 | 14 | 12 | 8 | **91** 🥇 |
+| 4 · Burndown Ledger | 19 | 18 | 18 | 15 | 10 | 8 | **88** 🥈 |
+| 7 · Executive One-Liner | 25 | 17 | 12 | 14 | 12 | 8 | **88** 🥈 |
+| 5 · Kanban Lanes | 20 | 17 | 16 | 13 | 10 | 8 | **84** |
+| 1 · Cockpit | 18 | 15 | 20 | 14 | 9 | 7 | **83** |
+| 6 · Telemetry / Machine | 12 | 20 | 17 | 15 | 11 | 8 | **83** |
+| 3 · Dashboard Tiles | 21 | 16 | 15 | 13 | 10 | 6 | **81** |
+
+## Recommendation + conclusion
+
+**Default for `postflight`: a dual-register pair (+ optional 1-line header).**
+
+- 🥇 **Model 2 (Traffic-Light Strip, 91)** → the **human-facing default**: fastest clean
+  glance that still shows the full checklist + pulse + next. Lowest noise, no box-width risk.
+- 🥈 **Model 6 (Telemetry, 83)** → the **agent-facing sidecar**: its JSON-RPC block matches
+  postflight's *existing* P3 seed envelope, so an agent reading the handoff parses it directly
+  (dual-register per `language-policy §7`: human strip + machine sidecar).
+- 🥈 **Model 7 (One-Liner, 88)** → optional **header line** prepended to M2 for the operator's
+  literal 1-second "bater o olho".
+
+**Why not a single rich card (M1/M3):** comprehensiveness costs glance-speed + portability
+(box+emoji width). M1 stays the best *full debrief* (`--model 1`) for substantive sessions, but
+the per-turn default should optimise glance + parse, where **M2 + M6** win. **M4** is the best
+pick when a session is backlog-heavy (burndown framing). All 7 stay available via `--model N` —
+the operator picks the default; the rest are on-demand.
+
+## Usage
+
+```bash
+bin/scorecard.py --model 2 --demo                 # human strip (recommended default)
+bin/scorecard.py --model 6 --demo --auto-git      # machine sidecar + self-calc git facts
+bin/scorecard.py --all  --demo                     # render every model
+echo "$AGENT_JSON" | bin/scorecard.py --model 2 -  # real session (agent supplies atoms via stdin)
+bin/scorecard.py --model 1 --params session.json   # full Cockpit debrief from a params file
+```
+`NO_COLOR=1` or `--no-color` for logs/CI.

--- a/skills/postflight/scorecards/GALLERY.md
+++ b/skills/postflight/scorecards/GALLERY.md
@@ -26,10 +26,15 @@
   "autonomy": {"green": 5, "blue": 1, "orange": 0, "red": 0},
   "vitals":   [{"icon": "📦", "label": "Escopo", "pct": 100, "note": "..."}],
   "checklist":[{"state": "green|blue|orange|yellow|red", "label": "...", "note": "...", "confidence": 97}],
-  "whats_left":[{"state": "done|orange|red|yellow", "text": "..."}]
+  "whats_left":[{"state": "done|orange|red|yellow", "text": "..."}],
+  "tickets":  [{"id": "PROJ-204", "status": "closed|in-progress|review|open|blocked", "title": "..."}]
 }
 ```
-`state` aliases: `done→green · human→blue · hitl→orange · doing/wip→yellow · todo/blocked→red`.
+`state` aliases: `done/closed/merged→green · human→blue · hitl/review→orange · doing/wip/in-progress/open→yellow · todo/blocked→red`.
+**Tickets** (Jira/Linear/GH issues) are AI-supplied atoms — the agent lists which the session
+touched + their status. Surfaced in M1 (TICKETS section), M2 (tickets line), M5 (kanban lanes),
+M6 (telemetry + JSON-RPC), M7 (🎫 count). Cross-provider auto-detect is out of scope (per-provider
+MCP/CLI) — the agent already knows the linked tickets from the session.
 
 ## The 7 models (run `--model N --demo` to see each rendered)
 

--- a/skills/postflight/scorecards/gallery.md
+++ b/skills/postflight/scorecards/gallery.md
@@ -30,6 +30,7 @@
   "tickets":  [{"id": "PROJ-204", "status": "closed|in-progress|review|open|blocked", "title": "..."}]
 }
 ```
+
 `state` aliases: `done/closed/merged→green · human→blue · hitl/review→orange · doing/wip/in-progress/open→yellow · todo/blocked→red`.
 **Tickets** (Jira/Linear/GH issues) are AI-supplied atoms — the agent lists which the session
 touched + their status. Surfaced in M1 (TICKETS section), M2 (tickets line), M5 (kanban lanes),
@@ -87,7 +88,8 @@ the operator picks the default; the rest are on-demand.
 bin/scorecard.py --model 2 --demo                 # human strip (recommended default)
 bin/scorecard.py --model 6 --demo --auto-git      # machine sidecar + self-calc git facts
 bin/scorecard.py --all  --demo                     # render every model
-echo "$AGENT_JSON" | bin/scorecard.py --model 2 -  # real session (agent supplies atoms via stdin)
+echo "$AGENT_JSON" | bin/scorecard.py --model 2 --params -  # real session (agent supplies atoms via stdin)
 bin/scorecard.py --model 1 --params session.json   # full Cockpit debrief from a params file
 ```
+
 `NO_COLOR=1` or `--no-color` for logs/CI.

--- a/skills/postflight/scorecards/sample-params.json
+++ b/skills/postflight/scorecards/sample-params.json
@@ -1,0 +1,24 @@
+{
+  "session":  {"title": "cross-ref end-of-action-* policy ⇄ postflight executable", "id": "49702159", "date": "2026-06-09", "time": "22:07", "duration": "~25min"},
+  "verdict":  {"state": "done", "label": "DONE · green · merged"},
+  "autonomy": {"green": 5, "blue": 1, "orange": 0, "red": 0},
+  "vitals": [
+    {"icon": "📦", "label": "Escopo",   "pct": 100, "note": "já existia (PRs #114-#121)"},
+    {"icon": "🎯", "label": "Entregue", "pct": 100, "note": "1/1 remnant (§B-row-3)"},
+    {"icon": "🔀", "label": "PR #138",  "pct": 100, "note": "MERGED · squash · c568d40"},
+    {"icon": "✅", "label": "Checks",   "pct": 100, "note": "gitleaks ✓ · amazon-q ✓"},
+    {"icon": "⚠️", "label": "Risco",    "pct": 10,  "note": "baixo · docs-only · sem deploy"}
+  ],
+  "checklist": [
+    {"state": "green", "label": "Reuse-verify",   "note": "escopo já merged · nada reinventado",   "confidence": 97},
+    {"state": "blue",  "label": "Decisão escopo", "note": "build-novo vs confirmar → você (HITL)", "confidence": null},
+    {"state": "green", "label": "Remnant §B",     "note": "cross-ref PATCH (1.1.1 + 1.3.1)",       "confidence": 95},
+    {"state": "green", "label": "PR/merge",       "note": "auto-merge sob standing-auth",          "confidence": 93},
+    {"state": "green", "label": "persisted?",     "note": "origin/main + ledger + plan",           "confidence": 99},
+    {"state": "green", "label": "boy-scout?",     "note": "worktree+branch removidos · MAOS 0/0",  "confidence": 99}
+  ],
+  "whats_left": [
+    {"state": "done",   "text": "Nada nesta tarefa — fechada."},
+    {"state": "orange", "text": "(opcional) housekeeping ~/.claude: index.lock stale · 5 worktrees órfãos"}
+  ]
+}

--- a/skills/postflight/scorecards/sample-params.json
+++ b/skills/postflight/scorecards/sample-params.json
@@ -20,5 +20,11 @@
   "whats_left": [
     {"state": "done",   "text": "Nada nesta tarefa — fechada."},
     {"state": "orange", "text": "(opcional) housekeeping ~/.claude: index.lock stale · 5 worktrees órfãos"}
+  ],
+  "tickets": [
+    {"id": "PROJ-204", "status": "closed",      "title": "spec round-2 — as-built fidelity"},
+    {"id": "PROJ-211", "status": "in-progress", "title": "POC: dev branch + protections"},
+    {"id": "PROJ-218", "status": "review",      "title": "add module test oracles"},
+    {"id": "PROJ-220", "status": "open",        "title": "capture infra config in VC"}
   ]
 }


### PR DESCRIPTION
**[PR-as-Enhancement-Prompt]** Candidate end-of-action output formats for `postflight` P3 HANDOFF + the `end-of-action-briefing` §4.1 legend.

**ONE renderer · ONE param schema · 7 models** — `bin/scorecard.py`. Self-calculates every bar/%/count/tally/sparkline/burndown + (`--auto-git`) git/PR facts; the AI agent supplies only the atoms (verdict, per-item state/label/note/confidence, what's-left) as a JSON params blob. 5-state legend 🔴🟡🟠🟢🔵 (icon+word+machine-token), pulse %green, `NO_COLOR`/`--no-color`, stdlib-only.

Models: 1 Cockpit · 2 Traffic-Light Strip · 3 KPI Tiles · 4 Burndown Ledger · 5 Kanban Lanes · 6 Telemetry/JSON-RPC · 7 Executive One-Liner. Scoring + recommendation in `skills/postflight/scorecards/GALLERY.md`.

**Additive** — does NOT yet change postflight's default output; the operator picks which model(s) become the default in a follow-up. Verified: `--all --demo` (7 render), `--auto-git`, `--params` paths; Layer-Purity 0 violations; gitleaks clean.

Files: `bin/scorecard.py` · `skills/postflight/scorecards/{GALLERY.md,sample-params.json}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)