### PR TITLE
feat(postflight): scorecard design-polish — equal-rail · icon-anchor · ticket/provenance parity

### DIFF
--- a/bin/scorecard.py
+++ b/bin/scorecard.py
@@ -282,16 +282,18 @@ def model_1(d):
     a = d["autonomy"]; _, _, _, gp = pulse_line(a)
     vi = VERDICT_ICON.get(d["verdict"].get("state"), "•")
     L = []
-    L.append(c("┏━━ 🛬 END-OF-ACTION SCORECARD " + "━" * 8, 244))
+    RAIL = 40  # equal-width left-rail: top/mid/bottom rules share ONE visual width
+    _top = "┏━━ 🛬 END-OF-ACTION SCORECARD "
+    L.append(c(_top + "━" * max(2, RAIL - vlen(_top)), 244))
     L.append(c("┃ ", 244) + c(t, bold=True))
     L.append(c("┃ ", 244) + c(meta, dim=True))
-    L.append(c("┣" + "━" * 38, 244))
+    L.append(c("┣" + "━" * (RAIL - 1), 244))
     L.append(c("┃ ", 244) + c("VERDICT ", dim=True) + f"{vi} " + c(d["verdict"].get("label", ""), 46, bold=True)
               + "   " + c("autonomy ", dim=True) + bar(gp, 10) + f" {gp:.0f}%")
     L.append(c("┃", 244))
     L.append(c("┃ ", 244) + c("VITALS", 244, bold=True))
     for v in d["vitals"]:
-        L.append(c("┃  ", 244) + f"{v.get('icon','•')} " + pad(v.get("label", ""), 9)
+        L.append(c("┃  ", 244) + pad(v.get("icon", "•"), 2) + " " + pad(v.get("label", ""), 9)
                  + bar(v.get("pct", 0), 10) + "  " + c(v.get("note", ""), dim=True))
     L.append(c("┃", 244))
     L.append(c("┃ ", 244) + c("CHECKLIST", 244, bold=True))
@@ -312,8 +314,8 @@ def model_1(d):
     L.append(c("┃ ", 244) + c("WHAT'S LEFT", 244, bold=True))
     for w in d["whats_left"]:
         mark = "✔" if w["state"] == "done" else dot(w["state"])
-        L.append(c("┃  ", 244) + f"{mark} " + w.get("text", ""))
-    L.append(c("┗" + "━" * 38, 244))
+        L.append(c("┃  ", 244) + pad(mark, 2) + " " + w.get("text", ""))
+    L.append(c("┗" + "━" * (RAIL - 1), 244))
     L.append(c("  " + legend_line(), dim=True))
     return "\n".join(L)
 
@@ -374,6 +376,11 @@ def model_3(d):
     L.append("")
     for it in d["checklist"]:
         L.append(f"  {dot(it['state'])} {pad(it.get('label',''),14)} {c(it.get('note',''),dim=True)}")
+    ts = tk_summary(d)
+    if ts:
+        dn, tt = tk_counts(d)
+        L.append("")
+        L.append(f"  {c('🎫 tickets',244)} {ts}   {c(f'({dn}/{tt} done)',dim=True)}")
     return "\n".join(L)
 
 
@@ -392,6 +399,11 @@ def model_4(d):
     for i, it in enumerate(items, 1):
         L.append(f"  {c(f'[{i:>2}]',240)} {dot(it['state'])} {pad(it.get('label',''),16)}"
                  f" {c(pad(it.get('note',''),40),dim=True)} {c(conf(it),46)}")
+    ts = tk_summary(d)
+    if ts:
+        dn, tt = tk_counts(d)
+        L.append("")
+        L.append(f"  {c('🎫 tickets',244)} {ts}   {c(f'({dn}/{tt} done)',dim=True)}")
     rem = [w for w in d["whats_left"] if w["state"] != "done"]
     L.append("")
     if rem:
@@ -415,8 +427,8 @@ def model_5(d):
     for it in d["checklist"]:
         key = ALIAS.get(it["state"], it["state"])
         buckets.setdefault(key, []).append(it.get("label", ""))
-    # fold blue(done-human) into DONE lane
-    buckets["green"] = buckets.get("green", []) + buckets.get("blue", [])
+    # fold blue(done-human) into DONE lane, keeping the 🔵 human-provenance marker
+    buckets["green"] = buckets.get("green", []) + [f"{dot('blue')} {lbl}" for lbl in buckets.get("blue", [])]
     for w in d["whats_left"]:
         if w["state"] != "done":
             buckets.setdefault(ALIAS.get(w["state"], w["state"]), []).append(w["text"])

--- a/skills/postflight/scorecards/gallery.md
+++ b/skills/postflight/scorecards/gallery.md
@@ -33,9 +33,10 @@
 
 `state` aliases: `done/closed/merged→green · human→blue · hitl/review→orange · doing/wip/in-progress/open→yellow · todo/blocked→red`.
 **Tickets** (Jira/Linear/GH issues) are AI-supplied atoms — the agent lists which the session
-touched + their status. Surfaced in M1 (TICKETS section), M2 (tickets line), M5 (kanban lanes),
-M6 (telemetry + JSON-RPC), M7 (🎫 count). Cross-provider auto-detect is out of scope (per-provider
-MCP/CLI) — the agent already knows the linked tickets from the session.
+touched + their status. Surfaced in **all 7 models** — M1 (TICKETS section), M2 (tickets line),
+M3 (🎫 footer), M4 (🎫 footer), M5 (kanban lanes), M6 (telemetry + JSON-RPC), M7 (🎫 count).
+Cross-provider auto-detect is out of scope (per-provider MCP/CLI) — the agent already knows the
+linked tickets from the session.
 
 ## The 7 models (run `--model N --demo` to see each rendered)
 


### PR DESCRIPTION
## Design-polish pass over the 7 postflight scorecard models

A designer's-eye refinement of `bin/scorecard.py` (the deterministic end-of-action
scorecard renderer). **Visual polish only** — param schema, JSON-RPC sidecar, and
layer-purity are unchanged. Every change was verified by deterministic re-render and
an independent design-critique reviewer (verdict: *ship-ready, no must-fix*).

### What changed
| Model | Change | Why |
|---|---|---|
| **M1 Cockpit** | 3 horizontal rules now share one width (`vlen=40`) | top rule was shorter than mid/bottom → ragged "broken-box"; equal rules = intentional left-rail |
| **M1 vitals + WHAT'S LEFT** | icon/mark column width-anchored (`pad(.,2)`) | label column lines up regardless of which glyph an AI supplies (deterministic across terminals) |
| **M3 tiles · M4 burndown** | now surface a `🎫 tickets` footer | closes the consistency gap (M1/M2/M5/M6/M7 already showed tickets); reuses existing `tk_summary`/`tk_counts` — no new logic |
| **M5 Kanban** | human-done items in the DONE lane keep their `🔵` marker | preserves green-vs-blue provenance parity with every other model |
| `gallery.md` | ticket note → "all 7 models" | docs match the code |

### Acceptance / verification
- [x] `--all --demo` renders (color **and** `--no-color`) with no crash
- [x] `--auto-git` self-calculation intact
- [x] `bin/check-layer-purity bin/scorecard.py` → **0 violations** (only neutral `PROJ-*` placeholders; no org IDs)
- [x] `tests/validate-plugin.sh` → **PASSED (0 errors / 0 warnings)**
- [x] gitleaks pre-commit clean
- [x] independent design review: all changes confirmed *improved*; gallery *ship-ready*

### Scope / risk
Additive + low-risk. Does **not** change the postflight default output format (that
choice + the postflight→`scorecard.py` wiring remain a separate follow-up). Diff is
2 files, +23/-10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
