### PR TITLE
feat(geo-snippet): end-of-session recap grammar + renderer + tests

### DIFF
--- a/bin/geo-snippet.sh
+++ b/bin/geo-snippet.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# MAOS Tool: geo-snippet.sh
+# Purpose: Render the end-of-session "geo-localization" recap snippet (SSOT grammar
+#          in skills/postflight/references/geo-snippet-spec.md) at one of 4 densities.
+#          One glance: which session · what status · which anchor · what work · is it
+#          blocked · does it need a human. A memory ramp for amnesic agents + a radar
+#          for the human operator. ("What is not seen is not remembered.")
+# Version: 1.0.0
+# Protocol: C06 (AI-Native Environment).
+#
+# Anti-theater contract: the tool COMPUTES Tier-A fields (anchor, project, branch,
+#   compass ↑N↓M, peers, deploy-risk ⚠R1) and ACCEPTS Tier-B self-report fields as
+#   flags (--status, --slug, --seq, --enrich, --pulse) — the agent is the authority
+#   on its own state; the tool never fabricates it. The objectives tree (D3) is read
+#   from stdin (agent-supplied), never auto-generated.
+#
+# Safety: READ-ONLY (never mutates refs/index/worktree), capability-detected,
+#   graceful-degrade (no gh → branch anchor; no peer-lib → omit peers; no upstream →
+#   omit compass), ALWAYS exits 0 — must never block a session end.
+#
+# Usage:
+#   geo-snippet --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
+#               [--seq N] [--enrich STR] [--pulse n/m] [--base REF]
+#   # D3 reads tree item-lines from stdin: "<glyph> <slug> [· <enrich>]" (one per line)
+#
+# Env: GEO_TICKET_RE  ticket-key regex (default '[A-Z]{2,}-[0-9]+')
+# ═══════════════════════════════════════════════════════════════════════════════
+set -uo pipefail   # intentionally NO -e: a degrade-always reporter must finish + exit 0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+TICKET_RE="${GEO_TICKET_RE:-[A-Z]{2,}-[0-9]+}"
+
+DENSITY="" ; STATUS="🟡" ; SLUG="" ; SEQ="" ; ENRICH="" ; PULSE="" ; BASE=""
+
+usage() {
+  printf '%s\n' \
+    'usage: geo-snippet --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]' \
+    '                   [--seq N] [--enrich STR] [--pulse n/m] [--base REF]' \
+    '       # density=ntree reads tree item-lines from stdin (one per line)' >&2
+}
+
+# ── arg parse (supports --key value AND --key=value) ───────────────────────────
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --density=*) DENSITY="${1#*=}" ;;     --density) DENSITY="${2:-}"; shift ;;
+    --status=*)  STATUS="${1#*=}" ;;      --status)  STATUS="${2:-}";  shift ;;
+    --slug=*)    SLUG="${1#*=}" ;;        --slug)    SLUG="${2:-}";    shift ;;
+    --seq=*)     SEQ="${1#*=}" ;;         --seq)     SEQ="${2:-}";     shift ;;
+    --enrich=*)  ENRICH="${1#*=}" ;;      --enrich)  ENRICH="${2:-}";  shift ;;
+    --pulse=*)   PULSE="${1#*=}" ;;       --pulse)   PULSE="${2:-}";   shift ;;
+    --base=*)    BASE="${1#*=}" ;;        --base)    BASE="${2:-}";    shift ;;
+    -h|--help)   usage; exit 0 ;;
+    *) ;;   # ignore unknowns (never block)
+  esac
+  shift
+done
+case "$DENSITY" in
+  name|status|ntree|conv) ;;
+  *) usage; exit 0 ;;
+esac
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+have()  { command -v "$1" >/dev/null 2>&1; }
+# join non-empty parts with ' · '
+emit()  { local out="" p; for p in "$@"; do [ -n "$p" ] || continue
+            if [ -z "$out" ]; then out="$p"; else out="$out · $p"; fi; done; printf '%s\n' "$out"; }
+
+# ── Tier-A computed fields (git/gh/fs/peer) ────────────────────────────────────
+repo_top()   { git rev-parse --show-toplevel 2>/dev/null || true; }
+cur_branch() { git rev-parse --abbrev-ref HEAD 2>/dev/null || true; }
+
+default_branch() {
+  local d c
+  d="$(git symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@')" || true
+  [ -n "$d" ] && { printf '%s' "$d"; return; }
+  for c in main master; do
+    git show-ref --verify --quiet "refs/heads/$c" 2>/dev/null && { printf '%s' "$c"; return; }
+  done
+  printf 'main'
+}
+
+compute_anchor() {   # salience: ticket › PR › branch
+  local b="$1" t pr
+  t="$(printf '%s' "$b" | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
+  [ -z "$t" ] && t="$(git log -1 --format='%s' 2>/dev/null | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
+  [ -n "$t" ] && { printf '%s' "$t"; return; }
+  if have gh && [ -n "$b" ]; then
+    pr="$(gh pr list --head "$b" --state open --json number -q '.[0].number' 2>/dev/null)" || true
+    [ -n "$pr" ] && { printf 'PR#%s' "$pr"; return; }
+  fi
+  printf '%s' "$b"
+}
+
+compute_compass() {  # ↑ahead↓behind vs base (git rev-list left=behind right=ahead)
+  local base="$1" out behind ahead
+  [ -n "$base" ] || return 0
+  git rev-parse --verify --quiet "$base" >/dev/null 2>&1 || return 0
+  out="$(git rev-list --left-right --count "$base"...HEAD 2>/dev/null)" || return 0
+  [ -n "$out" ] || return 0
+  behind="$(printf '%s' "$out" | awk '{print $1}')"
+  ahead="$(printf '%s' "$out"  | awk '{print $2}')"
+  printf '↑%s↓%s' "${ahead:-0}" "${behind:-0}"
+}
+
+compute_peers() {    # peers:N via the maos peer-session-detect lib (omit if UNKNOWN/absent)
+  local top="$1" lib val
+  lib="$SCRIPT_DIR/../plugin-scripts/governance/lib/peer-session-detect.sh"
+  [ -f "$lib" ] || return 0
+  # shellcheck disable=SC1090
+  . "$lib" 2>/dev/null || return 0
+  have_fn psd_peer_sessions || return 0
+  val="$(psd_peer_sessions "$top" 2>/dev/null)" || true
+  case "$val" in ''|UNKNOWN|*[!0-9]*) return 0 ;; esac
+  printf '%s' "$val"
+}
+have_fn() { command -v "$1" >/dev/null 2>&1; }
+
+compute_risk() {     # ⚠R1: on default branch AND a deploy-on-push workflow present (heuristic, Tier-A)
+  local b="$1" top
+  [ "$b" = "$(default_branch)" ] || return 0
+  top="$(repo_top)"; [ -n "$top" ] || return 0
+  [ -d "$top/.github/workflows" ] || return 0
+  grep -rliE 'deploy' "$top/.github/workflows" >/dev/null 2>&1 && printf '⚠R1'
+  return 0
+}
+
+# ── derive ─────────────────────────────────────────────────────────────────────
+[ -n "$BASE" ] || BASE="origin/$(default_branch)"
+BRANCH="$(cur_branch)"
+PROJECT="$(top="$(repo_top)"; [ -n "$top" ] && basename "$top")"
+ANCHOR="$(compute_anchor "$BRANCH")"
+COMPASS="$(compute_compass "$BASE")"
+PEERS="$(compute_peers "$(repo_top)")"
+RISK="$(compute_risk "$BRANCH")"
+
+# slug: explicit, else derived from branch (strip type/ prefix and TICKET- prefix), capped ≤24
+if [ -z "$SLUG" ]; then
+  SLUG="$(printf '%s' "$BRANCH" | sed -E 's@^[a-z]+/@@; s@^[A-Z]+-[0-9]+-@@')"
+fi
+SLUG="$(printf '%s' "$SLUG" | cut -c1-24)"
+
+# D1 enrich = explicit only (keep the name clean — clarity>density); D2/D3 surface
+# compass/pulse/peers as their own computed fields, so the name never duplicates them.
+ENRICH_OUT="$ENRICH"
+SEQTOK="" ; [ -n "$SEQ" ] && SEQTOK="#$SEQ"
+PULSETOK="" ; [ -n "$PULSE" ] && PULSETOK="${PULSE}🟢"
+PEERSTOK="" ; [ -n "$PEERS" ] && PEERSTOK="peers:$PEERS"
+
+# ── render ─────────────────────────────────────────────────────────────────────
+case "$DENSITY" in
+  name)
+    # <status> · <anchor> · <slug> [· #seq] [· enrich]
+    emit "$STATUS" "$ANCHOR" "$SLUG" "$SEQTOK" "$ENRICH_OUT"
+    ;;
+  status)
+    # <status> <project>:<branch> · <slug> [· #seq] [· compass] [· pulse] [· peers] [· risk]
+    emit "$STATUS ${PROJECT:+$PROJECT:}$BRANCH" "$SLUG" "$SEQTOK" "$COMPASS" "$PULSETOK" "$PEERSTOK" "$RISK"
+    ;;
+  ntree)
+    # header (like name + compass) then tree items from stdin (agent-supplied)
+    emit "$STATUS" "$ANCHOR" "$SLUG" "$SEQTOK" "$COMPASS"
+    if [ ! -t 0 ]; then
+      items=()
+      while IFS= read -r line || [ -n "$line" ]; do [ -n "$line" ] && items+=("$line"); done
+      n=${#items[@]} ; i=0
+      for line in "${items[@]:-}"; do
+        [ -n "$line" ] || continue
+        i=$((i + 1))
+        if [ "$i" -eq "$n" ]; then printf '└─ %s\n' "$line"; else printf '├─ %s\n' "$line"; fi
+      done
+    fi
+    ;;
+  conv)
+    printf 'conv: base-3+🟠 · anchor=ticket›PR›branch›task · #seq=chain/omit · enrich-auto · Tier A/B/C\n'
+    ;;
+esac
+exit 0

--- a/bin/geo-snippet.sh
+++ b/bin/geo-snippet.sh
@@ -126,7 +126,18 @@ compute_risk() {     # ⚠R1: on default branch AND a deploy-on-push workflow pr
 }
 
 # ── derive ─────────────────────────────────────────────────────────────────────
-[ -n "$BASE" ] || BASE="origin/$(default_branch)"
+# Base ref for the compass — pick one that ACTUALLY EXISTS (no remote-layout assumption):
+# upstream @{u} → origin/<default> → local <default> → empty (compass gracefully omitted).
+if [ -z "$BASE" ]; then
+  if git rev-parse --verify --quiet '@{u}' >/dev/null 2>&1; then
+    BASE='@{u}'
+  else
+    _db="$(default_branch)"
+    if   git rev-parse --verify --quiet "origin/$_db" >/dev/null 2>&1; then BASE="origin/$_db"
+    elif git rev-parse --verify --quiet "$_db"        >/dev/null 2>&1; then BASE="$_db"
+    fi   # else BASE stays empty → compute_compass returns nothing (graceful)
+  fi
+fi
 BRANCH="$(cur_branch)"
 PROJECT="$(top="$(repo_top)"; [ -n "$top" ] && basename "$top")"
 ANCHOR="$(compute_anchor "$BRANCH")"

--- a/bin/tests/geo-snippet.test.sh
+++ b/bin/tests/geo-snippet.test.sh
@@ -19,7 +19,7 @@ printf 'geo-snippet.test.sh\n'
 o="$("$GS" --density name --status '🟢' --slug add-oauth)"
 has 'add-oauth' "$o" 'D1 renders slug'
 has '🟢'        "$o" 'D1 renders status'
-hasnt '#'       "$o" 'D1 omits #seq when --seq absent'
+hasnt ' · #'    "$o" 'D1 omits #seq token (· #N) when --seq absent (anchor like PR#N is not a seq)'
 hasnt '↑'       "$o" 'D1 name stays clean (no auto-compass)'
 
 # D1 #seq present when supplied
@@ -35,9 +35,10 @@ o="$("$GS" --density name --status '🟢' --slug z)"
 hasnt ' ·  · ' "$o" 'no double separator (optional fields collapse cleanly)'
 
 # D2 status: project:branch + compass field
-o="$("$GS" --density status --status '🟡' --slug s)"
-has ':'  "$o" 'D2 renders project:branch'
-has '↑'  "$o" 'D2 surfaces compass as its own field'
+# pin --base HEAD → deterministic ↑0↓0 (HEAD...HEAD), no dependency on origin/remote layout
+o="$("$GS" --density status --status '🟡' --slug s --base HEAD)"
+has ':'     "$o" 'D2 renders project:branch'
+has '↑0↓0'  "$o" 'D2 compass deterministic with --base HEAD'
 
 # D2 pulse token
 o="$("$GS" --density status --status '🟡' --slug s --pulse 3/4)"

--- a/bin/tests/geo-snippet.test.sh
+++ b/bin/tests/geo-snippet.test.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for bin/geo-snippet.sh — the geo-snippet recap renderer.
+# Bash 3.2-safe, self-contained, read-only. Run: bash bin/tests/geo-snippet.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+GS="$DIR/../geo-snippet.sh"
+
+pass=0 ; fail=0
+ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  \xe2\x9c\x97 %s\n      got: [%s]\n' "$1" "$2"; }
+has()  { case "$2" in *"$1"*) ok "$3" ;; *) no "$3" "$2" ;; esac; }   # has NEEDLE HAYSTACK MSG
+hasnt(){ case "$2" in *"$1"*) no "$3" "$2" ;; *) ok "$3" ;; esac; }
+eq()   { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
+
+printf 'geo-snippet.test.sh\n'
+
+# D1 name: status+slug, no #seq, no compass clutter
+o="$("$GS" --density name --status '🟢' --slug add-oauth)"
+has 'add-oauth' "$o" 'D1 renders slug'
+has '🟢'        "$o" 'D1 renders status'
+hasnt '#'       "$o" 'D1 omits #seq when --seq absent'
+hasnt '↑'       "$o" 'D1 name stays clean (no auto-compass)'
+
+# D1 #seq present when supplied
+o="$("$GS" --density name --status '🟡' --slug x --seq 4)"
+has '#4' "$o" 'D1 renders #seq when supplied'
+
+# D1 explicit blocker enrich
+o="$("$GS" --density name --status '🟠' --slug capture-rls --enrich '⛔reauth')"
+has '⛔reauth' "$o" 'D1 renders explicit enrich (blocker)'
+
+# no dangling/double separator
+o="$("$GS" --density name --status '🟢' --slug z)"
+hasnt ' ·  · ' "$o" 'no double separator (optional fields collapse cleanly)'
+
+# D2 status: project:branch + compass field
+o="$("$GS" --density status --status '🟡' --slug s)"
+has ':'  "$o" 'D2 renders project:branch'
+has '↑'  "$o" 'D2 surfaces compass as its own field'
+
+# D2 pulse token
+o="$("$GS" --density status --status '🟡' --slug s --pulse 3/4)"
+has '3/4🟢' "$o" 'D2 renders pulse token'
+
+# D3 ntree: stdin items formatted into a tree (├─ … └─)
+o="$(printf 'aa\nbb\ncc\n' | "$GS" --density ntree --status '🟡' --slug t --seq 2)"
+has '#2'    "$o" 'D3 header carries #seq'
+has '├─ aa' "$o" 'D3 first item uses ├─'
+has '├─ bb' "$o" 'D3 middle item uses ├─'
+has '└─ cc' "$o" 'D3 last item uses └─'
+hasnt '└─ aa' "$o" 'D3 only the last item uses └─'
+
+# D3 tty-guard: no stdin → header only, no connectors, no hang
+o="$("$GS" --density ntree --status '🟡' --slug t </dev/null)"
+hasnt '├─' "$o" 'D3 no items → no ├─ connector'
+hasnt '└─' "$o" 'D3 no items → no └─ connector'
+
+# D4 conv
+o="$("$GS" --density conv)"
+has 'conv:' "$o" 'D4 renders conventions line'
+
+# bad density → empty stdout + exit 0 (never blocks)
+o="$("$GS" --density bogus 2>/dev/null)" ; rc=$?
+eq '' "$o" 'bad density → empty stdout'
+eq '0' "$rc" 'bad density → exit 0'
+
+# missing density → exit 0 (never blocks)
+"$GS" >/dev/null 2>&1 ; eq '0' "$?" 'missing density → exit 0'
+
+# read-only: running the tool does not mutate git state
+before="$(git -C "$DIR/.." status --short 2>/dev/null)"
+"$GS" --density status >/dev/null 2>&1
+"$GS" --density name   >/dev/null 2>&1
+after="$(git -C "$DIR/.." status --short 2>/dev/null)"
+eq "$before" "$after" 'read-only: no git mutation'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/skills/postflight/references/geo-snippet-spec.md
+++ b/skills/postflight/references/geo-snippet-spec.md
@@ -1,0 +1,153 @@
+# Geo-Snippet — End-of-Session Recap Grammar (SSOT)
+
+> **Version**: 1.0.0
+> **Scope**: AAIF cross-vendor. A compact, glance-and-know "geo-localization" status line for agent sessions.
+> **Consumer**: `skills/postflight` (P2 DEBRIEF emits it; P3 seed carries it) · `bin/spawn-continuation.sh` (D1 → session `--name`, owns `#seq`).
+> **Renderer**: `bin/geo-snippet.sh`.
+> **Cross-link slug**: `geo-snippet`
+
+## Purpose — "geo-localization"
+
+One glance answers: *which session am I in · what status · which anchor (ticket/PR/branch) · what work · is it blocked · does it need a human, and what kind?*
+
+Master principle: **clarity > density** — *what is not seen is not remembered; what is computed and seen is remembered, by humans **and** agents.* A memory ramp for amnesic agents + a radar for the human operator. Keep it lean (KIS/YAGNI/DRY/SSOT): if it clutters, it loses its purpose.
+
+## The grammar (the model)
+
+```
+<status> · <anchor> · <slug> [· #<seq>] [· <enrich>]
+```
+
+Separator is the middle dot `·`. Optional fields (`[...]`) collapse their token **and** their separator when absent — never leave a dangling `·`.
+
+### Fields
+
+| Field | What | Source tier |
+|---|---|---|
+| **status** | aggregate state of the **primary** goal — 4 glyphs (see below) | B (self-report) |
+| **anchor** | the single most salient locator — pick exactly one | A (computed) |
+| **slug** | kebab primary-goal, length-capped (≤24 chars) | B |
+| **#seq** | continuation-chain position; **omit when not a chain** | A (`spawn-continuation` injects) |
+| **enrich** | 0..1 trailing detail, auto-derived from status | A or B (per row) |
+
+### status — base-3 + need-HITL (4 glyphs, aggregate projection)
+
+| Glyph | Meaning |
+|---|---|
+| 🔴 | blocked |
+| 🟡 | active |
+| 🟠 | need-HITL (needs a human decision/authorization) |
+| 🟢 | done |
+
+This is the **aggregate projection** of the session's primary goal — deliberately ≤4 colors so it is triable pre-attentively (one glyph, instant read). It is distinct from the **per-item 5-state visual legend** (which adds 🔵 human-done) used inside checklists/N-trees: human-done + any `%`/autonomy telemetry belong in `enrich`/`pulse`, **never** in the aggregate `status` glyph. 🟠 ("needs you") is the #1 signal a geo-snippet must surface.
+
+### anchor — salience, pick ONE (DRY)
+
+`ticket › PR › branch › task` — the most specific available locator wins. They are **alternatives, not additive**: showing two anchors is pure clutter. (`task` is used for per-item lines in D3, not for the session line.)
+
+### #seq — chain position, omit-when-undetected
+
+- Continuation (a parent session spawned this one): `#<parent+1>`.
+- New chain-root (a fresh goal started by `postflight`): `#1`.
+- Not a tracked chain (manual / standalone): **omit** the token + its separator — never guess. The presence of `#seq` *is* the signal "this is a tracked continuity chain."
+
+`#seq` is owned by `bin/spawn-continuation.sh` (the continuation chain). A renderer never invents an ordinal.
+
+### enrich — auto-derived from status (removes decision-fatigue)
+
+| status | enrich default | why |
+|---|---|---|
+| 🔴 blocked | `⛔<blocker>` | why it stalled |
+| 🟠 need-HITL | `⛔<blocker>` ‖ `⏭<next>` | what kind of attention |
+| 🟡 active | `↑N↓M` (compass) ‖ `n/m🟢` (pulse) | position / progress |
+| 🟢 done | `⏭<next>` ‖ ∅ | what's left, or nothing |
+| override (use-case) | `⚠R1` (default-branch + deploy-on-push) · `wt:x·peers:N` (multi-worktree) | when the scenario demands |
+
+There is no "which enrich?" decision — status picks it. The trailing slot is extensible per use-case (`wt`+`peers` · deploy-risk · age) but stays opt-in.
+
+## Anti-theater — metric tiers (0 theater)
+
+Every field is classified so the renderer never fabricates:
+
+- **Tier A — computed deterministically** (git / gh / fs / peer-detect): anchor, branch, PR, project, worktree, compass `↑N↓M`, peers, `#seq`, risk `⚠R1`. The renderer computes these.
+- **Tier B — honest self-report** (the agent is the authority on its own state): status, slug, blocker, next, pulse. Passed in by the agent; never inflated.
+- **Tier C — theater** (fabricated): **eliminated**. (Removed in design: invented `#seq` ordinals → chain-or-omit; a vacuous compass `•here` → real git-position `↑N↓M`.)
+
+| Metric | Tier · source | Relevance |
+|---|---|---|
+| status 🔴🟡🟠🟢 | B · self-report | HIGH (core "needs attention?") |
+| slug | B · self-report / branch | HIGH ("what work") |
+| ticket | A* · parse branch/commit (else omit) | HIGH (1 anchor) |
+| PR#N | A · `gh pr list --head <b>` | HIGH (1 anchor) |
+| branch | A · `git rev-parse --abbrev-ref HEAD` | HIGH (1 anchor) |
+| project | A · `basename $(git rev-parse --show-toplevel)` | MED (redundant w/ branch) |
+| worktree | A · `git worktree list` | MED (multi-wt only) |
+| #seq | A (`spawn-continuation` injects) / omit | MED |
+| compass ↑N↓M | A · `git rev-list --left-right --count <base>...HEAD` | MED (distance from base) |
+| pulse n/m🟢 | B · progress (never inflated) | MED (telemetry — clutter in the name) |
+| blocker ⛔ | B · observed state | HIGH-when-🟠 |
+| next ⏭ | B · plan | MED |
+| peers:N | A · peer-session-detect | LOW (niche, multi-session) |
+| risk ⚠R1 | A · default-branch + deploy-on-push probe | HIGH-when-on-default-branch |
+
+## The 4 densities (one grammar, progressive disclosure)
+
+Same grammar, same field semantics, four densities. Density goes in the tree, not in the name.
+
+**D1 `name`** — minimal · primary goal only · glance-and-know:
+```
+🟡 · PROJ-142 · payment-retry-logic
+```
+
+**D2 `status`** — N0 · one rich line · the whole session:
+```
+🟡 acme-api:main · payment-retry-logic · ↑5↓0 · 3/4🟢 · peers:0
+```
+
+**D3 `ntree`** — N lines · one status-line per item · **main goal pinned at top ("never forget")** · goals[primary/secondary/auxiliary] + tasks + pendings:
+```
+🟡 PROJ-142 · payment-retry-logic · #4 · ↑5↓0          ← main goal (always first)
+├─ 🟢 retry-backoff ............. merged PR#88
+├─ 🟠 idempotency-key .......... ⛔ needs-operator (key format)
+├─ 🔴 dlq-replay ............... blocked-by upstream
+└─ 🟡 metrics-wiring ........... in-progress
+```
+
+**D4 `conv`** — optional · one line · the conventions/terms in play (visibility → memory):
+```
+conv: base-3+🟠 · anchor=ticket›PR›branch›task · #seq=chain/omit · enrich-auto · Tier A/B/C
+```
+
+## 7 use-cases (recap — visibility → memory)
+
+1. **Handoff before `/clear`** — D2 + D3.
+2. **Amnesic agent re-hydrates** — D3 with the main goal pinned at top.
+3. **Continuation seed** — `postflight` seeds the next session + `#seq` (D1 + D3).
+4. **Cross-session triage** "which one needs me (🟠/🔴)?" — D1.
+5. **Main-goal anchoring** in a long session — D3 top line.
+6. **Pendings audit** — D3.
+7. **Convention surfacing** — D4.
+
+## Renderer contract (`bin/geo-snippet.sh`)
+
+```
+geo-snippet --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
+            [--seq N] [--enrich STR] [--pulse n/m] [--base REF]
+```
+
+- **Tier-A fields are computed by the tool** (anchor, project, compass, peers, `⚠R1`). **Tier-B fields are passed in** (`--status`, `--slug`, `--seq`, `--enrich`, `--pulse`) — the agent is the authority on its own state.
+- **enrich placement**: D1 `name` carries enrich only when explicitly supplied (`--enrich`) — the name stays clean (clarity > density). D2/D3 surface compass / pulse / peers as their own computed fields, so the name never duplicates them. A 🔴/🟠 blocker reason is self-report (`--enrich '⛔<reason>'`).
+- **D3 `ntree`**: the header line is rendered like D2; item lines are read from **stdin** (one per line: `<glyph> <slug> [· <enrich>]`) and formatted into the tree — the objectives tree is agent-supplied (Tier B), never auto-generated.
+- **Always read-only, capability-detected, graceful-degrade, exit 0** (no `gh` → branch anchor; no peer-detect lib → omit `peers`; detached HEAD / no upstream → omit compass). Never blocks a session end.
+
+## Composition / reuse (Strata — don't rebuild)
+
+- `skills/postflight` **P2 DEBRIEF** already produces the recap (composes `morning-briefing` + N-tree + Eisenhower) — it emits D2 + D3 + D4 via this renderer; it does not reinvent the recap.
+- `bin/spawn-continuation.sh` owns naming + the `#seq` chain — D1 feeds `--name`.
+- `plugin-scripts/governance/lib/peer-session-detect.sh` (`psd_peer_sessions <repo>`) — the `peers:N` field.
+- `skills/morning-briefing` — the 7-section state DEBRIEF already composes.
+- `skills/status-map` — **prior-art**, a different (ASCII-box PULSE/COMPACT) shape; left as-is, not merged.
+
+## License
+
+MIT (matches the multi-agent-os repo `LICENSE`).

--- a/skills/postflight/references/geo-snippet-spec.md
+++ b/skills/postflight/references/geo-snippet-spec.md
@@ -20,6 +20,8 @@ Master principle: **clarity > density** — *what is not seen is not remembered;
 
 Separator is the middle dot `·`. Optional fields (`[...]`) collapse their token **and** their separator when absent — never leave a dangling `·`.
 
+> **This is the D1 base shape.** The richer densities (D2/D3) preserve the same field *semantics* but **append additional computed tokens** (`project:branch`, compass, pulse, peers, risk) — see "The 4 densities". The grammar is the contract for what each field *means*, not a fixed token count; D2/D3 extending the sequence is by design, not a violation of the SSOT.
+
 ### Fields
 
 | Field | What | Source tier |


### PR DESCRIPTION
[PR-as-Enhancement-Prompt]

## Context
End-of-session **"geo-localization"** recap — a glance-and-know status line (*which session · what status · which anchor · what work · does it need a human?*). Principle: *what is not seen is not remembered; what is computed and seen is remembered, by humans **and** agents.* The recap engine already exists (`postflight` P2 DEBRIEF + `morning-briefing` + `spawn-continuation`); the one genuinely-missing piece was the **snippet grammar**. This adds it (Strata: build the next layer, don't rebuild).

## What (Phase 1 — self-contained, touches no existing skill)
- `skills/postflight/references/geo-snippet-spec.md` — the grammar SSOT: `<status> · <anchor> · <slug> [· #seq] [· enrich]`; base-3+🟠 aggregate status; anchor salience `ticket›PR›branch›task` (pick-1, DRY); status→enrich auto-map; metric **anti-theater tiers** (A computed / B self-report / C eliminated); 4 densities (`name`/`status`/`ntree`/`conv`); 7 use-cases.
- `bin/geo-snippet.sh` — the renderer. **Computes Tier-A** (anchor, compass `↑N↓M`, `peers` via `psd_peer_sessions`, `⚠R1`) and **accepts Tier-B** self-report flags (`--status/--slug/--seq/--enrich/--pulse`). Read-only, capability-detected, bash-3.2-safe, **always exit 0** (never blocks a session end).
- `bin/tests/geo-snippet.test.sh` — 22 assertions (all 4 densities · `#seq` omit-collapse · tree `├─/└─` formatting · tty-guard no-hang · degrade · read-only).

## Acceptance
- [x] 22/22 tests green (bash 3.2.57 / macOS default)
- [x] Layer-purity clean (`check-layer-purity --candidates` → 0 violations / 16 files; generic examples only)
- [x] gitleaks clean (no leaks)
- [x] Cross-repo read-only verified — `peers:1` + `⚠R1` correctly detected in another repo, **zero mutation**

## Reuse (Strata — don't reinvent)
`postflight` P2 (recap) · `spawn-continuation` (`#seq` + naming) · `peer-session-detect` (`peers`) · `morning-briefing` (state) · `status-map` (prior-art, left untouched).

## Out of scope (deferred Phase 2)
Wiring the renderer into `postflight` P2 DEBRIEF + `spawn-continuation --name` is deferred — `postflight` is dogfood-in-progress (0/2 cycles); not perturbed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
