### PR TITLE
feat(postflight): wire geo-snippet emission into P2/P3 + honest spec consumer claim

### DIFF
--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -11,7 +11,7 @@ description: |
   continuation session so the work continues across the compact/clear boundary. The
   end-of-session counterpart to the `preflight` skill. Reads whatever governance is present
   at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories) and adapts.
-version: 0.2.0
+version: 0.3.0
 triggers:
   - postflight
   - run postflight
@@ -25,7 +25,7 @@ triggers:
   - spawn the continuation session
   - spawn the next session
 metadata:
-  version: "0.2.0"
+  version: "0.3.0"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -84,8 +84,8 @@ The environment MUST be left better, safer, and more traceable than it was found
 | # | Responsibility | How (safe-or-DEFER) | Composes |
 |---|---|---|---|
 | **P1** | **SWEEP** — operationalize the exit-hygiene checklist: no loose ends, no banana peels | for each axis {git · docs · ADRs · changelogs · memories · rules · tickets/backlogs · worktrees/branches · stale metrics}: *survey* gaps/opportunities → classify by Eisenhower → **act** (persist/fix/version/commit/push/close) **or register** a tracked follow-up. Read-before-discard is mandatory. | `protocols/exit-hygiene.md`, `skills/sync-to-git`, `skills/quiesce`, `commands/worktree.md`, `bin/dogfood-mark` |
-| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). | `skills/morning-briefing` |
-| **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from; print to screen + best-effort clipboard. DoR = P1+P2 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) |
+| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know geo-snippet** — D2 status line + D3 ntree + D4 conv — via `bin/geo-snippet.sh` (the compact projection of this debrief; grammar SSOT `references/geo-snippet-spec.md`). | `skills/morning-briefing`, `bin/geo-snippet.sh` |
+| **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` geo-snippet `<status>·<anchor>·<slug>[·#seq]`); print to screen + best-effort clipboard. DoR = P1+P2 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) |
 | **P3.5** | **SPAWN** *(optional, default-ON)* — launch the next session, pre-seeded | hand the P3 seed to `bin/spawn-continuation.sh`, which launches a fresh **named** (`<ticket>-<slug>-#<short>`) detached `claude` session (tmux/cmux) with the seed injected as durable system context — so the work *continues itself* across the compact/clear boundary instead of waiting on a manual paste. DoR = P3 seed. Opt out: `--no-spawn`. | `bin/spawn-continuation.sh` (consumes the P3 seed; reuses `session-fission`'s reseed idea) |
 
 **SWEEP never clobbers**: a dirty tree, a divergence-with-conflict, a held `.git/index.lock`,
@@ -132,7 +132,8 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
 2. P2 DEBRIEF: invoke `morning-briefing` for the 7-section state, then synthesize ON TOP the
    objectives N-Tree + Eisenhower next-actions (non-blocked first) + gaps/pendings/undecided/
    unasked-Qs. (The community `morning-briefing` provides state + next-action; postflight adds
-   the N-Tree + Eisenhower ranking.) This is the session map.
+   the N-Tree + Eisenhower ranking.) This is the session map — then render it as the
+   glance-and-know geo-snippet (D2+D3+D4) via `bin/geo-snippet.sh`.
 3. P3 HANDOFF: synthesize the continuation seed (below) from P1+P2 → print + clipboard.
 3.5 P3.5 SPAWN (default-ON; skip on --no-spawn / kill-switch / depth-cap / already-spawned):
    write the P3 seed to a file, then `bin/spawn-continuation.sh --ticket <KEY> --slug <kebab>
@@ -154,6 +155,7 @@ amnesia premise: a gifted agent with no cross-session recall). Two registers, sa
   "goal":"<one-line mission>",
   "context":"<state-of-world the next agent needs>",
   "git":{"repo":"<name>","branch":"<b>","worktree":"<path|none>","prs":["#<n> <state>"]},
+  "locus":"<D1 geo-snippet: <status>·<anchor>·<slug>[·#seq] — bin/geo-snippet.sh --density name>",
   "objectives":{"primary":["..."],"secondary":["..."],"auxiliary":["..."]},
   "done":["..."], "in_flight":["..."],
   "gaps":["..."], "pendings":["..."], "undecided":["..."], "unasked_questions":["..."],
@@ -223,6 +225,7 @@ postflight P1: branch=main tree=DIRTY → SWEEP DEFERRED (uncommitted tracked ch
 - `skills/preflight/SKILL.md` — the **start-of-session** counterpart (orient + heal + isolate); together they bound the session: `preflight → work → postflight`.
 - `protocols/exit-hygiene.md` — the Boy-Scout exit-gate checklist P1 operationalizes (policy → this executes it).
 - `skills/morning-briefing/SKILL.md` — its 7-section briefing is the P2 state substrate; postflight adds the N-Tree + Eisenhower synthesis that P3 elevates into an agent seed.
+- `skills/postflight/references/geo-snippet-spec.md` + `bin/geo-snippet.sh` — the **geo-snippet** grammar SSOT + renderer; P2 DEBRIEF emits the glance-and-know recap (D2/D3/D4) and P3 carries D1 (`locus`) in the seed.
 - `skills/sync-to-git/SKILL.md` · `skills/quiesce/SKILL.md` — git close-out + PR convergence P1 composes.
 - `skills/session-fission/SKILL.md` — orthogonal: it *splits* a tangled session into N seeds; P3 emits *one* resume seed for continuity, and P3.5 reuses its reseed-a-fresh-session idea for continuity-spawn.
 - `bin/spawn-continuation.sh` — the **P3.5 SPAWN** primitive: launches the named, pre-seeded `claude` continuation session (tmux/cmux) with the 7 guardrails; consumes the P3 seed.

--- a/skills/postflight/references/geo-snippet-spec.md
+++ b/skills/postflight/references/geo-snippet-spec.md
@@ -1,8 +1,8 @@
 # Geo-Snippet — End-of-Session Recap Grammar (SSOT)
 
-> **Version**: 1.0.0
+> **Version**: 1.0.1
 > **Scope**: AAIF cross-vendor. A compact, glance-and-know "geo-localization" status line for agent sessions.
-> **Consumer**: `skills/postflight` (P2 DEBRIEF emits it; P3 seed carries it) · `bin/spawn-continuation.sh` (D1 → session `--name`, owns `#seq`).
+> **Consumer**: `skills/postflight` (P2 DEBRIEF emits it; P3 seed carries it as `locus` — wired postflight v0.3.0) · `bin/spawn-continuation.sh` (owns `#seq`; D1 → session `--name` **wiring tracked** — needs an ascii-safe name variant, see follow-up issue).
 > **Renderer**: `bin/geo-snippet.sh`.
 > **Cross-link slug**: `geo-snippet`
 


### PR DESCRIPTION
[PR-as-Enhancement-Prompt]

## Context
PR #126 shipped the **geo-snippet** end-of-session "geo-localization" recap (grammar SSOT + `bin/geo-snippet.sh` renderer + 22 tests) as a deliberately **self-contained Phase 1** — *"touches no existing skill."* Verified independently this session: renderer **22/22 green**, dogfooded live across all 4 densities (D1 name / D2 status / D3 ntree / D4 conv) — the `⚠R1` deploy-risk override even fires correctly on a deploy-on-merge `main` and stays silent here (no deploy workflow). Strong convergence: a second session independently reached the *same* design (same grammar, anti-theater tiers, densities, Strata-on-postflight placement).

**The gap:** `geo-snippet-spec.md` line 5 declared `skills/postflight` as the consumer (*"P2 DEBRIEF emits it; P3 seed carries it"*) — but postflight did **not** actually emit it. A spec↔skill **drift** (the renderer was passive; nothing auto-called it → the documented "passive logging" anti-pattern).

## What (additive, docs-only — root-cause-first: make the claim *true*)
- **postflight P2 DEBRIEF** now renders the glance-and-know geo-snippet (D2 + D3 + D4) via `bin/geo-snippet.sh` — the compact projection of the debrief it already computes (composes, doesn't rebuild).
- **postflight P3 HANDOFF** seed now carries the D1 `locus` field (`<status>·<anchor>·<slug>[·#seq]`) so a fresh amnesic agent re-hydrates with its geo-coordinate.
- **geo-snippet-spec.md** consumer line made **honest**: postflight wiring is now real (v0.3.0); the riskier `spawn-continuation --name` swap is explicitly **deferred + tracked** (emoji+`·` in a tmux/cmux session name is fragile → needs an ascii-safe D1 variant).
- postflight `0.2.0 → 0.3.0` (MINOR: new emission). spec `1.0.0 → 1.0.1` (PATCH: honest consumer claim).

## Objectives
- Resolve the spec↔skill drift (anti-theater R1/R3) · close the cultural-loop so the tool is **used**, not passive · zero behavior-risk (additive prose; renderer untouched).

## Acceptance
- [x] Renderer untouched → **22/22 tests green**
- [x] Staged-diff `gitleaks protect --staged` → **0 leaks** (commit-time GAAS scan also passed)
- [x] Diff = 2 files, +10/−7, additive
- [x] Honest about what's wired (postflight) vs tracked (spawn `--name`)

## Cross-links
- Builds on #126 (geo-snippet Phase 1) · follow-up to be filed for the ascii-safe `spawn-continuation --name` (D1) wiring · siblings: `morning-briefing` (P2 substrate) · `spawn-continuation` (`#seq` owner).

## Out-of-scope note (surfaced, not actioned)
gitleaks flags 2 **pre-existing** historical hits in `mcp-tools/maos-mcp-hub/.env.example` + `README.md` (commit `20df6d93`, `vek-bitbucket-app-password`) — an `.env.example` placeholder (likely false-positive). Not introduced here; flagged for separate verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
