### PR TITLE
refactor(locus): rename geo-snippet → locus (Anima naming verdict)

### DIFF
--- a/bin/locus.sh
+++ b/bin/locus.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # ═══════════════════════════════════════════════════════════════════════════════
-# MAOS Tool: geo-snippet.sh
+# MAOS Tool: locus.sh
 # Purpose: Render the end-of-session "geo-localization" recap snippet (SSOT grammar
-#          in skills/postflight/references/geo-snippet-spec.md) at one of 4 densities.
+#          in skills/postflight/references/locus-spec.md) at one of 4 densities.
 #          One glance: which session · what status · which anchor · what work · is it
 #          blocked · does it need a human. A memory ramp for amnesic agents + a radar
 #          for the human operator. ("What is not seen is not remembered.")
@@ -20,7 +20,7 @@
 #   omit compass), ALWAYS exits 0 — must never block a session end.
 #
 # Usage:
-#   geo-snippet --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
+#   locus --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
 #               [--seq N] [--enrich STR] [--pulse n/m] [--base REF]
 #   # D3 reads tree item-lines from stdin: "<glyph> <slug> [· <enrich>]" (one per line)
 #
@@ -35,7 +35,7 @@ DENSITY="" ; STATUS="🟡" ; SLUG="" ; SEQ="" ; ENRICH="" ; PULSE="" ; BASE=""
 
 usage() {
   printf '%s\n' \
-    'usage: geo-snippet --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]' \
+    'usage: locus --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]' \
     '                   [--seq N] [--enrich STR] [--pulse n/m] [--base REF]' \
     '       # density=ntree reads tree item-lines from stdin (one per line)' >&2
 }

--- a/bin/tests/locus.test.sh
+++ b/bin/tests/locus.test.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
-# Tests for bin/geo-snippet.sh — the geo-snippet recap renderer.
-# Bash 3.2-safe, self-contained, read-only. Run: bash bin/tests/geo-snippet.test.sh
+# Tests for bin/locus.sh — the locus recap renderer.
+# Bash 3.2-safe, self-contained, read-only. Run: bash bin/tests/locus.test.sh
 set -uo pipefail
 
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
-GS="$DIR/../geo-snippet.sh"
+GS="$DIR/../locus.sh"
 
 pass=0 ; fail=0
 ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
@@ -13,7 +13,7 @@ has()  { case "$2" in *"$1"*) ok "$3" ;; *) no "$3" "$2" ;; esac; }   # has NEED
 hasnt(){ case "$2" in *"$1"*) no "$3" "$2" ;; *) ok "$3" ;; esac; }
 eq()   { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
 
-printf 'geo-snippet.test.sh\n'
+printf 'locus.test.sh\n'
 
 # D1 name: status+slug, no #seq, no compass clutter
 o="$("$GS" --density name --status '🟢' --slug add-oauth)"

--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -11,7 +11,7 @@ description: |
   continuation session so the work continues across the compact/clear boundary. The
   end-of-session counterpart to the `preflight` skill. Reads whatever governance is present
   at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories) and adapts.
-version: 0.3.0
+version: 0.3.1
 triggers:
   - postflight
   - run postflight
@@ -25,7 +25,7 @@ triggers:
   - spawn the continuation session
   - spawn the next session
 metadata:
-  version: "0.3.0"
+  version: "0.3.1"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -84,8 +84,8 @@ The environment MUST be left better, safer, and more traceable than it was found
 | # | Responsibility | How (safe-or-DEFER) | Composes |
 |---|---|---|---|
 | **P1** | **SWEEP** — operationalize the exit-hygiene checklist: no loose ends, no banana peels | for each axis {git · docs · ADRs · changelogs · memories · rules · tickets/backlogs · worktrees/branches · stale metrics}: *survey* gaps/opportunities → classify by Eisenhower → **act** (persist/fix/version/commit/push/close) **or register** a tracked follow-up. Read-before-discard is mandatory. | `protocols/exit-hygiene.md`, `skills/sync-to-git`, `skills/quiesce`, `commands/worktree.md`, `bin/dogfood-mark` |
-| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know geo-snippet** — D2 status line + D3 ntree + D4 conv — via `bin/geo-snippet.sh` (the compact projection of this debrief; grammar SSOT `references/geo-snippet-spec.md`). | `skills/morning-briefing`, `bin/geo-snippet.sh` |
-| **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` geo-snippet `<status>·<anchor>·<slug>[·#seq]`); print to screen + best-effort clipboard. DoR = P1+P2 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) |
+| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know locus** — D2 status line + D3 ntree + D4 conv — via `bin/locus.sh` (the compact projection of this debrief; grammar SSOT `references/locus-spec.md`). | `skills/morning-briefing`, `bin/locus.sh` |
+| **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` locus `<status>·<anchor>·<slug>[·#seq]`); print to screen + best-effort clipboard. DoR = P1+P2 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) |
 | **P3.5** | **SPAWN** *(optional, default-ON)* — launch the next session, pre-seeded | hand the P3 seed to `bin/spawn-continuation.sh`, which launches a fresh **named** (`<ticket>-<slug>-#<short>`) detached `claude` session (tmux/cmux) with the seed injected as durable system context — so the work *continues itself* across the compact/clear boundary instead of waiting on a manual paste. DoR = P3 seed. Opt out: `--no-spawn`. | `bin/spawn-continuation.sh` (consumes the P3 seed; reuses `session-fission`'s reseed idea) |
 
 **SWEEP never clobbers**: a dirty tree, a divergence-with-conflict, a held `.git/index.lock`,
@@ -133,7 +133,7 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
    objectives N-Tree + Eisenhower next-actions (non-blocked first) + gaps/pendings/undecided/
    unasked-Qs. (The community `morning-briefing` provides state + next-action; postflight adds
    the N-Tree + Eisenhower ranking.) This is the session map — then render it as the
-   glance-and-know geo-snippet (D2+D3+D4) via `bin/geo-snippet.sh`.
+   glance-and-know locus (D2+D3+D4) via `bin/locus.sh`.
 3. P3 HANDOFF: synthesize the continuation seed (below) from P1+P2 → print + clipboard.
 3.5 P3.5 SPAWN (default-ON; skip on --no-spawn / kill-switch / depth-cap / already-spawned):
    write the P3 seed to a file, then `bin/spawn-continuation.sh --ticket <KEY> --slug <kebab>
@@ -155,7 +155,7 @@ amnesia premise: a gifted agent with no cross-session recall). Two registers, sa
   "goal":"<one-line mission>",
   "context":"<state-of-world the next agent needs>",
   "git":{"repo":"<name>","branch":"<b>","worktree":"<path|none>","prs":["#<n> <state>"]},
-  "locus":"<D1 geo-snippet: <status>·<anchor>·<slug>[·#seq] — bin/geo-snippet.sh --density name>",
+  "locus":"<D1 locus: <status>·<anchor>·<slug>[·#seq] — bin/locus.sh --density name>",
   "objectives":{"primary":["..."],"secondary":["..."],"auxiliary":["..."]},
   "done":["..."], "in_flight":["..."],
   "gaps":["..."], "pendings":["..."], "undecided":["..."], "unasked_questions":["..."],
@@ -225,7 +225,7 @@ postflight P1: branch=main tree=DIRTY → SWEEP DEFERRED (uncommitted tracked ch
 - `skills/preflight/SKILL.md` — the **start-of-session** counterpart (orient + heal + isolate); together they bound the session: `preflight → work → postflight`.
 - `protocols/exit-hygiene.md` — the Boy-Scout exit-gate checklist P1 operationalizes (policy → this executes it).
 - `skills/morning-briefing/SKILL.md` — its 7-section briefing is the P2 state substrate; postflight adds the N-Tree + Eisenhower synthesis that P3 elevates into an agent seed.
-- `skills/postflight/references/geo-snippet-spec.md` + `bin/geo-snippet.sh` — the **geo-snippet** grammar SSOT + renderer; P2 DEBRIEF emits the glance-and-know recap (D2/D3/D4) and P3 carries D1 (`locus`) in the seed.
+- `skills/postflight/references/locus-spec.md` + `bin/locus.sh` — the **locus** grammar SSOT + renderer; P2 DEBRIEF emits the glance-and-know recap (D2/D3/D4) and P3 carries D1 (`locus`) in the seed.
 - `skills/sync-to-git/SKILL.md` · `skills/quiesce/SKILL.md` — git close-out + PR convergence P1 composes.
 - `skills/session-fission/SKILL.md` — orthogonal: it *splits* a tangled session into N seeds; P3 emits *one* resume seed for continuity, and P3.5 reuses its reseed-a-fresh-session idea for continuity-spawn.
 - `bin/spawn-continuation.sh` — the **P3.5 SPAWN** primitive: launches the named, pre-seeded `claude` continuation session (tmux/cmux) with the 7 guardrails; consumes the P3 seed.

--- a/skills/postflight/references/locus-spec.md
+++ b/skills/postflight/references/locus-spec.md
@@ -1,10 +1,11 @@
-# Geo-Snippet — End-of-Session Recap Grammar (SSOT)
+# Locus — End-of-Session Recap Grammar (SSOT)
 
-> **Version**: 1.0.1
+> **Version**: 1.1.0
+> **Renamed** 2026-06-10: `geo-snippet` (PR #126 grammar+renderer+tests, #127 postflight wiring) → `locus` — Anima naming verdict (Latin *locus* "place/position"; the snippet computes your position from anchor reference-points, mirroring a nautical position-fix). History preserved via `git mv`.
 > **Scope**: AAIF cross-vendor. A compact, glance-and-know "geo-localization" status line for agent sessions.
 > **Consumer**: `skills/postflight` (P2 DEBRIEF emits it; P3 seed carries it as `locus` — wired postflight v0.3.0) · `bin/spawn-continuation.sh` (owns `#seq`; D1 → session `--name` **wiring tracked** — needs an ascii-safe name variant, see follow-up issue).
-> **Renderer**: `bin/geo-snippet.sh`.
-> **Cross-link slug**: `geo-snippet`
+> **Renderer**: `bin/locus.sh`.
+> **Cross-link slug**: `locus`
 
 ## Purpose — "geo-localization"
 
@@ -41,7 +42,7 @@ Separator is the middle dot `·`. Optional fields (`[...]`) collapse their token
 | 🟠 | need-HITL (needs a human decision/authorization) |
 | 🟢 | done |
 
-This is the **aggregate projection** of the session's primary goal — deliberately ≤4 colors so it is triable pre-attentively (one glyph, instant read). It is distinct from the **per-item 5-state visual legend** (which adds 🔵 human-done) used inside checklists/N-trees: human-done + any `%`/autonomy telemetry belong in `enrich`/`pulse`, **never** in the aggregate `status` glyph. 🟠 ("needs you") is the #1 signal a geo-snippet must surface.
+This is the **aggregate projection** of the session's primary goal — deliberately ≤4 colors so it is triable pre-attentively (one glyph, instant read). It is distinct from the **per-item 5-state visual legend** (which adds 🔵 human-done) used inside checklists/N-trees: human-done + any `%`/autonomy telemetry belong in `enrich`/`pulse`, **never** in the aggregate `status` glyph. 🟠 ("needs you") is the #1 signal a locus must surface.
 
 ### anchor — salience, pick ONE (DRY)
 
@@ -130,10 +131,10 @@ conv: base-3+🟠 · anchor=ticket›PR›branch›task · #seq=chain/omit · en
 6. **Pendings audit** — D3.
 7. **Convention surfacing** — D4.
 
-## Renderer contract (`bin/geo-snippet.sh`)
+## Renderer contract (`bin/locus.sh`)
 
 ```
-geo-snippet --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
+locus --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
             [--seq N] [--enrich STR] [--pulse n/m] [--base REF]
 ```
 


### PR DESCRIPTION
[PR-as-Correction-Prompt]

## Context
Tool 8 shipped as `geo-snippet` (#126 grammar/renderer/tests, #127 postflight wiring). Per the operator's explicit *"invoque Anima"* directive, **Anima** named the tool **`locus`** (Latin *locus* "place/position"; the snippet computes your position from **anchor reference-points** — exactly a nautical *position-fix* — scoring 12/12 correctness + 4/4 resonance; rejected runner-up `waypoint`). Operator chose **full rename**.

## What (history-preserving rename — `git mv`)
- `bin/geo-snippet.sh` → **`bin/locus.sh`**
- `bin/tests/geo-snippet.test.sh` → **`bin/tests/locus.test.sh`**
- `skills/postflight/references/geo-snippet-spec.md` → **`.../locus-spec.md`**
- All internal references updated: postflight P2/P3 wiring (#127), renderer header + `usage:` line, spec title (`# Locus`), cross-link slug (`locus`). The **`geo-localization` metaphor is kept** (it's the concept; `locus` is the name).
- Versions: `locus-spec` 1.0.1→1.1.0 (+ rename breadcrumb for amnesic agents) · postflight 0.3.0→0.3.1 (ref update).

## Acceptance
- [x] 3 renames detected as **R** (history preserved) — not delete+add
- [x] **22/22 tests green** under the new name (`bin/tests/locus.test.sh`)
- [x] **Zero** `geo-snippet` identifiers remain (metaphor `geo-localization` intentionally kept)
- [x] Staged-diff `gitleaks protect --staged` → **0 leaks**
- [x] Renderer runs: `bin/locus.sh --density name` → `🟢 · <anchor> · <slug>`

## Cross-links
- Renames #126/#127 artifacts · follow-up #128 (ascii-safe `spawn-continuation --name`) unaffected (still tracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
