### PR TITLE
feat(postflight): wire scorecard round-robin into P2 DEBRIEF (tool 8)

### DIFF
--- a/bin/scorecard-next-model.sh
+++ b/bin/scorecard-next-model.sh
@@ -23,7 +23,10 @@
 #
 # Override (pin a model, skip rotation entirely — mirrors the POSTFLIGHT_SPAWN=0 idiom):
 #   export POSTFLIGHT_SCORECARD_MODEL=<1..7|cockpit|telemetry|...>
-#     → prints that value verbatim, NEVER touches the pointer (deterministic pin).
+#     → validated against bin/scorecard.py (the model-registry SSOT); if valid, prints it
+#       verbatim and NEVER touches the pointer (deterministic pin). An INVALID value (typo)
+#       warns to stderr + falls back to round-robin, so it can never break the downstream
+#       `scorecard.py --model` render (which rejects unknown values with exit 2).
 #
 # State file: ${POSTFLIGHT_SCORECARD_STATE:-$HOME/.claude/jobs/.postflight-scorecard-model}
 #   A single integer (the last-used model id, 1..7; 0 = none yet). A missing or
@@ -36,18 +39,41 @@
 
 N_MODELS=7
 STATE="${POSTFLIGHT_SCORECARD_STATE:-$HOME/.claude/jobs/.postflight-scorecard-model}"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd 2>/dev/null || printf '.')"
+SCORECARD="$DIR/scorecard.py"
 
-# --- override: pin a model, never rotate, never touch the pointer ---
+# Is VALUE a model bin/scorecard.py accepts? Delegate to scorecard.py (the SSOT for the
+# id/alias registry) rather than duplicating its alias list here (DRY — a local copy would
+# drift). A stable numeric id (1..N_MODELS) needs no probe. If python3/scorecard.py are not
+# available we cannot validate → accept (graceful; the selector must never block).
+_is_valid_model() {
+  case "$1" in
+    '') return 1 ;;
+    *[!0-9]*) ;;                                            # non-numeric → probe scorecard.py below
+    *) if [ "$1" -ge 1 ] && [ "$1" -le "$N_MODELS" ]; then return 0; else return 1; fi ;;
+  esac
+  command -v python3 >/dev/null 2>&1 && [ -f "$SCORECARD" ] || return 0   # cannot probe → accept
+  python3 "$SCORECARD" --model "$1" --demo --no-color >/dev/null 2>&1
+}
+
+# --- override: pin a model, skip rotation. Validate first so a typo can't break the
+#     downstream `scorecard.py --model` render; an invalid value warns + falls through to
+#     round-robin (never emits an unrenderable token, honouring the always-valid contract).
 if [ -n "${POSTFLIGHT_SCORECARD_MODEL:-}" ]; then
-  printf '%s\n' "$POSTFLIGHT_SCORECARD_MODEL"
-  exit 0
+  if _is_valid_model "$POSTFLIGHT_SCORECARD_MODEL"; then
+    printf '%s\n' "$POSTFLIGHT_SCORECARD_MODEL"
+    exit 0
+  fi
+  printf 'scorecard-next-model: ignoring invalid POSTFLIGHT_SCORECARD_MODEL=%s (not a scorecard.py model) — falling back to round-robin\n' "$POSTFLIGHT_SCORECARD_MODEL" >&2
 fi
 
 mode="${1:-advance}"
 
-_read() {  # echo the sanitised last-used id (0..N_MODELS); non-numeric/out-of-range → 0
-  local v
-  v="$(cat "$STATE" 2>/dev/null || printf '0')"
+_read() {  # echo the sanitised last-used id (0..N_MODELS); unreadable/non-numeric/out-of-range → 0
+  local v=0
+  # Read ONLY a regular file (excludes FIFO/device/dir → cannot block) and ONLY its first
+  # line (bounds a huge/garbage file → cannot stall) — preserves the "never abort" contract.
+  if [ -f "$STATE" ]; then IFS= read -r v <"$STATE" 2>/dev/null || v=0; fi
   case "$v" in '' | *[!0-9]*) v=0 ;; esac
   if [ "$v" -gt "$N_MODELS" ] 2>/dev/null; then v=0; fi
   printf '%s' "$v"

--- a/bin/scorecard-next-model.sh
+++ b/bin/scorecard-next-model.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# scorecard-next-model.sh — deterministic 1→7 round-robin selector for the
+# postflight end-of-action scorecard (bin/scorecard.py has 7 layout models).
+#
+# WHY this exists (and why NOT inside scorecard.py):
+#   scorecard.py is a PURE renderer by contract (same params → same output, no
+#   side-effects). Rotation needs persistent state (a pointer), which is a
+#   side-effect — so it lives HERE, outside the renderer, keeping it pure.
+#
+# WHY user-scope state (~/.claude/jobs/), not a repo file:
+#   The goal (operator decision 2026-06-10: "deixe lançado em round-robin até eu
+#   me acostumar e decidir") is to expose the OPERATOR to all 7 models over time
+#   so they can pick a favourite. That exposure is operator-GLOBAL, not per-repo —
+#   a repo-local pointer would cycle independently per repo and never give even
+#   coverage. The pointer is therefore user-scope.
+#
+# Usage:
+#   scorecard-next-model.sh             # advance the pointer + print next model id (1..7)
+#   scorecard-next-model.sh --peek      # print the next model id WITHOUT advancing
+#   scorecard-next-model.sh --current   # print the last-used model id (0 if none yet)
+#   scorecard-next-model.sh --reset     # reset pointer to 0 (next advance → 1)
+#   scorecard-next-model.sh -h|--help   # this header
+#
+# Override (pin a model, skip rotation entirely — mirrors the POSTFLIGHT_SPAWN=0 idiom):
+#   export POSTFLIGHT_SCORECARD_MODEL=<1..7|cockpit|telemetry|...>
+#     → prints that value verbatim, NEVER touches the pointer (deterministic pin).
+#
+# State file: ${POSTFLIGHT_SCORECARD_STATE:-$HOME/.claude/jobs/.postflight-scorecard-model}
+#   A single integer (the last-used model id, 1..7; 0 = none yet). A missing or
+#   invalid pointer is treated as 0 (next → 1). The write is atomic (temp-then-mv,
+#   no torn file). Any failure degrades gracefully: a valid model is always printed
+#   and the script always exits 0 — it must NEVER abort a session-end debrief.
+#
+# Bash 3.2-safe, self-contained. Composed by skills/postflight (P2 DEBRIEF).
+# License: MIT (matches the multi-agent-os repo LICENSE).
+
+N_MODELS=7
+STATE="${POSTFLIGHT_SCORECARD_STATE:-$HOME/.claude/jobs/.postflight-scorecard-model}"
+
+# --- override: pin a model, never rotate, never touch the pointer ---
+if [ -n "${POSTFLIGHT_SCORECARD_MODEL:-}" ]; then
+  printf '%s\n' "$POSTFLIGHT_SCORECARD_MODEL"
+  exit 0
+fi
+
+mode="${1:-advance}"
+
+_read() {  # echo the sanitised last-used id (0..N_MODELS); non-numeric/out-of-range → 0
+  local v
+  v="$(cat "$STATE" 2>/dev/null || printf '0')"
+  case "$v" in '' | *[!0-9]*) v=0 ;; esac
+  if [ "$v" -gt "$N_MODELS" ] 2>/dev/null; then v=0; fi
+  printf '%s' "$v"
+}
+
+_write() {  # atomic temp-then-mv; graceful (never errors out the caller)
+  local v="$1" dir tmp
+  dir="$(dirname "$STATE")"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  tmp="$STATE.tmp.$$"
+  printf '%s\n' "$v" >"$tmp" 2>/dev/null && mv -f "$tmp" "$STATE" 2>/dev/null
+  return 0
+}
+
+cur="$(_read)"
+next=$(( cur % N_MODELS + 1 ))   # 0→1, 1→2, …, 7→1 (round-robin wrap)
+
+case "$mode" in
+  --peek)    printf '%s\n' "$next" ;;
+  --current) printf '%s\n' "$cur" ;;
+  --reset)   _write 0; printf '%s\n' "0" ;;
+  -h|--help) sed -n '2,40p' "$0" ;;
+  *)         _write "$next"; printf '%s\n' "$next" ;;
+esac
+exit 0

--- a/bin/tests/scorecard-next-model.test.sh
+++ b/bin/tests/scorecard-next-model.test.sh
@@ -45,11 +45,23 @@ eq '1'  "$("$SEL" --current)" '--current reflects last-used (1), unchanged by pe
 eq '0' "$("$SEL" --reset)"  '--reset prints 0'
 eq '1' "$("$SEL")"          'after reset → 1'
 
-# env override pins a model and never advances the pointer
+# valid env override pins a model and never advances the pointer
 "$SEL" --reset >/dev/null
 eq '5'         "$(POSTFLIGHT_SCORECARD_MODEL=5         "$SEL")" 'env override (id) pins verbatim'
 eq 'telemetry' "$(POSTFLIGHT_SCORECARD_MODEL=telemetry "$SEL")" 'env override (name) pins verbatim'
 eq '0'         "$("$SEL" --current)" 'override never touched the pointer (still 0)'
+
+# INVALID override (typo) → warns + falls back to round-robin, never emits the junk token
+# (needs python3 + scorecard.py to reject a bad NAME; otherwise the selector accepts gracefully).
+if command -v python3 >/dev/null 2>&1 && [ -f "$DIR/../scorecard.py" ]; then
+  "$SEL" --reset >/dev/null
+  out="$(POSTFLIGHT_SCORECARD_MODEL=telemetery "$SEL" 2>/dev/null)"   # 'telemetery' = typo of 'telemetry'
+  case "$out" in 1|2|3|4|5|6|7) ok 'invalid override falls back to a valid 1..7 id' ;; *) no 'invalid override falls back to a valid 1..7 id' "$out" ;; esac
+  case "$out" in telemetery) no 'invalid override NOT emitted verbatim' "$out" ;; *) ok 'invalid override NOT emitted verbatim' ;; esac
+  POSTFLIGHT_SCORECARD_MODEL=telemetery "$SEL" 2>&1 >/dev/null | grep -q 'ignoring invalid' && ok 'invalid override warns to stderr' || no 'invalid override warns to stderr' '(no warning seen)'
+else
+  printf '  - skipped invalid-override-fallback (python3/scorecard.py unavailable)\n'
+fi
 
 # invalid pointer content self-heals to 0 → next is 1
 printf 'garbage\n' > "$POSTFLIGHT_SCORECARD_STATE"

--- a/bin/tests/scorecard-next-model.test.sh
+++ b/bin/tests/scorecard-next-model.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Tests for bin/scorecard-next-model.sh — the postflight scorecard round-robin selector.
+# Bash 3.2-safe, self-contained. Uses an ISOLATED temp pointer (never the real
+# user-scope state). Run: bash bin/tests/scorecard-next-model.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+SEL="$DIR/../scorecard-next-model.sh"
+
+pass=0 ; fail=0
+ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  \xe2\x9c\x97 %s\n      got: [%s]\n' "$1" "$2"; }
+eq() { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
+
+printf 'scorecard-next-model.test.sh\n'
+
+# Isolate the pointer to a throwaway file (never touch the real ~/.claude state).
+TMP="$(mktemp -d 2>/dev/null || echo /tmp/scnm.$$)"; mkdir -p "$TMP"
+export POSTFLIGHT_SCORECARD_STATE="$TMP/ptr"
+unset POSTFLIGHT_SCORECARD_MODEL 2>/dev/null || true
+cleanup() { rm -rf "$TMP" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# fresh pointer (no file) → first advance is model 1
+rm -f "$POSTFLIGHT_SCORECARD_STATE"
+eq '1' "$("$SEL")"          'fresh pointer → first model is 1'
+eq '2' "$("$SEL")"          'advance → 2'
+eq '3' "$("$SEL")"          'advance → 3'
+
+# full wrap 3→7→1
+eq '4' "$("$SEL")" 'advance → 4'
+eq '5' "$("$SEL")" 'advance → 5'
+eq '6' "$("$SEL")" 'advance → 6'
+eq '7' "$("$SEL")" 'advance → 7'
+eq '1' "$("$SEL")" 'wraps 7 → 1 (round-robin)'
+
+# --peek does NOT advance the pointer (idempotent read). Pointer is at 1 here
+# (the 7→1 wrap above), so --current stays 1 and --peek keeps reporting 2.
+p1="$("$SEL" --peek)"; p2="$("$SEL" --peek)"
+eq "$p1" "$p2" '--peek is non-advancing (two peeks equal)'
+eq '2'  "$p1"                 '--peek reports the next id (2) without advancing'
+eq '1'  "$("$SEL" --current)" '--current reflects last-used (1), unchanged by peeks'
+
+# --reset → pointer back to 0, next advance is 1 again
+eq '0' "$("$SEL" --reset)"  '--reset prints 0'
+eq '1' "$("$SEL")"          'after reset → 1'
+
+# env override pins a model and never advances the pointer
+"$SEL" --reset >/dev/null
+eq '5'         "$(POSTFLIGHT_SCORECARD_MODEL=5         "$SEL")" 'env override (id) pins verbatim'
+eq 'telemetry' "$(POSTFLIGHT_SCORECARD_MODEL=telemetry "$SEL")" 'env override (name) pins verbatim'
+eq '0'         "$("$SEL" --current)" 'override never touched the pointer (still 0)'
+
+# invalid pointer content self-heals to 0 → next is 1
+printf 'garbage\n' > "$POSTFLIGHT_SCORECARD_STATE"
+eq '1' "$("$SEL")" 'non-numeric pointer self-heals → 1'
+printf '99\n'      > "$POSTFLIGHT_SCORECARD_STATE"
+eq '1' "$("$SEL")" 'out-of-range pointer self-heals → 1'
+
+# every emitted id is a valid scorecard model (1..7) over a full cycle
+"$SEL" --reset >/dev/null
+bad=0
+for _ in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do
+  m="$("$SEL")"
+  case "$m" in 1|2|3|4|5|6|7) ;; *) bad=1 ;; esac
+done
+eq '0' "$bad" 'all emitted ids over 14 advances are in 1..7'
+
+# always exits 0 (must never abort a session-end debrief)
+"$SEL" >/dev/null 2>&1 ; eq '0' "$?"          'advance exits 0'
+"$SEL" --peek >/dev/null 2>&1 ; eq '0' "$?"   '--peek exits 0'
+"$SEL" --bogus >/dev/null 2>&1 ; eq '0' "$?"  'unknown arg falls through to advance, exits 0'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/commands/postflight.md
+++ b/commands/postflight.md
@@ -25,7 +25,7 @@ entry point over the [`postflight` skill](../skills/postflight/SKILL.md).
 |--------|-------------|
 | *(none)* / `full` | P1+P2+P3: sweep → debrief → emit + clipboard the continuation seed. |
 | `sweep` | P1 only — exit-hygiene sweep (git close-out + docs/ADRs/changelogs/memories/rules persist + ticket close-or-register), classified by Eisenhower, safe-or-DEFER. |
-| `debrief` | P2 only — calculate the session map: compose `morning-briefing` (7-section state) + synthesize the objectives N-Tree + Eisenhower next-actions + gaps/pendings/undecided on top. No mutations. |
+| `debrief` | P2 only — calculate the session map: compose `morning-briefing` (7-section state) + synthesize the objectives N-Tree + Eisenhower next-actions + gaps/pendings/undecided on top, then render the glance-and-know **locus** + the end-of-action **scorecard** (`bin/scorecard.py`, model picked round-robin by `bin/scorecard-next-model.sh`). No mutations to tracked files. |
 | `seed` | P3 only — emit the ai-agnostic continuation seed (agent-register envelope + human mirror) + clipboard. Requires P1+P2 (DoR). |
 | `spawn` | P3.5 only — launch a fresh, named `claude` continuation session pre-seeded with the P3 seed (`bin/spawn-continuation.sh`). Requires a seed (DoR). |
 
@@ -57,6 +57,7 @@ entry point over the [`postflight` skill](../skills/postflight/SKILL.md).
 ─────────────────────────────────────────────────
 SWEEP    pushed feat/x · PR #42 → green · pruned 1 stale ref · changelog bumped
 DEBRIEF  objectives 2/3 done · 1 gap · 1 undecided · 3 next-actions (Q1×1, Q2×2)
+         📊 scorecard model 4/7 (burndown, round-robin) rendered from debrief state
 HANDOFF  🌱 continuation seed → printed + copied to clipboard
 SPAWN    🛫 TICKET-123-add-retry-#a1b2c3d4 (tmux) — attach: tmux attach -t '…' · or --no-spawn next time
 ─────────────────────────────────────────────────
@@ -71,6 +72,8 @@ Next agent: /maos:preflight, then start at the first non-blocked next-action.
 | `POSTFLIGHT_SNAPSHOT_PRS=1` | The PreCompact hook also fetches open-PR state via `gh` (network; default off = fast/offline-safe). |
 | `POSTFLIGHT_SEED_DIR=<path>` | Override where the PreCompact hook writes the seed snapshot (default: inside the repo's git dir — git-ignored, so it never dirties the working tree). |
 | `POSTFLIGHT_SPAWN=0` | **P3.5 kill-switch** — never spawn a continuation session (deterministic opt-out; overrides `--spawn`). |
+| `POSTFLIGHT_SCORECARD_MODEL=<1..7\|name>` | Pin the P2 scorecard layout model + skip the round-robin rotation entirely (e.g. `cockpit`, `telemetry`, `4`). Default: round-robin via `bin/scorecard-next-model.sh`. |
+| `POSTFLIGHT_SCORECARD_STATE=<path>` | Override the round-robin pointer file (default: `~/.claude/jobs/.postflight-scorecard-model`). |
 | `POSTFLIGHT_SPAWN_DEPTH=N` | Current auto-chain depth (default 0); `>=` the depth-cap (default 1) → P3.5 graceful no-op (anti-recursion). |
 | `MAOS_SPAWN_LAUNCHER` | Force the spawn launcher: `tmux` \| `cmux` \| `print` (default: auto-detect; `print` = register + emit the resume command). |
 
@@ -78,5 +81,5 @@ Next agent: /maos:preflight, then start at the first non-blocked next-action.
 
 - Skill: [`skills/postflight/SKILL.md`](../skills/postflight/SKILL.md) (the orchestrator).
 - Hook: `plugin-scripts/governance/postflight-precompact.sh` (PreCompact — deterministic seed snapshot; never blocks; never spawns).
-- Composes: `protocols/exit-hygiene.md`, `skills/{sync-to-git,quiesce,morning-briefing,session-fission}`, `commands/worktree.md`, `bin/dogfood-mark`, `bin/spawn-continuation.sh` (P3.5 spawn primitive).
+- Composes: `protocols/exit-hygiene.md`, `skills/{sync-to-git,quiesce,morning-briefing,session-fission}`, `commands/worktree.md`, `bin/dogfood-mark`, `bin/spawn-continuation.sh` (P3.5 spawn primitive), `bin/locus.sh` (P2 locus) + `bin/scorecard.py` + `bin/scorecard-next-model.sh` (P2 scorecard, round-robin).
 - Counterpart: `/preflight` (start-of-session) — together the loop: `preflight → work → postflight → (spawn) → preflight …`.

--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -11,7 +11,7 @@ description: |
   continuation session so the work continues across the compact/clear boundary. The
   end-of-session counterpart to the `preflight` skill. Reads whatever governance is present
   at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories) and adapts.
-version: 0.3.1
+version: 0.4.0
 triggers:
   - postflight
   - run postflight
@@ -25,7 +25,7 @@ triggers:
   - spawn the continuation session
   - spawn the next session
 metadata:
-  version: "0.3.1"
+  version: "0.4.0"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -84,7 +84,7 @@ The environment MUST be left better, safer, and more traceable than it was found
 | # | Responsibility | How (safe-or-DEFER) | Composes |
 |---|---|---|---|
 | **P1** | **SWEEP** — operationalize the exit-hygiene checklist: no loose ends, no banana peels | for each axis {git · docs · ADRs · changelogs · memories · rules · tickets/backlogs · worktrees/branches · stale metrics}: *survey* gaps/opportunities → classify by Eisenhower → **act** (persist/fix/version/commit/push/close) **or register** a tracked follow-up. Read-before-discard is mandatory. | `protocols/exit-hygiene.md`, `skills/sync-to-git`, `skills/quiesce`, `commands/worktree.md`, `bin/dogfood-mark` |
-| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know locus** — D2 status line + D3 ntree + D4 conv — via `bin/locus.sh` (the compact projection of this debrief; grammar SSOT `references/locus-spec.md`). | `skills/morning-briefing`, `bin/locus.sh` |
+| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know locus** — D2 status line + D3 ntree + D4 conv — via `bin/locus.sh` (the compact projection of this debrief; grammar SSOT `references/locus-spec.md`), **and the end-of-action scorecard** — `bin/scorecard.py --model N` where `N` is chosen by `bin/scorecard-next-model.sh` (deterministic 1→7 round-robin; see "The End-of-Action Scorecard" below). | `skills/morning-briefing`, `bin/locus.sh`, `bin/scorecard.py`, `bin/scorecard-next-model.sh` |
 | **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` locus `<status>·<anchor>·<slug>[·#seq]`); print to screen + best-effort clipboard. DoR = P1+P2 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) |
 | **P3.5** | **SPAWN** *(optional, default-ON)* — launch the next session, pre-seeded | hand the P3 seed to `bin/spawn-continuation.sh`, which launches a fresh **named** (`<ticket>-<slug>-#<short>`) detached `claude` session (tmux/cmux) with the seed injected as durable system context — so the work *continues itself* across the compact/clear boundary instead of waiting on a manual paste. DoR = P3 seed. Opt out: `--no-spawn`. | `bin/spawn-continuation.sh` (consumes the P3 seed; reuses `session-fission`'s reseed idea) |
 
@@ -133,7 +133,12 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
    objectives N-Tree + Eisenhower next-actions (non-blocked first) + gaps/pendings/undecided/
    unasked-Qs. (The community `morning-briefing` provides state + next-action; postflight adds
    the N-Tree + Eisenhower ranking.) This is the session map — then render it as the
-   glance-and-know locus (D2+D3+D4) via `bin/locus.sh`.
+   glance-and-know locus (D2+D3+D4) via `bin/locus.sh`, AND render the end-of-action
+   scorecard: `N=$(bin/scorecard-next-model.sh)` (round-robin selector; honours
+   `POSTFLIGHT_SCORECARD_MODEL` override) then build the params JSON from the P1/P2
+   state (verdict · autonomy pulse · vitals · checklist · whats_left · tickets) and
+   `printf '%s' "$params" | bin/scorecard.py --model "$N" --auto-git --repo <repo>`.
+   The renderer is PURE (no side-effects); the rotation pointer lives in the selector.
 3. P3 HANDOFF: synthesize the continuation seed (below) from P1+P2 → print + clipboard.
 3.5 P3.5 SPAWN (default-ON; skip on --no-spawn / kill-switch / depth-cap / already-spawned):
    write the P3 seed to a file, then `bin/spawn-continuation.sh --ticket <KEY> --slug <kebab>
@@ -174,6 +179,31 @@ designed so the next agent runs `/maos:preflight` (orient) then resumes from the
 non-blocked next-action — and, when **P3.5 SPAWN** fires, that next agent is *launched
 already holding the seed*, closing the loop `preflight → work → postflight → (spawn) → preflight …`.
 
+## The End-of-Action Scorecard (a P2 DEBRIEF output)
+
+`bin/scorecard.py` renders a glanceable end-of-action **scorecard** (verdict · autonomy
+pulse · vitals bars · checklist · what's-left · tickets) in one of **7 layout models**. It is
+a **PURE renderer** by contract — same params → same output, no side-effects — so it consumes
+a params JSON (built by the agent from the P1 SWEEP + P2 DEBRIEF state) and self-derives only
+git/PR facts (`--auto-git`).
+
+**Model selection — round-robin (interim) → dynamic (target):**
+
+- **Now (round-robin):** `bin/scorecard-next-model.sh` is the deterministic 1→7 selector. It
+  keeps the renderer pure by holding the rotation pointer **outside** it, in **user-scope**
+  state (`~/.claude/jobs/.postflight-scorecard-model`) — so the operator is exposed to all 7
+  models across sessions *and repos* (the exposure goal is operator-global, not per-repo). Per
+  operator decision 2026-06-10 (*"deixe lançado em round-robin até eu me acostumar e decidir"*):
+  rotate until a favourite emerges.
+  - `scorecard-next-model.sh` → advance + print next id · `--peek` (no advance) · `--current` · `--reset`.
+  - **Override:** `export POSTFLIGHT_SCORECARD_MODEL=<1..7|name>` pins a model and skips
+    rotation entirely (mirrors the `POSTFLIGHT_SPAWN=0` kill-switch idiom).
+- **Future (target):** replace round-robin with a **dynamic context-based selector** (factors:
+  contexto · propósito · objetivo · tipo[humano|agente] · status · risco · impacto · urgência ·
+  segurança · roadmap · timeline). Round-robin is the interim exposure mechanism, not the end state.
+
+Gallery of the 7 models: `skills/postflight/scorecards/gallery.md`.
+
 ## Conditions / Invocation
 
 | Condition | Path |
@@ -190,6 +220,7 @@ already holding the seed*, closing the loop `preflight → work → postflight �
 You: "I'm about to /compact — wrap this up."
 postflight P1: 1 unpushed commit on feat/x → pushed; PR #42 → driven green; 1 stale ref → pruned.
 postflight P2: objectives 2/3 done; 1 gap (tests for edge-case); 1 undecided (naming of Y).
+postflight P2: 📊 scorecard model 4/7 (burndown, round-robin) rendered from the debrief state.
 postflight P3: 🌱 continuation seed → printed + copied to clipboard. Next agent: /maos:preflight then task #1.
 postflight P3.5: 🛫 spawned TICKET-123-add-retry-#a1b2c3d4 (tmux), seed injected. Attach: tmux attach -t '…'.
 ```
@@ -226,6 +257,7 @@ postflight P1: branch=main tree=DIRTY → SWEEP DEFERRED (uncommitted tracked ch
 - `protocols/exit-hygiene.md` — the Boy-Scout exit-gate checklist P1 operationalizes (policy → this executes it).
 - `skills/morning-briefing/SKILL.md` — its 7-section briefing is the P2 state substrate; postflight adds the N-Tree + Eisenhower synthesis that P3 elevates into an agent seed.
 - `skills/postflight/references/locus-spec.md` + `bin/locus.sh` — the **locus** grammar SSOT + renderer; P2 DEBRIEF emits the glance-and-know recap (D2/D3/D4) and P3 carries D1 (`locus`) in the seed.
+- `bin/scorecard.py` (pure 7-model renderer) + `bin/scorecard-next-model.sh` (round-robin selector) + `skills/postflight/scorecards/gallery.md` — the **end-of-action scorecard** P2 DEBRIEF emits; the selector holds the rotation pointer so the renderer stays pure.
 - `skills/sync-to-git/SKILL.md` · `skills/quiesce/SKILL.md` — git close-out + PR convergence P1 composes.
 - `skills/session-fission/SKILL.md` — orthogonal: it *splits* a tangled session into N seeds; P3 emits *one* resume seed for continuity, and P3.5 reuses its reseed-a-fresh-session idea for continuity-spawn.
 - `bin/spawn-continuation.sh` — the **P3.5 SPAWN** primitive: launches the named, pre-seeded `claude` continuation session (tmux/cmux) with the 7 guardrails; consumes the P3 seed.


### PR DESCRIPTION
**[PR-as-Enhancement-Prompt]** — tool 8 finish: wire the postflight scorecard round-robin.

## Context
Tool 8 `[postflight, locus]` is feature-complete & merged (PRs #123/#124/#126/#127/#129). The one remaining 🔴 OPEN loop was that **postflight P2/P3 never actually rendered the scorecard** — `bin/scorecard.py` (7 pure models, `--model` selector merged #124) existed but was never called. The scorecard-default decision memory (2026-06-10) captured the operator's interim choice — *"deixe lançado em round-robin até eu me acostumar e decidir"* — and the explicit "next agent: wire round-robin into postflight P2/P3" step.

## Objectives
- **Primary**: postflight P2 DEBRIEF renders the end-of-action scorecard, model rotated 1→7 round-robin, **keeping `scorecard.py` pure** (no side-effects).
- **Secondary**: operator can pin a model (`POSTFLIGHT_SCORECARD_MODEL=<id|name>`) to skip rotation while getting used to the models.
- **Auxiliary**: leave the dynamic context-based selector documented as the FUTURE target (not built here).

## What changed
- **NEW `bin/scorecard-next-model.sh`** — deterministic 1→7 rotation pointer. State is **user-scope** (`~/.claude/jobs/.postflight-scorecard-model`) because the "expose me to all 7" goal is operator-global, not per-repo. `--peek`/`--current`/`--reset` + env override + graceful atomic write (always exits 0).
- **NEW `bin/tests/scorecard-next-model.test.sh`** — 22 cases (rotation · 7→1 wrap · peek-non-advance · reset · env override · self-heal on bad pointer · always-exit-0), isolated pointer, Bash 3.2-safe (mirrors `locus.test.sh`).
- **`skills/postflight/SKILL.md`** — P2 wires the render; new "End-of-Action Scorecard" SSOT subsection; v0.3.1 → **0.4.0**.
- **`commands/postflight.md`** — debrief action + Output + env table (`POSTFLIGHT_SCORECARD_MODEL`, `POSTFLIGHT_SCORECARD_STATE`) + Integration.

## Design rationale (Strata / anti-over-eng)
Rotation = side-effect → cannot live in the pure renderer → a tiny selector holds it (reuse-and-elevate, not reinvention). User-scope pointer over a repo file: even coverage across the operator's whole work, not per-repo cycles. Env override mirrors the existing `POSTFLIGHT_SPAWN=0` kill-switch idiom (consistency). No new framework, no agent-managed mutable state (amnesia-safe).

## Open design question answered
*"Should we merge postflight + locus?"* → **NO.** postflight = workflow; locus = a pure renderer it consumes (and now the scorecard is a second such consumed renderer). Merging would collapse a clean single-responsibility boundary (DRY/Strata). Kept separate, as already built.

## Acceptance criteria
- [x] postflight P2 renders the scorecard via a documented round-robin rule
- [x] `scorecard.py` unchanged (purity preserved)
- [x] selector: 22/22 tests · locus regression 22/22 · gitleaks clean · shellcheck-safe syntax
- [x] env override + state-path override documented
- [x] FUTURE dynamic selector documented, not built (YAGNI)

## Cross-links
- decision memory: `project_postflight_scorecard_default_decision.md` (the OPEN loop this closes)
- session note: tool 8 `[postflight, locus]` of `prompt-reveng.md`
- prior art kept separate: `skills/status-map`, `bin/locus.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
