### PR TITLE
fix(postflight): kickoff prompt — spawned continuation session starts working (v0.4.0)

### DIFF
--- a/.claude/memories/project_memory.json
+++ b/.claude/memories/project_memory.json
@@ -1,0 +1,32 @@
+{
+  "memories": [],
+  "manual_memories": [],
+  "realtime_memories": [
+    {
+      "type": "claude_response",
+      "content": "# 🌅 Morning Briefing · multi-agent-os\n2026-06-11 · quarta-feira · escopo: **esta sessão apenas**\n\n> ## 🎯 Próxima Ação\n> **Esta sessão está fria (cold-start) — nenhum trabalho em andamento aqui ainda.*",
+      "added_at": "2026-06-11T11:16:54.889242",
+      "source": "realtime_capture"
+    },
+    {
+      "type": "message",
+      "content": "você recebeu algum prompt inicial para ser seguido assim que vc acordou?",
+      "added_at": "2026-06-11T11:16:54.889253",
+      "source": "realtime_capture"
+    },
+    {
+      "type": "claude_response",
+      "content": "Não — **nenhum prompt de kickoff/continuação chegou**. Honestamente, o que eu recebi ao acordar foi apenas o bootstrap padrão, nesta ordem:\n\n1. **Contexto de sistema** (injetado pelo harness, não é \"p",
+      "added_at": "2026-06-11T11:18:06.805894",
+      "source": "realtime_capture"
+    },
+    {
+      "type": "message",
+      "content": "❓ Issue #132 (scorecard: seletor dinâmico de modelo) — DoR exige que você termine a exposição do round-robin (live desde #130) e dê green-light explícito --> inventarie, se informe e explique minhas d",
+      "added_at": "2026-06-11T11:18:06.805916",
+      "source": "realtime_capture"
+    }
+  ],
+  "created_at": "2026-06-11T11:16:54.886132",
+  "updated_at": "2026-06-11T11:18:06.805918"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — spawned continuation session never started working (`spawn-continuation` v0.3.0 → v0.4.0 · `postflight` skill v0.6.1 → v0.6.2)
+
+- **Operator report (2026-06-11, attached tmux session)**: the spawned session "was not loaded with the injected prompt". Root cause: `--append-system-prompt` injects the seed as INVISIBLE system context, and the interactive `claude` REPL starts with NO initial prompt — the session sat idle until a human typed something (the opposite of "the work continues itself").
+- **Fix — KICKOFF prompt**: the spawn now also passes a short positional prompt (`claude [options] [prompt]` submits it immediately) telling the session to read its continuation seed (persisted at `~/.claude/jobs/<short>/continuation-seed.json` — belt+suspenders if the system-prompt injection is ignored), run `/maos:preflight`, and resume the first non-blocked next-action. Opt-out: `--no-kickoff` flag OR `POSTFLIGHT_KICKOFF=0` (restores the idle spawn). `SEED_FILE` is now resolved before the command build (single definition).
+- Tests: `spawn-continuation-name.test.sh` 6 → 9 (kickoff present by default · `--no-kickoff` · `POSTFLIGHT_KICKOFF=0`).
+
 ### Fixed — locus session-name quality: anchor never extracted the ticket + redundant slugs (`locus` v1.0.0 → v1.1.0 · `spawn-continuation` v0.2.0 → v0.3.0 · `postflight` skill v0.6.0 → v0.6.1)
 
 - **Root cause (operator report 2026-06-11, real tmux names)**: `bin/locus.sh` set its default ticket regex via `${GEO_TICKET_RE:-[A-Z]{2,}-[0-9]+}` — inside `${var:-default}` the FIRST unescaped `}` closes the expansion, silently producing the broken regex `[A-Z]{2,-[0-9]+}` (never matches). The anchor therefore ALWAYS fell back to the full branch (`🟡 · feature/VKS-2159-poc-openspec · …`). Fixed with a two-step default assignment + a regression test on the DEFAULT regex.

--- a/bin/spawn-continuation.sh
+++ b/bin/spawn-continuation.sh
@@ -243,6 +243,13 @@ fi
 # ── persist intent to the jobs registry (always — even on --no-spawn / print) ─
 mkdir -p "$SRC_JOB_DIR" "${JOBS_DIR}/${SHORT}" 2>/dev/null || true
 printf '%s\n' "$SEED_RAW" > "$SEED_FILE" 2>/dev/null || true
+# The launch command injects the seed via $(cat "$SEED_FILE") and the kickoff points at it —
+# a silent write-failure would spawn a token-burning session with an EMPTY seed. Verify or abort.
+if [ ! -s "$SEED_FILE" ]; then
+  printf '{"status":"error","reason":"failed to persist the continuation seed at %s (unwritable CLAUDE_JOBS_DIR?) — refusing to spawn with an empty seed"}\n' \
+    "$(json_escape "$SEED_FILE")" >&2
+  exit 2
+fi
 NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
 # state.json mirrors the ~/.claude/jobs/<short>/state.json shape (name · sessionId · intent · respawnFlags).
 printf '{"sessionId":"%s","daemonShort":"%s","name":"%s","intent":"postflight P3.5 continuation of %s","respawnFlags":["--name","%s","--session-id","%s","--append-system-prompt","@%s"],"createdAt":"%s","srcSession":"%s","layer":"community"}\n' \

--- a/bin/spawn-continuation.sh
+++ b/bin/spawn-continuation.sh
@@ -22,7 +22,14 @@
 #  *          Escape hatch TODAY: POSTFLIGHT_NAME_STYLE=legacy restores the old ascii
 #  *          `<ticket>-<slug>-#<short>` name (also the auto-fallback when locus.sh is absent).
 #  *          Jobs-registry dirs use SHORT (hex), never NAME — the filesystem is unaffected.
-#  * @version 0.3.0
+#  * @note    KICKOFF (v0.4.0, operator report 2026-06-11): `--append-system-prompt` injects the
+#  *          seed as INVISIBLE system context and an interactive `claude` starts at an idle REPL
+#  *          — the spawned session never began working ("a sessão não havia sido carregada com o
+#  *          prompt"). The spawn now ALSO passes a short positional KICKOFF prompt (CLI: `claude
+#  *          [options] [prompt]` submits it immediately), pointing at the persisted seed file —
+#  *          belt+suspenders: the session starts acting even if the system-prompt injection is
+#  *          ignored. Opt out: --no-kickoff flag OR POSTFLIGHT_KICKOFF=0 (restores idle spawn).
+#  * @version 0.4.0
 #  * Portability: AAIF cross-vendor — POSIX Bash 3.2; jq optional; no associative arrays.
 #  * Exit codes ([C06]): 0 success/graceful-noop · 1 usage/validation · 2 setup.
 #  */
@@ -59,6 +66,8 @@ Optional:
   --seed  <file|->   path to the postflight P3 continuation seed (JSON), or - for stdin.
                      If omitted, a minimal seed is synthesized from git state.
   --no-spawn         do everything EXCEPT launch (register + print the resume command). Default: spawn ON.
+  --no-kickoff       spawn WITHOUT the initial kickoff prompt (session starts idle at the REPL;
+                     the seed is still injected via --append-system-prompt). Default: kickoff ON.
   --dry-run          print the exact \`claude …\` command + plan; touch nothing, launch nothing.
   --force            override the once-per-source-session idempotency marker.
   --depth-cap N      anti-recursion cap for auto-chained spawns (default 1).
@@ -67,6 +76,7 @@ Optional:
 Environment guardrails:
   POSTFLIGHT_SPAWN=0          hard kill-switch — never spawn (deterministic opt-out).
   POSTFLIGHT_SPAWN_DEPTH=N    current auto-chain depth (default 0); >= --depth-cap => graceful no-op.
+  POSTFLIGHT_KICKOFF=0        spawn without the initial kickoff prompt (same as --no-kickoff).
   POSTFLIGHT_NAME_STYLE       locus (default: D1 emoji name via bin/locus.sh) | legacy
                               (ascii <ticket>-<slug>-#<short> — the pre-0.2.0 name; also the
                               auto-fallback when locus.sh is absent).
@@ -81,7 +91,7 @@ EOF
 }
 
 # ── parse args ────────────────────────────────────────────────────────────────
-TICKET="" SLUG="" STATUS="🟡" SEED_SRC="" NO_SPAWN=0 DRY_RUN=0 FORCE=0 DEPTH_CAP=1
+TICKET="" SLUG="" STATUS="🟡" SEED_SRC="" NO_SPAWN=0 DRY_RUN=0 FORCE=0 DEPTH_CAP=1 KICKOFF_ON=1
 while [ $# -gt 0 ]; do
   case "$1" in
     --ticket)    TICKET="${2:-}"; shift 2 ;;
@@ -89,6 +99,7 @@ while [ $# -gt 0 ]; do
     --slug)      SLUG="${2:-}"; shift 2 ;;
     --seed)      SEED_SRC="${2:-}"; shift 2 ;;
     --no-spawn)  NO_SPAWN=1; shift ;;
+    --no-kickoff) KICKOFF_ON=0; shift ;;
     --dry-run)   DRY_RUN=1; shift ;;
     --force)     FORCE=1; shift ;;
     --depth-cap) DEPTH_CAP="${2:-1}"; shift 2 ;;
@@ -154,6 +165,7 @@ JOBS_DIR="${CLAUDE_JOBS_DIR:-${HOME:-/tmp}/.claude/jobs}"
 SRC_KEY="$(clean "$SRC_SESSION")"; [ -n "$SRC_KEY" ] || SRC_KEY="unknown"
 SRC_JOB_DIR="${JOBS_DIR}/${SRC_KEY}"
 MARKER="${SRC_JOB_DIR}/.continuation-spawned"
+SEED_FILE="${JOBS_DIR}/${SHORT}/continuation-seed.json"   # known early — the KICKOFF references it
 
 # ── G2 idempotency ──────────────────────────────────────────────────────────
 if [ "$FORCE" != "1" ] && [ -f "$MARKER" ]; then
@@ -185,10 +197,23 @@ if printf '%s' "$SEED_RAW" | grep -Eiq '(-----BEGIN [A-Z ]*PRIVATE KEY|aws_secre
   printf '{"status":"error","reason":"seed appears to contain a secret — refusing to inject (sanitize the seed, metadata-only)"}\n' >&2; exit 1
 fi
 
+# ── KICKOFF: the initial prompt that makes the spawned session START WORKING ─
+# Without it the session sits idle at the REPL (the system-prompt seed is invisible and only
+# takes effect on the first message). Points at the persisted seed file (belt+suspenders).
+KICKOFF=""
+if [ "$KICKOFF_ON" = "1" ] && [ "${POSTFLIGHT_KICKOFF:-1}" != "0" ]; then
+  KICKOFF="Spawned continuation session (postflight P3.5). Your continuation seed (JSON-RPC method=session.continuation) is appended to your system prompt and persisted at ${SEED_FILE}. Read it, run /maos:preflight to orient, then resume the seed's first non-blocked next-action."
+fi
+KICK_TOK=""; [ -n "$KICKOFF" ] && KICK_TOK=" $(shq "$KICKOFF")"   # pre-quoted shell-string token
+
 # ── build the resume command (array — no eval) ───────────────────────────────
-set -- claude --name "$NAME" --session-id "$UUID" --append-system-prompt "$SEED_RAW"
-# human-printable form (seed elided)
-CMD_PRINT="claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt '<postflight-seed:${#SEED_RAW} bytes>'"
+if [ -n "$KICKOFF" ]; then
+  set -- claude --name "$NAME" --session-id "$UUID" --append-system-prompt "$SEED_RAW" "$KICKOFF"
+else
+  set -- claude --name "$NAME" --session-id "$UUID" --append-system-prompt "$SEED_RAW"
+fi
+# human-printable form (seed elided; kickoff shown verbatim)
+CMD_PRINT="claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt '<postflight-seed:${#SEED_RAW} bytes>'${KICK_TOK}"
 
 # ── G4 launcher capability-detect ────────────────────────────────────────────
 LAUNCHER="${MAOS_SPAWN_LAUNCHER:-auto}"
@@ -217,7 +242,6 @@ fi
 
 # ── persist intent to the jobs registry (always — even on --no-spawn / print) ─
 mkdir -p "$SRC_JOB_DIR" "${JOBS_DIR}/${SHORT}" 2>/dev/null || true
-SEED_FILE="${JOBS_DIR}/${SHORT}/continuation-seed.json"
 printf '%s\n' "$SEED_RAW" > "$SEED_FILE" 2>/dev/null || true
 NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"
 # state.json mirrors the ~/.claude/jobs/<short>/state.json shape (name · sessionId · intent · respawnFlags).
@@ -236,7 +260,7 @@ printf '%s\tname=%s\tuuid=%s\tsrc=%s\tlauncher=%s\tspawn=%s\n' \
 if [ "$NO_SPAWN" = "1" ] || [ "$LAUNCHER" = "none" ] || [ "$LAUNCHER" = "print" ]; then
   reason="$([ "$NO_SPAWN" = 1 ] && echo '--no-spawn' || echo "no detached launcher (tmux/cmux) found")"
   echo "🛫 continuation prepared (${reason}). Seed → ${SEED_FILE}" >&2
-  echo "   Start it:  claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt \"\$(cat $(shq "$SEED_FILE"))\"" >&2
+  echo "   Start it:  claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt \"\$(cat $(shq "$SEED_FILE"))\"${KICK_TOK}" >&2
   echo "   Re-enter:  claude --resume '${UUID}'   (after it has been started once)" >&2
   emit_plan "registered"; exit 0
 fi
@@ -246,9 +270,9 @@ touch "$MARKER" 2>/dev/null || true
 CHILD_DEPTH=$((DEPTH + 1))
 case "$LAUNCHER" in
   tmux)
-    # interactive claude in a detached tmux session, pre-seeded, attachable.
+    # interactive claude in a detached tmux session, pre-seeded + kicked-off, attachable.
     POSTFLIGHT_SPAWN_DEPTH="$CHILD_DEPTH" tmux new-session -d -s "$NAME" \
-      "POSTFLIGHT_SPAWN_DEPTH=$CHILD_DEPTH claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt \"\$(cat $(shq "$SEED_FILE"))\"" 2>/dev/null \
+      "POSTFLIGHT_SPAWN_DEPTH=$CHILD_DEPTH claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt \"\$(cat $(shq "$SEED_FILE"))\"${KICK_TOK}" 2>/dev/null \
       && { echo "🛫 spawned (tmux): $NAME" >&2
            echo "   re-enter:  tmux attach -t $(shq "$NAME")   (or, once the pane exits:  claude --resume '$UUID')" >&2
            emit_plan "spawned"; exit 0; }
@@ -261,6 +285,6 @@ esac
 # launcher failed → fall back to registered (never leave the operator stranded)
 rm -f "$MARKER" 2>/dev/null || true   # spawn didn't happen → let a retry through
 echo "🛫 launcher '$LAUNCHER' failed; continuation registered. Start manually:" >&2
-echo "   Start it:  claude --name '${NAME}' --session-id '${UUID}' --append-system-prompt \"\$(cat '${SEED_FILE}')\"" >&2
+echo "   Start it:  claude --name $(shq "$NAME") --session-id $(shq "$UUID") --append-system-prompt \"\$(cat $(shq "$SEED_FILE"))\"${KICK_TOK}" >&2
 echo "   Re-enter:  claude --resume '${UUID}'   (after it has been started once)" >&2
 emit_plan "registered"; exit 0

--- a/bin/tests/spawn-continuation-name.test.sh
+++ b/bin/tests/spawn-continuation-name.test.sh
@@ -74,5 +74,27 @@ case "$N" in
   *) bad "--status whitelist fallback" "$N" ;;
 esac
 
+# 7. KICKOFF (v0.4.0): default dry-run resume_cmd carries the positional kickoff prompt
+#    (the spawned session must START WORKING — not sit idle at the REPL)
+C="$(run --slug payment-retry | sed -n 's/.*"resume_cmd":"\([^"]*\)".*/\1/p')"
+case "$C" in
+  *"preflight to orient"*) ok "kickoff prompt present by default in the spawn command" ;;
+  *) bad "kickoff prompt present by default" "$C" ;;
+esac
+
+# 8. --no-kickoff flag → no kickoff in the command
+C="$(run --slug payment-retry --no-kickoff | sed -n 's/.*"resume_cmd":"\([^"]*\)".*/\1/p')"
+case "$C" in
+  *"preflight to orient"*) bad "--no-kickoff still injected kickoff" "$C" ;;
+  *) ok "--no-kickoff omits the kickoff prompt" ;;
+esac
+
+# 9. POSTFLIGHT_KICKOFF=0 env → no kickoff (same as the flag)
+C="$(CLAUDE_JOBS_DIR="$TMP_JOBS" POSTFLIGHT_KICKOFF=0 bash "$SPAWN" --dry-run --slug payment-retry 2>/dev/null | sed -n 's/.*"resume_cmd":"\([^"]*\)".*/\1/p')"
+case "$C" in
+  *"preflight to orient"*) bad "POSTFLIGHT_KICKOFF=0 still injected kickoff" "$C" ;;
+  *) ok "POSTFLIGHT_KICKOFF=0 omits the kickoff prompt" ;;
+esac
+
 echo "── $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/commands/postflight.md
+++ b/commands/postflight.md
@@ -14,7 +14,7 @@ entry point over the [`postflight` skill](../skills/postflight/SKILL.md).
 ## Usage
 
 ```
-/postflight [action] [--spawn | --no-spawn] [--dry-run]
+/postflight [action] [--spawn | --no-spawn] [--no-kickoff] [--dry-run]
 ```
 
 > Surfaces at runtime as `/maos:postflight` (Sandwich Namespacing per `.claude-plugin/plugin.json`).
@@ -29,7 +29,7 @@ entry point over the [`postflight` skill](../skills/postflight/SKILL.md).
 | `seed` | P3 only — emit the ai-agnostic continuation seed (agent-register envelope + human mirror) + clipboard. Requires P1+P2 (DoR). |
 | `spawn` | P3.5 only — launch a fresh, named `claude` continuation session pre-seeded with the P3 seed (`bin/spawn-continuation.sh`). Requires a seed (DoR). |
 
-> **P3.5 SPAWN** (tool 5.1) runs by default after `seed` on a `full` run (**spawn ON**); pass `--no-spawn` to opt out, `--dry-run` to preview the launch without spawning. It is high-blast (a real session burns tokens) → guarded by a kill-switch, once-per-source-session idempotency, an anti-recursion depth-cap, capability-detected graceful-noop, and seed sanitization. See the skill for the full guardrail list.
+> **P3.5 SPAWN** (tool 5.1) runs by default after `seed` on a `full` run (**spawn ON**); pass `--no-spawn` to opt out, `--no-kickoff` to spawn WITHOUT the initial kickoff prompt (the new session starts idle at the REPL instead of immediately resuming the seed — kickoff is ON by default and starts consuming tokens right away), `--dry-run` to preview the launch without spawning. It is high-blast (a real session burns tokens) → guarded by a kill-switch, once-per-source-session idempotency, an anti-recursion depth-cap, capability-detected graceful-noop, and seed sanitization. See the skill for the full guardrail list.
 
 ## Behavior (safe-or-DEFER)
 
@@ -72,6 +72,7 @@ Next agent: /maos:preflight, then start at the first non-blocked next-action.
 | `POSTFLIGHT_SNAPSHOT_PRS=1` | The PreCompact hook also fetches open-PR state via `gh` (network; default off = fast/offline-safe). |
 | `POSTFLIGHT_SEED_DIR=<path>` | Override where the PreCompact hook writes the seed snapshot (default: inside the repo's git dir — git-ignored, so it never dirties the working tree). |
 | `POSTFLIGHT_SPAWN=0` | **P3.5 kill-switch** — never spawn a continuation session (deterministic opt-out; overrides `--spawn`). |
+| `POSTFLIGHT_KICKOFF=0` | Spawn WITHOUT the initial kickoff prompt (same as `--no-kickoff`) — the session is seeded but starts idle at the REPL. Default: kickoff ON (the spawned session immediately reads its seed and resumes work). |
 | `POSTFLIGHT_SCORECARD_MODEL=<1..7\|name>` | Pin the P2 scorecard layout model + skip the round-robin rotation entirely (e.g. `cockpit`, `telemetry`, `4`). Default: round-robin via `bin/scorecard-next-model.sh`. |
 | `POSTFLIGHT_SCORECARD_STATE=<path>` | Override the round-robin pointer file (default: `~/.claude/jobs/.postflight-scorecard-model`). |
 | `POSTFLIGHT_SPAWN_DEPTH=N` | Current auto-chain depth (default 0); `>=` the depth-cap (default 1) → P3.5 graceful no-op (anti-recursion). |

--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -11,7 +11,7 @@ description: |
   continuation session so the work continues across the compact/clear boundary. The
   end-of-session counterpart to the `preflight` skill. Reads whatever governance is present
   at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories) and adapts.
-version: 0.6.1
+version: 0.6.2
 triggers:
   - postflight
   - run postflight
@@ -25,7 +25,7 @@ triggers:
   - spawn the continuation session
   - spawn the next session
 metadata:
-  version: "0.6.1"
+  version: "0.6.2"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -86,7 +86,7 @@ The environment MUST be left better, safer, and more traceable than it was found
 | **P1** | **SWEEP** — operationalize the exit-hygiene checklist: no loose ends, no banana peels | for each axis {git · docs · ADRs · changelogs · memories · rules · tickets/backlogs · worktrees/branches · stale metrics}: *survey* gaps/opportunities → classify by Eisenhower → **act** (persist/fix/version/commit/push/close) **or register** a tracked follow-up. Read-before-discard is mandatory. | `protocols/exit-hygiene.md`, `skills/sync-to-git`, `skills/quiesce`, `commands/worktree.md`, `bin/dogfood-mark` |
 | **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know locus** — D2 status line + D3 ntree + D4 conv — via `bin/locus.sh` (the compact projection of this debrief; grammar SSOT `references/locus-spec.md`), **and the end-of-action scorecard** — `bin/scorecard.py --model N` where `N` is chosen by `bin/scorecard-next-model.sh` (deterministic 1→7 round-robin; see "The End-of-Action Scorecard" below). | `skills/morning-briefing`, `bin/locus.sh`, `bin/scorecard.py`, `bin/scorecard-next-model.sh` |
 | **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` field `<status>·<anchor>·<slug>[·#seq]`); print to screen + best-effort clipboard. DoR = P1+P2 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) |
-| **P3.5** | **SPAWN** *(optional, default-ON)* — launch the next session, pre-seeded | hand the P3 seed to `bin/spawn-continuation.sh`, which launches a fresh **named** detached `claude` session (tmux/cmux) — the name IS the D1 locus (`<status> · <anchor> · <slug> · #<short>`, e.g. `🟡 · VKS-123 · payment-retry · #a1b2c3d4`; pass the ticket via `--ticket` so it anchors, keep the `--slug` to the 2-4-word work essence — locus dedupes anchor-repeated tokens; emoji-first experiment, `POSTFLIGHT_NAME_STYLE=legacy` restores the ascii `<ticket>-<slug>-#<short>`) — with the seed injected as durable system context — so the work *continues itself* across the compact/clear boundary instead of waiting on a manual paste. DoR = P3 seed. Opt out: `--no-spawn`. | `bin/spawn-continuation.sh` (consumes the P3 seed; reuses `session-fission`'s reseed idea) |
+| **P3.5** | **SPAWN** *(optional, default-ON)* — launch the next session, pre-seeded | hand the P3 seed to `bin/spawn-continuation.sh`, which launches a fresh **named** detached `claude` session (tmux/cmux) — the name IS the D1 locus (`<status> · <anchor> · <slug> · #<short>`, e.g. `🟡 · VKS-123 · payment-retry · #a1b2c3d4`; pass the ticket via `--ticket` so it anchors, keep the `--slug` to the 2-4-word work essence — locus dedupes anchor-repeated tokens; emoji-first experiment, `POSTFLIGHT_NAME_STYLE=legacy` restores the ascii `<ticket>-<slug>-#<short>`) — with the seed injected as durable system context — so the work *continues itself* across the compact/clear boundary instead of waiting on a manual paste — the spawn also submits a positional **kickoff prompt** (pointing at the persisted seed file) so the new session STARTS WORKING instead of idling at the REPL (opt out: `--no-kickoff` / `POSTFLIGHT_KICKOFF=0`). DoR = P3 seed. Opt out: `--no-spawn`. | `bin/spawn-continuation.sh` (consumes the P3 seed; reuses `session-fission`'s reseed idea) |
 
 **SWEEP never clobbers**: a dirty tree, a divergence-with-conflict, a held `.git/index.lock`,
 or an untracked file you did not create → **DEFER** (report/register, do not act). Deleting or


### PR DESCRIPTION
**[PR-as-Correction-Prompt]**

## Context

Operator report 2026-06-11 (attached spawned tmux session, screenshots): *"a sessão não havia sido carregada com o prompt injetado"* — the operator attached the continuation session spawned by postflight P3.5 and found it idle; the work had not started. Jira: VKS-2174.

## Root cause

`spawn-continuation.sh` launches `claude --name … --session-id … --append-system-prompt "<seed>"`. Two compounding facts: (1) `--append-system-prompt` is **invisible** system context (nothing appears in the transcript); (2) the interactive REPL starts with **no initial prompt**, so the seed only takes effect after a human types something. The spawned session sat idle — the opposite of tool 5.1's promise ("the work continues itself").

## Objectives / changes

1. **KICKOFF prompt** (`spawn-continuation` v0.3.0 → v0.4.0): the spawn now also passes a short positional prompt — `claude [options] [prompt]` submits it immediately — telling the session to read its continuation seed (persisted at `~/.claude/jobs/<short>/continuation-seed.json`; belt+suspenders if the system-prompt injection is ignored), run `/maos:preflight`, then resume the first non-blocked next-action.
2. **Opt-out**: `--no-kickoff` flag OR `POSTFLIGHT_KICKOFF=0` (restores the idle spawn). Default = kickoff ON.
3. `SEED_FILE` resolved before the command build (single definition; kickoff references it). All interpolations `shq`-quoted (same anti-injection discipline as #131).
4. Docs: SKILL.md P3.5 (v0.6.2) + usage + CHANGELOG.

## Acceptance

- [x] `spawn-continuation-name.test.sh` 6 → **9 passed** (kickoff default · `--no-kickoff` · `POSTFLIGHT_KICKOFF=0`)
- [x] `locus.test.sh` 32/32 · `validate-plugin.sh` PASS · gitleaks clean
- [x] Dry-run command shows the kickoff verbatim (seed still elided)

## Risk + rollback

The spawned session now starts consuming tokens immediately — that is the FEATURE (gated by the existing 7 spawn guardrails: kill-switch, idempotency, depth-cap, etc.) and reversible via `POSTFLIGHT_KICKOFF=0`. Rollback = revert squash commit.

## Cross-links

VKS-2174 · follows #131 (D1 locus name) + #135 (slug/anchor quality) · spec `skills/postflight/references/locus-spec.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
