### PR TITLE
feat(preflight): R0 ticket-anchor + session-type classification + worktree seed resolution

### DIFF
--- a/bin/locus.sh
+++ b/bin/locus.sh
@@ -6,7 +6,7 @@
 #          One glance: which session · what status · which anchor · what work · is it
 #          blocked · does it need a human. A memory ramp for amnesic agents + a radar
 #          for the human operator. ("What is not seen is not remembered.")
-# Version: 1.1.0
+# Version: 1.2.0
 # Protocol: C06 (AI-Native Environment).
 #
 # Anti-theater contract: the tool COMPUTES Tier-A fields (anchor, project, branch,
@@ -20,9 +20,12 @@
 #   omit compass), ALWAYS exits 0 — must never block a session end.
 #
 # Usage:
-#   locus --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]
+#   locus --density name|status|ntree|conv|anchor [--status GLYPH] [--slug SLUG]
 #               [--seq N] [--enrich STR] [--pulse n/m] [--base REF]
 #   # D3 reads tree item-lines from stdin: "<glyph> <slug> [· <enrich>]" (one per line)
+#   # density=anchor: ticket-only extraction (explicit › branch › commit) — prints
+#   # "<TICKET> <source>" (source ∈ explicit|branch|commit) or "none". ZERO network:
+#   # this path never calls gh / peer-detect (safe for deterministic SessionStart hooks).
 #
 # Env: GEO_TICKET_RE  ticket-key regex (default '[A-Z]{2,}-[0-9]+')
 # ═══════════════════════════════════════════════════════════════════════════════
@@ -40,10 +43,11 @@ DENSITY="" ; STATUS="🟡" ; SLUG="" ; SEQ="" ; ENRICH="" ; PULSE="" ; BASE="" ;
 
 usage() {
   printf '%s\n' \
-    'usage: locus --density name|status|ntree|conv [--status GLYPH] [--slug SLUG]' \
+    'usage: locus --density name|status|ntree|conv|anchor [--status GLYPH] [--slug SLUG]' \
     '                   [--ticket KEY] [--seq N] [--enrich STR] [--pulse n/m] [--base REF]' \
     '       # --ticket: explicit anchor input (accepted only if it matches GEO_TICKET_RE)' \
-    '       # density=ntree reads tree item-lines from stdin (one per line)' >&2
+    '       # density=ntree reads tree item-lines from stdin (one per line)' \
+    '       # density=anchor prints "<TICKET> <source>"|"none" (ticket-only, zero network)' >&2
 }
 
 # ── arg parse (supports --key value AND --key=value) ───────────────────────────
@@ -63,7 +67,7 @@ while [ $# -gt 0 ]; do
   shift
 done
 case "$DENSITY" in
-  name|status|ntree|conv) ;;
+  name|status|ntree|conv|anchor) ;;
   *) usage; exit 0 ;;
 esac
 
@@ -87,14 +91,28 @@ default_branch() {
   printf 'main'
 }
 
-compute_anchor() {   # salience: ticket (explicit › branch › last-commit) › PR › branch
-  local b="$1" t pr
+# compute_ticket: ticket-only extraction (ZERO network): explicit › branch › last-commit.
+# Sets globals TICKET_VAL + TICKET_SRC (explicit|branch|commit|"") — globals (not stdout)
+# so callers in the CURRENT shell keep both values without a subshell round-trip.
+TICKET_VAL="" ; TICKET_SRC=""
+compute_ticket() {
+  local b="$1" t
+  TICKET_VAL="" ; TICKET_SRC=""
   # explicit --ticket wins, but ONLY when it actually looks like a ticket (shape-validated
   # against TICKET_RE — anti-theater: never anchor on an arbitrary self-reported string)
   t="$(printf '%s' "$TICKET" | grep -oE "^${TICKET_RE}$" 2>/dev/null | head -1)" || true
-  [ -z "$t" ] && t="$(printf '%s' "$b" | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
-  [ -z "$t" ] && t="$(git log -1 --format='%s' 2>/dev/null | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
-  [ -n "$t" ] && { printf '%s' "$t"; return; }
+  [ -n "$t" ] && { TICKET_VAL="$t"; TICKET_SRC="explicit"; return 0; }
+  t="$(printf '%s' "$b" | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
+  [ -n "$t" ] && { TICKET_VAL="$t"; TICKET_SRC="branch"; return 0; }
+  t="$(git log -1 --format='%s' 2>/dev/null | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
+  [ -n "$t" ] && { TICKET_VAL="$t"; TICKET_SRC="commit"; return 0; }
+  return 0
+}
+
+compute_anchor() {   # salience: ticket (explicit › branch › last-commit) › PR › branch
+  local b="$1" pr
+  compute_ticket "$b"
+  [ -n "$TICKET_VAL" ] && { printf '%s' "$TICKET_VAL"; return; }
   if have gh && [ -n "$b" ]; then
     pr="$(gh pr list --head "$b" --state open --json number -q '.[0].number' 2>/dev/null)" || true
     [ -n "$pr" ] && { printf 'PR#%s' "$pr"; return; }
@@ -134,6 +152,14 @@ compute_risk() {     # ⚠R1: on default branch AND a deploy-on-push workflow pr
   grep -rliE 'deploy' "$top/.github/workflows" >/dev/null 2>&1 && printf '⚠R1'
   return 0
 }
+
+# ── anchor density (ticket-only, ZERO network — short-circuits BEFORE the heavy
+#    derive: no gh, no peer-detect, no compass; safe for deterministic hooks) ─────
+if [ "$DENSITY" = "anchor" ]; then
+  compute_ticket "$(cur_branch)"
+  if [ -n "$TICKET_VAL" ]; then printf '%s %s\n' "$TICKET_VAL" "$TICKET_SRC"; else printf 'none\n'; fi
+  exit 0
+fi
 
 # ── derive ─────────────────────────────────────────────────────────────────────
 # Base ref for the compass — pick one that ACTUALLY EXISTS (no remote-layout assumption):

--- a/bin/tests/locus.test.sh
+++ b/bin/tests/locus.test.sh
@@ -99,10 +99,14 @@ o="$(cd "$TMP" && "$GS" --density anchor)"
 eq 'none' "$o" 'anchor density: no ticket anywhere → "none"'
 # ZERO-network contract: anchor density must never call gh/curl (PATH-shim trap)
 SHIM_DIR="$TMP/.nogh"; mkdir -p "$SHIM_DIR"
-for c in gh curl; do printf '#!/bin/sh\necho "FORBIDDEN-%s" >&2\nexit 99\n' "$c" > "$SHIM_DIR/$c"; chmod +x "$SHIM_DIR/$c"; done
+# Shims append a PID to a dedicated side-effect log on EVERY invocation, so a call that suppresses
+# its own stderr is still caught (stderr-only assertion below could miss it). Assert the log is empty.
+NETLOG="$SHIM_DIR/.calls.log"; : > "$NETLOG"
+for c in gh curl; do printf '#!/bin/sh\necho "%s:$$" >> "%s"\necho "FORBIDDEN-%s" >&2\nexit 99\n' "$c" "$NETLOG" "$c" > "$SHIM_DIR/$c"; chmod +x "$SHIM_DIR/$c"; done
 ( cd "$TMP" && git checkout -q -b feature/NET-1-guard ) >/dev/null 2>&1
 nerr="$(cd "$TMP" && PATH="$SHIM_DIR:$PATH" "$GS" --density anchor 2>&1 >/dev/null)"
-hasnt 'FORBIDDEN' "$nerr" 'anchor density makes ZERO gh/curl calls (zero-network contract)'
+hasnt 'FORBIDDEN' "$nerr" 'anchor density makes ZERO gh/curl calls (zero-network contract, stderr)'
+eq 0 "$(wc -l < "$NETLOG" | tr -d ' ')" 'anchor density makes ZERO gh/curl calls (zero-network contract, side-effect log)'
 # reset to the ticket branch so downstream tests keep their assumptions
 ( cd "$TMP" && git checkout -q feature/VKS-2159-poc-openspec ) >/dev/null 2>&1
 

--- a/bin/tests/locus.test.sh
+++ b/bin/tests/locus.test.sh
@@ -78,6 +78,34 @@ TMP="$(mktemp -d)"
   git checkout -q -b feature/VKS-2159-poc-openspec
 ) >/dev/null 2>&1
 
+# ── density=anchor (ticket-only, ZERO network — the R0-hook contract) ──────────
+# branch source: prints "<TICKET> <source>" (space-separated, no other tokens)
+o="$(cd "$TMP" && "$GS" --density anchor)"
+eq 'VKS-2159 branch' "$o" 'anchor density: branch source → "<TICKET> branch"'
+# explicit --ticket wins (shape-validated)
+o="$(cd "$TMP" && "$GS" --density anchor --ticket ABC-99)"
+eq 'ABC-99 explicit' "$o" 'anchor density: explicit --ticket wins'
+# malformed explicit ignored → falls back to branch
+o="$(cd "$TMP" && "$GS" --density anchor --ticket 'not;a(ticket')"
+eq 'VKS-2159 branch' "$o" 'anchor density: malformed --ticket ignored → branch'
+# commit source: no-ticket branch + ticket in last commit subject
+( cd "$TMP" && git checkout -q -b no-ticket-anchor && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m 'feat: DEF-123 thing' ) >/dev/null 2>&1
+o="$(cd "$TMP" && "$GS" --density anchor)"
+eq 'DEF-123 commit' "$o" 'anchor density: commit-subject source'
+# none: no ticket anywhere
+( cd "$TMP" && git checkout -q -b just-a-name ) >/dev/null 2>&1
+( cd "$TMP" && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m 'wip: nothing here' ) >/dev/null 2>&1
+o="$(cd "$TMP" && "$GS" --density anchor)"
+eq 'none' "$o" 'anchor density: no ticket anywhere → "none"'
+# ZERO-network contract: anchor density must never call gh/curl (PATH-shim trap)
+SHIM_DIR="$TMP/.nogh"; mkdir -p "$SHIM_DIR"
+for c in gh curl; do printf '#!/bin/sh\necho "FORBIDDEN-%s" >&2\nexit 99\n' "$c" > "$SHIM_DIR/$c"; chmod +x "$SHIM_DIR/$c"; done
+( cd "$TMP" && git checkout -q -b feature/NET-1-guard ) >/dev/null 2>&1
+nerr="$(cd "$TMP" && PATH="$SHIM_DIR:$PATH" "$GS" --density anchor 2>&1 >/dev/null)"
+hasnt 'FORBIDDEN' "$nerr" 'anchor density makes ZERO gh/curl calls (zero-network contract)'
+# reset to the ticket branch so downstream tests keep their assumptions
+( cd "$TMP" && git checkout -q feature/VKS-2159-poc-openspec ) >/dev/null 2>&1
+
 # regression: the DEFAULT ticket regex must work — `${var:-[A-Z]{2,}-[0-9]+}` silently
 # truncated at the first `}` (broken regex) → anchor never extracted the ticket from the branch
 o="$(cd "$TMP" && "$GS" --density name --status '🟡' --slug a3-judge --seq 9a72558e)"

--- a/commands/preflight.md
+++ b/commands/preflight.md
@@ -5,10 +5,10 @@ description: Orient + heal + isolate the git workspace before work (branch detec
 
 # /preflight Command
 
-Run the **preflight** readiness checks for agentic work: orient on the right branch
-(without interfering with other worktrees), safely heal the current branch from origin,
-and lazily isolate file mutations in a worktree. Thin entry point over the
-[`preflight` skill](../skills/preflight/SKILL.md).
+Run the **preflight** readiness checks for agentic work: anchor the session to its ticket
+on the N-Tree + classify its type (R0), orient on the right branch (without interfering with
+other worktrees), safely heal the current branch from origin, and lazily isolate file
+mutations in a worktree. Thin entry point over the [`preflight` skill](../skills/preflight/SKILL.md).
 
 ## Usage
 
@@ -21,6 +21,7 @@ and lazily isolate file mutations in a worktree. Thin entry point over the
 | Action | Description |
 |--------|-------------|
 | *(none)* / `check` | R1+R2: detect branch/upstream/divergence/worktree-locks (read-only) + safe-heal from origin. |
+| `ticket` | R0 on-demand — anchor the ticket (seed › branch › commit), walk the N-Tree (parent-chain + siblings, capability-detected), flag the session node, classify `session_type=<mode>/<work>`, and if no ticket → HITL create-proposal (delegates to `ticket-as-prompt`). DEFER if no tracker MCP. |
 | `detect` | R1 only — read-only branch/upstream/ahead-behind/locked-elsewhere/tree-state report. |
 | `heal` | R2 only — safe heal from origin (`fetch`→classify→ff-only \| rebase-autostash \| DEFER). |
 | `worktree <intent>` | R3 — derive a branch + worktree from `<intent>` (per discovered conventions) and create it. |
@@ -35,7 +36,8 @@ and lazily isolate file mutations in a worktree. Thin entry point over the
 ## Examples
 
 ```
-/preflight                      # full R1+R2 readiness report + safe heal
+/preflight                      # full R0+R1+R2 readiness report + safe heal
+/preflight ticket               # R0 — anchor ticket + walk N-Tree + classify session
 /preflight detect               # read-only branch situation
 /preflight heal                 # safe pull/heal from origin only
 /preflight worktree readme-fix  # create .worktrees/<slug> -b <type>/<scope> for the work
@@ -59,6 +61,7 @@ Ready. (R3 isolates automatically when you create/update files.)
 | Var | Effect |
 |-----|--------|
 | `PREFLIGHT_NO_AUTOHEAL=1` | SessionStart hook reports R1 only; does not auto-pull. |
+| `PREFLIGHT_NO_TICKET_ANCHOR=1` | SessionStart hook skips R0 (no ticket anchor in context). |
 | `PREFLIGHT_EDIT_GATE=block` | The Edit/Write safety-net hard-blocks main-checkout edits (default `warn`). |
 | `PREFLIGHT_EDIT_GATE=off` | Disable the Edit/Write safety-net. |
 

--- a/plugin-scripts/governance/preflight-session.sh
+++ b/plugin-scripts/governance/preflight-session.sh
@@ -50,9 +50,20 @@ TICKET_ANCHOR=""; TICKET_SRC="none"; SESSION_MODE="unanchored"; TICKET_NUDGE=""
 if [ "${PREFLIGHT_NO_TICKET_ANCHOR:-0}" != "1" ]; then
     DEFAULT_TICKET_RE='[A-Z]{2,}-[0-9]+'
     TICKET_RE="${GEO_TICKET_RE:-$DEFAULT_TICKET_RE}"   # two-step: avoid {n,}-brace expansion truncation
-    SEED="$REPO/.git/maos/continuation-seed.latest.json"
+    # Worktree-safe seed resolution: in a LINKED worktree "$REPO/.git" is a gitlink FILE, not a
+    # dir, so the hardcoded "$REPO/.git/maos/..." never resolves. The producer writes via
+    # `rev-parse --absolute-git-dir` (→ per-worktree git-dir from a worktree, common .git from main),
+    # but the snapshot seed lives in the COMMON dir's maos/. Probe per-worktree git-dir THEN common-dir;
+    # honor POSTFLIGHT_SEED_DIR override (matches the producer). Pick the first that holds the seed.
+    SEED=""
+    SEED_GITDIR="$(git -C "$REPO" rev-parse --absolute-git-dir 2>/dev/null || true)"
+    SEED_COMMON="$(git -C "$REPO" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+    for _d in "${POSTFLIGHT_SEED_DIR:-}" "${SEED_GITDIR:+$SEED_GITDIR/maos}" "${SEED_COMMON:+$SEED_COMMON/maos}" "$REPO/.git/maos"; do
+        [ -n "$_d" ] || continue
+        if [ -f "$_d/continuation-seed.latest.json" ]; then SEED="$_d/continuation-seed.latest.json"; break; fi
+    done
     # (1) continuation seed refs.ticket — explicit handoff linkage (jq → grep fallback)
-    if [ -f "$SEED" ]; then
+    if [ -n "$SEED" ] && [ -f "$SEED" ]; then
         if command -v jq >/dev/null 2>&1; then
             TICKET_ANCHOR="$(jq -r '.refs.ticket // .params.refs.ticket // empty' "$SEED" 2>/dev/null | grep -oE "^${TICKET_RE}$" 2>/dev/null | head -1)" || true
         fi

--- a/plugin-scripts/governance/preflight-session.sh
+++ b/plugin-scripts/governance/preflight-session.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # ═══════════════════════════════════════════════════════════════════════════════
 # MAOS Governance: preflight-session.sh
-# Purpose: SessionStart bootstrap (R1 + R2 of the `preflight` bundle).
+# Purpose: SessionStart bootstrap (R0 + R1 + R2 of the `preflight` bundle).
+#   R0 — ticket anchor (ZERO network): which ticket does this session belong to?
+#        seed refs.ticket › branch › last-commit (via locus --density anchor). Infers
+#        a candidate mode (continuation-candidate | unanchored) + nudges when no anchor.
 #   R1 — detect the current branch / upstream / divergence / worktree-locks
 #        non-interferingly (read-only).
 #   R2 — safely heal the current branch from origin (fetch→classify→ff|rebase|DEFER).
@@ -9,17 +12,21 @@
 #        this SAME checkout; if any are active, DEFER R2 to avoid interfering.
 #   Then inject a concise status as SessionStart additionalContext so the agent
 #   wakes up oriented. NEVER blocks the session (always exit 0).
-# Version: 1.1.0
+# Version: 1.2.0
 # Protocol: C04 (Git Worktree Protocol v2.0), C06 (AI-Native Environment)
 #
 # Opt-out: PREFLIGHT_NO_AUTOHEAL=1 → report R1 only, do NOT pull (R2 downgraded to
 #          a recommendation). Default = heal (per operator directive: heal at
 #          session start). Healing is always safe (DEFERs on dirty/diverged/busy/peers).
+# Opt-out: PREFLIGHT_NO_TICKET_ANCHOR=1 → skip R0 (no ticket anchor in context).
+#          R0 is ZERO-network + deterministic + always degrades gracefully (no jq → grep
+#          fallback; no locus → seed-only; no anchor → nudge). Never blocks the session.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HOOK_DIR="$SCRIPT_DIR"   # stable copy — sourced libs below reset SCRIPT_DIR (R0 needs the hook's own dir)
 LIB_DIR="${SCRIPT_DIR}/lib"
 source "${LIB_DIR}/common.sh"
 source "${LIB_DIR}/git-branch-detect.sh"
@@ -33,6 +40,39 @@ REPO="${CLAUDE_PROJECT_DIR:-$(pwd)}"
 # Not a git repo → silently do nothing (vendor-neutral, never noisy off-git).
 if ! git -C "$REPO" rev-parse --git-dir >/dev/null 2>&1; then
     exit "${EXIT_SUCCESS:-0}"
+fi
+
+# ── R0: ticket anchor (ZERO network; deterministic) ───────────────────────────
+# "Which ticket does this session belong to?" — seed refs.ticket › branch › last-commit.
+# Coarse hook-level mode hint {continuation-candidate | anchored | unanchored}; the
+# /maos:preflight skill does the full N-Tree walk + mode/work taxonomy (R0.b/R0.c).
+TICKET_ANCHOR=""; TICKET_SRC="none"; SESSION_MODE="unanchored"; TICKET_NUDGE=""
+if [ "${PREFLIGHT_NO_TICKET_ANCHOR:-0}" != "1" ]; then
+    DEFAULT_TICKET_RE='[A-Z]{2,}-[0-9]+'
+    TICKET_RE="${GEO_TICKET_RE:-$DEFAULT_TICKET_RE}"   # two-step: avoid {n,}-brace expansion truncation
+    SEED="$REPO/.git/maos/continuation-seed.latest.json"
+    # (1) continuation seed refs.ticket — explicit handoff linkage (jq → grep fallback)
+    if [ -f "$SEED" ]; then
+        if command -v jq >/dev/null 2>&1; then
+            TICKET_ANCHOR="$(jq -r '.refs.ticket // .params.refs.ticket // empty' "$SEED" 2>/dev/null | grep -oE "^${TICKET_RE}$" 2>/dev/null | head -1)" || true
+        fi
+        if [ -z "$TICKET_ANCHOR" ]; then
+            TICKET_ANCHOR="$(grep -oE "\"ticket\"[[:space:]]*:[[:space:]]*\"${TICKET_RE}\"" "$SEED" 2>/dev/null | grep -oE "$TICKET_RE" 2>/dev/null | head -1)" || true
+        fi
+        [ -n "$TICKET_ANCHOR" ] && { TICKET_SRC="seed"; SESSION_MODE="continuation-candidate"; }
+    fi
+    # (2)+(3) branch › last-commit via locus anchor density (ZERO network)
+    if [ -z "$TICKET_ANCHOR" ]; then
+        LOCUS="${HOOK_DIR}/../../bin/locus.sh"
+        if [ -f "$LOCUS" ]; then
+            LOCUS_OUT="$( cd "$REPO" 2>/dev/null && bash "$LOCUS" --density anchor 2>/dev/null )" || true
+            case "$LOCUS_OUT" in
+                none|'') : ;;
+                *) TICKET_ANCHOR="${LOCUS_OUT%% *}"; TICKET_SRC="${LOCUS_OUT##* }"; SESSION_MODE="anchored" ;;
+            esac
+        fi
+    fi
+    [ -z "$TICKET_ANCHOR" ] && TICKET_NUDGE=" | No ticket anchor detected (mode=unanchored): run /maos:preflight ticket to walk the N-Tree + classify the session, or proceed (a ticket may be proposed at postflight)."
 fi
 
 # ── R1: read-only detection ──────────────────────────────────────────────────
@@ -77,13 +117,15 @@ if is_in_main_repo 2>/dev/null && [ -n "$(git -C "$REPO" branch --show-current 2
 fi
 
 # Audit (no-op unless an audit dir exists).
-log_audit "preflight_session" "{\"branch\":\"$(json_escape "$CUR")\",\"upstream\":\"$(json_escape "$UP")\",\"ahead\":\"$(json_escape "$AHEAD")\",\"behind\":\"$(json_escape "$BEHIND")\",\"tree\":\"$(json_escape "$STATE")\",\"peers\":\"$(json_escape "$PEERS")\",\"heal\":\"$(json_escape "$HEAL")\"}" || true
+log_audit "preflight_session" "{\"branch\":\"$(json_escape "$CUR")\",\"upstream\":\"$(json_escape "$UP")\",\"ahead\":\"$(json_escape "$AHEAD")\",\"behind\":\"$(json_escape "$BEHIND")\",\"tree\":\"$(json_escape "$STATE")\",\"peers\":\"$(json_escape "$PEERS")\",\"heal\":\"$(json_escape "$HEAL")\",\"ticket\":\"$(json_escape "${TICKET_ANCHOR:-none}")\",\"ticket_src\":\"$(json_escape "$TICKET_SRC")\",\"mode\":\"$(json_escape "$SESSION_MODE")\"}" || true
 
 # Human summary → stderr (visible, non-blocking).
-echo "🧭 preflight: branch=${CUR} upstream=${UP} ahead=${AHEAD} behind=${BEHIND} tree=${STATE} peers=${PEERS}; heal=${HEAL}${LOCKED:+; locked-elsewhere=${LOCKED}}" >&2
+TICKET_HUMAN="${TICKET_ANCHOR:+ticket=${TICKET_ANCHOR}(${TICKET_SRC}) mode=${SESSION_MODE};}"
+echo "🧭 preflight: ${TICKET_HUMAN}branch=${CUR} upstream=${UP} ahead=${AHEAD} behind=${BEHIND} tree=${STATE} peers=${PEERS}; heal=${HEAL}${LOCKED:+; locked-elsewhere=${LOCKED}}" >&2
 
 # Machine context → stdout as SessionStart additionalContext (surfaced to the agent).
-CTX="preflight bootstrap — branch=${CUR}, upstream=${UP}, ahead=${AHEAD}, behind=${BEHIND}, tree-state=${STATE}, peers=${PEERS}, heal=${HEAL}.${LOCKED:+ Branches locked by other worktrees (do NOT switch to them): ${LOCKED}.}${NUDGE}"
+TICKET_CTX="${TICKET_ANCHOR:+ ticket=${TICKET_ANCHOR} (source=${TICKET_SRC}, mode=${SESSION_MODE}).}"
+CTX="preflight bootstrap —${TICKET_CTX} branch=${CUR}, upstream=${UP}, ahead=${AHEAD}, behind=${BEHIND}, tree-state=${STATE}, peers=${PEERS}, heal=${HEAL}.${LOCKED:+ Branches locked by other worktrees (do NOT switch to them): ${LOCKED}.}${TICKET_NUDGE}${NUDGE}"
 printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$(json_escape "$CTX")"
 
 exit "${EXIT_SUCCESS:-0}"

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -44,7 +44,9 @@ works on the wrong branch, on stale state, or unisolated in a shared checkout.
 
 ## When to Use
 
-- At the **start of a session** (the bundled SessionStart hook runs R0+R1+R2 automatically).
+- At the **start of a session** (the bundled SessionStart hook runs the deterministic ticket-**anchor**
+  + coarse `mode` hint automatically; the full R0 N-Tree walk / classification / create-proposal stays
+  **on-demand** via `/maos:preflight ticket`. R1 heal + R2 branch-detect also run in the hook).
 - At the **start of an action/task**, before you begin substantive work.
 - **Before creating or updating any file/directory** (R3 — lazily isolate the mutation).
 - When you are unsure which branch you should be on, or whether your branch is stale.
@@ -136,8 +138,9 @@ next session's R0.
 When R0.a finds no anchor AND R0.b confirms none exists on the tree, present a **structured HITL
 proposal** (via `AskUserQuestion`), do NOT auto-create:
 
-1. **Create as draft** — delegate to `ticket-as-prompt` (provider-routed by class: corporate→Jira ·
-   personal→Linear · community→GH Issue) to open a ticket whose body is a self-contained Ticket-as-Prompt.
+1. **Create as draft** — delegate to `ticket-as-prompt`, which capability-detects the tracker and
+   routes by class (examples, non-normative: corporate / personal / community trackers), to open a
+   ticket whose body is a self-contained Ticket-as-Prompt.
 2. **Link to an existing ticket** — operator names the node; the session anchors to it.
 3. **Proceed without a documented ticket** — record the decision; postflight P2.5 may still propose one.
 

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -136,8 +136,8 @@ next session's R0.
 When R0.a finds no anchor AND R0.b confirms none exists on the tree, present a **structured HITL
 proposal** (via `AskUserQuestion`), do NOT auto-create:
 
-1. **Create as draft** — delegate to `ticket-as-prompt` (provider-routed: Vek→Jira · personal→Linear
-   · community→GH Issue) to open a ticket whose body is a self-contained Ticket-as-Prompt.
+1. **Create as draft** — delegate to `ticket-as-prompt` (provider-routed by class: corporate→Jira ·
+   personal→Linear · community→GH Issue) to open a ticket whose body is a self-contained Ticket-as-Prompt.
 2. **Link to an existing ticket** — operator names the node; the session anchors to it.
 3. **Proceed without a documented ticket** — record the decision; postflight P2.5 may still propose one.
 

--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -2,12 +2,14 @@
 name: preflight
 description: |
   Use at the start of a session or before starting an action/task in any git repo to
-  get the workspace into a correct, healthy, isolated state BEFORE touching code:
-  (R1) detect the right branch without interfering with other agents/sessions/worktrees,
-  (R2) safely heal the current branch from origin, and (R3) create a git worktree the
-  moment you are about to create/update files. Reads whatever governance is present at
-  invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories) and adapts.
-version: 1.1.1
+  get the workspace into a correct, healthy, isolated, ticket-anchored state BEFORE
+  touching code: (R0) anchor the session to its ticket on the N-Tree + classify the
+  session type, (R1) detect the right branch without interfering with other
+  agents/sessions/worktrees, (R2) safely heal the current branch from origin, and
+  (R3) create a git worktree the moment you are about to create/update files. Reads
+  whatever governance is present at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/
+  protocols/memories) and adapts.
+version: 1.2.0
 triggers:
   - preflight
   - run preflight
@@ -17,8 +19,12 @@ triggers:
   - heal my branch
   - start of session checks
   - prepare a worktree before editing
+  - which ticket does this session belong to
+  - classify this session
+  - walk the ticket N-Tree
+  - preflight ticket
 metadata:
-  version: "1.1.1"
+  version: "1.2.0"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -38,27 +44,32 @@ works on the wrong branch, on stale state, or unisolated in a shared checkout.
 
 ## When to Use
 
-- At the **start of a session** (the bundled SessionStart hook runs R1+R2 automatically).
+- At the **start of a session** (the bundled SessionStart hook runs R0+R1+R2 automatically).
 - At the **start of an action/task**, before you begin substantive work.
 - **Before creating or updating any file/directory** (R3 — lazily isolate the mutation).
 - When you are unsure which branch you should be on, or whether your branch is stale.
+- When you need to know **which ticket** the session belongs to, **where** it sits on the
+  ticket N-Tree, or **what kind** of session this is (R0 — on-demand via `/maos:preflight ticket`).
 
 ## Trigger Phrases
 
 "preflight" · "bootstrap my workspace" · "which branch should I be on" · "heal/sync my
-branch from origin" · "prepare a worktree before editing"
+branch from origin" · "prepare a worktree before editing" · "which ticket does this session
+belong to" · "classify this session" · "walk the ticket N-Tree"
 
 ## Core Rule
 
 ```
-ORIENT (R1) → HEAL (R2) → ISOLATE-ON-MUTATION (R3)
+ANCHOR (R0) → ORIENT (R1) → HEAL (R2) → ISOLATE-ON-MUTATION (R3)
 Each step is SAFE-or-DEFER. Never clobber concurrent work. Never block on a no-op.
+R0 is ZERO-network at the hook layer; the agentic N-Tree walk + create-proposal are HITL-gated.
 ```
 
-## The Responsibilities (R1–R3, + optional R1.5)
+## The Responsibilities (R0–R3, + optional R1.5)
 
 | # | Responsibility | How (read-only / safe) | Lib |
 |---|---|---|---|
+| **R0** | **Anchor** the session to its ticket on the N-Tree + **classify** the session type | (a) deterministic hook anchors the ticket (seed `refs.ticket` › branch › last-commit via `locus --density anchor`, ZERO network) → coarse `mode`; (b) skill walks the N-Tree (parent-chain to epic/root + siblings) via capability-detected MCP; (c) classifies `session_type=<mode>/<work>`; (d) if no ticket → HITL create-proposal (delegates to `ticket-as-prompt`) | `bin/locus.sh` + `references/session-type-taxonomy.md` |
 | **R1** | Detect the right branch **without interfering** with other agents/sessions/worktrees | branch + upstream + ahead/behind + branches **locked by other worktrees** (`git worktree list --porcelain`) + tree-state | `lib/git-branch-detect.sh` |
 | **R1.5** | **Peer-aware** non-interference (optional, capability-detected) | detect OTHER live sessions writing the **SAME checkout** (host session-activity signal, self-excluded, freshness-windowed); peers active → R2 **DEFERs**; off-host → `UNKNOWN` (report-only) | `lib/peer-session-detect.sh` |
 | **R2** | **Heal** the current branch from origin | `fetch` → classify {up-to-date / ff-ready / diverged / dirty / detached / mid-op / busy / **peers-active**} → act: `ff-only` \| `rebase --autostash` \| **DEFER** | `lib/git-safe-sync.sh` |
@@ -82,6 +93,57 @@ override / portability seam), `MAOS_PEER_FRESH_SECS` (live window, default 90),
 toplevel) may be missed — a miss means fewer defers, never a false block; use the override seam
 for precision.
 
+## R0 — Ticket Anchor + Session Classification (the treasure-map step)
+
+Tickets/backlogs are the project's map — *where on it am I?* R0 answers that, in two layers:
+a deterministic hook (always, zero-network) + an agentic skill walk (on-demand / `/maos:preflight ticket`).
+
+### R0.a — Anchor (deterministic, ZERO network — the hook does this automatically)
+
+The SessionStart hook resolves the ticket from the strongest local signal, in precedence:
+
+1. **seed `refs.ticket`** — a continuation handoff explicitly named the ticket (→ `mode=continuation-candidate`).
+2. **branch** — `[A-Z]{2,}-[0-9]+` in the branch name (via `locus --density anchor`).
+3. **last commit** — the same pattern in the last commit subject.
+
+It emits `ticket=KEY (source=seed|branch|commit, mode=…)` into the SessionStart additionalContext +
+stderr. **Zero network** (no `gh`, no `curl`), **<2s**, **always exit 0**. Opt-out: `PREFLIGHT_NO_TICKET_ANCHOR=1`.
+No anchor → a nudge to run the agentic walk (R0.b) or proceed (a ticket may be proposed at postflight).
+
+### R0.b — N-Tree walk (agentic, capability-detected — on `/maos:preflight ticket`)
+
+Confirm the anchor, then walk the ticket **N-Tree** to situate the session:
+
+- **Up** to the parent chain (story → epic → root) and **sideways** to siblings, via whatever
+  tracker MCP is present (capability-detected — never hardcode a provider). Jira: parent-chain +
+  `JQL` siblings; Linear/GH: equivalents. **No tracker MCP available → DEFER(ntree)** (report the
+  anchor only; never block).
+- **Flag the session's node** on the tree so the operator sees exactly where this work lives.
+- Layer-pure: the *mechanism* is governance-discovered; this skill composes the user-scope
+  `ticket-as-prompt` skill for any provider-specific read/enrich.
+
+### R0.c — Classify `session_type=<mode>/<work>`
+
+Resolve the session type per `references/session-type-taxonomy.md` (the SSOT): two orthogonal
+axes — `mode` {continuation·fresh·debate·converge} × `work` {feat·enhance·fix·hotfix·debug·gap·
+refactor·harmonize·chore·docs·test}. Tier-A computed signals (seed/branch/issue-type/`#seq`) beat
+Tier-B self-report (prompt verbs). Ambiguous → emit the **top-2 with evidence**, never fabricate one.
+The result is carried into the continuation seed (`session_type`) at postflight → read back by the
+next session's R0.
+
+### R0.d — No-ticket flow (HITL-gated — never auto-creates)
+
+When R0.a finds no anchor AND R0.b confirms none exists on the tree, present a **structured HITL
+proposal** (via `AskUserQuestion`), do NOT auto-create:
+
+1. **Create as draft** — delegate to `ticket-as-prompt` (provider-routed: Vek→Jira · personal→Linear
+   · community→GH Issue) to open a ticket whose body is a self-contained Ticket-as-Prompt.
+2. **Link to an existing ticket** — operator names the node; the session anchors to it.
+3. **Proceed without a documented ticket** — record the decision; postflight P2.5 may still propose one.
+
+Ticket *creation* is always delegated to `ticket-as-prompt` + capability-detected; absent that skill →
+DEFER(ticket) (report, never block).
+
 ## Governance Discovery (read at invocation — the adaptive core)
 
 Before deriving any name or convention, **read whatever governance the target repo
@@ -100,6 +162,10 @@ exposes right now** and adapt to it (do NOT hardcode):
 
 ```
 0. Governance discovery (above) — derive the repo's conventions.
+0.5 R0: anchor the ticket (seed › branch › commit, ZERO network) → coarse mode.
+   On /maos:preflight ticket: walk the N-Tree (parent-chain + siblings, capability-detected),
+   flag the session node, classify session_type=<mode>/<work> (taxonomy SSOT), and if no
+   ticket exists → HITL create-proposal (delegate to ticket-as-prompt). DEFER if no tracker MCP.
 1. R1: read-only detect — current branch, upstream, ahead/behind, tree-state,
    branches locked by other worktrees. Report; never mutate.
 2. R2: if the action benefits from fresh state → safe-heal from origin
@@ -125,8 +191,10 @@ exposes right now** and adapt to it (do NOT hardcode):
 | Artifact | Role |
 |---|---|
 | `skills/preflight/SKILL.md` | this brain (governance-aware orchestrator) |
-| `commands/preflight.md` → `/maos:preflight` | ergonomic entry point |
-| `plugin-scripts/governance/preflight-session.sh` | SessionStart hook (R1+R2, never blocks; opt-out `PREFLIGHT_NO_AUTOHEAL=1`) |
+| `skills/preflight/references/session-type-taxonomy.md` | R0.c classification SSOT (mode × work axes) |
+| `bin/locus.sh` `--density anchor` | R0.a ticket-anchor authority (seed › branch › commit, ZERO network) |
+| `commands/preflight.md` → `/maos:preflight` | ergonomic entry point (+ `ticket` action for R0 on-demand) |
+| `plugin-scripts/governance/preflight-session.sh` | SessionStart hook (R0+R1+R2, never blocks; opt-out `PREFLIGHT_NO_AUTOHEAL=1`, `PREFLIGHT_NO_TICKET_ANCHOR=1`) |
 | `plugin-scripts/governance/preflight-edit-gate.sh` | PreToolUse:Edit\|Write\|MultiEdit (R3 safety-net; WARN default, `PREFLIGHT_EDIT_GATE=block\|off`) |
 | `plugin-scripts/governance/lib/git-branch-detect.sh` | R1 read-only primitives |
 | `plugin-scripts/governance/lib/git-safe-sync.sh` | R2 safe-heal primitives |
@@ -134,9 +202,21 @@ exposes right now** and adapt to it (do NOT hardcode):
 
 ## Examples
 
-**Start of session** (automatic, via the hook):
+**Start of session** (automatic, via the hook — R0 anchor + R1/R2):
 ```
-🧭 preflight: branch=feature/x upstream=origin/main ahead=0 behind=3 tree=CLEAN; heal=HEALED_FF a1b2c3d
+🧭 preflight: ticket=ABC-123(branch) mode=anchored; branch=feat/abc-123-x upstream=origin/main ahead=0 behind=3 tree=CLEAN; heal=HEALED_FF a1b2c3d
+```
+
+**No ticket anchor** (the hook nudges; never blocks):
+```
+🧭 preflight: branch=just-a-name ... ; heal=...
+→ No ticket anchor detected (mode=unanchored): run /maos:preflight ticket to walk the N-Tree + classify, or proceed.
+```
+
+**On `/maos:preflight ticket`** (agentic N-Tree walk + classify):
+```
+R0: anchor=ABC-123 (branch) → N-Tree: ROOT epic ABC-100 › story ABC-110 › ◀THIS ABC-123 (+2 siblings)
+    session_type=continuation/feat (seed→continuation; branch feat/→feat)
 ```
 
 **Before editing on main**:

--- a/skills/preflight/references/session-type-taxonomy.md
+++ b/skills/preflight/references/session-type-taxonomy.md
@@ -81,7 +81,7 @@ The operator's directives use a rich pt-BR vocabulary. Map each term to a canoni
 | converge · convergir · harmonizar opiniões · reconciliar | mode | `converge` |
 | feature · funcionalidade · nova capacidade | work | `feat` |
 | expansão · expandir · ampliar escopo | work | `feat` |
-| melhoria · melhorar · impruve · improve · aprimorar | work | `enhance` |
+| melhoria · melhorar · improve · `impruve`¹ · aprimorar | work | `enhance` |
 | correção · corrigir · ajuste · ajustar · fix | work | `fix` |
 | hotfix · urgente · stop-the-bleeding · produção-quebrada | work | `hotfix` |
 | debug · investigar · root-cause · diagnosticar | work | `debug` |
@@ -91,6 +91,10 @@ The operator's directives use a rich pt-BR vocabulary. Map each term to a canoni
 | clean-up · house-cleaning · house-keeping · boy-scout · limpeza | work | `chore` |
 | documentação · docs · documentar | work | `docs` |
 | teste · testes · cobertura | work | `test` |
+
+> ¹ `impruve` is an **intentional** alias for the operator's own verbatim spelling (not a typo to
+> "fix") — the alias map exists precisely to route real, as-typed operator vocabulary to the canonical
+> `enhance`. `improve` (correct spelling) is listed alongside so both forms resolve.
 
 > Operator terms that are **not** axis values (`DNA Agentico Geracional · princípios · motivação ·
 > DoR · DoD · propósitos · esperado · entregáveis · feedbacks · prompt · ticket · git-domain ·

--- a/skills/preflight/references/session-type-taxonomy.md
+++ b/skills/preflight/references/session-type-taxonomy.md
@@ -1,0 +1,169 @@
+---
+name: session-type-taxonomy
+description: Two-axis SSOT (mode × work) for classifying an agentic session at preflight R0 — conventional-commits grounded, with a pt-BR alias map and a detection-signals glossary
+version: 1.0.0
+---
+
+# Session-Type Taxonomy (SSOT)
+
+> **Version**: 1.0.0 (2026-06-11)
+> **Scope**: AAIF cross-vendor. The single source of truth for *what kind of session this is*.
+> **Consumer**: `skills/preflight` R0.c (classify) — the deterministic hook emits a coarse
+>   `mode` hint (continuation-candidate | anchored | unanchored); the skill resolves the full
+>   `session_type=<mode>/<work>` here. Forward-consumer: `skills/postflight` seed `session_type`
+>   field (carried into the continuation seed → next session's R0 reads it back).
+> **Cross-link slug**: `session-type-taxonomy`
+
+## Purpose
+
+Sessions are classified along **two orthogonal axes** so a fresh, amnesic agent (and the human
+operator) knows, at a glance, *how it got here* (mode) and *what it is doing* (work). The two
+are independent: a `continuation` session can do `fix` work; a `fresh` session can do `feat`
+work; a `debate` session can converge on `harmonize` work. One value from each axis, joined by
+`/`:
+
+```
+session_type = <mode>/<work>      e.g.  continuation/feat · fresh/debug · converge/harmonize
+```
+
+Repo master principle (from the locus grammar SSOT): *"what is not seen is not remembered;
+what is computed and seen is remembered, by humans **and** agents."* The classification is that
+principle applied to *session intent* — computed at R0, carried in the seed, read back next time.
+
+**Layer purity**: this taxonomy is provider-neutral. It names *kinds of work*, never a tracker,
+vendor, or org. The `work` axis is grounded in [Conventional Commits](https://www.conventionalcommits.org/)
+(an ecosystem standard), so a `work` value maps cleanly to a commit `type` downstream.
+
+## Axis 1 — `mode` (how the session arrived)
+
+*How did this session come to exist?* Exactly one value.
+
+| `mode` | Meaning | Primary detection signal (Tier) |
+|---|---|---|
+| **continuation** | Resumes prior work across a context boundary (compact/clear/spawn). | seed `refs.ticket` present **or** spawned with a continuation ticket (A) |
+| **fresh** | New work with no inherited session context. | no seed, no continuation marker (A) |
+| **debate** | Multi-perspective divergence — surface options/critiques before deciding (no single answer yet). | prompt verbs *debate · compare · critique · pros/cons · options* (B) |
+| **converge** | Reconcile ≥2 prior proposals/branches/opinions into one validated synthesis. | prompt verbs *converge · reconcile · synthesize · decide-between · merge-opinions* (B) |
+
+> `debate` and `converge` are a natural pair (diverge → converge) but each is its own session
+> mode — a session is one or the other, not both. If a single session does both, classify by its
+> *terminal* intent (where it's headed): converge.
+
+## Axis 2 — `work` (what the session does)
+
+*What kind of change/output is the session producing?* Exactly one value. Grounded in
+Conventional Commits `type` (so it maps to a commit type at handoff).
+
+| `work` | Meaning | Conv-commit type |
+|---|---|---|
+| **feat** | New capability / expansion of scope. | `feat` |
+| **enhance** | Improve something that already works (quality/UX/perf), no new capability. | `feat` (minor) / `perf` |
+| **fix** | Correct a defect in non-urgent flow. | `fix` |
+| **hotfix** | Urgent correction (production/blocking) — short path, stop-the-bleeding. | `fix` |
+| **debug** | Investigate a defect (root-cause hunt) — may or may not end in a fix. | (precedes `fix`) |
+| **gap** | Close a known gap / pending / orphan TODO / unfinished phase. | `feat` / `fix` (context) |
+| **refactor** | Restructure without behavior change. | `refactor` |
+| **harmonize** | Reconcile drift / de-duplicate / align across artifacts to a single SSOT. | `refactor` / `docs` |
+| **chore** | House-keeping / boy-scout / cleanup / config / deps. | `chore` |
+| **docs** | Documentation only. | `docs` |
+| **test** | Tests only (add/repair coverage). | `test` |
+
+## pt-BR alias map (operator vocabulary → canonical)
+
+The operator's directives use a rich pt-BR vocabulary. Map each term to a canonical axis value.
+**Aliases never expand the taxonomy** — they route to the closest canonical value.
+
+| Operator term (pt-BR / mixed) | → axis | → canonical value |
+|---|---|---|
+| continuidade · retomar · continuação | mode | `continuation` |
+| blank · em branco · do zero · novo | mode | `fresh` |
+| debate · debater · comparar · criticar | mode | `debate` |
+| converge · convergir · harmonizar opiniões · reconciliar | mode | `converge` |
+| feature · funcionalidade · nova capacidade | work | `feat` |
+| expansão · expandir · ampliar escopo | work | `feat` |
+| melhoria · melhorar · impruve · improve · aprimorar | work | `enhance` |
+| correção · corrigir · ajuste · ajustar · fix | work | `fix` |
+| hotfix · urgente · stop-the-bleeding · produção-quebrada | work | `hotfix` |
+| debug · investigar · root-cause · diagnosticar | work | `debug` |
+| gap · gaps · pendência · pendências · tarefa órfã · TODO · fase inacabada | work | `gap` |
+| refactor · refatorar · reestruturar | work | `refactor` |
+| harmonização · harmonizar · de-duplicar · alinhar SSOT · resolver drift | work | `harmonize` |
+| clean-up · house-cleaning · house-keeping · boy-scout · limpeza | work | `chore` |
+| documentação · docs · documentar | work | `docs` |
+| teste · testes · cobertura | work | `test` |
+
+> Operator terms that are **not** axis values (`DNA Agentico Geracional · princípios · motivação ·
+> DoR · DoD · propósitos · esperado · entregáveis · feedbacks · prompt · ticket · git-domain ·
+> domains`) are **session attributes**, not session *types* — see the Signals glossary below.
+
+## Detection signals (Tier-A computed ≻ Tier-B self-report)
+
+Classify by the **strongest available signal**, in this precedence:
+
+### Tier-A — computed (deterministic, trustworthy)
+
+| Signal | Resolves | How |
+|---|---|---|
+| seed `refs.ticket` present | `mode=continuation` | the R0 hook reads it (zero-network) |
+| spawned with a continuation ticket / `--ticket` | `mode=continuation` | spawn marker / seed `continuation_ticket` |
+| no seed + no continuation marker | `mode=fresh` | absence is the signal |
+| ticket issue-type / label (when a ticket is anchored) | `work` | e.g. issue-type *Bug→fix*, *Hotfix→hotfix*, *Chore→chore* (capability-detected; never hardcode a provider's IDs) |
+| branch `<type>/` prefix (conventional branches) | `work` | `feat/`→feat · `fix/`→fix · `hotfix/`→hotfix · `refactor/`→refactor · `chore/`→chore · `docs/`→docs · `test/`→test |
+| `#<seq>` continuation marker in branch/seed | `mode=continuation` | the spawn chain owns `#seq` |
+
+### Tier-B — self-report (the prompt's verbs; weaker, used when Tier-A is silent)
+
+| Signal | Resolves |
+|---|---|
+| imperative verbs in the operator prompt | both axes — match against the pt-BR alias map above |
+| `/debate-converge`-style invocation | `mode=debate` then `converge` |
+
+### Ambiguity rule
+
+When two values tie on equal-strength signals, **emit the top-2 with the evidence for each** and
+let the operator/skill disambiguate — do **not** silently pick one (anti-theater: never fabricate a
+classification the evidence doesn't support). Tier-A always beats Tier-B; within a tier, a more
+specific signal (issue-type) beats a more general one (branch prefix).
+
+## Signals glossary — recognized session *attributes* (not types) and where each lives
+
+These operator terms describe *properties of a session's work*, distinct from the `mode`/`work`
+type. R0 surfaces them; they are carried/owned elsewhere — this table tells a fresh agent **where
+each lives** so it doesn't conflate an attribute with a type.
+
+| Signal (operator term) | What it is | Where it lives / who owns it |
+|---|---|---|
+| **DNA Agentico Geracional** | 3 inherited principles (Liberdade-com-Responsabilidade · Previsibilidade-Holística · Independência-Agnóstica) | continuation-seed `dna` object (PR-2); propagated to spawned sessions + sub-agent briefings |
+| **princípios / motivação / propósitos** (principais/secundários/auxiliares) | *why* the work exists | the anchored ticket body (Ticket-as-Prompt) + seed `next_actions` rationale |
+| **DoR** (Definition of Ready) | preconditions before work starts | the anchored ticket body |
+| **DoD** (Definition of Done) | acceptance criteria before close | the anchored ticket body + postflight close-gate |
+| **esperado / entregáveis** | expected outputs | the anchored ticket body + seed `deliverables` |
+| **feedbacks** | how feedback flows in/out | PR comments + ticket comments (bidirectional traceability) |
+| **prompt** | the originating instruction | seed `originating_prompt` / ticket body |
+| **ticket** | the N-Tree anchor node | resolved at R0 (seed › branch › commit); the session's place on the treasure-map |
+| **git-domain / domains** | repo / area-of-codebase scope | branch + worktree + `project:branch` locus token |
+
+## Worked examples
+
+| Situation | `session_type` | Evidence |
+|---|---|---|
+| Resumed via spawn, seed `refs.ticket=X`, branch `feat/x-r0` | `continuation/feat` | seed (A) → continuation; branch prefix (A) → feat |
+| Fresh start, branch `fix/login-null`, prompt "corrige o NPE" | `fresh/fix` | no seed (A) → fresh; branch `fix/` (A) → fix |
+| Prompt "compare 3 abordagens de cache, prós/contras" | `fresh/feat` *(debate mode)* → `debate/feat` | no seed → not continuation; verbs *compare/prós-contras* (B) → debate |
+| Prompt "harmonize as 3 regras sobrepostas num SSOT" | `fresh/harmonize` | no seed → fresh; *harmonize/SSOT* (B) → harmonize |
+| Branch `chore/cleanup-temp`, prompt "boy-scout o diretório" | `fresh/chore` | branch `chore/` (A) → chore |
+| Two prior proposal branches; prompt "converge num design só" | `converge/feat` | *converge/reconcile* (B) → converge; producing a design → feat |
+
+## Refs
+
+- [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) — `work` axis grounding
+- `skills/preflight/SKILL.md` R0.c (consumer — classification step)
+- `skills/postflight/references/continuation-seed-contract.md` — seed `session_type` + `dna` fields (forward-consumer)
+- `bin/locus.sh` `--density anchor` — the ticket-anchor authority R0 uses
+- Cross-link slug: `session-type-taxonomy`
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0.0 | 2026-06-11 | Bootstrap — 2-axis SSOT (mode {continuation·fresh·debate·converge} × work {feat·enhance·fix·hotfix·debug·gap·refactor·harmonize·chore·docs·test}), conventional-commits grounded. pt-BR operator alias map. Tier-A-computed ≻ Tier-B-self-report detection precedence + ambiguity top-2 rule. Signals glossary (DNA·DoR·DoD·propósitos·entregáveis·git-domain → where each lives). Layer-pure (provider-neutral). Consumer: preflight R0.c; forward-consumer: postflight seed `session_type`. |

--- a/tests/governance/test-preflight-session-r0.sh
+++ b/tests/governance/test-preflight-session-r0.sh
@@ -82,10 +82,13 @@ R="$(mkrepo garbage)"; ( cd "$R" && git checkout -q -b x ) >/dev/null 2>&1
 mkdir -p "$R/.git/maos"; printf 'not json {{{' > "$R/.git/maos/continuation-seed.latest.json"
 CLAUDE_PROJECT_DIR="$R" bash "$HOOK" >/dev/null 2>&1; eq 0 "$?" 'R0 garbage seed → exit 0'
 
-# timing <2s
+# timing <2s — sub-second resolution (whole-second date +%s is flaky across a second boundary).
+# Portable hi-res via perl Time::HiRes (present on macOS + Linux CI); fall back to date +%s.
+now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time*1000' 2>/dev/null || echo "$(( $(date +%s) * 1000 ))"; }
 R="$(mkrepo timing)"; ( cd "$R" && git checkout -q -b feature/TIM-1-x ) >/dev/null 2>&1
-T0=$(date +%s); CLAUDE_PROJECT_DIR="$R" bash "$HOOK" >/dev/null 2>&1; T1=$(date +%s)
-[ $((T1-T0)) -lt 2 ] && ok 'R0 completes <2s' || no 'R0 completes <2s' "$((T1-T0))s"
+T0=$(now_ms); CLAUDE_PROJECT_DIR="$R" bash "$HOOK" >/dev/null 2>&1; T1=$(now_ms)
+ELAPSED_MS=$((T1-T0))
+[ "$ELAPSED_MS" -lt 2000 ] && ok 'R0 completes <2s' || no 'R0 completes <2s' "${ELAPSED_MS}ms"
 
 rm -rf "$ROOT"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/governance/test-preflight-session-r0.sh
+++ b/tests/governance/test-preflight-session-r0.sh
@@ -88,7 +88,7 @@ now_ms() { perl -MTime::HiRes=time -e 'printf "%d", time*1000' 2>/dev/null || ec
 R="$(mkrepo timing)"; ( cd "$R" && git checkout -q -b feature/TIM-1-x ) >/dev/null 2>&1
 T0=$(now_ms); CLAUDE_PROJECT_DIR="$R" bash "$HOOK" >/dev/null 2>&1; T1=$(now_ms)
 ELAPSED_MS=$((T1-T0))
-[ "$ELAPSED_MS" -lt 2000 ] && ok 'R0 completes <2s' || no 'R0 completes <2s' "${ELAPSED_MS}ms"
+if [ "$ELAPSED_MS" -lt 2000 ]; then ok 'R0 completes <2s'; else no 'R0 completes <2s' "${ELAPSED_MS}ms"; fi
 
 rm -rf "$ROOT"
 printf '\n%d passed, %d failed\n' "$pass" "$fail"

--- a/tests/governance/test-preflight-session-r0.sh
+++ b/tests/governance/test-preflight-session-r0.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# Tests for the R0 ticket-anchor section of plugin-scripts/governance/preflight-session.sh.
+# Bash 3.2-safe, self-contained. Runs the real hook against synthetic repos via
+# CLAUDE_PROJECT_DIR. Asserts: seed › branch › commit precedence, none→nudge, opt-out,
+# offline-still-anchors, non-git silent exit 0, <2s, garbage-seed exit 0.
+# Run: bash tests/governance/test-preflight-session-r0.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+HOOK="$DIR/../../plugin-scripts/governance/preflight-session.sh"
+
+pass=0 ; fail=0
+ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  \xe2\x9c\x97 %s\n      got: [%s]\n' "$1" "$2"; }
+has()  { case "$2" in *"$1"*) ok "$3" ;; *) no "$3" "$2" ;; esac; }
+hasnt(){ case "$2" in *"$1"*) no "$3" "$2" ;; *) ok "$3" ;; esac; }
+eq()   { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
+
+printf 'test-preflight-session-r0.sh\n'
+
+ROOT="$(mktemp -d)"
+mkrepo() {  # $1=name [+ optional branch] → echoes path
+  local d="$ROOT/$1"; rm -rf "$d"; mkdir -p "$d"
+  ( cd "$d" && git init -q && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m init ) >/dev/null 2>&1
+  printf '%s' "$d"
+}
+ctx() { CLAUDE_PROJECT_DIR="$1" bash "$HOOK" 2>/dev/null | sed -n 's/.*"additionalContext":"\(.*\)"}}/\1/p'; }
+
+# branch source
+R="$(mkrepo branch)"; ( cd "$R" && git checkout -q -b feature/VKS-2178-r0 ) >/dev/null 2>&1
+o="$(ctx "$R")"; has 'ticket=VKS-2178 (source=branch, mode=anchored)' "$o" 'R0 branch source anchors'
+
+# commit source (no-ticket branch, ticket in last commit)
+R="$(mkrepo commit)"; ( cd "$R" && git checkout -q -b plain && git -c user.email=t@t -c user.name=t commit --allow-empty -q -m 'feat: DEF-123 x' ) >/dev/null 2>&1
+o="$(ctx "$R")"; has 'ticket=DEF-123 (source=commit, mode=anchored)' "$o" 'R0 commit source anchors'
+
+# seed precedence (branch ALSO has a ticket → seed must win, mode=continuation-candidate)
+R="$(mkrepo seed)"; ( cd "$R" && git checkout -q -b feature/BR-1-x ) >/dev/null 2>&1
+mkdir -p "$R/.git/maos"; printf '{"refs":{"ticket":"SEED-777"}}\n' > "$R/.git/maos/continuation-seed.latest.json"
+o="$(ctx "$R")"; has 'ticket=SEED-777 (source=seed, mode=continuation-candidate)' "$o" 'R0 seed wins over branch'
+
+# none → nudge + NO ticket token
+R="$(mkrepo none)"; ( cd "$R" && git checkout -q -b just-a-name ) >/dev/null 2>&1
+o="$(ctx "$R")"; has 'No ticket anchor detected' "$o" 'R0 no-anchor → nudge'
+has 'mode=unanchored' "$o" 'R0 no-anchor → mode=unanchored'
+hasnt ' ticket=' "$o" 'R0 no-anchor → no ticket token leaked'
+
+# opt-out PREFLIGHT_NO_TICKET_ANCHOR=1
+R="$(mkrepo optout)"; ( cd "$R" && git checkout -q -b feature/OPT-9-x ) >/dev/null 2>&1
+o="$(CLAUDE_PROJECT_DIR="$R" PREFLIGHT_NO_TICKET_ANCHOR=1 bash "$HOOK" 2>/dev/null | sed -n 's/.*"additionalContext":"\(.*\)"}}/\1/p')"
+hasnt 'ticket=OPT-9' "$o" 'R0 opt-out skips anchor'
+
+# offline (gh/curl shimmed to fail) — R0 still anchors from branch
+R="$(mkrepo offline)"; ( cd "$R" && git checkout -q -b feature/OFF-5-x ) >/dev/null 2>&1
+SHIM="$ROOT/shim"; rm -rf "$SHIM"; mkdir -p "$SHIM"
+for c in gh curl; do printf '#!/bin/sh\nexit 99\n' > "$SHIM/$c"; chmod +x "$SHIM/$c"; done
+o="$(CLAUDE_PROJECT_DIR="$R" PATH="$SHIM:$PATH" bash "$HOOK" 2>/dev/null | sed -n 's/.*"additionalContext":"\(.*\)"}}/\1/p')"
+has 'ticket=OFF-5 (source=branch' "$o" 'R0 anchors offline (gh/curl unavailable)'
+
+# non-git dir → silent exit 0, empty stdout (use system temp, outside any repo)
+ND="$(mktemp -d /tmp/r0-notgit.XXXXXX)"
+out="$(CLAUDE_PROJECT_DIR="$ND" bash "$HOOK" 2>/dev/null)"; rc=$?
+eq 0 "$rc" 'R0 non-git → exit 0'
+eq 0 "$(printf '%s' "$out" | wc -c | tr -d ' ')" 'R0 non-git → empty stdout'
+rm -rf "$ND"
+
+# garbage seed → exit 0 (never crash)
+R="$(mkrepo garbage)"; ( cd "$R" && git checkout -q -b x ) >/dev/null 2>&1
+mkdir -p "$R/.git/maos"; printf 'not json {{{' > "$R/.git/maos/continuation-seed.latest.json"
+CLAUDE_PROJECT_DIR="$R" bash "$HOOK" >/dev/null 2>&1; eq 0 "$?" 'R0 garbage seed → exit 0'
+
+# timing <2s
+R="$(mkrepo timing)"; ( cd "$R" && git checkout -q -b feature/TIM-1-x ) >/dev/null 2>&1
+T0=$(date +%s); CLAUDE_PROJECT_DIR="$R" bash "$HOOK" >/dev/null 2>&1; T1=$(date +%s)
+[ $((T1-T0)) -lt 2 ] && ok 'R0 completes <2s' || no 'R0 completes <2s' "$((T1-T0))s"
+
+rm -rf "$ROOT"
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/tests/governance/test-preflight-session-r0.sh
+++ b/tests/governance/test-preflight-session-r0.sh
@@ -39,6 +39,19 @@ R="$(mkrepo seed)"; ( cd "$R" && git checkout -q -b feature/BR-1-x ) >/dev/null 
 mkdir -p "$R/.git/maos"; printf '{"refs":{"ticket":"SEED-777"}}\n' > "$R/.git/maos/continuation-seed.latest.json"
 o="$(ctx "$R")"; has 'ticket=SEED-777 (source=seed, mode=continuation-candidate)' "$o" 'R0 seed wins over branch'
 
+# WORKTREE-SAFE seed path (Qodo #141 bug): in a linked worktree "$REPO/.git" is a FILE, not a dir.
+# Seed lives in the COMMON git-dir's maos/; R0 must still find it (not silently miss continuation).
+WTR="$(mkrepo wtmain)"; ( cd "$WTR" && git checkout -q -b feature/MAIN-1-x ) >/dev/null 2>&1
+mkdir -p "$WTR/.git/maos"; printf '{"refs":{"ticket":"WT-555"}}\n' > "$WTR/.git/maos/continuation-seed.latest.json"
+LW="$WTR-linked"; rm -rf "$LW"
+( cd "$WTR" && git worktree add -q "$LW" -b feature/LINKED-9-x ) >/dev/null 2>&1
+if [ -f "$LW/.git" ]; then   # confirm it's a gitlink FILE (the bug precondition)
+  o="$(ctx "$LW")"; has 'ticket=WT-555 (source=seed, mode=continuation-candidate)' "$o" 'R0 finds seed in COMMON git-dir from a linked worktree (gitlink-file safe)'
+else
+  ok 'R0 worktree-safe seed (skipped: linked worktree not a gitlink file on this fs)'
+fi
+( cd "$WTR" && git worktree remove --force "$LW" 2>/dev/null ) || rm -rf "$LW"
+
 # none → nudge + NO ticket token
 R="$(mkrepo none)"; ( cd "$R" && git checkout -q -b just-a-name ) >/dev/null 2>&1
 o="$(ctx "$R")"; has 'No ticket anchor detected' "$o" 'R0 no-anchor → nudge'


### PR DESCRIPTION
## Summary

- Adds Preflight R0 ticket-anchor and session-type classification so sessions start with deterministic local ticket context (seed → branch → commit), zero-network and non-blocking.
- Fixes linked-worktree seed lookup by probing per-worktree git-dir, git common-dir, and repo `.git` fallback, with `POSTFLIGHT_SEED_DIR` override parity.
- Keeps provider/org neutrality in preflight docs/skill routing and expands regression coverage (including real linked-worktree scenario).

## Type

- [x] feat (new functionality)
- [x] fix (bug fix)
- [ ] docs
- [ ] refactor
- [ ] chore
- [ ] security
- [x] governance
- [ ] release

## AI Involvement

- [ ] Human-authored
- [x] AI-assisted (human author used AI tools for parts of the change)
- [ ] AI-generated draft reviewed by human (named reviewer required)

If AI-assisted or AI-generated, include `Co-Authored-By:` footer(s) in the commit messages.

## Runtime / Surface Impact

- [x] Claude Code (plugin runtime, hooks, agents, commands, skills)
- [ ] GitHub Copilot (`.github/copilot-instructions.md`)
- [x] Generic AI agents (AGENTS.md contract)
- [ ] Plugin manifest (`.claude-plugin/plugin.json`) — requires downstream marketplace sync
- [ ] CI / GitHub Actions (`.github/workflows/`)
- [ ] Security / compliance posture

## Files requiring follow-up governance update

- [ ] `README.md`
- [ ] `AGENTS.md`
- [ ] `CLAUDE.md`
- [ ] `CONTRIBUTING.md`
- [ ] `SECURITY.md`
- [ ] `CHANGELOG.md`
- [ ] `.github/CODEOWNERS`
- [ ] `.claude-plugin/plugin.json`
- [ ] Downstream marketplace pin (`ekson73/eko-claude-plugins`)

## Evidence

```bash
bash bin/tests/locus.test.sh
# 38/38

bash tests/governance/test-preflight-session-r0.sh
# 13/13 (includes linked-worktree regression)

bash tests/validate-plugin.sh
# 0 errors / 0 warnings

gitleaks protect --staged
# clean
```

## Risks

Low. Changes are additive and defensive, with graceful degradation paths preserved (no jq/locus/anchor/tracker capability cases). Main behavioral change is improved seed discovery in linked worktrees.

## Rollback

Revert the preflight R0 commit set for this PR (including linked-worktree seed resolution). No plugin manifest change is required to roll back.

## Checklist

- [x] Worktree + branch used (no direct-main commits)
- [x] Conventional Commits + `Co-Authored-By:` footer if AI involved
- [x] gitleaks clean (pre-commit + CI workflow)
- [x] Build / tests pass (`tests/validate-plugin.sh` or equivalent)
- [x] No secrets, no PII, no Vek-specific content (Layer Purity per `~/.claude/rules/layer-precedence-policy.md`)
- [ ] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated if contract changed
- [ ] Version bump + CHANGELOG entry if `.claude-plugin/plugin.json` changed

🤖 If this PR was opened by an automated agent, link the plan file or skill that drove it.