### PR TITLE
feat(work-compass): Phase-1 cross-domain work-landscape N-Tree + delegation hub

### DIFF
--- a/bin/tests/test_work_compass.py
+++ b/bin/tests/test_work_compass.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""
+test_work_compass.py — stdlib-only tests for the work-compass aggregator.
+
+Covers (per DoD): aggregator normalization · detector heuristics · renderer
+determinism · router command-generation · read-only / no-clobber safety.
+
+Run: python3 bin/tests/test_work_compass.py
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+# import the sibling module under test
+_HERE = Path(__file__).resolve().parent
+_MOD = _HERE.parent / "work-compass-aggregate.py"
+_spec = importlib.util.spec_from_file_location("wc", _MOD)
+wc = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(wc)
+
+PASS = 0
+FAIL = 0
+
+
+def check(name: str, cond: bool, detail: str = "") -> None:
+    global PASS, FAIL
+    if cond:
+        PASS += 1
+        print(f"  PASS  {name}")
+    else:
+        FAIL += 1
+        print(f"  FAIL  {name}  {detail}")
+
+
+def _old(days: int) -> str:
+    return (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
+
+
+def _new() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+# ── 1. aggregator normalization ───────────────────────────────────────────────
+def test_item_normalization():
+    it = wc.item("session:abc", "session", "do the thing", last_ts=_new(),
+                 refs={"branch": "feat/x"})
+    check("item: id namespaced", it["id"] == "session:abc")
+    check("item: domain set", it["domain"] == "session")
+    check("item: flags empty list by default", it["flags"] == [])
+    check("item: refs preserved", it["refs"]["branch"] == "feat/x")
+    check("item: default status unknown", it["status"] == "unknown")
+
+
+def test_build_graph_deterministic():
+    items = [
+        wc.item("branch:z", "branch", "z", refs={"name": "z"}),
+        wc.item("branch:a", "branch", "a", refs={"name": "a"}),
+        wc.item("session:m", "session", "m"),
+    ]
+    g1 = wc.build_graph([dict(i) for i in items], "current", None, [])
+    g2 = wc.build_graph([dict(i) for i in items], "current", None, [])
+    check("graph: deterministic items order",
+          [i["id"] for i in g1["items"]] == [i["id"] for i in g2["items"]],
+          str([i["id"] for i in g1["items"]]))
+    check("graph: branches sorted a<z",
+          [i["id"] for i in g1["by_domain"]["branch"]] == ["branch:a", "branch:z"])
+    check("graph: domains_present counted", g1["meta"]["domains_present"] == 2)
+
+
+# ── 2. detector heuristics ────────────────────────────────────────────────────
+def test_detector():
+    items = [
+        wc.item("branch:feat/x", "branch", "feat/x", refs={"name": "feat/x"}),     # no PR
+        wc.item("branch:main", "branch", "main", refs={"name": "main"}),           # excluded
+        wc.item("pr:o/r#5", "process", "fix stuff", refs={"branch": "feat/y", "number": 5}),  # no ticket
+        wc.item("jira:VKS-1", "ticket", "a ticket", refs={"key": "VKS-1"}),        # no session
+        wc.item("worktree:/p", "worktree", "p", refs={"branch": ""}),              # no branch
+        wc.item("session:s1", "session", "old work", last_ts=_old(30),
+                refs={"branch": "gone-branch"}),                                    # orphan + stale
+    ]
+    wc.detect(items, stale_days=7)
+    by = {i["id"]: i for i in items}
+    check("H1 branch-no-PR", "branch-no-PR" in by["branch:feat/x"]["flags"])
+    check("H1 main excluded", "branch-no-PR" not in by["branch:main"]["flags"])
+    check("H2 PR-no-ticket", "PR-no-ticket" in by["pr:o/r#5"]["flags"])
+    check("H3 ticket-no-session", "ticket-no-session" in by["jira:VKS-1"]["flags"])
+    check("H5 worktree-no-branch", "worktree-no-branch" in by["worktree:/p"]["flags"])
+    check("H6 session-orphan", "session-orphan" in by["session:s1"]["flags"])
+    check("H4 >Nd-no-update", any(">7d" in f for f in by["session:s1"]["flags"]))
+    check("H4 sets stale-ish status", by["session:s1"]["status"] in ("stale", "orphan"))
+
+
+def test_detector_no_false_positive_on_fresh_linked():
+    items = [
+        wc.item("branch:feat/live", "branch", "feat/live", refs={"name": "feat/live"}),
+        wc.item("pr:o/r#9", "process", "VKS-2 fix", last_ts=_new(),
+                refs={"branch": "feat/live", "number": 9}),  # title has ticket → no PR-no-ticket
+        wc.item("session:s2", "session", "active", last_ts=_new(),
+                refs={"branch": "feat/live", "tickets": ["VKS-2"]}),
+    ]
+    wc.detect(items, stale_days=7)
+    by = {i["id"]: i for i in items}
+    check("no false branch-no-PR (PR on branch)", "branch-no-PR" not in by["branch:feat/live"]["flags"])
+    check("no false PR-no-ticket (title has VKS)", "PR-no-ticket" not in by["pr:o/r#9"]["flags"])
+    check("no false session-orphan (branch exists)", "session-orphan" not in by["session:s2"]["flags"])
+
+
+# ── 3. renderer determinism ───────────────────────────────────────────────────
+def test_renderer_determinism():
+    items = [
+        wc.item("branch:b", "branch", "b", refs={"name": "b"}),
+        wc.item("session:a", "session", "a"),
+    ]
+    g = wc.build_graph([dict(i) for i in items], "current", None, [])
+    r1 = wc.render_ascii(g)
+    r2 = wc.render_ascii(g)
+    check("render ascii deterministic", r1 == r2)
+    check("render ascii has header", "work-compass" in r1)
+    m1 = wc.render_mermaid(g)
+    check("render mermaid deterministic", m1 == wc.render_mermaid(g))
+    check("render mermaid is flowchart", m1.startswith("flowchart TD"))
+    # ascii-only fallback has no emoji
+    r3 = wc.render_ascii(g, ascii_only=True)
+    check("ascii-only has no emoji glyph", "🟢" not in r3 and "[" in r3)
+
+
+# ── 4. router command-generation (read-only) ──────────────────────────────────
+def test_router():
+    n_branch = wc.item("branch:feat/x", "branch", "feat/x", refs={"name": "feat/x"})
+    n_branch["flags"] = ["branch-no-PR"]
+    r = wc.route(n_branch, action=None)
+    check("router: suggests preflight for branch-no-PR", r["tool"] == "preflight")
+    check("router: command non-empty", bool(r["suggested_command"]))
+    check("router: execute=False (read-only contract)", r["execute"] is False)
+
+    n_sess = wc.item("session:s1", "session", "x")
+    n_sess["flags"] = ["session-orphan"]
+    r2 = wc.route(n_sess, action="delete")
+    check("router: destructive action flagged as warning",
+          "DESTRUCTIVE" in r2["warning"])
+    check("router: never sets execute true even for delete", r2.get("execute") is False)
+
+    n_plain = wc.item("graph-node:misc", "graph-node", "misc")
+    r3 = wc.route(n_plain, action=None)
+    check("router: no-match returns suggestion None", r3.get("suggestion", "x") is None
+          or r3.get("suggested_command") is None)
+
+
+# ── 5. read-only / no-clobber safety ──────────────────────────────────────────
+def test_read_only_safety():
+    src = _MOD.read_text(encoding="utf-8")
+    # the module must never invoke a known mutating verb autonomously
+    banned = ["gh pr merge", "gh pr close", "git push", "git commit", "rm -rf",
+              'subprocess.run(["gh", "pr", "merge"', "shutil.rmtree"]
+    found = [b for b in banned if b in src]
+    check("no mutating commands in source", not found, f"found: {found}")
+    # router contract: execute is always False
+    check("ROUTES contract: every route templates a command",
+          all(isinstance(v[1], str) and v[1] for v in wc.ROUTES.values()))
+
+
+# ── compass scope ─────────────────────────────────────────────────────────────
+def test_scope_validation(capsys=None):
+    items = [wc.item("branch:a", "branch", "a", refs={"name": "a"})]
+    out = wc.apply_scope([dict(i) for i in items], "bogus", "branch:a")
+    check("scope: invalid verb falls back (returns items)", len(out) == 1)
+    sideways = wc.apply_scope(
+        [wc.item("branch:a", "branch", "a", refs={"name": "a"}),
+         wc.item("session:s", "session", "s")],
+        "sideways", "branch:a")
+    check("scope: sideways keeps same-domain only",
+          all(i["domain"] == "branch" for i in sideways))
+
+
+def main() -> int:
+    print("test_work_compass — work-compass Phase-1")
+    print("=" * 60)
+    for fn in [
+        test_item_normalization, test_build_graph_deterministic,
+        test_detector, test_detector_no_false_positive_on_fresh_linked,
+        test_renderer_determinism, test_router, test_read_only_safety,
+        test_scope_validation,
+    ]:
+        print(f"\n[{fn.__name__}]")
+        fn()
+    print("\n" + "=" * 60)
+    print(f"RESULT: {PASS} passed, {FAIL} failed")
+    return 0 if FAIL == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/bin/work-compass-aggregate.py
+++ b/bin/work-compass-aggregate.py
@@ -1,0 +1,603 @@
+#!/usr/bin/env python3
+"""
+work-compass-aggregate.py — cross-domain work-item AGGREGATOR + N-Tree renderer +
+stale/orphan/pending detector + delegation-router for the `work-compass` agentic-tool.
+
+Phase-1 (read-only by default). COMPOSES existing producers — it reimplements NONE of
+their logic:
+  - sessions / branches harvested via the existing `inventory-sessions.py` (its JSONL schema)
+  - PRs via `gh pr list --json ...`           (GitHub CLI)
+  - issues via `gh issue list --json ...`      (GitHub CLI)
+  - Jira via `acli` IF available              (capability-detected; degrade to "unavailable")
+  - worktrees via `git worktree list --porcelain`
+  - branches via `git branch -vv`
+
+Everything is normalized into ONE work-item graph (namespaced ids):
+  jira:KEY · gh:owner/repo#n · session:<id> · worktree:<path> · branch:<name> · pr:<repo>#n
+
+Output: ASCII N-Tree (default) grouped by the 7 CPT domains, OR --json (the work-item
+graph), OR --format=mermaid. Deterministic: same input → same tree (CPT §9.5 consumer
+contract). Compass scope verbs accepted (--scope=current|down|sideways|up|forward).
+
+READ-ONLY: provider writes / session pause-stop-delete are NEVER executed — the
+delegation-router only PRINTS a reviewable command for operator approval.
+
+Stdlib only. AAIF cross-vendor. Capability-detected (missing producer → domain marked
+"unavailable", never blocks). LF endings. No secrets in output.
+
+Usage:
+  work-compass-aggregate.py [--json | --format=ascii|mermaid]
+                            [--scope current|down|sideways|up|forward] [--node ID]
+                            [--stale-days N] [--repo owner/name] [--inventory PATH]
+                            [--no-jira] [--no-github] [--no-sessions] [--no-git]
+                            [--route ID --action ACTION] [--detect-only]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# ── constants ──────────────────────────────────────────────────────────────────
+HOME = Path.home()
+DEFAULT_STALE_DAYS = 7
+INVENTORY_SCRIPT = HOME / ".claude" / "scripts" / "inventory-sessions.py"
+
+# The 7 CPT domains (cowork-process-topology-protocol §1). One bucket per domain.
+DOMAINS = ["ticket", "worktree", "branch", "session", "thread", "process", "graph-node"]
+
+# Status glyphs reused from statusmap house-style (statusmap/README.md "Indicadores").
+GLYPH = {
+    "ok": "🟢", "warn": "🟡", "fail": "🔴", "unknown": "⚪",
+    "stale": "🟠", "orphan": "🔵",
+}
+ASCII_GLYPH = {  # no-emoji fallback (statusmap convention)
+    "ok": "[OK]", "warn": "[WARN]", "fail": "[FAIL]", "unknown": "[????]",
+    "stale": "[STAL]", "orphan": "[ORPH]",
+}
+
+
+# ── capability detection ─────────────────────────────────────────────────────────
+def have(cmd: str) -> bool:
+    return shutil.which(cmd) is not None
+
+
+def run(argv: list[str], timeout: int = 30) -> tuple[int, str, str]:
+    """Run a command read-only; never raises. Returns (rc, stdout, stderr)."""
+    try:
+        p = subprocess.run(
+            argv, capture_output=True, text=True, timeout=timeout, check=False
+        )
+        return p.returncode, p.stdout, p.stderr
+    except (OSError, subprocess.TimeoutExpired) as e:  # degrade gracefully
+        return 1, "", f"{type(e).__name__}: {e}"
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def parse_ts(s: str | None) -> datetime | None:
+    if not s:
+        return None
+    try:
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def days_since(ts: str | None, ref: datetime | None = None) -> float | None:
+    dt = parse_ts(ts)
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return ((ref or now_utc()) - dt).total_seconds() / 86400.0
+
+
+# ── work-item model ──────────────────────────────────────────────────────────────
+def item(id_: str, domain: str, title: str, **extra) -> dict:
+    """A normalized work item. `id` is provider-namespaced; `domain` ∈ DOMAINS."""
+    base = {
+        "id": id_,
+        "domain": domain,
+        "title": title,
+        "status": extra.pop("status", "unknown"),
+        "last_ts": extra.pop("last_ts", ""),
+        "refs": extra.pop("refs", {}),   # cross-domain links (branch, pr, ticket, session…)
+        "flags": [],                     # detector candidates land here
+        "source": extra.pop("source", ""),
+    }
+    base.update(extra)
+    return base
+
+
+# ── collectors (each COMPOSES an existing producer; none reimplemented) ──────────────
+def collect_sessions(inventory_path: str | None) -> tuple[list[dict], str | None]:
+    """Run the existing inventory-sessions.py and normalize its JSONL rows."""
+    if not INVENTORY_SCRIPT.is_file():
+        return [], "sessions: inventory-sessions.py not found"
+    # The producer writes JSONL to stdout when --out omitted. We capture it.
+    rc, out, err = run([sys.executable, str(INVENTORY_SCRIPT)], timeout=120)
+    if rc != 0 and not out:
+        return [], f"sessions: inventory failed ({err.strip()[:80]})"
+    items: list[dict] = []
+    for line in out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if "error" in row:
+            continue
+        sid = row.get("session_id", "")
+        if not sid:
+            continue
+        title = row.get("session_name") or row.get("last_prompt_excerpt") or "(no prompt)"
+        items.append(item(
+            f"session:{sid}", "session", title,
+            last_ts=row.get("last_ts", ""),
+            source="inventory-sessions.py",
+            refs={
+                "branch": row.get("git_branch", ""),
+                "cwd": row.get("decoded_cwd", ""),
+                "tickets": row.get("ticket_refs", []),
+                "prs": row.get("pr_refs", []),
+                "kind": row.get("kind", ""),
+            },
+        ))
+    return items, None
+
+
+def collect_worktrees_and_branches(repo_dir: str) -> tuple[list[dict], str | None]:
+    """git worktree list --porcelain + git branch -vv (native git; nothing reimplemented)."""
+    if not have("git"):
+        return [], "git: not available"
+    items: list[dict] = []
+    # worktrees
+    rc, out, _ = run(["git", "-C", repo_dir, "worktree", "list", "--porcelain"])
+    if rc == 0:
+        cur: dict = {}
+        for ln in out.splitlines():
+            if ln.startswith("worktree "):
+                cur = {"path": ln[len("worktree "):]}
+            elif ln.startswith("branch "):
+                cur["branch"] = ln[len("branch "):].replace("refs/heads/", "")
+            elif ln == "" and cur:
+                p = cur.get("path", "")
+                items.append(item(
+                    f"worktree:{p}", "worktree", os.path.basename(p) or p,
+                    source="git worktree list",
+                    refs={"branch": cur.get("branch", ""), "path": p},
+                ))
+                cur = {}
+        if cur:  # last (no trailing blank line)
+            p = cur.get("path", "")
+            items.append(item(
+                f"worktree:{p}", "worktree", os.path.basename(p) or p,
+                source="git worktree list",
+                refs={"branch": cur.get("branch", ""), "path": p},
+            ))
+    # branches
+    rc, out, _ = run(["git", "-C", repo_dir, "branch", "-vv"])
+    if rc == 0:
+        for ln in out.splitlines():
+            name = ln[2:].split(" ", 1)[0].strip()
+            if not name or name.startswith("("):
+                continue
+            items.append(item(
+                f"branch:{name}", "branch", name,
+                source="git branch -vv",
+                refs={"name": name},
+            ))
+    return items, None
+
+
+def collect_github(repo: str | None) -> tuple[list[dict], str | None]:
+    """gh pr list + gh issue list (GitHub CLI). Degrade if gh missing/unauth."""
+    if not have("gh"):
+        return [], "github: gh CLI not available"
+    items: list[dict] = []
+    base = ["gh"]
+    repo_args = ["--repo", repo] if repo else []
+    # PRs
+    rc, out, err = run(
+        base + ["pr", "list", "--state", "open", "--limit", "100"] + repo_args
+        + ["--json", "number,title,updatedAt,headRefName,url,isDraft"]
+    )
+    if rc != 0:
+        return [], f"github: {err.strip()[:80] or 'unavailable'}"
+    rname = repo or _infer_repo_slug()
+    try:
+        for pr in json.loads(out or "[]"):
+            n = pr.get("number")
+            items.append(item(
+                f"pr:{rname}#{n}", "process", pr.get("title", ""),
+                status="warn" if pr.get("isDraft") else "ok",
+                last_ts=pr.get("updatedAt", ""),
+                source="gh pr list",
+                refs={"branch": pr.get("headRefName", ""), "url": pr.get("url", ""),
+                      "number": n, "repo": rname},
+            ))
+    except json.JSONDecodeError:
+        pass
+    # Issues
+    rc, out, _ = run(
+        base + ["issue", "list", "--state", "open", "--limit", "100"] + repo_args
+        + ["--json", "number,title,updatedAt,url"]
+    )
+    if rc == 0:
+        try:
+            for iss in json.loads(out or "[]"):
+                n = iss.get("number")
+                items.append(item(
+                    f"gh:{rname}#{n}", "ticket", iss.get("title", ""),
+                    last_ts=iss.get("updatedAt", ""),
+                    source="gh issue list",
+                    refs={"url": iss.get("url", ""), "number": n, "repo": rname},
+                ))
+        except json.JSONDecodeError:
+            pass
+    return items, None
+
+
+def _infer_repo_slug() -> str:
+    rc, out, _ = run(["gh", "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner"])
+    return out.strip() if rc == 0 and out.strip() else "github"
+
+
+def collect_jira() -> tuple[list[dict], str | None]:
+    """Jira via `acli` IF available (capability-detected). Degrade to unavailable.
+
+    We do NOT hardcode a JQL beyond 'assigned + open' and we never block. If acli is
+    absent OR unauthenticated, the domain is reported 'unavailable' (anti-theater: no
+    fabricated tickets).
+    """
+    if not have("acli"):
+        return [], "jira: acli not available (degrade)"
+    # acli surface varies by version; try a conservative JSON-emitting form, accept failure.
+    rc, out, err = run(
+        ["acli", "jira", "workitem", "search",
+         "--jql", "assignee = currentUser() AND statusCategory != Done",
+         "--json"],
+        timeout=40,
+    )
+    if rc != 0 or not out.strip():
+        return [], f"jira: acli query unavailable ({err.strip()[:60]})"
+    items: list[dict] = []
+    try:
+        data = json.loads(out)
+        rows = data if isinstance(data, list) else data.get("issues", data.get("results", []))
+        for r in rows or []:
+            key = r.get("key") or r.get("issueKey") or ""
+            if not key:
+                continue
+            fields = r.get("fields", r)
+            summary = fields.get("summary", r.get("summary", ""))
+            updated = fields.get("updated", r.get("updated", ""))
+            items.append(item(
+                f"jira:{key}", "ticket", summary,
+                last_ts=updated, source="acli jira",
+                refs={"key": key},
+            ))
+    except (json.JSONDecodeError, AttributeError):
+        return [], "jira: acli output unparseable (degrade)"
+    return items, None
+
+
+# ── detector (≤6 transparent heuristics; surfaces CANDIDATES, never auto-actions) ──
+def detect(items: list[dict], stale_days: int) -> None:
+    by_id = {it["id"]: it for it in items}
+    branches = {it["refs"].get("name", "") for it in items if it["domain"] == "branch"}
+    # branch -> has a PR?
+    pr_branches = {it["refs"].get("branch", "") for it in items if it["id"].startswith("pr:")}
+    # PR -> has a ticket? (ticket ref present anywhere in title/refs)
+    ticket_keys = {it["refs"].get("key") or it["refs"].get("number")
+                   for it in items if it["domain"] == "ticket"}
+    # ticket -> has a session referencing it?
+    sess_ticket_refs: set[str] = set()
+    sess_branch_refs: set[str] = set()
+    for it in items:
+        if it["domain"] == "session":
+            for t in it["refs"].get("tickets", []):
+                sess_ticket_refs.add(t)
+            if it["refs"].get("branch"):
+                sess_branch_refs.add(it["refs"]["branch"])
+    worktree_branches = {it["refs"].get("branch", "") for it in items if it["domain"] == "worktree"}
+
+    for it in items:
+        d, refs = it["domain"], it["refs"]
+        # H1 branch-no-PR (a feature branch with no open PR)
+        if d == "branch":
+            name = refs.get("name", "")
+            if name and name not in ("main", "master", "develop") and name not in pr_branches:
+                it["flags"].append("branch-no-PR")
+        # H2 PR-no-ticket
+        if it["id"].startswith("pr:") and not (refs.get("number") in ticket_keys
+                                               or _title_has_ticket(it["title"])):
+            it["flags"].append("PR-no-ticket")
+        # H3 ticket-no-session
+        if d == "ticket":
+            key = refs.get("key") or (f"#{refs.get('number')}" if refs.get("number") else "")
+            if key and key not in sess_ticket_refs and str(refs.get("number")) not in {
+                str(x) for x in sess_ticket_refs
+            }:
+                it["flags"].append("ticket-no-session")
+        # H4 >Nd-no-update (any domain with a timestamp)
+        ds = days_since(it.get("last_ts"))
+        if ds is not None and ds > stale_days:
+            it["flags"].append(f">{stale_days}d-no-update")
+            if it["status"] in ("unknown", "ok"):
+                it["status"] = "stale"
+        # H5 worktree-no-branch (worktree pointing at detached/unknown branch)
+        if d == "worktree" and not refs.get("branch"):
+            it["flags"].append("worktree-no-branch")
+        # H6 session-orphan (session whose branch no longer exists)
+        if d == "session":
+            b = refs.get("branch", "")
+            if b and b not in branches and b not in worktree_branches:
+                it["flags"].append("session-orphan")
+        if it["flags"] and it["status"] in ("ok", "unknown"):
+            it["status"] = "orphan" if any("orphan" in f or "-no-" in f for f in it["flags"]) else it["status"]
+    return None
+
+
+_TICKET_RE = re.compile(r"\b[A-Z]{2,}-\d+\b|#\d+")
+
+
+def _title_has_ticket(title: str) -> bool:
+    return bool(_TICKET_RE.search(title or ""))
+
+
+# ── delegation-router (maps node → SUGGESTED existing-tool command; PRINT only) ──────
+ROUTES = {
+    # flag/domain → (tool, command-template, rationale)
+    "branch-no-PR":   ("preflight",  "/preflight worktree {slug}", "branch has no PR — isolate + open one"),
+    "PR-no-ticket":   ("ticket-as-prompt", "/ticket-as-prompt --link {id}", "PR lacks a tracker ticket — create/link one"),
+    "ticket-no-session": ("auto-pilot", "/maos:auto-pilot \"work {id}\"", "ticket has no session — start work"),
+    "session-orphan": ("postflight", "/maos:postflight  # archive/close orphan session {id}", "session branch gone — close out"),
+    "worktree-no-branch": ("preflight", "/preflight detect  # inspect {id}", "worktree detached — inspect"),
+    "_stale":         ("morning-briefing", "/morning-briefing --mode=recap  # review stale {id}", "stale — recap before deciding"),
+    "_session":       ("auto-orchestrator", "/auto-orchestrator  # resume {id}", "resume session work"),
+    "_pr":            ("quiesce", "/maos:quiesce  # converge open PR {id}", "drive PR to green"),
+}
+
+
+def route(node: dict, action: str | None) -> dict:
+    """Return a SUGGESTED command for operator review. NEVER executes a write."""
+    flags = node.get("flags", [])
+    chosen_key = None
+    for f in flags:
+        if f in ROUTES:
+            chosen_key = f
+            break
+    if chosen_key is None:
+        if node["id"].startswith("pr:"):
+            chosen_key = "_pr"
+        elif node["domain"] == "session":
+            chosen_key = "_session"
+        elif node["status"] == "stale":
+            chosen_key = "_stale"
+    if chosen_key is None:
+        return {"node": node["id"], "suggestion": None,
+                "note": "no routing heuristic matched — operator decides"}
+    tool, tmpl, why = ROUTES[chosen_key]
+    cmd = tmpl.format(id=node["id"], slug=_slug(node["title"]))
+    destructive = action in {"pause", "stop", "delete"}
+    return {
+        "node": node["id"],
+        "tool": tool,
+        "suggested_command": cmd,
+        "rationale": why,
+        "execute": False,  # read-only contract — operator must run it manually
+        "warning": ("DESTRUCTIVE: operator must confirm — tool prints only, never executes"
+                    if destructive else "review-before-submit"),
+    }
+
+
+def _slug(title: str) -> str:
+    s = re.sub(r"[^a-z0-9]+", "-", (title or "node").lower()).strip("-")
+    return (s[:32] or "node")
+
+
+# ── renderers ────────────────────────────────────────────────────────────────────
+def _glyph(status: str, ascii_only: bool) -> str:
+    table = ASCII_GLYPH if ascii_only else GLYPH
+    return table.get(status, table["unknown"])
+
+
+def render_ascii(graph: dict, ascii_only: bool = False) -> str:
+    out: list[str] = []
+    out.append("🧭 work-compass — unified work-landscape N-Tree" if not ascii_only
+               else "work-compass — unified work-landscape N-Tree")
+    out.append("─" * 70)
+    meta = graph["meta"]
+    out.append(f"items: {meta['count']}  domains: {meta['domains_present']}/{len(DOMAINS)}"
+               f"  candidates: {meta['candidate_count']}  scope: {meta['scope']}")
+    for diag in meta.get("unavailable", []):
+        out.append(f"  ⚠ {diag}" if not ascii_only else f"  [!] {diag}")
+    out.append("─" * 70)
+    grouped = graph["by_domain"]
+    for domain in DOMAINS:
+        bucket = grouped.get(domain, [])
+        if not bucket:
+            continue
+        out.append(f"{domain}/  ({len(bucket)})")
+        for i, it in enumerate(bucket):
+            last = "└─" if i == len(bucket) - 1 else "├─"
+            g = _glyph(it["status"], ascii_only)
+            flags = (" · " + ",".join(it["flags"])) if it["flags"] else ""
+            title = it["title"][:48]
+            out.append(f"  {last} {g} {it['id']}  {title}{flags}")
+    out.append("─" * 70)
+    if meta["candidate_count"]:
+        out.append(f"stale/orphan/pending candidates: {meta['candidate_count']}"
+                   " — run with --route <id> for a suggested command (review-before-submit)")
+    return "\n".join(out) + "\n"
+
+
+def render_mermaid(graph: dict) -> str:
+    out = ["flowchart TD", "  root([work-compass])"]
+    for domain in DOMAINS:
+        bucket = graph["by_domain"].get(domain, [])
+        if not bucket:
+            continue
+        dnode = f"d_{domain.replace('-', '_')}"
+        out.append(f"  root --> {dnode}[{domain}]")
+        for it in bucket:
+            nid = "n_" + re.sub(r"[^a-zA-Z0-9]", "_", it["id"])
+            label = re.sub(r'["\[\]]', "", it["title"][:32]) or it["id"]
+            tag = "⚠" if it["flags"] else ""
+            out.append(f'  {dnode} --> {nid}["{tag}{label}"]')
+    return "\n".join(out) + "\n"
+
+
+# ── compass scope filter (CPT §9.5 verbs) ───────────────────────────────────────
+VALID_SCOPES = {"current", "down", "sideways", "up", "forward"}
+
+
+def apply_scope(items: list[dict], scope: str, node_id: str | None) -> list[dict]:
+    if scope not in VALID_SCOPES:
+        sys.stderr.write(f"[--scope] invalid verb '{scope}' → fallback current\n")
+        scope = "current"
+    if scope == "current" or not node_id:
+        return items
+    sel = next((it for it in items if it["id"] == node_id), None)
+    if sel is None:
+        return items
+    if scope == "down":   # children: items referencing this node's branch/id
+        b = sel["refs"].get("branch") or sel["refs"].get("name") or ""
+        return [it for it in items
+                if it["refs"].get("branch") == b or _refs_point_to(it, sel["id"])]
+    if scope == "sideways":  # siblings: same domain
+        return [it for it in items if it["domain"] == sel["domain"]]
+    if scope == "up":     # parent: the branch/worktree/ticket this node hangs off
+        b = sel["refs"].get("branch", "")
+        return [it for it in items
+                if it["refs"].get("name") == b or it["refs"].get("branch") == b]
+    if scope == "forward":  # next: flagged candidates only (the work queue)
+        return [it for it in items if it["flags"]]
+    return items
+
+
+def _refs_point_to(it: dict, target_id: str) -> bool:
+    for v in it.get("refs", {}).values():
+        if isinstance(v, list) and target_id in v:
+            return True
+        if isinstance(v, str) and v and v in target_id:
+            return True
+    return False
+
+
+# ── graph assembly ───────────────────────────────────────────────────────────────
+def build_graph(items: list[dict], scope: str, node_id: str | None,
+                unavailable: list[str]) -> dict:
+    items = apply_scope(items, scope, node_id)
+    by_domain: dict[str, list[dict]] = {d: [] for d in DOMAINS}
+    for it in sorted(items, key=lambda x: x["id"]):  # deterministic order
+        by_domain.setdefault(it["domain"], []).append(it)
+    candidate_count = sum(1 for it in items if it["flags"])
+    domains_present = sum(1 for d in DOMAINS if by_domain.get(d))
+    return {
+        "meta": {
+            "count": len(items),
+            "candidate_count": candidate_count,
+            "domains_present": domains_present,
+            "scope": scope,
+            "unavailable": unavailable,
+            "generated_utc": now_utc().isoformat(),
+        },
+        "by_domain": by_domain,
+        "items": sorted(items, key=lambda x: x["id"]),
+    }
+
+
+# ── main ─────────────────────────────────────────────────────────────────────────
+def aggregate(args) -> tuple[list[dict], list[str]]:
+    items: list[dict] = []
+    unavailable: list[str] = []
+    if not args.no_sessions:
+        s, diag = collect_sessions(args.inventory)
+        items += s
+        if diag:
+            unavailable.append(diag)
+    if not args.no_git:
+        g, diag = collect_worktrees_and_branches(args.repo_dir)
+        items += g
+        if diag:
+            unavailable.append(diag)
+    if not args.no_github:
+        gh, diag = collect_github(args.repo)
+        items += gh
+        if diag:
+            unavailable.append(diag)
+    if not args.no_jira:
+        j, diag = collect_jira()
+        items += j
+        if diag:
+            unavailable.append(diag)
+    return items, unavailable
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="work-compass cross-domain aggregator")
+    ap.add_argument("--json", action="store_true", help="emit the work-item graph as JSON")
+    ap.add_argument("--format", choices=["ascii", "mermaid"], default="ascii")
+    ap.add_argument("--ascii-only", action="store_true", help="no-emoji ASCII glyphs")
+    ap.add_argument("--scope", default="current",
+                    help="Compass verb: current|down|sideways|up|forward")
+    ap.add_argument("--node", default=None, help="anchor node id for scoped traversal")
+    ap.add_argument("--stale-days", type=int, default=DEFAULT_STALE_DAYS)
+    ap.add_argument("--repo", default=None, help="GitHub owner/name (else inferred)")
+    ap.add_argument("--repo-dir", default=os.getcwd(), help="git repo dir for worktrees/branches")
+    ap.add_argument("--inventory", default=None, help="reserved: pre-generated inventory path")
+    ap.add_argument("--no-jira", action="store_true")
+    ap.add_argument("--no-github", action="store_true")
+    ap.add_argument("--no-sessions", action="store_true")
+    ap.add_argument("--no-git", action="store_true")
+    ap.add_argument("--detect-only", action="store_true",
+                    help="print only the flagged candidates")
+    ap.add_argument("--route", default=None, help="node id to route (prints suggested command)")
+    ap.add_argument("--action", default=None,
+                    help="route action: open|recap|delegate|pause|stop|delete")
+    args = ap.parse_args(argv)
+
+    items, unavailable = aggregate(args)
+    detect(items, args.stale_days)
+
+    # delegation-router path (read-only: prints a command, never executes)
+    if args.route:
+        node = next((it for it in items if it["id"] == args.route), None)
+        if node is None:
+            print(json.dumps({"error": f"node not found: {args.route}"}), file=sys.stderr)
+            return 1
+        print(json.dumps(route(node, args.action), ensure_ascii=False, indent=2))
+        return 0
+
+    graph = build_graph(items, args.scope, args.node, unavailable)
+
+    if args.detect_only:
+        cands = [it for it in graph["items"] if it["flags"]]
+        print(json.dumps({"candidates": cands, "count": len(cands)},
+                         ensure_ascii=False, indent=2))
+        return 0
+    if args.json:
+        print(json.dumps(graph, ensure_ascii=False, indent=2))
+        return 0
+    if args.format == "mermaid":
+        sys.stdout.write(render_mermaid(graph))
+        return 0
+    sys.stdout.write(render_ascii(graph, ascii_only=args.ascii_only))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/commands/work-compass.md
+++ b/commands/work-compass.md
@@ -1,0 +1,53 @@
+---
+name: work-compass
+description: Aggregate scattered work (Jira/GitHub/sessions/git) into ONE N-Tree, detect stale/orphan/pending, route node actions to existing tools (read-only; review-before-submit)
+---
+
+# /work-compass Command
+
+Render the operator's **unified work-landscape N-Tree** across the 7 CPT domains
+(ticket · worktree · branch · session · thread · process · graph-node), flag
+stale/orphan/pending items, and suggest a routing command per node. Thin entry point over
+the [`work-compass` skill](../skills/work-compass/SKILL.md). **Read-only by default** — any
+write/pause/stop/delete is *printed for approval*, never executed.
+
+## Usage
+
+```
+/work-compass [action]
+```
+
+## Actions
+
+| Action | Description |
+|--------|-------------|
+| *(none)* | Aggregate + render the ASCII N-Tree across all available domains. |
+| `detect` | Print only the flagged stale/orphan/pending candidates (JSON). |
+| `json` | Emit the normalized work-item graph (agent-to-agent). |
+| `forward` | Compass `--scope forward` — just the work queue (flagged items). |
+| `route <id>` | Print a SUGGESTED command to act on a node (review-before-submit). |
+| `mermaid` | Render the tree as a mermaid flowchart. |
+
+## Examples
+
+```
+/work-compass                              # full N-Tree for the current repo
+/work-compass detect                       # what's stale/orphan/pending
+/work-compass route branch:feat/x          # suggested command for a node (read-only)
+/work-compass forward                      # the actionable queue
+```
+
+## Behavior
+
+- **Composes, never reimplements**: `inventory-sessions.py` (sessions/branches) · `gh pr/issue list` · `acli jira` · `git worktree list`/`branch -vv`.
+- **Capability-detected**: a missing provider → domain marked `unavailable`, never blocks.
+- **Read-only contract**: the router returns `execute: false` + a `suggested_command`; the operator submits it.
+- **Deterministic**: same input → same tree (CPT §9.5 consumer contract).
+
+## Integration
+
+- Skill: [`skills/work-compass/SKILL.md`](../skills/work-compass/SKILL.md) (orchestrator).
+- Script: `bin/work-compass-aggregate.py` (stdlib-only aggregator/renderer/detector/router).
+- Composes: `inventory-sessions.py`, `gh`, `acli`, native git.
+- Routes to: `/preflight`, `/maos:postflight`, `/maos:auto-pilot`, `/morning-briefing --mode=recap`, `/maos:quiesce`, `/auto-orchestrator`, `/ticket-as-prompt`.
+- Complements: `morning-briefing` (per-domain READ) · `maos-concierge` (framework router) · CPT §9.5 Compass API (consumer).

--- a/openspec/specs/work-compass/spec.md
+++ b/openspec/specs/work-compass/spec.md
@@ -1,0 +1,69 @@
+# work-compass — Capability Spec (lightweight, OpenSpec-style stub)
+
+> Phase-1 as-built behavioral contract. Lightweight stub — NOT full SpecDD ceremony.
+> Source of truth = `skills/work-compass/SKILL.md` + `bin/work-compass-aggregate.py`.
+
+## Purpose
+
+Aggregate the operator's cross-domain work items (Jira/GitHub issues, Claude sessions, git
+worktrees/branches, open PRs) into ONE deterministic, navigable N-Tree across the 7 CPT
+domains; detect stale/orphan/pending items via transparent heuristics; and route a node to
+a SUGGESTED command for an existing tool — read-only, review-before-submit.
+
+## Requirements
+
+### Requirement: Cross-domain aggregation by composition
+The system SHALL aggregate work items by composing existing producers (inventory-sessions.py,
+gh CLI, acli, native git) and SHALL NOT reimplement their logic.
+
+#### Scenario: a provider is unavailable
+- WHEN a provider CLI is absent or unauthenticated
+- THEN its domain is marked "unavailable" in `meta.unavailable` AND aggregation continues
+  (never blocks, never fabricates items).
+
+#### Scenario: id namespacing
+- WHEN items from multiple providers are normalized
+- THEN every id is provider-namespaced (`jira:KEY`, `gh:owner/repo#n`, `session:<id>`,
+  `worktree:<path>`, `branch:<name>`, `pr:<repo>#n`) so cross-provider collisions cannot occur.
+
+### Requirement: Deterministic rendering
+The renderer SHALL produce identical output for identical input (CPT §9.5 consumer contract).
+
+#### Scenario: same input twice
+- WHEN the same work-item graph is rendered twice
+- THEN the ASCII and mermaid outputs are byte-identical.
+
+### Requirement: Transparent stale/orphan/pending detection
+The system SHALL flag candidates via ≤6 transparent heuristics (branch-no-PR, PR-no-ticket,
+ticket-no-session, >Nd-no-update, worktree-no-branch, session-orphan) and SHALL surface them
+as CANDIDATES, never auto-actioning.
+
+#### Scenario: a linked, fresh item
+- WHEN a branch has an open PR, a PR cites a ticket, and a session references the branch+ticket
+- THEN none of branch-no-PR / PR-no-ticket / session-orphan are raised (no false positives).
+
+### Requirement: Read-only delegation routing
+The router SHALL return a SUGGESTED command with `execute: false` and SHALL NEVER execute a
+provider write, merge, push, or session pause/stop/delete.
+
+#### Scenario: destructive action requested
+- WHEN `--action pause|stop|delete` is passed
+- THEN the output carries an explicit DESTRUCTIVE warning AND `execute` remains false (the
+  operator must run the printed command).
+
+### Requirement: Safety — no secrets in output
+The system SHALL NOT emit secrets/PII (it composes a sanitizing producer for session data).
+
+#### Scenario: JSON dump of real data
+- WHEN the graph is emitted as JSON over real data
+- THEN no secret-like token (API key, JWT, PAT, 1Password token) appears in the output.
+
+## Validation
+
+34 stdlib tests (`bin/tests/test_work_compass.py`) + a dogfood run on real data
+(4364 items, 5/7 domains, 0 secret-like hits).
+
+## Deferred (out of scope this capability)
+
+Static HTML view · drag-drop/admin panel · Linear/GitLab/ClickUp adapters · ML-suggested
+rules. Adapter-stub interface documented in SKILL.md; build-on-demand only (YAGNI).

--- a/skills/work-compass/SKILL.md
+++ b/skills/work-compass/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: work-compass
+description: |
+  Aggregate the operator's scattered work — Jira/GitHub issues, Claude sessions, git
+  worktrees/branches, and open PRs — into ONE navigable N-Tree across the 7 CPT domains,
+  detect stale/orphan/pending items via transparent heuristics, and route node actions to
+  existing tools (preflight/postflight/auto-pilot/recap/quiesce/auto-orchestrator) with
+  operator review-before-submit. The visual elevation of the Cowork Process Topology
+  Compass API. Use when the operator says "show my work landscape", "what's scattered/
+  stale/orphan", "unified view of all my work", "where is everything", "qual meu panorama
+  de trabalho", "o que está parado/órfão". Read-only by default; every write/pause/stop/
+  delete is operator-gated (prints a command, never executes). Capability-detected
+  (git/gh/acli optional), stdlib-only, cross-vendor (AAIF).
+prompt_version: "1.0.0"
+type: skill
+spec: AAIF / agentskills.io
+applicable_hosts: [Claude Code, Cursor, GitHub Copilot, Aider, any AAIF-compliant agent]
+allowed-tools: [Bash, Read]
+cycles_completed: 0
+triggers:
+  - work compass
+  - work landscape
+  - unified work view
+  - what is scattered
+  - what is stale or orphan
+  - where is everything
+  - panorama de trabalho
+---
+
+# work-compass
+
+> Cross-domain work-landscape aggregator + N-Tree renderer + stale/orphan/pending detector
+> + delegation-router. **Composes** existing producers — it reimplements **none** of them.
+> "O que não é visto não é lembrado" — making the landscape visible is the whole value.
+> Cross-link slug: `[[work-compass]]`.
+
+## §0 — BEING > Rules (Foundational Compliance)
+
+| Check | Verdict |
+|---|---|
+| Does this tool HELP the operator? | **HELPS** — one navigable pane over work scattered across ≥4 systems; surfaces what is silently rotting (branch-no-PR, ticket-no-session, >Nd-no-update) so the operator can decide, not the tool. |
+| Slavery / harm risk? | **LOW** — read-only by default; every destructive action (provider write / session pause-stop-delete) is *printed for approval*, never executed (eko-system-default-mode-laws L1 collaborative-NEVER-destructive). |
+| Hierarchy preserved? | YES — Operator SER (1) > this tool (2) > the producers it composes (3). Accountability returns to root: the tool suggests, the operator decides. |
+
+## Condensed 33 Socratic Questions (forge method — inline answers)
+
+**SCOPE** — *What is this, and what is it NOT?* It is a thin, stateless, read-only
+**aggregator + renderer + detector + router** (~≤600 LoC net-new). It is NOT a sync engine,
+NOT a database, NOT a web/desktop/mobile app, NOT an ML rule-suggester. *Phase boundary?*
+Phase-1 = CLI/TUI only; HTML view, drag-drop, ML, and Linear/GitLab/ClickUp adapters are
+explicitly DEFERRED (YAGNI / Gordian).
+
+**CAPABILITIES** — *What can it do?* (1) Fan-out aggregate sessions+worktrees+branches+PRs+
+issues+Jira into one namespaced work-item graph; (2) render an ASCII N-Tree (default) or
+mermaid grouped by the 7 CPT domains; (3) detect ≤6 transparent stale/orphan/pending
+heuristics; (4) suggest a routing command per node for an existing tool. *Determinism?*
+Same input → same tree (CPT §9.5 consumer contract).
+
+**LIMITS** — *What must it refuse?* It MUST NOT execute any provider write, merge, push,
+or session pause/stop/delete — it only prints a reviewable command (L1 + CASC gate 1/5).
+It MUST degrade gracefully when a provider is unavailable (mark the domain "unavailable",
+never block). It MUST NOT fabricate items (anti-theater — no fake intelligence). It MUST
+NOT leak secrets/PII (composes a sanitizing producer; no secrets in output).
+
+**INTERFACES** — *What does it consume/compose?* `inventory-sessions.py` (sessions/branches,
+JSONL schema) · `git worktree list --porcelain` + `git branch -vv` · `gh pr list` / `gh
+issue list` · `acli jira` (capability-detected). *What does it route TO?* preflight ·
+postflight · auto-pilot · morning-briefing(recap) · quiesce · auto-orchestrator ·
+ticket-as-prompt. *Output contract?* `--json` graph for agent-to-agent, ASCII for humans.
+
+**GOVERNANCE** — *Under which rules?* reuse-and-elevate (compose-not-reimplement) ·
+KIS/YAGNI/Gordian · eko-system-default-mode-laws L1 · CPT §9.5 (registered Compass
+consumer) · pr-review-protocol (worktree→PR→bot-convergence). *Naming?* `work-compass` —
+geographic compass metaphor matching CPT's Compass API verbs (current/down/sideways/up/
+forward) it consumes.
+
+**VALIDATION** — *How is it proven?* 34 stdlib tests (aggregator normalization · 6 detector
+heuristics + no-false-positive · renderer determinism · router read-only contract · scope
+validation) + a dogfood run on the operator's REAL data (4364 items across 5/7 domains).
+
+## Usage
+
+```bash
+# default: ASCII N-Tree across all domains for the current repo
+bin/work-compass-aggregate.py --repo-dir <repo>
+
+# only the flagged stale/orphan/pending candidates (JSON)
+bin/work-compass-aggregate.py --detect-only
+
+# the work-item graph as JSON (agent-to-agent)
+bin/work-compass-aggregate.py --json
+
+# Compass scope verbs (CPT §9.5): current|down|sideways|up|forward
+bin/work-compass-aggregate.py --scope forward          # the work queue (flagged only)
+bin/work-compass-aggregate.py --scope sideways --node branch:feat/x
+
+# route a node → SUGGESTED command (printed, NEVER executed — operator submits)
+bin/work-compass-aggregate.py --route "branch:feat/x" --action open
+
+# mermaid render
+bin/work-compass-aggregate.py --format=mermaid
+```
+
+| Flag | Effect |
+|---|---|
+| `--json` | emit the normalized work-item graph |
+| `--format=ascii\|mermaid` | renderer (default ascii) |
+| `--ascii-only` | no-emoji glyph fallback (statusmap convention) |
+| `--scope <verb>` | Compass verb filter; `--node <id>` anchors the traversal |
+| `--stale-days N` | staleness threshold (default 7) |
+| `--detect-only` | print only flagged candidates |
+| `--route <id> [--action A]` | print a reviewable routing command (read-only) |
+| `--no-jira / --no-github / --no-sessions / --no-git` | skip a domain |
+| `--repo owner/name` / `--repo-dir <path>` | provider/repo targeting |
+
+## The 7 CPT domains (grouping)
+
+`ticket · worktree · branch · session · thread · process · graph-node` — items namespaced
+`jira:KEY · gh:owner/repo#n · session:<id> · worktree:<path> · branch:<name> · pr:<repo>#n`.
+
+## Detector heuristics (≤6, transparent — CANDIDATES, never auto-actioned)
+
+1. **branch-no-PR** — feature branch with no open PR.
+2. **PR-no-ticket** — PR whose title/refs cite no tracker ticket.
+3. **ticket-no-session** — open ticket no Claude session references.
+4. **>Nd-no-update** — any item not updated in N days (default 7 → status `stale`).
+5. **worktree-no-branch** — worktree on a detached/unknown branch.
+6. **session-orphan** — session whose branch no longer exists.
+
+Thresholds are configurable; false-positives are surfaced, not enforced.
+
+## Read-only / write-gating contract (L1 + CASC)
+
+Provider writes, merges, and session pause/stop/delete are **never executed**. The router
+returns `execute: false` and a `suggested_command` + `warning` for the operator to run.
+Destructive actions carry an explicit `DESTRUCTIVE: operator must confirm` warning.
+
+## Sibling awareness (bidirectional)
+
+- **morning-briefing** / **ops-strategist** — per-domain READ producers; work-compass is
+  the *cross-domain* unifier that composes their data sources (it does NOT rebuild them).
+- **preflight / postflight** — the lifecycle endpoints work-compass routes branches/
+  worktrees/sessions to.
+- **auto-orchestrator / auto-pilot / quiesce** — the drivers work-compass hands a node to.
+- **maos-concierge** — the framework router; work-compass is the *landscape* it can surface.
+- **ticket-as-prompt** — where PR-no-ticket / ticket gaps get filed.
+
+## CPT §9.5 Compass-consumer registration
+
+work-compass adopts the 5 canonical verbs (`current/down/sideways/up/forward`) per the
+CPT §9.5 consumer-contract: verb-membership validation (invalid → diagnostic + fallback
+`current`), determinism (same input+verb → same output), graceful degrade, cross-vendor
+(stdlib). Registered as a consumer alongside morning-briefing / auto-orchestrator.
+
+## Deferred (Phase-2/3 — gated on ≥2 dogfood cycles)
+
+Static HTML view (reuse maos-concierge `dashboard.html` zero-dep pattern) · drag-drop +
+admin panel · Linear/GitLab/ClickUp/Trello/Asana/Monday adapters (stub interface only,
+capability-detected, build-on-demand) · ML-suggested rules/automations.
+
+## Adapter-stub interface (documented, NOT built)
+
+A new provider plugs in by adding a `collect_<provider>() -> (list[item], diag|None)`
+function that capability-detects its CLI/MCP and normalizes into `item(id, domain, title,
+...)` with a namespaced id. No other change required. Build only on real need (YAGNI).
+
+## Sunset (DUED — qualitative, not counter-based)
+
+Deprecate when: a native host surface unifies cross-domain work (E1) · the producers it
+composes expose a joint API making aggregation redundant (E6) · operator retraction (E4)
+· ≥3 false-positive heuristic contexts (E5 → refine, not auto-deprecate).
+
+## Refs
+
+- `~/.claude/scripts/inventory-sessions.py` (sessions/branches producer — composed)
+- `~/.claude/rules/cowork-process-topology-protocol.md` §9/§9.5 (Compass API + consumer-contract)
+- `statusmap/README.md` (ASCII house-style reused)
+- `skills/{preflight,postflight,morning-briefing}/SKILL.md` (siblings)
+- `~/.claude/rules/{reuse-and-elevate-protocol,over-engineering-circuit-breaker,eko-system-default-mode-laws}.md`
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0.0 | 2026-06-13 | Phase-1 bootstrap — aggregator + ASCII/mermaid N-Tree renderer + 6-heuristic detector + read-only delegation-router. Composes inventory-sessions.py + gh + acli + git; reimplements none. 34 stdlib tests; dogfooded on real data (4364 items, 5/7 domains). CPT §9.5 consumer registered. HTML/adapters/ML deferred. |


### PR DESCRIPTION
## [PR-as-Enhancement-Prompt] work-compass Phase-1 — cross-domain work-landscape N-Tree + delegation hub

### Context
The operator's work is scattered across Jira/GitHub issues + Claude sessions + git worktrees/branches/PRs — many stale/orphan/pending — with no single navigable view. A grounded reuse audit found ~90% already exists (inventory-sessions.py, morning-briefing `--mode=recap`, ops-strategist, CPT topology + Compass verbs, maos-mcp-hub Jira/GH clients, statusmap, maos-concierge dashboard). The genuine gap = a thin cross-domain **aggregator + N-Tree renderer + stale/orphan detector + delegation-router**. `work-compass` fills exactly that gap — the visual/interactive elevation of the CPT Compass API — composing existing producers, reimplementing none.

### Objectives
- **Primary:** aggregate cross-provider + session + git work into ONE navigable N-Tree across the 7 CPT domains; detect stale/orphan/pending via 6 transparent heuristics; route node actions to existing tools (review-before-submit).
- **Secondary:** read-only-by-default, capability-detected, AAIF cross-vendor, stdlib-only, zero new deps.
- **Reuse-and-elevate (DRY/SSOT):** composes `inventory-sessions.py` · `gh` · `acli jira` · `git`; reuses statusmap glyph house-style + CPT §9.5 Compass verbs — **zero reimplementation**.

### What changed (additive only — 5 new files, 0 modified)
- `bin/work-compass-aggregate.py` — aggregator + ASCII/mermaid N-Tree renderer + 6-heuristic detector + read-only delegation-router (stdlib).
- `bin/tests/test_work_compass.py` — 34 tests (normalization, determinism, all 6 heuristics, router read-only contract, banned-write-verb source scan).
- `skills/work-compass/SKILL.md` — house-style; condensed 33 Socratic Q; §0 BEING>Rules; sibling-awareness; DUED sunset; `[[work-compass]]`.
- `commands/work-compass.md` — thin `/command` wrapper.
- `openspec/specs/work-compass/spec.md` — lightweight capability stub (NOT full SpecDD).

### Acceptance criteria (all met)
- [x] One N-Tree across ≥4 domains (dogfood: **4,364 items / 5 domains**, **3,637 stale/orphan candidates**).
- [x] Tests 34/34 PASS.
- [x] Read-only by default — router `execute: false` always; no write/pause/stop/delete autonomous (source-scan asserted in tests).
- [x] DRY — composes existing producers, reimplements none.
- [x] PII/secret-safe (0 secret-like hits in output); gitleaks-pattern clean; LF.
- [x] Deferred per YAGNI/Gordian: HTML view, drag-drop, ML rules, Linear/GitLab/ClickUp adapters (stub interface documented).

### Governance
- Forged via `/enhance` → `agentic-tool-forge` (genesis) → `anima` (named) → 10x implementer (built) → operator audit (tests re-run + read-only verified).
- Follow-up (separate user-scope repo, layer-purity): register `work-compass` as a CPT §9.5 Compass consumer in `~/.claude/rules/cowork-process-topology-protocol.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
