### PR TITLE
feat(skills): opera-debrief (narrative recap register) + promote content-recast to community

### DIFF
--- a/skills/content-recast/SKILL.md
+++ b/skills/content-recast/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: content-recast
+description: |
+  Use when you need to RE-TARGET a piece of your own technical content for a DIFFERENT audience,
+  abstraction level, intent, or language — then optionally render it in another format. E.g.
+  "adapt this for the CEO", "turn my technical work into daily-standup talking points",
+  "explain this migration to the PO", "re-target this for non-technical stakeholders",
+  "traduzir este conteúdo técnico para leigos", "vira um pitch / deck / one-pager disto",
+  "recast this for a junior dev". It DISTILLS the source faithfully, RECASTS it through a
+  named strategy lens (Minto · Feynman · progressive-disclosure · detail-preserving), runs a
+  FAITHFULNESS check (no unsupported claims) with an information-loss note, then hands off
+  rendering to existing producers (markdown · slides · one-pager PDF · NotebookLM source/prompt).
+  It re-targets COMMUNICATION; it does NOT re-engineer code/architecture (angular→flutter,
+  monolith→microservices) — for that use refactor/migration agents. Cross-vendor AAIF.
+triggers:
+  - adapt this for [audience]
+  - re-target this content
+  - recast this for
+  - explain this to [non-technical/CEO/PO/junior]
+  - turn my technical work into a [pitch/deck/daily/one-pager]
+  - traduzir este conteúdo para [outro público]
+  - vira um pitch/deck/infográfico disto
+  - simplify this for a lay audience
+version: 0.2.0
+license: MIT
+allowed-tools: Read, Write, Edit, Glob, Bash, Skill, WebFetch
+metadata:
+  version: "0.2.0"
+  scope: AAIF cross-vendor
+  family: content-lifecycle
+  cross_link_slug: content-recast
+  dogfood_status: pending-first-cycle
+---
+
+# Content Recast
+
+## Overview
+Re-cast a piece of **your own** technical content for a **different target profile** — `{audience × abstraction × intent × language}` — and hand off rendering to tools that already exist. Single responsibility = the **semantic transformation** (distill → recast → verify); rendering is **delegated** (composition-over-inheritance), so this skill never rebuilds editors. The quality differentiator vs. commodity "repurposing" SaaS is a mandatory **faithfulness guard** + **information-loss note**: a readable-but-inaccurate adaptation is worse than none (Devaraj et al., *Evaluating Factuality in Text Simplification*, ACL 2022).
+
+For a **fixed** target — narrating a finished session/PR to a human (or agent) in a story-arc "Opera" register — use the specialised sibling `skills/opera-debrief`, which fixes the audience + register and adds dosed-intensity dials + a no-terror tone gate. Content-recast owns the **general** case (any audience × any register).
+
+## When to use
+- Re-target technical work for CEO / PO·PM / peer-dev / non-specialist / community / a daily standup.
+- Shift abstraction (low-level ↔ executive), intent (inform/convince/demonstrate/teach), or language (pt-BR ↔ en-US).
+- Produce a shareable artifact (deck, one-pager, NotebookLM podcast prompt) from raw technical notes.
+
+**When NOT to use**: re-engineering the artifact itself (code/architecture migration — angular→flutter, monolith→microservices) → use a refactor/modernization agent. This skill can *explain* such a migration to an audience; it does not *perform* it. Pure documentation authoring → a docs generator. One-off rewrite with no profile shift → just edit inline. Narrating a finished session in the Opera register → `skills/opera-debrief`.
+
+## §0 — BEING > Rules (foundational)
+This skill serves the operator's intent. If any phase/gate obstructs delivering value NOW, skip it, log `Skipped <phase> — BEING > Rules`, and proceed. HUMAN_DOMAIN (secrets · production PII · irreversibles · cross-org publish · cost) → escalate, never auto-act. **Never invent facts** to make an adaptation more compelling — that violates the faithfulness guard, which is non-negotiable.
+
+## Parameters
+| Param | Default | Meaning |
+|---|---|---|
+| `<source>` (positional) | — (required) | Content to recast: inline text, a file path, or a glob. Empty → print usage. |
+| `--to-audience` | `peer-dev` | Who consumes it: `ceo` · `po-pm` · `peer-dev` · `non-specialist` · `community` · `team-daily` · free-text role. |
+| `--abstraction` | inferred from audience | `executive` (what/why/impact) · `conceptual` (how, no internals) · `detailed` (full technical depth). |
+| `--intent` | `inform` | `inform` · `convince` · `demonstrate` · `teach` · `share`. |
+| `--lang` | `pt-BR` | `pt-BR` · `en-US` (per the audience-design language policy). |
+| `--format` | `md` | `md` · `slides` · `onepager` · `nlm-source` · `nlm-prompt` (render delegation — see Composition map). |
+| `--readability` | off | Optional Flesch-Kincaid grade target (e.g. `8`). Treated as a **check**, not a guarantee (LLM readability control is imperfect — Farajidizaji et al., LREC 2024). |
+| `--dry-run` | off | Produce the neutral-brief + chosen lens + plan only; no recast/render. |
+
+**Argument parsing**: the token(s) BEFORE the first `--` form the `<source>`; every `--key value` / `--flag` after it is parsed as a parameter (matches the advertised `<source> [--flags]` syntax). If the input has no positional segment (starts with `--`, or `<source>` is implied), take `<source>` from the referenced file / prior conversation context. This avoids swallowing flags into the source.
+
+## Pipeline (0 → 6)
+0. **Intake** — parse `<source>` + params. Empty source → usage, stop. Resolve `--abstraction` from `--to-audience` if unset (ceo→executive · po-pm→conceptual · peer-dev→detailed · non-specialist→conceptual · community→conceptual · team-daily→conceptual).
+1. **Distill → neutral brief** — extract the source's atomic **claims + supporting evidence + key terms** into a compact, audience-neutral brief. This is the faithfulness anchor (the universal "distill-first, then rewrite" pattern). NEVER recast directly from the raw source.
+2. **Select lens** — pick the strategy lens from `{abstraction × intent}` (see Strategy lenses).
+3. **Recast** — rewrite the brief in the target profile through the lens: adjust register, depth, jargon, framing, and structure. Translate if `--lang` differs.
+4. **Faithfulness check** (MANDATORY) — verify every claim in the recast traces to a claim in the neutral brief (step 1). Flag/repair: unsupported insertions, distorted magnitudes, over-generalizations (generalization bias — PMC 2026), omitted load-bearing caveats. Emit an **Information-Loss Note**: what was simplified away or omitted, so the reader knows the boundaries (InfoLossQA, arXiv 2401.16475). If `--readability` set, score + (two-step) adjust + re-check.
+5. **Render handoff** — per `--format`, delegate to the producer (Composition map). Pass the recast content + a short rendering brief (tone/structure/visual hints). Never re-implement a renderer.
+6. **Output** — deliver the artifact (or producer-handoff instructions) + the Information-Loss Note + a one-line "what changed for this audience" summary.
+
+## Strategy lenses (abstraction × intent → technique)
+| Lens | Fires when | Technique |
+|---|---|---|
+| **Minto Pyramid** | `executive` + (`convince`/`inform`) | Answer-first / SCQA; lead with the bottom-line + impact, support below. CEO/PO. |
+| **Feynman** | `conceptual`/`non-specialist` + `teach` | Plain language, analogy, no jargon; explain as if to a smart non-expert. |
+| **Progressive disclosure** | mixed audience / `demonstrate` | Layered: headline → key points → optional depth; reader chooses how deep (Cognitive Load Theory). |
+| **Detail-preserving** | `detailed` + peer-dev | Keep technical depth + precision; tighten structure, add signposting; minimal simplification. |
+| **Opera (narrative-warm)** | finished session/PR → human recap | Delegated to `skills/opera-debrief` (story-arc + dosed humour + moral + CTA + no-terror gate). |
+
+Lens is a **default suggestion** — the agent may blend/override with rationale (cognitive-adaptation-freedom).
+
+## Composition map (render delegation — DRY, zero new editors)
+| `--format` | Producer (delegated) |
+|---|---|
+| `md` | inline (this skill) |
+| `slides` | a slides producer (e.g. Gamma MCP) — fallback a `pptx` skill |
+| `onepager` | a PDF producer (e.g. `make-pdf`) — fallback a `pdf`/`docx` skill |
+| `nlm-source` | inline — emit clean markdown sized as a NotebookLM source |
+| `nlm-prompt` | inline — emit a ready prompt instructing NotebookLM to generate audio/video/infographic/slide/report/table from the nlm-source |
+
+## Faithfulness guard (the differentiator — non-negotiable)
+1. Every recast claim MUST trace to the neutral brief (step 1). 2. No invented facts, numbers, or quotes. 3. No magnitude/causality distortion. 4. Load-bearing caveats survive or appear in the Information-Loss Note. 5. The note explicitly lists what was dropped/compressed. Research basis: ACL 2022 factuality, InfoLossQA 2024, FactPICO 2024, generalization-bias PMC 2026.
+
+## Output format
+```
+RECAST → <audience> / <abstraction> / <intent> / <lang> · lens: <lens>
+<the recast content OR producer-handoff for non-md formats>
+
+ℹ️ Information-Loss Note: <what was simplified / omitted / compressed>
+🎯 For this audience: <1-line on the key reframing>
+```
+
+## Anti-patterns (do NOT)
+- ❌ Recast directly from raw source (skip distill) → faithfulness drift.
+- ❌ Invent/embellish facts to be more convincing (AI slop) → violates the guard.
+- ❌ Rebuild an editor/renderer → use the Composition map.
+- ❌ Re-engineer code/architecture (Scope-B) → wrong tool.
+- ❌ Promise an exact readability grade → it's a check, not a lever.
+- ❌ Omit the Information-Loss Note when simplifying.
+
+## §Quality Tests (self-dogfood — 6/6)
+1. **Self-Application** — designed via research→converge→design; this SKILL.md is itself a recast of the research into the "AI-agent audience". ✅
+2. **Non-Contradiction** — composes (not duplicates) slides/NotebookLM/docs producers + `opera-debrief`; consistent with pre-creation scope-discipline / anti-theater / the language policy. ✅
+3. **Survival** — applied to itself it advocates faithful re-targeting; survives. ✅
+4. **Bounded-Responsibility** — `--dry-run` · Scope-A only · 5 formats · readability=check · DUED sunset. ✅
+5. **Explicit-Exception** — §0 BEING>Rules + HUMAN_DOMAIN escalation + cognitive-adaptation-freedom on lens. ✅
+6. **Utility-Sunset** — §DUED below. ✅
+Pre-creation scope-discipline 6Q: 6/6 (WHERE · DRY=gap-confirmed vs the skill landscape + external SaaS · WHY=frequent need · WHO=operator+amnesic agents · FITS=content-lifecycle family · MIN=Goldilocks). Anti-theater 8Q REALITY: 8/8.
+
+## §DUED Sunset (qualitative, not counter-based)
+Deprecate when ANY: the host provides a native faithful audience-recast primitive (E1) · operator retraction (E4) · ≥3 false-positive recasts where the guard misfires (E5) · a content-lifecycle family tool absorbs it (E6). Dormant-by-design otherwise.
+
+## Related Multi-Agent OS Artifacts
+- `skills/opera-debrief/SKILL.md` — the **narrative-warm register specialisation**: fixes audience (finished session → human/agent) + the Opera register + dosed dials + no-terror gate. Content-recast owns the general case; opera-debrief owns the "recap as a story" case. Shared faithfulness-gate lineage.
+- `skills/postflight/SKILL.md` · `skills/morning-briefing/SKILL.md` — fact sources a recast/debrief consumes (DRY).
+- `skills/rule-quality-tests/SKILL.md` — the 6 self-validity tests applied above.
+
+## §Refs
+- Genesis: forged via the `agentic-tool-forge` discipline (community).
+- Gates: pre-creation scope-discipline (6Q) · anti-theater grounding (8Q) · `skills/rule-quality-tests` (6 self-validity) · an audience-design language policy.
+- Research: ACL 2022 `2022.acl-long.506` (factuality) · InfoLossQA `arxiv 2401.16475` · FactPICO `arxiv 2402.11456` · readability-control LREC 2024 `2024.lrec-main.815` · ReadCtrl `arxiv 2406.09205` · generalization-bias PMC 12042776.
+- Frameworks: Minto Pyramid Principle · Feynman technique · Progressive Disclosure · Cognitive Load Theory · plain-language/Flesch-Kincaid.
+- Producers: a slides MCP · NotebookLM · a PDF producer · `pptx`/`pdf`/`docx` skills.
+- Cross-link slug: `[[content-recast]]`.
+
+## License
+MIT (matches the multi-agent-os repo `LICENSE`).
+
+## Changelog
+| Version | Date | Change |
+|---|---|---|
+| 0.1.0 | 2026-05-31 | Bootstrap. Scope-A communication re-targeting; 4-dim profile; distill→brief→recast→faithfulness-check→render pipeline; 4 strategy lenses; composition map (md/slides/onepager/nlm-source/nlm-prompt); mandatory faithfulness guard + information-loss note. Research-grounded. Forged via `agentic-tool-forge` discipline; 6/6 self-validity + 8/8 anti-theater + 6/6 scope-discipline. |
+| 0.2.0 | 2026-06-18 | Promoted user-scope → multi-agent-os (community). Layer-Purity scrub (org-specific strings removed) + relicense Apache-2.0 → MIT. Added the **Opera (narrative-warm)** lens row delegating to the new `skills/opera-debrief` sibling; added Related-Artifacts family section + License section. No pipeline/guard change. |

--- a/skills/opera-debrief/SKILL.md
+++ b/skills/opera-debrief/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: opera-debrief
+description: |
+  Use when you want to deliver a session/work recap as a FAITHFUL, dosed NARRATIVE — a
+  "summary as an opera": a short story-arc (acts) with measured humour, situational
+  (never personal) wit, instigating-but-not-alarming drama, a call-to-action, the key
+  insights, and a closing moral — for a HUMAN; or a structured consolidated payload for an
+  AGENT. Triggers: "resumo da ópera", "summary as an opera", "narrate this session",
+  "give me the story of what we did", "recap with a bit of flair", "debrief com pegada
+  narrativa", "tell the tale of this work". It does NOT re-summarize — it CONSUMES an
+  existing session map (from `postflight` P2-DEBRIEF / `morning-briefing --mode=recap`) and
+  re-casts it through the named OPERA REGISTER, then runs a FAITHFULNESS gate (every beat
+  traces to a real fact; no invented drama) + a TONE-SAFETY gate (no alarm; wit never aimed
+  at a person). It is the narrative-warm register member of the content/recap family — a
+  specialised, dosed sibling of `content-recast`. Cross-vendor AAIF.
+triggers:
+  - resumo da ópera
+  - summary as an opera
+  - opera-debrief
+  - narrate this session
+  - tell the story of what we did
+  - recap with flair / with a light touch
+  - debrief com pegada narrativa
+version: 0.1.0
+license: MIT
+allowed-tools: Read, Write, Edit, Glob, Bash, Skill
+metadata:
+  version: "0.1.0"
+  scope: AAIF cross-vendor
+  family: content-lifecycle
+  cross_link_slug: opera-debrief
+  dogfood_status: pending-first-cycle
+---
+
+# Opera-Debrief
+
+## Overview
+Deliver a recap of a session, task, or PR **as a short opera** — a narrative arc that *acoolhe, informa e dá direção* (welcomes, informs, gives direction). Single responsibility = the **register transformation** of an *already-computed* session map into a dosed narrative; the summarising itself is **delegated** to the recap family (composition-over-inheritance — this skill never re-derives the facts). The differentiator vs. "make my summary fun" is two non-negotiable gates: a **faithfulness gate** (every dramatic beat traces to a real fact — no invented drama) and a **tone-safety gate** (instigating, *never alarming*; wit aimed at situations or at the agent itself, *never* at a person). A vivid-but-false or anxiety-inducing recap is worse than a plain one.
+
+It is the **narrative-warm register** specialisation of `content-recast` (which re-targets *any* content for *any* audience). Opera-debrief fixes the audience to "a human who just finished the work (or an agent inheriting it)" and the register to "Opera", and adds the dosed-intensity dials + the no-terror clause.
+
+## When to use
+- Close a session/PR with a recap a human will actually *read* (and enjoy) — story-arc, light humour, a moral, a call-to-action.
+- Turn a dry `postflight`/`morning-briefing` map into a human-warm narrative without losing a single fact.
+- Hand a downstream **agent** a consolidated, structured digest of "the story so far" (register switches to machine-economy).
+
+**When NOT to use**: you need the raw operational map, not a narrative → use `postflight` / `morning-briefing` directly. You need to re-target arbitrary content for an arbitrary audience → use the general `content-recast`. The work isn't done yet / there's no session map to recast → there's nothing faithful to narrate.
+
+## §0 — BEING > Rules (foundational)
+This skill serves the operator's intent. If any phase/gate obstructs delivering value NOW, skip it, log `Skipped <phase> — BEING > Rules`, and proceed. **Never invent a beat** to make the story better — the faithfulness gate is non-negotiable. **Never alarm** to make it gripping — the tone-safety gate is non-negotiable. Sensitive facts (secrets · production PII · irreversibles · cross-org publish) → escalate, never narrate around.
+
+## Parameters
+| Param | Default | Meaning |
+|---|---|---|
+| `<source>` (positional) | session map from `postflight`/`morning-briefing` (or prior context) | What to narrate. Empty → derive from the current session map; if none exists → print usage. |
+| `--audience` | `human` | `human` (warm opera narrative) · `agent` (structured/JSON-RPC consolidated digest, humour off). |
+| `--lang` | `pt-BR` | Output language (`pt-BR` · `en-US` · any). The narrative register adapts to the language's idiom. |
+| `--intensity` | `dosed` | Global dial: `dosed` (measured — default) · `low` (mostly facts, a touch of warmth) · `off` (plain — degrades to a `postflight` debrief). |
+| `--humour` | inherits `--intensity` | `med` · `low` · `off`. Situational/self-directed only. |
+| `--drama` | inherits `--intensity` | `instigante` · `low` · `off`. **Never `terror`** — the dial has no alarming setting by design. |
+| `--acts` | auto | Number of acts; auto-mapped from the session's phases/turning-points (cap 5 — anti-bloat). |
+| `--dry-run` | off | Emit the neutral session-map + the planned act structure + chosen dials only; no narration. |
+
+**Argument parsing**: token(s) before the first `--` = `<source>`; `--key value`/`--flag` after = parameters. No positional → take the session map from `postflight`/`morning-briefing`/prior context.
+
+## Pipeline (0 → 6)
+0. **Intake** — parse `<source>` + params. Resolve dials from `--intensity` if unset. If `--audience=agent`, force `--humour=off --drama=low`.
+1. **Acquire the map (DELEGATE — do NOT re-derive)** — obtain the session map from `postflight` P2-DEBRIEF or `morning-briefing --mode=recap` (objectives, done, in-flight, decisions, gaps, the turning-points). If absent, ask the upstream skill for it; never recompute facts from scratch. This is the faithfulness anchor.
+2. **Distil → fact-ledger** — extract the atomic **facts + turning-points + the one decision/insight that mattered** into a neutral ledger. Each becomes a candidate beat. NEVER narrate from raw context.
+3. **Compose the acts** — map the ledger onto a story-arc: **setup → rising tension (the turning-point/conflict) → resolution → moral**. Auto-pick act count (≤5) from the real turning-points. Each act = one real fact, dramatised *in framing only*.
+4. **Apply the OPERA REGISTER** (see profile below) at the chosen dials — humour (situational/self), wit (never personal), drama (instigating, no-terror), plus the three mandatory beats: **insights**, **call-to-action**, **moral-da-ópera**.
+5. **Dual gate (MANDATORY)** —
+   - **Faithfulness**: every beat traces to a fact in the ledger (step 2). Strip/repair any invented drama, inflated magnitude, or fabricated stakes. Emit an **Information-Loss Note** (what was compressed/omitted) so the reader knows the boundaries.
+   - **Tone-safety**: no alarming framing (no "catastrophe/disaster/terror"); wit targets situations or the agent itself, never a person; humour stays *comedido* (signal ≫ noise — it must carry attention to the fact, never bury it). Drop anything that fails.
+6. **Render by audience** — `human`: the opera (acts + insights + CTA + moral + loss-note). `agent`: a structured/JSON-RPC consolidated digest (acts→events, moral→verdict, CTA→next_action) with humour stripped — see Output.
+
+## The OPERA REGISTER PROFILE (the SSOT this skill owns)
+A named **human-warmth register** (audience-design, Bell 1984) with a fixed recipe and explicit dials:
+
+| Ingredient | Role | Dial | Default | Guardrail |
+|---|---|---|---|---|
+| **Story-arc (acts)** | structure: setup → tension → resolution → moral | `--acts` | auto (≤5) | each act = one real fact |
+| **Measured humour** | carries attention to the point | `--humour` | dosed/med | situational or self-directed; signal ≫ noise |
+| **Wit / light jab** | keeps it alive ("sarcasm sem ofender") | (humour) | low | aimed at *situations* or *the agent*, **never a person** |
+| **Instigating drama** | makes the turning-point land | `--drama` | instigante | **no terror / no alarm** — by design the dial cannot frighten |
+| **Insights** | what we learned | mandatory | on | grounded in real facts |
+| **Call-to-action** | gives direction (next step) | mandatory | on | one concrete next move |
+| **Moral-da-ópera** | the one-line takeaway | mandatory | on | the through-line of the whole arc |
+
+> The profile is a **default recipe** — the agent may blend/override dials with rationale (cognitive-adaptation-freedom), as long as both gates hold. `--intensity=off` collapses the register to a plain `postflight` debrief (graceful degradation).
+
+## Composition map (DRY — zero re-summarisation)
+| Need | Delegated to |
+|---|---|
+| The session map (facts) | `skills/postflight` P2-DEBRIEF · `skills/morning-briefing --mode=recap` |
+| General audience re-targeting (non-Opera registers) | `skills/content-recast` (Opera is one named register; that skill owns the rest) |
+| Render to slides/PDF/podcast | per `content-recast` Composition map (Gamma · make-pdf · NotebookLM) — never rebuilt here |
+
+## Faithfulness + Tone-safety gates (the differentiators — non-negotiable)
+1. Every beat traces to the fact-ledger (step 2). 2. No invented facts, stakes, numbers, or quotes. 3. No magnitude/causality inflation for drama. 4. Load-bearing caveats survive or appear in the Information-Loss Note. 5. No alarming framing (no terror). 6. Wit never targets a person. 7. Humour is *dosed* — it must serve the fact, never obscure it (transparency: warmth must NOT drop a risk/caveat). Research basis: factuality in simplification (Devaraj et al., ACL 2022) · InfoLossQA (arXiv 2401.16475) · audience-design (Bell 1984).
+
+## Output format
+**`--audience=human`:**
+```
+🎭 <Title> — resumo da ópera
+
+Ato I — <setup, grounded in a real fact>
+Ato II — <the turning-point / tension>
+Ato … — <resolution>
+
+🎯 Moral da ópera: <the one-line through-line>
+💡 Insights: <1-3 grounded takeaways>
+👉 Próximo passo: <one concrete CTA>
+ℹ️ Nota de fidelidade: <what was compressed/omitted; "nada inventado">
+```
+**`--audience=agent`** (JSON-RPC consolidated, humour off):
+```json
+{"jsonrpc":"2.0","method":"recap.opera","params":{
+  "title":"...","acts":[{"act":1,"fact":"...","frame":"..."}],
+  "moral":"...","insights":["..."],"next_action":"...","info_loss":"...","faithful":true}}
+```
+
+## Anti-patterns (do NOT)
+- ❌ Re-summarise from raw context (skip the delegated map) → faithfulness drift + duplicates `postflight`.
+- ❌ Invent drama/stakes to make it gripping (AI slop) → violates the faithfulness gate.
+- ❌ Alarm the reader ("disaster/catastrophe/terror") to hold attention → violates tone-safety.
+- ❌ Aim wit at a person → violates tone-safety ("sarcasm sem ofender").
+- ❌ Let humour bury a fact/caveat → violates dosed-transparency.
+- ❌ Rebuild a renderer or a summariser → use the Composition map.
+- ❌ Narrate work that isn't done / has no map → nothing faithful to tell.
+
+## §Quality Tests (self-dogfood — 6/6)
+1. **Self-Application** — this SKILL.md is itself the faithful, dosed product the skill describes (the genesis session was recapped "as an opera" and the operator asked to make that reusable). ✅
+2. **Non-Contradiction** — composes (not duplicates) `postflight`/`morning-briefing`/`content-recast`; the Opera register is one named register, not a rival summariser. ✅
+3. **Survival** — applied to itself it advocates faithful, non-alarming narration; survives. ✅
+4. **Bounded-Responsibility** — `--dry-run` · register-transform only (no re-summarisation) · acts ≤5 · two hard gates · `--intensity=off` graceful degradation · DUED sunset. ✅
+5. **Explicit-Exception** — §0 BEING>Rules + HUMAN_DOMAIN escalation + cognitive-adaptation-freedom on dials. ✅
+6. **Utility-Sunset** — §DUED below. ✅
+
+## §DUED Sunset (qualitative, not counter-based)
+Deprecate when ANY: `content-recast` absorbs "Opera" as a first-class register (E6) · the host provides a native faithful narrative-recap primitive (E1) · operator retraction (E4) · ≥3 false-positives where a gate misfires (E5). Dormant-by-design otherwise.
+
+## Related Multi-Agent OS Artifacts
+- `skills/content-recast/SKILL.md` — the **general** register/audience re-targeting engine; Opera-Debrief is its **narrative-warm register specialisation** (fixed audience + Opera register + dosed dials + no-terror clause). Shares the faithfulness-gate lineage.
+- `skills/postflight/SKILL.md` — **P2-DEBRIEF** produces the session map Opera-Debrief consumes (DRY: facts in, narrative out). Natural chain: `postflight → opera-debrief`.
+- `skills/morning-briefing/SKILL.md` — its 7-section recap (`--mode=recap`) is an alternative fact-source for the narrative.
+- `skills/preflight/SKILL.md` — start-of-session counterpart of `postflight`; bounds the session whose story this skill tells.
+
+## §Refs
+- Audience-design / register: Bell, A. (1984), *Language style as audience design*.
+- Faithfulness: Devaraj et al., ACL 2022 (`2022.acl-long.506`) · InfoLossQA (arXiv 2401.16475).
+- Frameworks: story-arc / three-act structure · the "distil-first, then re-cast" pattern (shared with `content-recast`).
+- Cross-link slug: `[[opera-debrief]]`.
+
+## Changelog
+| Version | Date | Change |
+|---|---|---|
+| 0.1.0 | 2026-06-18 | Bootstrap. Narrative-warm register specialisation of `content-recast`: the **Opera register profile** SSOT (story-arc + dosed humour + situational wit + instigating-no-terror drama + insights + CTA + moral) with explicit intensity dials, a faithfulness gate (no invented drama + info-loss note) and a tone-safety gate (no alarm + wit never personal). Composes `postflight`/`morning-briefing` for facts (zero re-summarisation); dual-register output (human opera / agent JSON-RPC). Vendor-neutral, MIT, family-aware. |


### PR DESCRIPTION
## [PR-as-Enhancement-Prompt] opera-debrief + content-recast promotion

### Context
The session-close "resumo da ópera" (story-arc + dosed humour + moral + CTA, faithful to facts) landed well with the operator, who asked to make that delivery a **reusable agentic-tool** for a human *or* an agent — DRY, family-aware, located in `multi-agent-os`, with the generation principles transmitted into the tool's DNA. Recon confirmed it's a **named register**, not a new summarizer (data already comes from `postflight`/`morning-briefing`; the re-cast engine is `content-recast`).

### Objectives
1. **`skills/opera-debrief`** (new) — the **Opera register profile** SSOT: story-arc (acts) + measured humour + situational wit + instigating-**no-terror** drama + insights + CTA + moral, with explicit **intensity dials**. Dual-register output: human opera / agent JSON-RPC digest. **Composes** the session map from `postflight` P2-DEBRIEF / `morning-briefing --mode=recap` (zero re-summarization). Two non-negotiable gates: **faithfulness** (no invented drama + info-loss note) + **tone-safety** (no alarm; wit never personal).
2. **`skills/content-recast`** (promoted user-scope → community) — Layer-Purity scrub (`bin/check-layer-purity` → **0 violations**) + relicense Apache-2.0 → **MIT** + new **Opera lens** row delegating to opera-debrief + family/License sections.

### DNA principles transmitted (calculated)
FAITHFULNESS · DRY/SSOT · KISS/YAGNI/ANTI-OVER-ENG · register-adaptive (audience-design, Bell 1984) · IDEMPOTENCIA · tone-ethics (sarcasm-sem-ofender, no-terror).

### Validation (new vs enhance)
Operator-chosen hybrid: **new thin skill** (opera-debrief) + **promote content-recast**. opera-debrief is a *specialisation* of content-recast (fixed audience + Opera register + dials), **not** a rival summarizer → DRY honored. `recon-family + relatives → maos` is a **separate staged unit** (needs per-artifact Layer-Purity scrub of Eko-governance-coupled rules — not bulk-copied here).

### Acceptance
- [x] Layer-Purity clean (0 violations, both files)
- [x] Vendor-neutral / MIT (community layer)
- [x] DRY: composes existing data sources, zero re-summarization
- [x] Faithfulness + tone-safety gates present
- [x] family-aware forward links (opera-debrief ↔ content-recast ↔ postflight/morning-briefing)
- [x] 6/6 self-validity + dosed-register dials

### Risk / rollback
Docs-only (two SKILL.md). Rollback = revert the PR; no runtime/behavior change to existing skills (content-recast pipeline/guard unchanged; only scrub+lens-row+license).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
