### PR TITLE
feat(maos-hub): add pull_request.decline op (close obsolete/superseded PRs)

### DIFF
--- a/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
+++ b/mcp-tools/maos-mcp-hub/gateways/bitbucket/actions.py
@@ -46,6 +46,7 @@ RESOURCE_MAP = {
         "merge": BB_TOOLS["merge_pull_request"],
         "approve": BB_TOOLS["approve_pull_request"],
         "unapprove": BB_TOOLS["unapprove_pull_request"],
+        "decline": BB_TOOLS["decline_pull_request"],
         "get_comments": BB_TOOLS["get_pr_comments"],
         "get_build_statuses": BB_TOOLS["get_pr_build_statuses"],
         # VKS-1853 (2026-04-23) — unblock Step 8 7-Mentes PDCA loop
@@ -121,6 +122,11 @@ _GOVERNANCE = {
             "Verificar que todos os findings aceitos foram implementados",
             "Verificar que findings rejeitados tem justificativa documentada no PR",
             "Se 2+ bots concordam num finding nao resolvido — NAO aprovar",
+        ],
+        "decline": [
+            "Decline = fechar SEM merge (PR obsoleto/superseded). NAO deleta a branch — reabrir exige novo push/PR.",
+            "Confirme que o PR e realmente obsoleto antes (ex: substituido por outra config/PR vencedor).",
+            "Deixe um comentario citando o PR/commit que o supersede (rastreabilidade).",
         ],
         "get_comments": [
             "Ativar 7 mentes para analise: critica, tome, suspicious, curiosa, sistemica, resolutiva, retrospectiva",

--- a/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
+++ b/mcp-tools/maos-mcp-hub/lib/bitbucket/client.py
@@ -1297,6 +1297,35 @@ class BitbucketPipelineClient:
             limiter=self.rate_limiter,
         )
 
+    async def decline_pull_request(self, pr_id: int) -> dict:
+        """
+        Decline (close without merging) a pull request as the authenticated user.
+
+        Use to close obsolete/superseded PRs that must NOT be merged. Reversal
+        requires reopening (a new push/PR). Registered under the token owner's
+        identity (or the named `account` resolved by the caller).
+
+        Bitbucket API: POST /2.0/repositories/{workspace}/{repo}/pullrequests/{id}/decline
+
+        Args:
+            pr_id: Pull request ID
+
+        Returns:
+            dict: The declined PR object (state == "DECLINED")
+
+        Raises:
+            ApiError: If API request fails (404 if not found, 555 if already declined/merged)
+        """
+        return await request_json(
+            method="POST",
+            url=f"{self.base_url}/pullrequests/{pr_id}/decline",
+            provider=self._provider_name,
+            auth_hint=self._auth_hint,
+            auth_kwargs=self._auth_kwargs,
+            timeout=30.0,
+            limiter=self.rate_limiter,
+        )
+
     async def create_pull_request(
         self,
         title: str,

--- a/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
+++ b/mcp-tools/maos-mcp-hub/servers/bitbucket/tools.py
@@ -1973,6 +1973,62 @@ async def unapprove_pull_request(
         return {"success": False, "error": f"Failed to unapprove PR: {sanitize_error(e)}"}
 
 
+async def decline_pull_request(
+    pr_id: int | None = None,
+    pull_request_id: int | None = None,
+    account: str = "",
+    workspace: str = "",
+    repo_slug: str = "",
+) -> dict:
+    """
+    Decline (close without merging) a pull request.
+
+    Use to close obsolete / superseded PRs that must NOT be merged (e.g. a stopgap
+    replaced by a better config). Declining is close-not-delete: the branch survives
+    and a new PR can reopen the work. Registered under the token owner's identity
+    (or `account` if a named persona is passed).
+
+    Args:
+        pr_id: Pull request ID (canonical).
+        pull_request_id: Alias for pr_id (VKS-1853 standardization).
+        account: Named account to use. Default uses the bot account.
+        workspace: Optional workspace override
+        repo_slug: Optional repo slug override
+
+    Returns:
+        dict: Decline result with PR state
+    """
+    try:
+        effective_pr_id = _normalize_pr_id(pr_id, pull_request_id)
+    except ValueError as ve:
+        return {"success": False, "error": str(ve)}
+
+    client = get_client_for_account(account=account, workspace=workspace, repo_slug=repo_slug)
+
+    try:
+        result = await client.decline_pull_request(pr_id=effective_pr_id)
+        return {
+            "success": True,
+            "pr_id": effective_pr_id,
+            "state": result.get("state", "DECLINED"),
+            "declined_by": (result.get("closed_by") or {}).get("display_name")
+            or (result.get("author") or {}).get("display_name", "MCP Hub Bot"),
+            "title": result.get("title", ""),
+        }
+    except ApiError as e:
+        status = getattr(e, "status_code", getattr(e, "status", None))
+        if status == 404:
+            return {"success": False, "error": f"Pull request #{effective_pr_id} not found"}
+        return {
+            "success": False,
+            "error": "Failed to decline PR",
+            "details": sanitize_exception(e),
+            "hint": getattr(e, "hint", ""),
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Failed to decline PR: {sanitize_error(e)}"}
+
+
 # ---------------------------------------------------------------------------
 # PR Interaction tools — add_comment / update_description / reply_to_comment
 # (VKS-1853: unblock Step 8 of AI-Native Protocol — 7 Mentes PDCA loop)
@@ -3381,6 +3437,7 @@ TOOLS = {
     "merge_pull_request": merge_pull_request,
     "approve_pull_request": approve_pull_request,
     "unapprove_pull_request": unapprove_pull_request,
+    "decline_pull_request": decline_pull_request,
     # PR Interaction tools — VKS-1853 (2026-04-23) — unblock Step 8 7-Mentes loop
     "add_pr_comment": add_pr_comment,
     "update_pr_description": update_pr_description,

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_bitbucket.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_bitbucket.py
@@ -29,10 +29,10 @@ def test_all_bitbucket_tools_have_gateway_mapping():
     assert unmapped == [], f"Unmapped tools: {unmapped}"
 
 
-def test_resource_map_has_55_actions():
-    """Total action count matches expected 55 (52 legacy + 3 VKS-1853)."""
+def test_resource_map_has_56_actions():
+    """Total action count matches expected 56 (52 legacy + 3 VKS-1853 + 1 decline)."""
     total = sum(len(ops) for ops in RESOURCE_MAP.values())
-    assert total == 55, f"Expected 55 actions, got {total}"
+    assert total == 56, f"Expected 56 actions, got {total}"
 
 
 # ---------------------------------------------------------------------------
@@ -94,14 +94,16 @@ def test_discovery_level1_pull_request_operations():
     asyncio.run(run())
 
 
-def test_vks1853_pull_request_has_11_ops():
-    """VKS-1853: pull_request must expose 11 ops (8 legacy + 3 new)."""
+def test_vks1853_pull_request_has_12_ops():
+    """pull_request must expose 12 ops (8 legacy + 3 VKS-1853 + 1 decline)."""
     pr_ops = RESOURCE_MAP["pull_request"]
     expected = {
         "list", "get", "create", "merge", "approve", "unapprove",
         "get_comments", "get_build_statuses",
         # VKS-1853 additions
         "add_comment", "reply_to_comment", "update_description",
+        # decline op (2026-06-18) — close obsolete/superseded PRs without merging
+        "decline",
     }
     assert set(pr_ops.keys()) == expected, (
         f"pull_request ops mismatch: expected {expected}, got {set(pr_ops.keys())}"
@@ -205,7 +207,7 @@ def test_discovery_unknown_resource():
 
 def test_router_action_count():
     router = build_router()
-    assert router.action_count == 55
+    assert router.action_count == 56  # +1: pull_request.decline (2026-06-18)
 
 
 def test_router_tool_name():


### PR DESCRIPTION
## Summary
The `atlassian_bitbucket` gateway could **merge / approve / unapprove** a PR but had **no way to close one WITHOUT merging**. This adds a `decline` operation across the 3 layers, mirroring `approve`:
- `lib/bitbucket/client.py` — `decline_pull_request()` → `POST /pullrequests/{id}/decline`
- `servers/bitbucket/tools.py` — `decline_pull_request` handler + `TOOLS` registry entry
- `gateways/bitbucket/actions.py` — `RESOURCE_MAP` `pull_request.decline` + governance hints

**Decline = close-not-delete:** branch survives; reopen via a new push/PR. Use to close superseded PRs (e.g. a stopgap replaced by a better config).

## Test plan
- `action_count` 55→56, `pull_request` ops 11→12 — updated 3 count asserts
- `pytest tests/test_gateway_bitbucket.py tests/test_bitbucket_client.py` → **35 passed**
- `py_compile` clean on all 3 source files

## Risk / rollback
Additive op only (no existing behavior changed). Rollback = revert this commit. Goes live for agents after the maos MCP server restarts.

## Origin
Operator directive 2026-06-18 ("se não tem, cria") — the gap left obsolete PRs uncloseable via MCP. Independência Agnóstica: seja a solução.

🤖 agent-created (Claude Opus 4.8)