### PR TITLE
fix(maos): quote statusline path + accurate context meter + docs casing (Qodo #155 follow-up)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,7 @@
 {
+  "_comment": "MAOS plugin manifest. Edit version on release; see CHANGELOG.md. Namespacing + vendor-reserved details below.",
   "name": "maos",
-  "version": "1.14.0",
+  "version": "1.15.0",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",

--- a/plugin-scripts/session-start.sh
+++ b/plugin-scripts/session-start.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 # =============================================================================
 
 PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$(dirname "$0")")}"
-PLUGIN_VERSION="1.14.0"
+PLUGIN_VERSION="1.15.0"
 CLAUDE_DIR="${HOME}/.claude"
 AUDIT_DIR="${CLAUDE_DIR}/audit"
 SESSION_ID="${CLAUDE_SESSION_ID:-$(date +%Y%m%d)-$(openssl rand -hex 2)}"
@@ -84,7 +84,7 @@ configure_statusline_settings() {
   "\$schema": "https://json.schemastore.org/claude-code-settings.json",
   "statusLine": {
     "type": "command",
-    "command": "bash ${dest}"
+    "command": "bash \"${dest}\""
   }
 }
 SETTINGS
@@ -107,7 +107,7 @@ SETTINGS
   cp "$settings" "${settings}.bak"
   local tmp
   tmp=$(mktemp)
-  if jq --arg cmd "bash ${dest}" \
+  if jq --arg cmd "bash \"${dest}\"" \
         'del(.statusline) | .statusLine = {type: "command", command: $cmd}' \
         "$settings" > "$tmp" 2>/dev/null && jq empty "$tmp" 2>/dev/null; then
     mv "$tmp" "$settings"; echo "configured"

--- a/templates/README.md
+++ b/templates/README.md
@@ -50,9 +50,10 @@ If using multi-agent-os plugin, templates are synced automatically via `/multi-a
 cp statusline-command.sh ~/.claude/
 chmod +x ~/.claude/statusline-command.sh
 
-# Add to ~/.claude/settings.json:
+# Add to ~/.claude/settings.json (key is camelCase "statusLine" -- lowercase is silently ignored):
 {
-  "statusline": {
+  "statusLine": {
+    "type": "command",
     "command": "bash ~/.claude/statusline-command.sh"
   }
 }

--- a/templates/statusline-command.sh
+++ b/templates/statusline-command.sh
@@ -2,7 +2,7 @@
 
 # /**
 #  * Enriched Status Line for Claude Code with Multi-Agent-OS Integration
-#  * @version 1.0.2
+#  * @version 1.1.0
 #  * @author Multi-Agent-OS Framework
 #  * @context Displays model, project, branch, worktree, state, cost, and context metrics
 #  * @reason Provides real-time visibility into session state and resource usage
@@ -59,18 +59,29 @@ COST_USD=$(echo "$INPUT" | jq -r '.cost.total_cost_usd // 0')
 
 # Context window info
 CONTEXT_MAX=$(echo "$INPUT" | jq -r '.context_window.context_window_size // 200000')
+CONTEXT_USED_PCT_RAW=$(echo "$INPUT" | jq -r '.context_window.used_percentage // empty')
 CONTEXT_INPUT=$(echo "$INPUT" | jq -r '.context_window.current_usage.input_tokens // 0')
 CONTEXT_OUTPUT=$(echo "$INPUT" | jq -r '.context_window.current_usage.output_tokens // 0')
+CONTEXT_CACHE_READ=$(echo "$INPUT" | jq -r '.context_window.current_usage.cache_read_input_tokens // 0')
+CONTEXT_CACHE_CREATE=$(echo "$INPUT" | jq -r '.context_window.current_usage.cache_creation_input_tokens // 0')
 
 # ============================================================================
 # CALCULATED METRICS
 # ============================================================================
 
-# Context usage percentage
+# Context usage percentage.
+# Prefer Claude Code's authoritative .context_window.used_percentage (computed over
+# ALL token types). Fallback: sum input + output + cache_read + cache_creation over
+# the window size -- NOT input-only, which under-reports when the cache dominates.
 CONTEXT_USED_PCT=0
-if [ "$CONTEXT_MAX" -gt 0 ]; then
-  CONTEXT_USED_PCT=$((CONTEXT_INPUT * 100 / CONTEXT_MAX))
+if [ -n "$CONTEXT_USED_PCT_RAW" ] && [ "$CONTEXT_USED_PCT_RAW" != "null" ]; then
+  CONTEXT_USED_PCT=$(printf '%.0f' "$CONTEXT_USED_PCT_RAW" 2>/dev/null || echo 0)
+elif [ "$CONTEXT_MAX" -gt 0 ]; then
+  CONTEXT_TOTAL=$((CONTEXT_INPUT + CONTEXT_OUTPUT + CONTEXT_CACHE_READ + CONTEXT_CACHE_CREATE))
+  CONTEXT_USED_PCT=$((CONTEXT_TOTAL * 100 / CONTEXT_MAX))
 fi
+[ "$CONTEXT_USED_PCT" -lt 0 ] && CONTEXT_USED_PCT=0
+[ "$CONTEXT_USED_PCT" -gt 100 ] && CONTEXT_USED_PCT=100
 
 # Until auto-compact percentage (threshold ~95%)
 UNTIL_COMPACT=$((95 - CONTEXT_USED_PCT))


### PR DESCRIPTION
## [PR-as-Correction-Prompt] Quote statusline path + accurate context meter + docs casing

Follow-up to **#155** (merged green) — addresses Qodo's advisory findings + the operator's metric-accuracy validation.

### Qodo findings (#155) — disposition
| # | Finding | Verdict | Action |
|---|---|---|---|
| 1 | `command: "bash ${dest}"` unquoted → breaks on paths with spaces | ✅ fixed | Quote path in heredoc + jq (`bash "${dest}"`) |
| 2 | `templates/README.md` manual install used lowercase `statusline` | ✅ fixed | → canonical `statusLine` + `type` (same root cause as #155) |
| 3 | `plugin.json` lacks top-level `_comment` | ✅ fixed | added top-level `_comment` |
| 4 | version drift in docs | ⚪ moot | no hardcoded version refs in README (`git grep` = 0) |

### Metric-accuracy fix (operator question)
The context meter computed `%` from **`input_tokens` only**, ignoring `output_tokens` + `cache_read_input_tokens` + `cache_creation_input_tokens` → it **under-reported** real context usage (the cache dominates the window). Now:
- Prefers Claude Code's authoritative `context_window.used_percentage`.
- Fallback: sum of **all** token types ÷ `context_window_size`.
- Dead `CONTEXT_OUTPUT` now used. Renderer `1.0.2 → 1.1.0`.

Proof: cache-dominated payload (in5k+out1k+cacheR80k+cacheC4k = 90k/200k) → **45%** (the old formula showed **2%**).

### Acceptance criteria
- [x] `bash -n` clean (hook + renderer)
- [x] #1 regression: AUTO mode with `HOME=/…/John Doe/…` → `statusLine.command` quoted + valid JSON
- [x] renderer math: authoritative `used_percentage` honored; all-token fallback correct
- [x] gitleaks clean
- [x] plugin `1.14.0 → 1.15.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
