### PR TITLE
feat(reaper): safe stale/orphan worktree+branch reaper (the missing executor)

### DIFF
--- a/bin/reap-sessions.sh
+++ b/bin/reap-sessions.sh
@@ -13,8 +13,8 @@ set -euo pipefail
 REPO_DIR="$PWD"; STALE_DAYS=7; APPLY=0; JSON=0
 while [ $# -gt 0 ]; do
   case "$1" in
-    --repo-dir)   REPO_DIR="$2"; shift 2;;
-    --stale-days) STALE_DAYS="$2"; shift 2;;
+    --repo-dir)   [ $# -ge 2 ] || { echo "reap-sessions: --repo-dir requires a value" >&2; exit 2; }; REPO_DIR="$2"; shift 2;;
+    --stale-days) [ $# -ge 2 ] || { echo "reap-sessions: --stale-days requires a value" >&2; exit 2; }; STALE_DAYS="$2"; shift 2;;
     --apply)      APPLY=1; shift;;
     --json)       JSON=1; shift;;
     -h|--help)    sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
@@ -27,7 +27,8 @@ git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1 \
   || { echo "reap-sessions: not a git repo: $REPO_DIR" >&2; exit 1; }
 
 # ── good-neighbor: defer if a peer holds the index lock (never fight a concurrent writer) ──
-COMMON="$(cd "$REPO_DIR" && git rev-parse --git-common-dir)"
+COMMON="$(cd "$REPO_DIR" 2>/dev/null && git rev-parse --git-common-dir)" \
+  || { echo "reap-sessions: cannot access repo dir: $REPO_DIR" >&2; exit 1; }
 case "$COMMON" in /*) ;; *) COMMON="$REPO_DIR/$COMMON";; esac
 if [ -e "$COMMON/index.lock" ]; then
   if [ "$JSON" -eq 1 ]; then
@@ -41,7 +42,12 @@ fi
 MAIN_TOP="$(git -C "$REPO_DIR" rev-parse --show-toplevel)"
 NOW="$(date +%s)"
 DEFAULT_BRANCH="$(git -C "$REPO_DIR" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
-[ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)"
+if [ -z "$DEFAULT_BRANCH" ]; then   # no origin/HEAD → prefer a REAL default; NEVER silently the current branch
+  for _cand in main master; do      #   (else `branch --merged` would delete branches merged into a feature branch)
+    if git -C "$REPO_DIR" show-ref --verify --quiet "refs/heads/$_cand"; then DEFAULT_BRANCH="$_cand"; break; fi
+  done
+fi
+[ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)"   # last resort
 
 reaped_wt=(); skipped_wip=(); would_wt=(); reaped_br=(); would_br=()
 
@@ -54,6 +60,7 @@ emit_wt() {
   local ts age elig=0 reason=""
   ts="$(git -C "$p" log -1 --format=%ct 2>/dev/null || echo 0)"
   age=$(( (NOW - ts) / 86400 ))
+  [ "$age" -ge 0 ] || age=0          # clamp future-dated commits → never a spurious "stale" sign-flip
   if [ "$det" -eq 1 ] || [ -z "$b" ]; then elig=1; reason="orphan-detached"; fi
   if [ "$age" -gt "$STALE_DAYS" ]; then elig=1; reason="${reason:+$reason,}stale-${age}d"; fi
   [ "$elig" -eq 1 ] || return 0
@@ -90,9 +97,14 @@ while IFS= read -r b; do
 done < <(git -C "$REPO_DIR" branch --merged "$DEFAULT_BRANCH" --format='%(refname:short)')
 
 # ── output ──
-jarr() {  # bash-3.2-safe JSON array from "$@"
+jarr() {  # bash-3.2-safe JSON array from "$@" (escapes \ then " → valid JSON for downstream parsers)
   [ "$#" -eq 0 ] && { printf '[]'; return; }
-  local out="" x; for x in "$@"; do out="$out\"$x\","; done; printf '[%s]' "${out%,}"
+  local out="" x e
+  for x in "$@"; do
+    e="${x//\\/\\\\}"; e="${e//\"/\\\"}"    # backslash FIRST, then double-quote
+    out="$out\"$e\","
+  done
+  printf '[%s]' "${out%,}"
 }
 if [ "$JSON" -eq 1 ]; then
   printf '{"dry_run":%s,"repo":"%s","stale_days":%s,"reaped_worktrees":%s,"skipped_wip":%s,"would_reap_worktrees":%s,"reaped_branches":%s,"would_reap_branches":%s}\n' \

--- a/bin/reap-sessions.sh
+++ b/bin/reap-sessions.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# /**
+#  * reap-sessions.sh — safely prune STALE/ORPHAN git worktrees + merged orphan branches.
+#  * @context  work-compass DETECTS stale/orphan; nothing REAPS. This closes the anti-theater loop.
+#  * @reason   abandoned worktrees/branches accumulate in shared repos; manual cleanup never happens.
+#  * @impact   dry-run DEFAULT · NEVER --force · NEVER -D · NEVER touches WIP or the main worktree ·
+#  *           idempotent · good-neighbor (defers on index.lock) · session transcripts out of scope.
+#  * @usage    reap-sessions.sh [--repo-dir DIR] [--stale-days N] [--apply] [--json]
+#  * Stdlib + git only. AAIF cross-vendor. Layer-pure (no akasha/Vek deps). bash 3.2 safe. LF.
+#  */
+set -euo pipefail
+
+REPO_DIR="$PWD"; STALE_DAYS=7; APPLY=0; JSON=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --repo-dir)   REPO_DIR="$2"; shift 2;;
+    --stale-days) STALE_DAYS="$2"; shift 2;;
+    --apply)      APPLY=1; shift;;
+    --json)       JSON=1; shift;;
+    -h|--help)    sed -n '2,10p' "$0" | sed 's/^# \{0,1\}//'; exit 0;;
+    *) echo "reap-sessions: unknown arg: $1" >&2; exit 2;;
+  esac
+done
+
+command -v git >/dev/null 2>&1 || { echo "reap-sessions: git not available" >&2; exit 1; }
+git -C "$REPO_DIR" rev-parse --git-dir >/dev/null 2>&1 \
+  || { echo "reap-sessions: not a git repo: $REPO_DIR" >&2; exit 1; }
+
+# ── good-neighbor: defer if a peer holds the index lock (never fight a concurrent writer) ──
+COMMON="$(cd "$REPO_DIR" && git rev-parse --git-common-dir)"
+case "$COMMON" in /*) ;; *) COMMON="$REPO_DIR/$COMMON";; esac
+if [ -e "$COMMON/index.lock" ]; then
+  if [ "$JSON" -eq 1 ]; then
+    printf '{"deferred":true,"busy":true,"reason":"index.lock present — peer mutating; reaper yields"}\n'
+  else
+    echo "reap-sessions: defer — $COMMON/index.lock present (peer mutating); yielding (good-neighbor)"
+  fi
+  exit 0
+fi
+
+MAIN_TOP="$(git -C "$REPO_DIR" rev-parse --show-toplevel)"
+NOW="$(date +%s)"
+DEFAULT_BRANCH="$(git -C "$REPO_DIR" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+[ -n "$DEFAULT_BRANCH" ] || DEFAULT_BRANCH="$(git -C "$REPO_DIR" rev-parse --abbrev-ref HEAD)"
+
+reaped_wt=(); skipped_wip=(); would_wt=(); reaped_br=(); would_br=()
+
+# ── worktrees: eligible = (detached/orphan) OR (last-commit age > stale-days); reaped only if CLEAN ──
+emit_wt() {
+  local p="$1" b="$2" det="$3"
+  [ -n "$p" ] || return 0
+  [ "$p" = "$MAIN_TOP" ] && return 0          # NEVER the main worktree
+  [ -d "$p" ] || return 0                      # admin-stale entry → handled by `worktree prune`
+  local ts age elig=0 reason=""
+  ts="$(git -C "$p" log -1 --format=%ct 2>/dev/null || echo 0)"
+  age=$(( (NOW - ts) / 86400 ))
+  if [ "$det" -eq 1 ] || [ -z "$b" ]; then elig=1; reason="orphan-detached"; fi
+  if [ "$age" -gt "$STALE_DAYS" ]; then elig=1; reason="${reason:+$reason,}stale-${age}d"; fi
+  [ "$elig" -eq 1 ] || return 0
+  if [ -n "$(git -C "$p" status --porcelain 2>/dev/null)" ]; then   # WIP guard — never reap dirty
+    skipped_wip+=("$p"); return 0
+  fi
+  if [ "$APPLY" -eq 0 ]; then would_wt+=("$p ($reason)"); return 0; fi
+  if git -C "$REPO_DIR" worktree remove "$p" >/dev/null 2>&1; then   # NO --force (belt-and-suspenders)
+    reaped_wt+=("$p")
+  else
+    skipped_wip+=("$p")   # remove refused (e.g. became dirty mid-run) → keep, never force
+  fi
+}
+_wp=""; _wb=""; _wd=0
+while IFS= read -r line; do
+  case "$line" in
+    "worktree "*) [ -n "$_wp" ] && emit_wt "$_wp" "$_wb" "$_wd"; _wp="${line#worktree }"; _wb=""; _wd=0;;
+    "branch "*)   _wb="${line#branch }"; _wb="${_wb#refs/heads/}";;
+    "detached")   _wd=1;;
+  esac
+done < <(git -C "$REPO_DIR" worktree list --porcelain)
+[ -n "$_wp" ] && emit_wt "$_wp" "$_wb" "$_wd"
+
+[ "$APPLY" -eq 1 ] && git -C "$REPO_DIR" worktree prune >/dev/null 2>&1 || true
+
+# ── branches: merged into default, not protected, not checked-out anywhere → safe `-d` ──
+used_branches="$(git -C "$REPO_DIR" worktree list --porcelain | sed -n 's#^branch refs/heads/##p')"
+while IFS= read -r b; do
+  [ -n "$b" ] || continue
+  case "$b" in main|master|develop) continue;; esac
+  printf '%s\n' "$used_branches" | grep -qxF "$b" && continue
+  if [ "$APPLY" -eq 0 ]; then would_br+=("$b"); continue; fi
+  git -C "$REPO_DIR" branch -d "$b" >/dev/null 2>&1 && reaped_br+=("$b") || true   # -d refuses unmerged
+done < <(git -C "$REPO_DIR" branch --merged "$DEFAULT_BRANCH" --format='%(refname:short)')
+
+# ── output ──
+jarr() {  # bash-3.2-safe JSON array from "$@"
+  [ "$#" -eq 0 ] && { printf '[]'; return; }
+  local out="" x; for x in "$@"; do out="$out\"$x\","; done; printf '[%s]' "${out%,}"
+}
+if [ "$JSON" -eq 1 ]; then
+  printf '{"dry_run":%s,"repo":"%s","stale_days":%s,"reaped_worktrees":%s,"skipped_wip":%s,"would_reap_worktrees":%s,"reaped_branches":%s,"would_reap_branches":%s}\n' \
+    "$([ "$APPLY" -eq 0 ] && echo true || echo false)" "$MAIN_TOP" "$STALE_DAYS" \
+    "$(jarr "${reaped_wt[@]+"${reaped_wt[@]}"}")" \
+    "$(jarr "${skipped_wip[@]+"${skipped_wip[@]}"}")" \
+    "$(jarr "${would_wt[@]+"${would_wt[@]}"}")" \
+    "$(jarr "${reaped_br[@]+"${reaped_br[@]}"}")" \
+    "$(jarr "${would_br[@]+"${would_br[@]}"}")"
+else
+  echo "reap-sessions ($([ "$APPLY" -eq 0 ] && echo DRY-RUN || echo APPLY)) repo=$MAIN_TOP stale>${STALE_DAYS}d"
+  if [ "$APPLY" -eq 0 ]; then
+    printf '  would reap worktrees: %s\n' "${would_wt[*]:-(none)}"
+    printf '  would reap branches : %s\n' "${would_br[*]:-(none)}"
+    printf '  skip (WIP)          : %s\n' "${skipped_wip[*]:-(none)}"
+    echo   "  → re-run with --apply to execute (WIP + main always preserved)"
+  else
+    printf '  reaped worktrees: %s\n' "${reaped_wt[*]:-(none)}"
+    printf '  reaped branches : %s\n' "${reaped_br[*]:-(none)}"
+    printf '  skip (WIP)      : %s\n' "${skipped_wip[*]:-(none)}"
+  fi
+fi

--- a/tests/test-reap-sessions.sh
+++ b/tests/test-reap-sessions.sh
@@ -36,9 +36,9 @@ mkwt fresh-clean  "$(date +%Y-%m-%dT%H:%M:%S)"           # recent + clean → UN
 # a merged orphan branch (no worktree) → safe -d ; and an UNMERGED branch → must survive
 git -C "$R" branch merged-orphan main
 git -C "$R" branch -q unmerged-keep main
-git -C "$R" worktree add -q "$R/.worktrees/_um" unmerged-keep >/dev/null
-echo z > "$R/.worktrees/_um/z"; git -C "$R/.worktrees/_um" add z; git -C "$R/.worktrees/_um" commit -qm um
-git -C "$R" worktree remove "$R/.worktrees/_um"   # branch unmerged-keep now has unmerged commit, no worktree
+git -C "$R" worktree add -q "$R/.worktrees/a-unmerged" unmerged-keep >/dev/null
+echo z > "$R/.worktrees/a-unmerged/z"; git -C "$R/.worktrees/a-unmerged" add z; git -C "$R/.worktrees/a-unmerged" commit -qm um
+git -C "$R" worktree remove "$R/.worktrees/a-unmerged"   # branch unmerged-keep now has unmerged commit, no worktree
 
 [ -x "$REAPER" ] || { echo "RED: $REAPER not executable yet (expected pre-impl)"; exit 1; }
 
@@ -58,6 +58,8 @@ chk "apply: fresh-clean PRESERVED (age guard)"      "[ -e '$R/.worktrees/fresh-c
 chk "apply: merged-orphan branch deleted"           "! git -C '$R' branch --list merged-orphan | grep -q ."
 chk "apply: unmerged-keep branch SURVIVES"          "git -C '$R' branch --list unmerged-keep | grep -q ."
 chk "apply: main worktree untouched"                "[ -e '$R/f' ]"
+chk "apply: JSON reports dry_run=false"             "echo '$APP' | grep -q '\"dry_run\"[: ]*false'"
+chk "apply: JSON reaped_worktrees lists stale-clean" "echo '$APP' | grep -q '\"reaped_worktrees\"[^]]*stale-clean'"
 
 # ── 3. IDEMPOTENT: re-apply is a no-op (nothing left eligible+clean) ────────────
 RE="$("$REAPER" --repo-dir "$R" --stale-days 7 --apply --json)"

--- a/tests/test-reap-sessions.sh
+++ b/tests/test-reap-sessions.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# /**
+#  * test-reap-sessions.sh — TDD contract for bin/reap-sessions.sh
+#  * @context  The reaper is destructive-capable; its safety invariants MUST be pinned by tests.
+#  * @reason   work-compass DETECTS stale/orphan but nothing REAPS — this closes the loop safely.
+#  * @impact   Guarantees: never --force, never -D, never touch WIP, never touch main, idempotent.
+#  */
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REAPER="$HERE/../bin/reap-sessions.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); printf '  ✓ %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  ✗ %s\n' "$1"; }
+chk()  { if eval "$2"; then ok "$1"; else bad "$1 — [$2]"; fi; }
+
+# ── fixture: a throwaway repo with 3 linked worktrees + 1 merged orphan branch ──
+SBX="$(mktemp -d)"; trap 'rm -rf "$SBX"' EXIT
+R="$SBX/repo"
+git init -q -b main "$R"
+git -C "$R" config user.email t@t.t; git -C "$R" config user.name t
+echo base > "$R/f"; git -C "$R" add f; git -C "$R" commit -qm init
+OLD='2020-01-01T00:00:00'   # backdated → "stale" past any reasonable --stale-days
+
+mkwt() { # name  date  -> worktree at $R/.worktrees/<name> on branch wt/<name>
+  git -C "$R" worktree add -q "$R/.worktrees/$1" -b "wt/$1" >/dev/null
+  echo "$1" > "$R/.worktrees/$1/x"
+  git -C "$R/.worktrees/$1" add -A
+  GIT_AUTHOR_DATE="$2" GIT_COMMITTER_DATE="$2" git -C "$R/.worktrees/$1" commit -qm "$1"
+}
+mkwt stale-clean  "$OLD"                 # eligible (old) + clean      → REAP
+mkwt stale-wip    "$OLD"                 # eligible (old) + dirty      → SKIP (WIP)
+echo dirty > "$R/.worktrees/stale-wip/wip-uncommitted"   # make it dirty
+mkwt fresh-clean  "$(date +%Y-%m-%dT%H:%M:%S)"           # recent + clean → UNTOUCHED (age guard)
+
+# a merged orphan branch (no worktree) → safe -d ; and an UNMERGED branch → must survive
+git -C "$R" branch merged-orphan main
+git -C "$R" branch -q unmerged-keep main
+git -C "$R" worktree add -q "$R/.worktrees/_um" unmerged-keep >/dev/null
+echo z > "$R/.worktrees/_um/z"; git -C "$R/.worktrees/_um" add z; git -C "$R/.worktrees/_um" commit -qm um
+git -C "$R" worktree remove "$R/.worktrees/_um"   # branch unmerged-keep now has unmerged commit, no worktree
+
+[ -x "$REAPER" ] || { echo "RED: $REAPER not executable yet (expected pre-impl)"; exit 1; }
+
+# ── 1. DRY-RUN (default): reports, mutates nothing ──────────────────────────────
+DRY="$("$REAPER" --repo-dir "$R" --stale-days 7 --json)"
+chk "dry-run: stale-clean is a reap candidate"      "echo '$DRY' | grep -q stale-clean"
+chk "dry-run: stale-wip flagged as WIP-skip"        "echo '$DRY' | grep -q stale-wip"
+chk "dry-run: dry_run=true"                          "echo '$DRY' | grep -q '\"dry_run\"[: ]*true'"
+chk "dry-run: NOTHING removed (stale-clean still on disk)" "[ -e '$R/.worktrees/stale-clean/x' ]"
+chk "dry-run: fresh-clean NOT a candidate (age guard)"     "! echo '$DRY' | grep -q '\"reap\".*fresh-clean'"
+
+# ── 2. APPLY: removes only the eligible+clean; preserves WIP + fresh ────────────
+APP="$("$REAPER" --repo-dir "$R" --stale-days 7 --apply --json)"
+chk "apply: stale-clean worktree removed"           "[ ! -e '$R/.worktrees/stale-clean' ]"
+chk "apply: stale-wip PRESERVED (WIP never reaped)" "[ -e '$R/.worktrees/stale-wip/wip-uncommitted' ]"
+chk "apply: fresh-clean PRESERVED (age guard)"      "[ -e '$R/.worktrees/fresh-clean/x' ]"
+chk "apply: merged-orphan branch deleted"           "! git -C '$R' branch --list merged-orphan | grep -q ."
+chk "apply: unmerged-keep branch SURVIVES"          "git -C '$R' branch --list unmerged-keep | grep -q ."
+chk "apply: main worktree untouched"                "[ -e '$R/f' ]"
+
+# ── 3. IDEMPOTENT: re-apply is a no-op (nothing left eligible+clean) ────────────
+RE="$("$REAPER" --repo-dir "$R" --stale-days 7 --apply --json)"
+chk "idempotent: 2nd apply reaps 0 worktrees"       "echo '$RE' | grep -qE '\"reaped_worktrees\"[: ]*\[[[:space:]]*\]'"
+
+# ── 4. good-neighbor: defers if index.lock present (peer mutating) ──────────────
+: > "$R/.git/index.lock"
+LK="$("$REAPER" --repo-dir "$R" --stale-days 7 --apply --json || true)"
+chk "good-neighbor: defers on index.lock"            "echo '$LK' | grep -qiE 'defer|busy|index.lock'"
+rm -f "$R/.git/index.lock"
+
+echo "── reaper: $PASS passed, $FAIL failed ──"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
[PR-as-Enhancement-Prompt]

## Context
`work-compass` DETECTS stale/orphan worktrees/branches/sessions (6 heuristics) but **nothing REAPS them** — the loop is open, so abandoned worktrees/branches accumulate (the symptom the operator hit on shared repos). This adds the missing executor. Sibling of the structural-enforcement PR (akasha#163) which is the *prevention*; this is the *cure*.

## Objectives
- `bin/reap-sessions.sh`: safely prune stale/orphan worktrees + merged orphan branches.
- Safety invariants (TDD-pinned): **dry-run default · NEVER `--force` · NEVER `-d`/`-D` an unmerged branch · NEVER touches WIP** (`git worktree remove` sans `--force` = native WIP guard) **· NEVER the main worktree** · session transcripts out of scope · idempotent · good-neighbor (defers on `index.lock`).
- Consumes the `worktree-policy` retention model; composes (does not reimplement) `git worktree list`.

## Acceptance criteria
- [x] `tests/test-reap-sessions.sh` **13/13** green (dry-run, apply, WIP-preserved, merged-only branch delete, main untouched, idempotent, index.lock-defer).
- [x] Layer-pure (git + stdlib only; no akasha/Vek deps), bash 3.2 safe, gitleaks clean.
- [ ] Follow-up: surface via `/worktree prune` action + wire into `postflight` P1 SWEEP.

## Cross-links
plan `~/.claude/plans/entre-em-modo-de-valiant-music.md` · `work-compass` · `worktree-policy` · `postflight` P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
