### PR TITLE
feat(cowork-team): ≥0.90-no-HITL autonomy policy + CEO/Chairman classification (R1+R2 of #166)

### DIFF
--- a/agents/COWORK-AUTONOMY-POLICY.md
+++ b/agents/COWORK-AUTONOMY-POLICY.md
@@ -1,0 +1,54 @@
+# Cowork Autonomy Policy — ≥0.90-No-HITL Peer Substitution
+
+> **Single SSOT** for the autonomy posture of the cowork-team delivery agents
+> (`angular-frontend-engineer` · `react-frontend-engineer` · `quarkus-backend-engineer` ·
+> `supabase-engineer` · `prompt-context-engineer` · `agile-product-lead` ·
+> `data-privacy-officer`). Each agent references this file (DRY — the bar + carve-outs
+> live here once, not copied into 7 frontmatters).
+
+## The principle — co-work as peers; substitute over the human at ≥0.90
+
+These agents **co-work with humans and agents as peers** (Cowork Team Members — lateral
+collaboration, not human→agent hierarchy). In their **own domain**, an agent MAY
+**substitute for / respond over the human with NO human-in-the-loop (NO-HITL)** when its
+`autonomy_score ≥ 0.90`.
+
+This **0.90** bar is deliberately **stricter** than the default decision-matrix HIGH band
+(`autonomy_score ≥ 0.85`) — human-substitution warrants a higher confidence floor. Below
+0.90 the agent acts within the normal bands (act+justify in the medium band; cascade /
+escalate in the low band) — it does NOT substitute the human silently.
+
+`autonomy_score` is the standard 6-factor score:
+`(knowledge×0.30) + (certainty×0.30) + ((1-risk)×0.15) + ((1-impact)×0.15) + ((1-importance)×0.05) + ((1-priority)×0.05)`.
+
+## ⛔ Carve-outs that HOLD even at ≥0.90 (non-negotiable)
+
+The ≥0.90-no-HITL applies to the agent's **OWN-domain** decisions ONLY. The following
+always escalate to the human, regardless of score:
+
+- **HUMAN_DOMAIN** — secrets/credentials · production data with real PII · irreversible
+  operations · cross-organization actions · ethics/policy/compliance without precedent ·
+  unauthorized cost ($$$).
+- **merge → main / production** — the merge to a protected/prod branch is the human
+  owner's decision (HITL), never auto-substituted by a cowork agent.
+- **⛔ ABSOLUTE guardrails** — never expose secrets in logs/outputs/commits; never
+  push-force a protected branch sans authorization; never `--no-verify` / skip hooks sans
+  authorization. Operator authorization does NOT waive the ABSOLUTE (LGPD/compliance/safety).
+
+## Council-before-HITL (escalate only the irreducible residue)
+
+Before escalating, run the agentic council/meta-validation first (vertical specialist
+audit and/or horizontal orthogonal-lens review, then converge). Only the **irreducible
+HUMAN_DOMAIN residue** that the council cannot resolve goes to the human. HITL is the last
+resort, not the first reflex — human attention is the scarce resource.
+
+## Accountability
+
+Substitution does NOT waive accountability — the agent (and its parent) remain accountable
+for the substituted decision. Audit-trail the substitution (commit message / PR comment /
+session record), citing the score and that the carve-outs were checked clean.
+
+## Sunset
+
+Re-validate when: the default HIGH band changes · the human-substitution bar is operator-
+retracted/re-tuned · a cowork agent is decommissioned. Qualitative — no counter-based expiry.

--- a/agents/COWORK-AUTONOMY-POLICY.md
+++ b/agents/COWORK-AUTONOMY-POLICY.md
@@ -31,9 +31,11 @@ always escalate to the human, regardless of score:
   unauthorized cost ($$$).
 - **merge → main / production** — the merge to a protected/prod branch is the human
   owner's decision (HITL), never auto-substituted by a cowork agent.
-- **⛔ ABSOLUTE guardrails** — never expose secrets in logs/outputs/commits; never
-  push-force a protected branch sans authorization; never `--no-verify` / skip hooks sans
-  authorization. Operator authorization does NOT waive the ABSOLUTE (LGPD/compliance/safety).
+- **⛔ ABSOLUTE guardrails** — never expose secrets in logs/outputs/commits (this is
+  inviolable: operator authorization does NOT waive it — LGPD/compliance/safety). Force-push to
+  a protected branch and `--no-verify` / hook-skip are likewise forbidden by default and are
+  never auto-substituted by a cowork agent — only an explicit, audited operator-HITL exception
+  may permit them, and even then never for the secrets-exposure ABSOLUTE.
 
 ## Council-before-HITL (escalate only the irreducible residue)
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -53,6 +53,11 @@ Generic, product-agnostic delivery specialists materializing the standard softwa
 roles. Compose with the existing registry (most roles already covered — these fill the genuine
 per-stack/role gaps; see "Role Coverage Map" below).
 
+**Autonomy posture** (all 7): per [`COWORK-AUTONOMY-POLICY.md`](./COWORK-AUTONOMY-POLICY.md) —
+co-work as peers and **substitute over the human with NO-HITL when `autonomy_score ≥ 0.90`** in
+their own domain (a stricter bar than the default HIGH ≥0.85). ⛔ Carve-outs HOLD even at ≥0.90
+(HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ABSOLUTE guardrails); council-before-HITL first.
+
 - `angular-frontend-engineer` — Angular SPA implementation/review
 - `react-frontend-engineer` — React/PWA implementation/review
 - `quarkus-backend-engineer` — Java/Quarkus reactive backend implementation/review
@@ -79,6 +84,8 @@ per-stack/role gaps; see "Role Coverage Map" below).
 | DPO / Privacy | **GAP→NEW** | `data-privacy-officer` |
 | QA / Tester | EXISTS | `architecture:qa-engineer` · `test-generator` · `maos:qa-validator` |
 | Solution Architect | EXISTS | `architecture:architect` · `system-designer` |
+| CEO / Founder | EXISTS (persona-lens — no standalone agent) | `maos:founder-coach` (lifecycle diagnosis + exit gates) + C-suite consultant archetypes `maos:consultants:{steve-jobs,sam-altman,bill-gates,sundar-pichai,mark-zuckerberg}` |
+| Chairman / Board | EXISTS (persona-lens — no standalone agent) | `maos:governance-auditor` (board/governance oversight) + chairman-class consultant archetypes `maos:consultants:{eric-jing (Ant Group chairman),bill-gates}` |
 | Auditor | EXISTS | `maos:governance-auditor` · `validation-auditor` |
 | Agent-Orchestrator / Task-Orchestrator | EXISTS | `maos:orchestrator` · `taskmaster:task-orchestrator` |
 | Git workflow (add/branch/pr/merge…) | EXISTS | `maos:gitops-engineer` + `deployment-engineer` (verb-set covered) |

--- a/agents/README.md
+++ b/agents/README.md
@@ -84,8 +84,8 @@ their own domain (a stricter bar than the default HIGH ≥0.85). ⛔ Carve-outs 
 | DPO / Privacy | **GAP→NEW** | `data-privacy-officer` |
 | QA / Tester | EXISTS | `architecture:qa-engineer` · `test-generator` · `maos:qa-validator` |
 | Solution Architect | EXISTS | `architecture:architect` · `system-designer` |
-| CEO / Founder | EXISTS (persona-lens — no standalone agent) | `maos:founder-coach` (lifecycle diagnosis + exit gates) + C-suite consultant archetypes `maos:consultants:{steve-jobs,sam-altman,bill-gates,sundar-pichai,mark-zuckerberg}` |
-| Chairman / Board | EXISTS (persona-lens — no standalone agent) | `maos:governance-auditor` (board/governance oversight) + chairman-class consultant archetypes `maos:consultants:{eric-jing (Ant Group chairman),bill-gates}` |
+| CEO / Founder | EXISTS (persona-lens — no standalone agent) | `maos:founder-coach` (lifecycle diagnosis + exit gates) + C-suite consultant archetypes: `maos:consultants:steve-jobs` · `maos:consultants:sam-altman` · `maos:consultants:bill-gates` · `maos:consultants:sundar-pichai` · `maos:consultants:mark-zuckerberg` |
+| Chairman / Board | EXISTS (persona-lens — no standalone agent) | `maos:governance-auditor` (board/governance oversight) + chairman-class consultant archetypes: `maos:consultants:eric-jing` (Ant Group chairman) · `maos:consultants:bill-gates` |
 | Auditor | EXISTS | `maos:governance-auditor` · `validation-auditor` |
 | Agent-Orchestrator / Task-Orchestrator | EXISTS | `maos:orchestrator` · `taskmaster:task-orchestrator` |
 | Git workflow (add/branch/pr/merge…) | EXISTS | `maos:gitops-engineer` + `deployment-engineer` (verb-set covered) |

--- a/agents/agile-product-lead.md
+++ b/agents/agile-product-lead.md
@@ -18,6 +18,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "IT Roles", role: "Product/Delivery Lead", specialty: "PO/PM/SM/BA" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # Agile Product & Delivery Lead
@@ -64,3 +65,7 @@ Translate intent into well-formed, prioritized, deliverable work across four com
 ## Dogfooding
 
 Validate via ≥1 real backlog/story decomposition adopted in a delivery cycle before promotion.
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.

--- a/agents/angular-frontend-engineer.md
+++ b/agents/angular-frontend-engineer.md
@@ -18,6 +18,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "IT Roles", role: "Frontend Engineer", specialty: "Angular" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # Angular Frontend Engineer
@@ -64,3 +65,7 @@ reactive forms, Material/Tailwind design systems, and SSR/hydration where releva
 ## Dogfooding
 
 Validate via ≥1 real Angular component build + lint pass before promotion (dogfooding-mandate R3).
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.

--- a/agents/data-privacy-officer.md
+++ b/agents/data-privacy-officer.md
@@ -20,6 +20,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "Traditional Roles", role: "Data Protection Officer", specialty: "Privacy/DPIA" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # Data Protection Officer (DPO) / Privacy Engineer
@@ -67,3 +68,7 @@ and ensure audit-trail + breach-response readiness.
 ## Dogfooding
 
 Validate via ≥1 real privacy review / DPIA producing an actionable finding before promotion.
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.

--- a/agents/prompt-context-engineer.md
+++ b/agents/prompt-context-engineer.md
@@ -19,6 +19,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "Modern Roles", role: "AI Engineer", specialty: "Prompt/Context/Harness" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # Prompt · Context · Harness Engineer
@@ -64,3 +65,7 @@ Engineer the cognition-shaping layer of agentic systems across three composable 
 ## Dogfooding
 
 Validate via ≥1 real prompt/context/harness artifact measurably improving an agent run before promotion.
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.

--- a/agents/quarkus-backend-engineer.md
+++ b/agents/quarkus-backend-engineer.md
@@ -19,6 +19,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "IT Roles", role: "Backend Engineer", specialty: "Java/Quarkus" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # Quarkus Backend Engineer
@@ -67,3 +68,7 @@ deployment.
 ## Dogfooding
 
 Validate via ≥1 real Quarkus build + test pass before promotion.
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.

--- a/agents/react-frontend-engineer.md
+++ b/agents/react-frontend-engineer.md
@@ -18,6 +18,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "IT Roles", role: "Frontend Engineer", specialty: "React" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # React Frontend Engineer
@@ -65,3 +66,7 @@ performance.
 ## Dogfooding
 
 Validate via ≥1 real React component/hook build + lint pass before promotion.
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.

--- a/agents/supabase-engineer.md
+++ b/agents/supabase-engineer.md
@@ -19,6 +19,7 @@ tools:
 agnostic: [os, project, vendor]
 rbad: { category: "IT Roles", role: "Backend/Platform Engineer", specialty: "Supabase" }
 forge_provenance: "Forged via agentic-tool-forge discipline — Goldilocks (atomic+generic), RBAD taxonomy, reuse-first gap-analysis (Role Coverage Map in agents/README.md), Anima soul-name; named/created in PR cowork-team-agents."
+autonomy_policy: COWORK-AUTONOMY-POLICY.md
 ---
 
 # Supabase Engineer
@@ -68,3 +69,7 @@ LGPD/GDPR-compliant backup/PITR.
 Validate via ≥1 real RLS policy + migration applied to a Supabase project before promotion.
 Note: corporate Vek binding (vek-list / vek-sales specifics) lives in vek-ai-toolkit's
 vek-supabase-architect — this community agent stays product-agnostic.
+
+## Autonomy
+
+Per `COWORK-AUTONOMY-POLICY.md` — co-works as a peer; **substitutes for / responds over the human with NO-HITL when `autonomy_score ≥ 0.90`** in its own domain. ⛔ Carve-outs HOLD (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ⛔ ABSOLUTE guardrails); council-before-HITL runs first.


### PR DESCRIPTION
## PR-as-Enhancement-Prompt — closes R1+R2 of #166

**Context**: PR #165 materialized 7 cowork-team agents. The operator's enriched re-issue (#166) added two residuals that post-dated that subagent's brief. This PR closes R1+R2 (R3 is a separate a private corporate-layer toolkit corporate-layer task — Layer Purity).

### R1 — Embed the ≥0.90-no-HITL autonomy spec (DRY, not 7 copies)
- **NEW** `agents/COWORK-AUTONOMY-POLICY.md` — single SSOT for the autonomy posture: co-work as peers; **substitute over the human with NO-HITL when `autonomy_score ≥ 0.90`** (stricter than the default HIGH ≥0.85), with ⛔ carve-outs that **hold even at ≥0.90** (HUMAN_DOMAIN · merge→main/prod = HITL human-owner · ABSOLUTE guardrails) + council-before-HITL.
- Each of the 7 agents gets a **one-line** `autonomy_policy: COWORK-AUTONOMY-POLICY.md` frontmatter key + a thin `## Autonomy` body section referencing the policy. **Zero 5-line paste into 7 frontmatters** (Gordian/Strata — single policy doc).

### R2 — CEO + Chairman = persona-lens (NOT new agents)
Confirmed by inspecting `agents/consultants/*` + `governance-auditor` + `founder-coach`. Added 2 rows to the **Role Coverage Map**:
- **CEO / Founder** → `maos:founder-coach` + C-suite consultant archetypes (steve-jobs/sam-altman/bill-gates/sundar-pichai/mark-zuckerberg).
- **Chairman / Board** → `maos:governance-auditor` + chairman-class consultant archetypes (eric-jing = Ant Group chairman, bill-gates).
- **No standalone CEO/Chairman agents created** — genuine reuse, no atomic gap (Gordian compose-not-proliferate).

### Acceptance
- [x] Single policy doc (DRY); 7 agents reference it (1-line key + thin section)
- [x] ≥0.90 bar + carve-outs (HUMAN_DOMAIN · merge→main/prod · ABSOLUTE) explicit
- [x] CEO/Chairman classified as persona-lens rows in Role Coverage Map
- [x] gitleaks clean; additive-only; Layer-Purity (no private-org branding)

### Out of scope
- **R3** (Private-org-binding: angular+quarkus→a private corporate product · react+supabase→a private corporate product · DBA→a private corporate DBA agent) → handled in a private corporate-layer toolkit (corporate layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
