### PR TITLE
feat(proofread): text-quality skill + /proofread command (grammar pt-BR+en · typos · format)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `proofread` skill — text-quality pass (grammar pt-BR+en · typos · mis-formatting) (`skills/proofread` v1.0.0 + `commands/proofread.md`)
+
+- **NEW skill `proofread`** (soul-name *Aristarchus*) — the THOROUGH on-demand text-quality pass fired when finalizing any text artifact (doc/ADR/README/ticket-body/PR-description/commit-message). An **ECE composition** (`agentic-first §4.7` — deterministic linters × probabilistic rewrite), builds no new engine: **cspell** (catch-anything spell-check, pt-BR dict — flags novel typos like `Aurona` that grep+codespell miss) + **LanguageTool** (grammar/concordância/acentos, run **LOCAL** — never a public API) + **markdownlint-cli2** (structure) + an optional **Grammar-Genie** rewrite.
+- **The cspell≠codespell split (empirically grounded)** — cspell = full-dictionary (catches novel typos, the workhorse); codespell = curated common-misspell pairs (low-noise CI/pre-commit backstop, does NOT catch novel typos). They complement, not compete. Verified: cspell flags `Aurona`, codespell doesn't, LanguageTool flags pt-BR concordância/acentos local.
+- **⛔ Privacy guardrail** — LanguageTool's public API uploads text; sensitive content runs LOCAL only (`languagetool` CLI / `--http` / Docker). Secrets/PII/LGPD.
+- **Self-describing WHEN** (the amnesic-agent trigger lives in the skill `description`) + thin `/proofread` command surface. **Named via `anima`**; forged via `agentic-tool-forge` discipline. Layer-Purity clean (generic, no Vek/org branding). Origin: akasha text-quality roadmap (`ekson73/akasha-claude` PR #182 + `plans/compressed-enchanting-shamir.md`).
+
 ### Added — `corpus-firing-audit` skill — audit a governance corpus FIRING vs THEATER (`skills/corpus-firing-audit` v1.0.0)
 
 - **NEW skill `corpus-firing-audit`** (#163) — audits whether a governance corpus is **alive or theater**: does each rule/memory/instruction actually FIRE at a live decision point, or is it present-but-dormant? Idempotent, read-only P0–P6 pipeline: recon → kind-aware firing classification → recon-readiness sub-check → re-learning detection → Eisenhower-ranked **effectivation** proposals (*sharpen an existing fire-point > add a new passive rule*) → idempotent ledger → verify-and-brief.

--- a/commands/proofread.md
+++ b/commands/proofread.md
@@ -1,0 +1,31 @@
+---
+name: proofread
+description: Proofread a text artifact (doc/ADR/ticket/PR-body/commit-msg) for grammar (pt-BR+en), typos, and mis-formatting before it ships — THOROUGH tier (cspell + LanguageTool-local + markdownlint + optional Grammar-Genie rewrite).
+---
+
+# /proofread Command
+
+Thin wrapper that invokes `skills/proofread/SKILL.md`. The skill holds all logic
+(the stack, when/how, the privacy guardrail, the cspell≠codespell split, output
+discipline); this file is the command surface only.
+
+## Usage
+
+```
+/proofread [<files-or-glob>]
+```
+
+- No argument → proofread the **changed / staged** text files (git diff scope).
+- `<files-or-glob>` → proofread those files (e.g. `/proofread docs/**/*.md`).
+
+## What it does
+
+1. **Typos** — `cspell` (catch-anything, pt-BR dict) → flags novel typos like `Aurona`.
+2. **Grammar** — `languagetool -l pt-BR|en-US` **LOCAL only** (never the public API).
+3. **Formatting** — `markdownlint-cli2`.
+4. **Rewrite (optional)** — a Grammar-Genie pass for tone/clarity over the suggestions.
+
+Reports issues with `file:line` + suggestion; applies high-confidence fixes only after
+confirming (never blind `replace_all`). Skip for trivial/throwaway text.
+
+See `skills/proofread/SKILL.md` for the full stack, install, and bounds.

--- a/skills/proofread/SKILL.md
+++ b/skills/proofread/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: proofread
+version: "1.0.0"
+description: |
+  Use when FINALIZING any text artifact — a doc / ADR / README / ticket body /
+  PR description / commit message / release note — to check GRAMMAR (pt-BR + en-US),
+  TYPOS, and MIS-FORMATTING before it ships. The THOROUGH tier: cspell (catch-anything
+  spell-check — flags novel typos like "Aurona" that grep and codespell miss) +
+  LanguageTool (grammar/concordância/acentos/spelling, run LOCAL — never a public API)
+  + markdownlint (structure) + an optional Grammar-Genie rewrite for tone. An ECE
+  composition (deterministic linters × probabilistic rewrite), not a new engine.
+  Reports issues with file:line + fix suggestions; applies fixes only with confirmation.
+  SKIP for trivial/throwaway text. Triggers: "proofread this", "revise / check grammar",
+  "revisar gramática / ortografia", "find typos", "antes de commitar revise o texto",
+  "is this text clean", "lint this doc", "check spelling pt-BR", "/proofread".
+allowed-tools: Read, Edit, Bash, Grep, Glob
+---
+
+# proofread — text-quality pass (gramática pt-BR+en · typos · mis-formatting)
+
+> **Soul-name**: *Aristarchus* (Aristarchus of Samothrace, ~150 BCE — head of the Library of
+> Alexandria, the founding textual critic who invented the editorial marks; display-only).
+> **System-name** (canonical slug/trigger) = `proofread`. Named via the `anima` envelope.
+> **Pattern**: Eko Convergence Engine — deterministic linters bound + verify a probabilistic
+> rewrite (`agentic-first §4.7`). **Reference catalog**: a host repo's `docs/text-quality-tooling.md`
+> (if present) holds the install matrix + the cspell≠codespell split + the privacy guardrail.
+
+## When to fire (self-describing trigger)
+At the moment you are **about to ship text a human will read**: a doc/ADR/README, a tracker
+ticket body, a PR description, a commit message, a release note. Fire on judgment — no gate.
+**Skip** trivial/throwaway text (a one-line ack, scratch notes), per anti-over-engineering.
+
+## The stack (4 axes — install once, then this skill orchestrates)
+| Axis | Tool | Role |
+|---|---|---|
+| Typos (THOROUGH) | **cspell** + `@cspell/dict-pt-br` | catch-anything — flags novel typos (`Aurona`) |
+| Typos (low-noise) | **codespell** | curated common-misspell pairs (backstop; misses novel) |
+| Grammar pt-BR+en | **LanguageTool** (LOCAL) | concordância · ortografia · acentos · spelling |
+| Mis-formatting | **markdownlint-cli2** | markdown structure |
+| Rewrite/tone | **Grammar-Genie** (this agent) | optional human rewrite over the suggestions |
+
+**Install** (if the CLIs are absent): use the host repo's install script when present
+(`scripts/install-text-quality-tooling.sh`), else: `brew install languagetool markdownlint-cli2`
+· `npm i -g cspell @cspell/dict-pt-br` · `pip install codespell`. Verify: `command -v cspell languagetool`.
+
+## How to run
+```bash
+# 1) typos (THOROUGH — uses repo cspell.json if present; pt-BR dict active)
+cspell <files-or-glob>                 # the workhorse: catches what grep can't enumerate
+# 2) grammar — LOCAL ONLY (see Privacy)
+languagetool -l pt-BR <file.md>        # or  -l en-US
+languagetool --http --port 8081        # local server → POST /v2/check for programmatic use
+# 3) formatting
+markdownlint-cli2 <files-or-glob>
+```
+Scope to the **changed/target files** (don't lint the whole repo). Read the output, then:
+- present a concise issue list (file:line · what · suggestion);
+- for high-confidence corrections (clear typos/accents), apply via Edit **after confirming** the
+  word is a genuine error — never blind `replace_all` (a real-word token may be intentional);
+- optionally offer a Grammar-Genie rewrite for tone/clarity over the mechanical suggestions.
+
+## ⛔ Privacy guardrail (non-negotiable)
+LanguageTool has a PUBLIC API that **uploads your text**. For any sensitive / proprietary
+content run it **LOCAL** (`languagetool` CLI / `--http` / Docker) — NEVER `api.languagetool.org`.
+Same discipline for any cloud grammar service. (Secrets/PII/LGPD.)
+
+## cspell ≠ codespell (the split — don't confuse them)
+- **cspell** = full-dictionary spell-check → flags any unknown token (catches novel typos like
+  `Aurona`); multi-language (pt-BR + en); the **workhorse** of this skill.
+- **codespell** = curated common-misspell pairs (English-biased, low-noise) → a fast CI/pre-commit
+  **backstop** that does NOT catch novel typos. Use both; they complement, not compete.
+
+## Output discipline (anti-theater)
+Report only REAL issues with evidence (file:line). Distinguish a genuine typo from a
+flagged-but-legitimate token (proper noun / coined term → add to the repo's cspell allowlist,
+e.g. `.cspell-akasha-words.txt`, not "fix" it). Verify before replacing (Mente Tomé).
+
+## Skip / bounds
+Skip trivial text · scope to changed files · time-box (don't lint a 200-file repo on a 1-file
+change) · never block a workflow (this is advisory — the on-demand THOROUGH pass; a repo may
+also wire a fast warn-only pre-commit backstop separately).
+
+## Cross-links
+- ECE pattern: `agentic-first-decision-protocol §4.7` (deterministic harness × probabilistic cognition).
+- Named via `skills/anima` (soul-name envelope). Forged via the `agentic-tool-forge` discipline.
+- A consuming repo's `docs/text-quality-tooling.md` = the install/when/how catalog.
+
+## Changelog
+| Version | Date | Change |
+|---|---|---|
+| 1.0.0 | 2026-06-24 | Bootstrap — forged from the akasha text-quality roadmap (`plans/compressed-enchanting-shamir.md`). ECE composition (cspell + LanguageTool-local + markdownlint × Grammar-Genie), pt-BR+en, privacy-local, self-describing WHEN. Soul-name *Aristarchus*. Empirically grounded: cspell catches `Aurona`, codespell doesn't, LanguageTool flags pt-BR concordância/acentos local. |


### PR DESCRIPTION
**[PR-as-Documentation-Prompt]** — forges the `proofread` agentic-tool (P2 of the akasha text-quality roadmap `plans/compressed-enchanting-shamir.md`).

## Context
Companion to `ekson73/akasha-claude` PR #182 (the install stack + configs + amnesic doc). This PR ships the **agentic-tool** half: a community-generic `proofread` skill so any agent knows WHEN/HOW to run the text-quality stack.

## What ships
- **`skills/proofread/SKILL.md`** (v1.0.0, soul-name *Aristarchus*) — ECE composition (cspell + LanguageTool-local + markdownlint × Grammar-Genie), pt-BR+en, privacy-local, self-describing WHEN (the amnesic trigger lives in `description`).
- **`commands/proofread.md`** — thin `/proofread` command surface.
- **CHANGELOG** `[Unreleased]` entry.

## Why community (multi-agent-os)
Generic, cross-vendor, no private-org branding (Layer-Purity) → community per `shared-main-worktree-discipline` D1. The private-org-specific install/config lives in akasha.

## Empirical grounding (validated in akasha PR #182)
- cspell catches `Aurona`; codespell does NOT (the cspell≠codespell split).
- LanguageTool flags pt-BR concordância/acentos + en, **LOCAL** (privacy guardrail).
- Dogfood: cspell on this PR's own files → only pt-BR/jargon false-positives, zero real typos.

## Acceptance
- [x] skill frontmatter valid (name/version/description/allowed-tools)
- [x] auto-discovered (plugin.json doesn't enumerate skills)
- [x] Layer-Purity clean (no org branding) · gitleaks clean · unsigned per `multi-identity §6.1`
- [x] dogfooded (cspell self-check)

Origin: `ekson73/akasha-claude` #182 + `plans/compressed-enchanting-shamir.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

