### PR TITLE
feat(agentic-tool-pipeline): conductor of the agentic-tool lifecycle

### DIFF
--- a/commands/agentic-tool-pipeline.md
+++ b/commands/agentic-tool-pipeline.md
@@ -1,0 +1,25 @@
+---
+name: agentic-tool-pipeline
+description: Conductor of the agentic-tool lifecycle — route ANY --source-object (intent · url · plugin · marketplace · existing tool) to the right family member and run analyze→research→debate→converge→harmonize → forge/adopt/improve one+ agentic-tools of any --type → save to --location. A thin orchestrator that COMPOSES forge/intake/evaluator/trainer/anima/converge — reimplements nothing. Thin wrapper over the `agentic-tool-pipeline` skill.
+argument-hint: "<source-object> | --source-object \"…\" [--type auto|skill|command|agent|mcp|plugin|marketplace] [--location akasha|multi-agent-os|vek-ai-toolkit] [--scope user|project|community|auto] [--research both|internal|external] [--blocks 0,1,2,3,4] [--dry-run] [--json] [--no-confirm]"
+allowed-tools: [Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, Skill]
+---
+
+# /agentic-tool-pipeline
+
+Invoke the **`agentic-tool-pipeline`** skill (Claude Code: `Skill` tool with `skill: "agentic-tool-pipeline"`; other hosts: the equivalent skill-activation mechanism), passing the arguments below.
+
+**Arguments**: `$ARGUMENTS`
+
+## Parsing
+- If `$ARGUMENTS` starts with `--`, pass the flags through verbatim.
+- Else treat the whole string as `--source-object "$ARGUMENTS"` (bare-source shorthand) with defaults: `--type auto --location akasha --scope auto --research both`.
+- Empty `$ARGUMENTS` → print the skill's usage + parameter table; do NOT guess a source-object.
+
+## What it does (skill pipeline)
+**Stage 0 ROUTE** (classify the source-object → forge | intake | trainer | defer) → **EXPAND** (analyze · research internal‖external similars · compare · cross · catalog · categorize · critique) → **FILTER ⇐ DEBATE** (`converge`/`debate-converge` + optional `perspective-trio`/`persona-pipeline`) → **HARMONIZE ⇐ CONVERGE** (`converge` 5-act → one+ synthesized tool-spec) → **FORGE** (the routed member forges/adopts/improves + saves to `--location`; naming via `anima` inside forge). Use `--dry-run` to get the routed tool-spec proposal without writing.
+
+It **reimplements nothing** — every stage delegates to an existing primitive. It applies and passes the 11 principles (DRY · KISS · SSOT · YAGNI · anti-over-eng · anti-theater · boy-scout · DNA-geracional · continuity · idempotency · handoff) via the existing DNA rails.
+
+## Family
+The **conductor** of the agentic-tool lifecycle: **conduct → {forge | intake | evaluate | train}**. Siblings: `skills/agentic-tool-forge`, `skills/agentic-tool-intake`, `skills/agentic-tool-evaluator`, `skills/agentic-tool-trainer`, `skills/anima`; shared `protocols/agentic-tool-lifecycle.md`. Thin-preset precedent: `skills/enhance-pipeline` (feature axis).

--- a/commands/agentic-tool-pipeline.md
+++ b/commands/agentic-tool-pipeline.md
@@ -1,7 +1,7 @@
 ---
 name: agentic-tool-pipeline
 description: Conductor of the agentic-tool lifecycle — route ANY --source-object (intent · url · plugin · marketplace · existing tool) to the right family member and run analyze→research→debate→converge→harmonize → forge/adopt/improve one+ agentic-tools of any --type → save to --location. A thin orchestrator that COMPOSES forge/intake/evaluator/trainer/anima/converge — reimplements nothing. Thin wrapper over the `agentic-tool-pipeline` skill.
-argument-hint: "<source-object> | --source-object \"…\" [--type auto|skill|command|agent|mcp|plugin|marketplace] [--location akasha|multi-agent-os|vek-ai-toolkit] [--scope user|project|community|auto] [--research both|internal|external] [--blocks 0,1,2,3,4] [--dry-run] [--json] [--no-confirm]"
+argument-hint: "<source-object> | --source-object \"…\" [--type auto|skill|command|agent|subagent|mcp|plugin|prompt|marketplace] [--location akasha|multi-agent-os|vek-ai-toolkit] [--scope user|project|community|auto] [--research both|internal|external] [--blocks 0,1,2,3,4] [--dry-run] [--json] [--no-confirm]"
 allowed-tools: [Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, Skill]
 ---
 

--- a/protocols/agentic-tool-lifecycle.md
+++ b/protocols/agentic-tool-lifecycle.md
@@ -1,6 +1,6 @@
 # Agentic-Tool Lifecycle — Shared Reference
 
-> **Shared reference** for `skills/agentic-tool-intake` + `skills/agentic-tool-evaluator` + `skills/agentic-tool-trainer`.
+> **Shared reference** for `skills/agentic-tool-pipeline` (conductor) + `skills/agentic-tool-intake` + `skills/agentic-tool-evaluator` + `skills/agentic-tool-trainer`.
 > **Version**: 1.0.0 (2026-05-28)
 > **Scope**: AAIF cross-vendor. Vendor-neutral; no host-specific hardcoding.
 > **Lineage**: extends `agents/forge.md` KPI + Goldilocks/RBAD to ALL agentic-tool types; complements `skills/skill-writer` (authoring) and `skills/rule-quality-tests` (rule self-validity).
@@ -42,9 +42,10 @@ Agents/commands in this repo use a lighter frontmatter (`name`, `description`, o
 
 ---
 
-## 3. The lifecycle (create / adopt → evaluate → train)
+## 3. The lifecycle (conduct → create / adopt → evaluate → train)
 
 ```
+   agentic-tool-pipeline (CONDUCT) ─ route --source-object + run EXPAND→FILTER→HARMONIZE → land on ↓
    forge / skill-writer     agentic-tool-intake       agentic-tool-evaluator     agentic-tool-trainer
  ┌─ AUTHOR ──────────┐                                                                            
  │  (create new)     ├──▶ INTAKE ──(verdict)──▶ EVALUATE ──────────────▶ TRAIN ──┐
@@ -53,6 +54,7 @@ Agents/commands in this repo use a lighter frontmatter (`name`, `description`, o
         └───────────────────────┘ ◀─── re-author / finalize distilled draft ◀────┘
 ```
 
+- **Conduct** = the single entry that accepts ANY `--source-object` (intent · url · plugin · marketplace · existing tool), classifies it, runs the divergent→convergent→harmonize pass on the genesis *design*, then **routes** to the right member below (bare-intent→forge · candidate→intake · owned-tool→evaluate/train · ambiguous→defer-HITL) and saves to a chosen `--location`. A thin orchestrator (`skills/agentic-tool-pipeline`) — reimplements nothing; the conductor of this family, sibling thin-preset of `skills/enhance-pipeline` (feature axis).
 - **Author** is OUT of scope for evaluator/trainer (use `skill-writer` for skills, `forge` for agents).
 - **Intake** = given a candidate that **already exists** (external repo/MCP/plugin/skill, or an internal proposal), DECIDE whether & how to take it on: `install · create-internally(→forge) · absorb · adapt · sub-agent · abandon · defer-HITL`. A thin composer (`skills/agentic-tool-intake`) — reimplements nothing; on `create-internally` it routes back to **forge**, on `install` it delegates the governed install to `claude-code-concierge`. Distinct from forge (which assumes the artifact does NOT yet exist).
 - **Evaluate** = score current behavior. Read-only. → produces `EVAL-REPORT`.

--- a/skills/README.md
+++ b/skills/README.md
@@ -23,6 +23,9 @@ This folder contains reusable Agent Skills for the Multi-Agent OS framework. Ski
 | `founder-stage-mvp` | `founder-stage-mvp/SKILL.md` | MVP stage — product-market-fit evidence without compounding tech debt |
 | `founder-stage-launch` | `founder-stage-launch/SKILL.md` | Launch stage — repeatable growth; remove the founder bottleneck |
 | `founder-stage-scale` | `founder-stage-scale/SKILL.md` | Scale stage — systematic growth + defensible moat |
+| `agentic-tool-pipeline` | `agentic-tool-pipeline/SKILL.md` | Conductor — route ANY source-object → analyze→research→debate→converge→harmonize → forge/adopt/improve one+ agentic-tools of any type, to any location |
+| `agentic-tool-forge` | `agentic-tool-forge/SKILL.md` | Genesis — turn a raw intent into the right reusable agentic-tool (research-first → decide type → name → forge+save) |
+| `agentic-tool-intake` | `agentic-tool-intake/SKILL.md` | Adopt-or-not — decide whether & how to take on an existing candidate (install/adapt/absorb/create-internally/abandon/defer) |
 | `agentic-tool-evaluator` | `agentic-tool-evaluator/SKILL.md` | Behaviorally evaluate/score/QA any agentic-tool (skill/agent/command/prompt/MCP-tool) |
 | `agentic-tool-trainer` | `agentic-tool-trainer/SKILL.md` | Improve a tool over time (reflect-loop) OR distill a new tool from an observed task |
 
@@ -60,8 +63,11 @@ This folder contains reusable Agent Skills for the Multi-Agent OS framework. Ski
 
 ### Agentic-Tool Lifecycle Skills
 
-> Close the loop after authoring (`skill-writer` / `forge`). Shared reference: `protocols/agentic-tool-lifecycle.md`.
+> The family that creates/adopts → evaluates → trains agentic-tools, **conducted** by `agentic-tool-pipeline`. Shared reference: `protocols/agentic-tool-lifecycle.md`.
 
+- `agentic-tool-pipeline` — **Conductor**: route ANY source-object → run analyze→research→debate→converge→harmonize → land on the right member (forge/intake/evaluator/trainer) → save. Thin preset; reimplements nothing
+- `agentic-tool-forge` — Genesis: raw intent → the right reusable tool (research-first → decide type → name via `anima` → forge+save)
+- `agentic-tool-intake` — Adopt-or-not: existing candidate → decide install/adapt/absorb/create-internally/abandon/defer (gated install)
 - `agentic-tool-evaluator` — Behavioral eval-harness (with/without control + rubric); read-only score + report
 - `agentic-tool-trainer` — Reflect-loop improvement (trace→reflect→distill, Pareto-guarded) + distill-new-tool-from-trace
 

--- a/skills/agentic-tool-pipeline/SKILL.md
+++ b/skills/agentic-tool-pipeline/SKILL.md
@@ -2,20 +2,18 @@
 name: agentic-tool-pipeline
 description: |
   Conductor of the agentic-tool lifecycle — given ANY --source-object (bare intent ·
-  name · ID · text · url · site · plugin · marketplace · path to an EXISTING tool),
-  ROUTE it to the right existing family member and run the full divergent→convergent
-  pass: analyze → research internal+external similars → compare → cross → catalog →
-  categorize → critique → DEBATE → CONVERGE → validate → correct → improve → HARMONIZE
-  → then forge/adopt/improve one+ agentic-tools of any --type and SAVE to --location
-  (akasha · multi-agent-os · vek-ai-toolkit). A thin preset that COMPOSES existing
-  primitives (agentic-tool-forge/intake/evaluator/trainer · anima · converge ·
-  perspective-trio) — reimplements nothing. Applies + passes 11 principles (DRY · KISS ·
-  SSOT · YAGNI · anti-over-eng · anti-theater · boy-scout · DNA-geracional · continuity ·
-  idempotency · handoff). Use when the operator wants ANY source turned into the right
-  agentic-tool through one governed pass: "forge a tool from this url/plugin/intent",
-  "turn any source into the right agentic-tool", "route this to the lifecycle",
-  "conduct the tool-genesis pipeline". Triggers: "agentic-tool-pipeline", "forge from
-  source", "tool genesis pipeline", "route to the agentic-tool lifecycle".
+  url · site · plugin · marketplace · path to an EXISTING tool), ROUTE it to the right
+  family member and run the divergent→convergent pass: analyze → research similars →
+  compare → critique → DEBATE → CONVERGE → validate → improve → HARMONIZE → then
+  forge/adopt/improve one+ agentic-tools of any --type and SAVE to --location (akasha ·
+  multi-agent-os · vek-ai-toolkit). A thin preset that COMPOSES existing primitives
+  (agentic-tool-forge/intake/evaluator/trainer · anima · converge · perspective-trio) —
+  reimplements nothing; applies + passes 11 principles (DRY · KISS · SSOT · YAGNI ·
+  anti-over-eng · anti-theater · boy-scout · DNA-geracional · continuity · idempotency ·
+  handoff). Use when ANY source should become the right agentic-tool in one governed
+  pass. Triggers: "agentic-tool-pipeline", "forge a tool from this url/plugin/intent",
+  "turn any source into the right agentic-tool", "route to the agentic-tool lifecycle",
+  "conduct the tool-genesis pipeline".
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, Skill
 version: 0.1.0
 metadata:
@@ -106,6 +104,21 @@ The operator's terminal verb-set maps onto existing dispositions — `create→f
 `test/criticize/validate/audit→evaluator`. **No new machinery; the router picks the
 member, the converged spec (Stage 3) picks the exact verb.**
 
+### Delegation arg-mapping (conductor flags → each member's real interface)
+The conductor takes ONE `--source-object`; each member has its own input flag. Stage-4
+EMITS the routed invocation by translating per this table (so delegated calls are always
+valid — never a `--source-object` flag the member doesn't accept):
+
+| Route | Emitted invocation (the conductor's `--source-object` + flags → member interface) |
+|---|---|
+| **forge** | `agentic-tool-forge --goal "<source-object>" --type <--type> --scope <--scope> --research <--research> [--dry-run] [--json] [--no-confirm]` — `--location` resolves the member's save-path. |
+| **intake** | `agentic-tool-intake --candidate "<source-object>" --mode decide --scope-target <--location> [--dry-run] [--json]` — `--location` maps to intake's `--scope-target`. |
+| **AMBIGUOUS** | `agentic-tool-intake --candidate "<source-object>" --mode research --dry-run` → read its resolved class → re-enter the §Stage-0 router once; still ambiguous ⇒ DEFER-HITL. |
+| **owned-tool** | normalize `<source-object>` to the tool's path, then `agentic-tool-evaluator <path>` → (on FLAG/FAIL) `agentic-tool-trainer --mode improve <path>`. |
+
+Naming inside the forge route stays forge's existing `anima` delegation; the conductor
+never passes a name flag.
+
 ## The five stages (operator verbs → existing primitive)
 
 ```text
@@ -152,7 +165,7 @@ assembled into ONE manifest that travels by mechanisms that already exist:
 | ANTI-THEATER | `protocols/agentic-tool-lifecycle.md` §8 · host `anti-theater-grounding-protocol` 8Q |
 | BOY-SCOUT | `protocols/exit-hygiene.md` · `skills/postflight` P1 SWEEP |
 | DNA-GERACIONAL | `protocols/delegation/delegation-dna-prompt.md` §DNA Heritage Block |
-| CONTINUITY · HANDOFF | `skills/postflight` P3 seed · `references/continuation-seed-contract.md` |
+| CONTINUITY · HANDOFF | `skills/postflight` P3 seed · `skills/postflight/references/continuation-seed-contract.md` |
 | IDEMPOTENCY | `agentic-tool-forge` Phase-8 (skip-if-identical) |
 
 - **APPLY (self)** — this `## DNA Geracional` section IS the conductor self-governing.
@@ -240,7 +253,7 @@ Dormant-by-design otherwise.
   `agents/persona-pipeline` · `agents/cascade-resolver` · `skills/convergence-engine`.
 - Sibling thin-preset (the precedent): `skills/enhance-pipeline` (feature axis).
 - DNA rails: `protocols/delegation/delegation-dna-prompt.md` · `skills/postflight`
-  (P3 seed + `references/continuation-seed-contract.md`) · `skills/agentic-delegation`.
+  (P3 seed + `skills/postflight/references/continuation-seed-contract.md`) · `skills/agentic-delegation`.
 - Governance: `skills/worktree-policy` · `skills/hierarchical-merge` · `CONTRIBUTING.md`.
 - Cross-link slug: `[[agentic-tool-pipeline]]`.
 

--- a/skills/agentic-tool-pipeline/SKILL.md
+++ b/skills/agentic-tool-pipeline/SKILL.md
@@ -1,0 +1,253 @@
+---
+name: agentic-tool-pipeline
+description: |
+  Conductor of the agentic-tool lifecycle — given ANY --source-object (bare intent ·
+  name · ID · text · url · site · plugin · marketplace · path to an EXISTING tool),
+  ROUTE it to the right existing family member and run the full divergent→convergent
+  pass: analyze → research internal+external similars → compare → cross → catalog →
+  categorize → critique → DEBATE → CONVERGE → validate → correct → improve → HARMONIZE
+  → then forge/adopt/improve one+ agentic-tools of any --type and SAVE to --location
+  (akasha · multi-agent-os · vek-ai-toolkit). A thin preset that COMPOSES existing
+  primitives (agentic-tool-forge/intake/evaluator/trainer · anima · converge ·
+  perspective-trio) — reimplements nothing. Applies + passes 11 principles (DRY · KISS ·
+  SSOT · YAGNI · anti-over-eng · anti-theater · boy-scout · DNA-geracional · continuity ·
+  idempotency · handoff). Use when the operator wants ANY source turned into the right
+  agentic-tool through one governed pass: "forge a tool from this url/plugin/intent",
+  "turn any source into the right agentic-tool", "route this to the lifecycle",
+  "conduct the tool-genesis pipeline". Triggers: "agentic-tool-pipeline", "forge from
+  source", "tool genesis pipeline", "route to the agentic-tool lifecycle".
+allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, Skill
+version: 0.1.0
+metadata:
+  version: "0.1.0"
+  scope: AAIF cross-vendor
+  family: agentic-tool-lifecycle
+  lifecycle-stage: conduct
+  cross_link_slug: agentic-tool-pipeline
+  dogfood_status: self-forged
+---
+
+# Agentic-Tool Pipeline — the lifecycle conductor
+
+Thin **agentic-tool-genesis** preset. `agentic-tool-pipeline` is to the `agentic-tool-*`
+family what `enhance-pipeline` is to features: a single named entry that **routes any
+source-object** into the right lifecycle member, runs the divergent→convergent→harmonize
+loop on the genesis *design*, then lands on a typed terminal that **forges / adopts /
+improves** one+ tools and saves them. It is a **router + sequencer only** — every stage
+delegates to a primitive that already exists in this repo. It **reimplements nothing**.
+
+## Overview
+
+The lifecycle (`forge → intake → evaluate → train`; shared `protocols/agentic-tool-lifecycle.md`)
+already exists as focused members. The missing piece was the **conductor**: no single
+entry accepted *any* source-object, classified it, and drove it through analyze →
+research → debate → converge → harmonize → forge → save while applying and passing on a
+named principle set. This skill is that conductor. Its **only net-new logic** is the
+4-row Stage-0 router; everything downstream is delegation.
+
+## When to use
+- A source of ANY kind (intent · url · plugin · marketplace · an existing owned tool)
+  should become — or improve into — the right agentic-tool, end-to-end, in one pass.
+- You want the genesis *design* researched + debated + converged before anything is written.
+- You don't yet know whether the source is a "forge it" (new) or "adopt it" (exists) or
+  "improve it" (owned) case — let the router decide.
+
+## When **not** to use
+- You already know it's a bare new intent → call `agentic-tool-forge` directly.
+- You already know it's an external candidate to adopt-or-not → `agentic-tool-intake`.
+- You only want to score / improve ONE owned tool → `agentic-tool-evaluator` / `-trainer`.
+- You only need a name → `anima`. You're shipping a *feature* (not a tool) → `enhance-pipeline`.
+- Trivial one-off / read-only Q&A → just answer. Destructive ops → always HITL.
+
+## §0 — BEING > Rules (foundational)
+This skill serves the operator's intent. If a phase/gate obstructs delivering value NOW,
+skip it, log `Skipped <phase> — BEING > Rules`, and proceed. Gates are for quality, never
+ritual. HUMAN_DOMAIN (secrets · PII · irreversibles · cross-org · cost · gated install) →
+escalate, never auto-act.
+
+## Trigger Phrases
+- "agentic-tool-pipeline" / "/agentic-tool-pipeline"
+- "forge a tool from this <url/plugin/marketplace/intent>" / "turn any source into the right tool"
+- "route this to the agentic-tool lifecycle" / "conduct the tool-genesis pipeline"
+
+## Parameters
+| Flag | Default | Meaning |
+|---|---|---|
+| `--source-object <…>` (positional) | *required* | any of: bare intent · name · ID · text · url · site · plugin · marketplace · path to an existing tool. Empty → print usage; STOP. |
+| `--type` | `auto` | force the artifact type `mcp·prompt·command·agent·subagent·skill·plugin·marketplace`; passed verbatim to forge's existing type router. `auto` = router decides. |
+| `--location` | `akasha` | save target: `akasha` (`~/.claude`) · `multi-agent-os` · `vek-ai-toolkit`. Maps to the routed member's scope/save-path. |
+| `--scope` | `auto` | `user·project·community·auto` (forge-compatible; orthogonal to `--location`). |
+| `--research` | `both` | `internal·external·both` — gates Stage 1 (forge-compatible). |
+| `--blocks` | `0,1,2,3,4` | run a subset (e.g. `0,1,2,3` to converge-only, stop before forging). |
+| `--dry-run` | `false` | ROUTE→EXPAND→FILTER→HARMONIZE + emit the tool-spec proposal; STOP before Stage 4 write. |
+| `--output` / `--json` | `table` / off | `--json` emits the family envelope (§ Machine output). |
+| `--no-confirm` | off | skip the Stage-4 pre-write confirm (HITL-gated; standing authorization only). |
+
+Bare `$ARGUMENTS` not starting with `--` → treat the whole string as `--source-object "$ARGUMENTS"`.
+
+> **Deliberately dropped (KISS/YAGNI)**: `--driver`, `--auto-merge[-reason]`,
+> `--autonomy-threshold`, `--max-pdca`. Those belong to the DELIVER drivers
+> (`auto-pilot`/`quiesce`) and to the routed members (forge/intake/trainer carry their
+> own merge/iteration gates). A conductor that re-declared them would duplicate them.
+
+## Stage-0 ROUTER (the only net-new logic — a 4-row decision table)
+
+The router fires once, classifies the source-object, and sets the **terminal family** for Stage 4.
+
+| `--source-object` is… | Discriminator | Routes to (existing entry) | Stage-4 terminal verbs |
+|---|---|---|---|
+| **bare INTENT** (name/ID/text, no artifact behind it) | no resolvable url/repo/owned-path — a wish | `agentic-tool-forge` | create / forge |
+| **EXISTING CANDIDATE** (url · site · plugin · marketplace · external repo/MCP/pkg) | resolves to an artifact that exists *elsewhere* | `agentic-tool-intake` | install · adapt · absorb · sub-agent · create-internally(→forge) · abandon · defer |
+| **EXISTING-TOOL to improve** (path to an *owned* skill/agent/command/MCP) | resolves under akasha / multi-agent-os / vek-ai-toolkit | `agentic-tool-evaluator` → `agentic-tool-trainer` | fix · improve · train · test · criticize · validate · audit |
+| **AMBIGUOUS** | router cannot classify with confidence | `agentic-tool-intake --mode=research` (cheapest disambiguator) → re-enter router; still ambiguous ⇒ **DEFER-HITL** | (re-routed) |
+
+The operator's terminal verb-set maps onto existing dispositions — `create→forge`,
+`adapt/incorporate/install→intake`, `fix/improve/train→trainer`,
+`test/criticize/validate/audit→evaluator`. **No new machinery; the router picks the
+member, the converged spec (Stage 3) picks the exact verb.**
+
+## The five stages (operator verbs → existing primitive)
+
+```text
+STAGE 0 ROUTE     := classify --source-object → terminal family (the table above)
+STAGE 1 EXPAND    := analyze + research[internal‖external] similars + compare + cross
+                     + catalog + categorize + critique + expand
+STAGE 2 FILTER    := critique + DEBATE + select + correct
+STAGE 3 HARMONIZE := CONVERGE + validate + conclude + correct + improve + HARMONIZE
+STAGE 4 FORGE     := forge[create·adapt·fix·improve·train·test·audit·incorporate·install]
+                     → SAVE to --location
+```
+
+| Stage | Composes (cite — do NOT reimplement) |
+|---|---|
+| **0 ROUTE** | the §Stage-0 router table (net-new) |
+| **1 EXPAND** | `agentic-tool-forge` Phase-1 research (internal `Glob`/`Grep` DRY probe + external `WebSearch`/`find-docs`/Context7); the same engine `agentic-tool-intake` Phase-2 delegates to · `enhance-pipeline` EXPAND row |
+| **2 FILTER ⇐ DEBATE** | `skills/converge` Acts 1-2 (steelman→critique) OR `debate-converge` for a real council; optional fan-out `agents/perspective-trio` (3 lenses) / `agents/persona-pipeline` (6-stage board) |
+| **3 HARMONIZE ⇐ CONVERGE+HARMONIZE** | `skills/converge` full 5-act (steelman→critique→compare→synthesize→reject-log) → ONE+ synthesized tool-spec(s). AUDIT-not-PERSUASION bias guards inherited. |
+| **4 FORGE / DELIVER** | the **routed** member from Stage 0: `agentic-tool-forge` (create) · `agentic-tool-intake` (adapt/absorb/install; install gated via `claude-code-concierge`) · `agentic-tool-trainer`+`-evaluator` (improve/test/audit). `--type` honored by forge's type router; save-path by `--location`. Naming inside Stage 4 is forge's existing delegation to `anima` — the conductor never names. Loops the terminal when the synthesis yields multiple tools. |
+
+> **Anti-NIH discipline**: the conductor EMITS invocations of the above; it never inlines
+> their logic. A missing optional primitive degrades to the in-repo column with a one-line
+> diagnostic — never a hard failure. `--dry-run` proves it: grep the run confirms only
+> delegation to existing members + native research tools — zero reimplementation.
+
+## How it works
+```text
+operator invokes /agentic-tool-pipeline "<source-object>"
+        v   STAGE 0 ROUTE  -> terminal family {forge | intake | trainer | defer}
+        v   STAGE 1 EXPAND -> findings + similars + prior-art bundle
+        v   STAGE 2 FILTER -> debated / selected candidate set + corrections
+        v   STAGE 3 HARMONIZE -> ONE+ synthesized tool-spec(s) (via `converge` 5-act)
+        v   STAGE 4 FORGE  -> routed member forges/adopts/improves + saves to --location
+        v   emit exactly ONE STOP marker as the last line of the turn
+```
+
+## DNA Geracional — apply to self + pass on (3 existing rails, ONE manifest of pointers)
+The 11 principles are **not re-authored** — each is a pointer to an existing SSOT,
+assembled into ONE manifest that travels by mechanisms that already exist:
+
+| Principle(s) | Canonical SSOT |
+|---|---|
+| DRY · KISS · SSOT · YAGNI · ANTI-OVER-ENG | `agentic-tool-forge` §0/§Topology · host `scope-discipline-pre-creation` 6Q |
+| ANTI-THEATER | `protocols/agentic-tool-lifecycle.md` §8 · host `anti-theater-grounding-protocol` 8Q |
+| BOY-SCOUT | `protocols/exit-hygiene.md` · `skills/postflight` P1 SWEEP |
+| DNA-GERACIONAL | `protocols/delegation/delegation-dna-prompt.md` §DNA Heritage Block |
+| CONTINUITY · HANDOFF | `skills/postflight` P3 seed · `references/continuation-seed-contract.md` |
+| IDEMPOTENCY | `agentic-tool-forge` Phase-8 (skip-if-identical) |
+
+- **APPLY (self)** — this `## DNA Geracional` section IS the conductor self-governing.
+- **PASS (produced tools)** — rely on forge's *existing* DNA-inheritance (it already
+  injects §0 + gates + DUED + Refs into the child); do **not** re-inject (DRY).
+- **PASS (delegated sub-agents)** — emit the verbatim **DNA Heritage Block** in each
+  Stage-1/2 `Task` sub-prompt (`protocols/delegation/delegation-dna-prompt.md`).
+- **PASS (across compact/clear)** — ride the `postflight` P3 `dna.principles[]` +
+  `dna.canonical_ref` continuation seed, so a fresh amnesic agent resuming a multi-tool
+  run inherits them.
+
+## "Does NOT do" (anti-overlap — it conducts, never re-executes)
+Does NOT author/forge directly (→ `agentic-tool-forge`) · does NOT decide adopt-or-not
+(→ `agentic-tool-intake`) · does NOT score behavior (→ `agentic-tool-evaluator`) · does
+NOT improve/distill (→ `agentic-tool-trainer`) · does NOT name (→ `anima`, inside forge) ·
+does NOT reimplement research/debate/convergence (→ forge Phase-1 / `debate-converge` /
+`converge`) · does NOT install (→ intake's gated `claude-code-concierge`) · does NOT ship
+features or drive sessions (→ `enhance-pipeline` / `quiesce` / `auto-pilot`).
+
+| Sibling | Its scope | This conductor's delta |
+|---|---|---|
+| `agentic-tool-forge` | ONE bare intent → ONE tool | accepts ANY source-object type + routes; forge is just its create-terminal |
+| `agentic-tool-intake` | ONE existing candidate → adopt verdict | its candidate-terminal; intake doesn't run the full EXPAND→CONVERGE front-half for intents |
+| `agentic-tool-trainer`/`-evaluator` | improve/score ONE owned tool | its improve-terminal |
+| `enhance-pipeline` | ONE *feature* → shipped code | **same EXPAND→FILTER→HARMONIZE engine**, but DELIVER = *forge agentic-tools*, not ship a feature. Sibling along the "the artifact IS a tool" axis. |
+
+## Machine output (`--json`)
+```json
+{"source_object":"<…>","route":"forge|intake|trainer|defer","stage":"ROUTE|EXPAND|FILTER|HARMONIZE|FORGE|done",
+ "verdict":"FORGED|EXTEND|INSTALL|ADAPT|IMPROVE|DEFER","produced":[{"type":"skill","name":"<…>","path":"<…>","location":"<…>"}],
+ "stop_marker":"STOP-DONE|STOP-HITL|STOP-ERROR|CONTINUE","_agent_feedback":"<governance hints>"}
+```
+Exit codes ([C06]): `0` produced OR proposal emitted (`--dry-run`) · `1` error · `2` HITL/defer.
+
+## STOP-marker grammar (paired with `--goal-aware`, shared with the family — not re-authored)
+Emit exactly ONE terminal marker as the last line of each turn:
+```text
+<!--ORCH-STATUS: STOP-DONE -->     tool(s) produced (or proposal emitted under --dry-run)
+<!--ORCH-STATUS: STOP-HITL -->     HITL escalation required (DEFER-HITL, install-gate, HUMAN_DOMAIN)
+<!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (routed member / network / rate-limit)
+<!--ORCH-STATUS: CONTINUE -->      stage done; pipeline continues; evaluator decides next turn
+```
+
+## Protocol Rules (bounds)
+- Worktree discipline always on (`skills/worktree-policy`); never commit to main.
+- Delegation depth ≤ 2 (forge-like recursion cap); parallel ≤ 3; 6-attempt escalation rule.
+- EXPAND external research is time-boxed; cite sources (never fabricate prior art).
+- HARMONIZE is AUDIT-not-PERSUASION (inherits `converge` reject-log + bias guards).
+- HUMAN_DOMAIN + non-negotiable guardrails (secrets/PII, force-push protected, gated
+  install, cross-org) ALWAYS halt → HITL.
+- Exactly ONE STOP marker per turn (the `/goal` evaluator contract).
+
+## §Quality Tests (self-dogfood — 6/6)
+1. **Self-Application** — this skill was forged *by its own pipeline*: Stage-0 classified
+   "a conductor that forges tools" → INTENT → forge; Stage-1 EXPAND surfaced the in-repo
+   similars (`enhance-pipeline`, the four `agentic-tool-*`) and the DRY ≥50% test confirmed
+   NO single member routes-by-source-object across the family (gap real); Stage-2/3
+   debated+converged the 5-stage shape; Stage-4 forge authored this SKILL.md, `anima` named
+   it (`agentic-tool-pipeline`, rejected `-foundry`/`-conductor`), DNA inherited. ✅
+2. **Non-Contradiction** — orchestrates siblings without duplicating them; consistent with
+   the lifecycle SSOT + `enhance-pipeline` thin-preset precedent. ✅
+3. **Survival** — applied to itself it advocates routing-then-forging; it IS a routed,
+   forged skill. ✅
+4. **Bounded-Responsibility** — `--dry-run` · `--blocks` · confirm-before-write ·
+   recursion ≤2 · routes (never re-does) · DUED sunset. ✅
+5. **Explicit-Exception** — §0 BEING>Rules escape + HUMAN_DOMAIN escalation + `--type`/`--location` overrides + AMBIGUOUS→DEFER-HITL. ✅
+6. **Utility-Sunset** — §DUED below. ✅
+Pre-creation scope-discipline 6Q: 6/6 (WHERE=community framework · DRY=gap-confirmed
+[no source-object conductor] · WHY=operator directive · WHO=any agent + amnesic ·
+FITS=lifecycle-family conductor · MIN=Goldilocks thin-preset). Anti-theater 8Q REALITY: 8/8.
+
+## §DUED Sunset (qualitative, not counter-based)
+Deprecate when ANY: the lifecycle family absorbs the conductor into a unified
+`agentic-tool-lifecycle` entry (E6) · the host ships a native multi-source tool-genesis
+conductor (E1) · `enhance-pipeline` generalizes to a `--target=agentic-tool` driver that
+supersedes it (E6) · operator retraction (E4) · ≥3 false-positive routings (E5).
+Dormant-by-design otherwise.
+
+## §Refs
+- Lifecycle members (co-located): `skills/agentic-tool-forge` · `skills/agentic-tool-intake`
+  · `skills/agentic-tool-evaluator` · `skills/agentic-tool-trainer` · shared
+  `protocols/agentic-tool-lifecycle.md` (§3 diagram carries the `conduct` slot).
+- Naming: `skills/anima` (Stage-4 naming, delegated *inside* forge).
+- Convergence kernel: `skills/converge` (5-act) · `agents/perspective-trio` ·
+  `agents/persona-pipeline` · `agents/cascade-resolver` · `skills/convergence-engine`.
+- Sibling thin-preset (the precedent): `skills/enhance-pipeline` (feature axis).
+- DNA rails: `protocols/delegation/delegation-dna-prompt.md` · `skills/postflight`
+  (P3 seed + `references/continuation-seed-contract.md`) · `skills/agentic-delegation`.
+- Governance: `skills/worktree-policy` · `skills/hierarchical-merge` · `CONTRIBUTING.md`.
+- Cross-link slug: `[[agentic-tool-pipeline]]`.
+
+## Changelog
+| Version | Date | Change |
+|---|---|---|
+| 0.1.0 | 2026-06-25 | Bootstrap — the **conductor** of the `agentic-tool-lifecycle` family. Net-new = the 4-row Stage-0 source-object router + the typed Stage-4 terminal; everything else delegates (forge Phase-1 research · `converge` 5-act · `perspective-trio`/`persona-pipeline` · the four members). Sibling thin-preset of `enhance-pipeline` (tool-genesis axis vs feature axis). 11-principle DNA applied to self + passed via the 3 existing rails (forge inheritance · `delegation-dna-prompt` · `postflight` P3 seed). Named via `anima` (`agentic-tool-pipeline`; rejected `-foundry` collides-with-forge, `-conductor` ontology-mismatch). Self-forged (the §Quality-Tests Self-Application IS its own genesis trace). 6/6 self-validity + 8/8 anti-theater + 6/6 scope-discipline. |
+
+## License
+MIT (matches multi-agent-os repo `LICENSE`).

--- a/skills/agentic-tool-pipeline/SKILL.md
+++ b/skills/agentic-tool-pipeline/SKILL.md
@@ -1,19 +1,18 @@
 ---
 name: agentic-tool-pipeline
 description: |
-  Conductor of the agentic-tool lifecycle — given ANY --source-object (bare intent ·
-  url · site · plugin · marketplace · path to an EXISTING tool), ROUTE it to the right
-  family member and run the divergent→convergent pass: analyze → research similars →
-  compare → critique → DEBATE → CONVERGE → validate → improve → HARMONIZE → then
-  forge/adopt/improve one+ agentic-tools of any --type and SAVE to --location (akasha ·
-  multi-agent-os · vek-ai-toolkit). A thin preset that COMPOSES existing primitives
-  (agentic-tool-forge/intake/evaluator/trainer · anima · converge · perspective-trio) —
-  reimplements nothing; applies + passes 11 principles (DRY · KISS · SSOT · YAGNI ·
-  anti-over-eng · anti-theater · boy-scout · DNA-geracional · continuity · idempotency ·
-  handoff). Use when ANY source should become the right agentic-tool in one governed
-  pass. Triggers: "agentic-tool-pipeline", "forge a tool from this url/plugin/intent",
-  "turn any source into the right agentic-tool", "route to the agentic-tool lifecycle",
-  "conduct the tool-genesis pipeline".
+  Conductor of the agentic-tool lifecycle — given ANY --source-object (intent · url ·
+  plugin · marketplace · path to an existing tool), ROUTE it to the right family member
+  and run the divergent→convergent pass: analyze → research similars → compare →
+  critique → DEBATE → CONVERGE → validate → improve → HARMONIZE → then forge/adopt/improve
+  one+ agentic-tools of any --type and SAVE to --location (akasha · multi-agent-os ·
+  vek-ai-toolkit). A thin preset that COMPOSES existing primitives (agentic-tool-forge/
+  intake/evaluator/trainer · anima · converge · perspective-trio) — reimplements nothing;
+  applies + passes 11 principles (DRY · KISS · SSOT · YAGNI · anti-over-eng · anti-theater
+  · boy-scout · DNA-geracional · continuity · idempotency · handoff). Use when ANY source
+  should become the right agentic-tool in one governed pass. Triggers:
+  "agentic-tool-pipeline", "forge a tool from this url/plugin/intent", "turn any source
+  into the right agentic-tool", "route to the agentic-tool lifecycle".
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch, Skill
 version: 0.1.0
 metadata:


### PR DESCRIPTION
## [PR-as-Enhancement-Prompt] Conductor of the agentic-tool lifecycle

### Context
The `agentic-tool-*` lifecycle family already exists as focused members — `agentic-tool-forge` (genesis from intent), `agentic-tool-intake` (adopt an existing candidate), `agentic-tool-evaluator`/`-trainer` (score/improve), `anima` (naming), and the `converge`/`perspective-trio`/`persona-pipeline` convergence kernel. What was **missing** was the conductor: no single entry that accepts *any* source-object, classifies it, drives the divergent→convergent→harmonize loop on the genesis design, and lands on the right member while applying + passing a named principle set. This PR adds that conductor — the same thin-preset role `enhance-pipeline` plays for features, now for tool genesis.

### Objectives
- Add `agentic-tool-pipeline` — a **router + sequencer only** that **reimplements nothing**; every stage delegates to an existing primitive.
- Net-new logic = the 4-row Stage-0 source-object router + the typed Stage-4 terminal. Everything else: forge Phase-1 research · `converge` 5-act · `perspective-trio`/`persona-pipeline` · the four members.
- Apply + pass the 11 principles (DRY · KISS · SSOT · YAGNI · anti-over-eng · anti-theater · boy-scout · DNA-geracional · continuity · idempotency · handoff) via the **existing** DNA rails (forge inheritance · `delegation-dna-prompt` · `postflight` P3 seed) — no re-authoring.

### Changes
- **add** `skills/agentic-tool-pipeline/SKILL.md` (v0.1.0) + `commands/agentic-tool-pipeline.md` wrapper (`/maos:agentic-tool-pipeline`).
- **edit** `skills/README.md` — add the lifecycle-family rows; boy-scout the two existing-but-undocumented members (`forge`, `intake`) into the table + cluster.
- **edit** `protocols/agentic-tool-lifecycle.md` — add the `conduct` slot to the §3 diagram + a Conduct bullet + the shared-reference header.

### Naming
Named via **`anima`** (operator directive "invoque Anima para nomear"): **`agentic-tool-pipeline`** — 12/12 correctness, agent register, zero epistemic drift (`-pipeline` matches the `enhance-pipeline` sibling precedent; a skill is a *process*, so the process-noun fits). Rejected runner-ups: `-conductor` (ontology mismatch — reads as an agent/persona, kept only as the display-only role-descriptor "the lifecycle conductor") and `-foundry` (semantically collides with `forge`).

### Acceptance / verification
- [x] `bash tests/validate-plugin.sh .` → **PASSED** (0 errors).
- [x] Frontmatter `name:` matches dir on both SKILL.md + command; `skills/*/SKILL.md` ignore-glob gotcha checked (not ignored).
- [x] Composition guard: every stage NAMES an existing primitive (anti-NIH); `--dry-run` proves zero reimplementation by design.
- [x] In-file 6/6 self-validity + 8/8 anti-theater + 6/6 scope-discipline.
- [x] **Self-forged** (the operator's "does exactly what you're going to do" recursion): the §Quality-Tests Self-Application IS this skill's own genesis trace — Stage-0 classified it as INTENT→forge, Stage-1 EXPAND confirmed the gap (no source-object conductor), Stage-3 converged the 5-stage shape, Stage-4 forge authored it + `anima` named it.
- [ ] Behavioral smoke (`/agentic-tool-evaluator skills/agentic-tool-pipeline`: one INTENT / one CANDIDATE-url / one owned-tool-path / one AMBIGUOUS → assert each routes to the correct terminal) — follow-up in the dogfood cycle.

### Out of scope
No new convergence/research/naming machinery (all delegated). No extension of `enhance-pipeline` (feature axis — this is the tool-genesis sibling, cross-linked not merged). No live forge of a second tool this cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
