### PR TITLE
feat(gap-loop): harness-agnostic convergence-loop skill distilled from --goal-n-loop

### DIFF
--- a/commands/gap-loop.md
+++ b/commands/gap-loop.md
@@ -23,6 +23,7 @@ The reusable methodology behind it lives in `protocols/gap-loop-protocol.md`.
           [--max-iterations=6]
           [--socratic-depth=N]          (from SSOT; never hardcode "33")
           [--auto-merge=hold|authorized|off]   (default hold — EKO-66 STAGE-only)
+          [--auto-merge-reason="<why>"]        (required when --auto-merge=authorized)
           [--driver=self|auto-pilot]
 ```
 
@@ -37,7 +38,7 @@ when you want a self-driven, self-scored, gap-register convergence loop in ANY h
 /gap-loop "harden the auth gaps before we ship"
 /gap-loop --state-source=ticket:VKS-1234 --max-iterations=4
 /gap-loop --autonomy-threshold=0.9 --socratic-depth=12
-/gap-loop --auto-merge=authorized   # only when the operator authorizes the merge
+/gap-loop --auto-merge=authorized --auto-merge-reason="green CI, operator-authorized"   # reason required when authorized
 ```
 
 ## Related

--- a/commands/gap-loop.md
+++ b/commands/gap-loop.md
@@ -1,0 +1,47 @@
+---
+name: gap-loop
+description: Drive a goal — as a GAP-REGISTER — to convergence via a harness-agnostic, self-scored 5-phase loop (DoR -> RECAP -> RESOLVE MoE-per-gap -> VALIDATE independent-audit -> PERSIST), looping until [every gap dispositioned AND agentic convergence AND autonomy_score >= 0.85]. No /goal dependency. Override-friendly.
+---
+
+# /gap-loop Command
+
+Thin wrapper that invokes `skills/gap-loop/SKILL.md`. The skill holds all logic
+(the CONVERGED termination predicate, the 5 phases, the anti-gaming derived SCORE rule,
+the low-score -> rotate-roster re-loop, the HITL-as-problem SOFT/HARD classification, the
+harness-agnostic declarative driver, the composition wiring, the override flags, and the
+STOP-marker grammar). This file is the command surface only.
+
+The reusable methodology behind it lives in `protocols/gap-loop-protocol.md`.
+
+## Usage
+
+```text
+/gap-loop "<goal / instructions>"
+          [--state-source=pulse|ticket:<id>|file|free-text]   (default pulse)
+          [--condition='<override predicate>']
+          [--autonomy-threshold=0.85]
+          [--max-iterations=6]
+          [--socratic-depth=N]          (from SSOT; never hardcode "33")
+          [--auto-merge=hold|authorized|off]   (default hold — EKO-66 STAGE-only)
+          [--driver=self|auto-pilot]
+```
+
+Sibling routing: use `/quiesce` when the host HAS `/goal` and you want session-PR
+quiescence; use `/auto-pilot` for plain decompose+delegate of ONE goal; use `gap-loop`
+when you want a self-driven, self-scored, gap-register convergence loop in ANY harness
+(including one with no `/goal`).
+
+## Examples
+
+```text
+/gap-loop "harden the auth gaps before we ship"
+/gap-loop --state-source=ticket:VKS-1234 --max-iterations=4
+/gap-loop --autonomy-threshold=0.9 --socratic-depth=12
+/gap-loop --auto-merge=authorized   # only when the operator authorizes the merge
+```
+
+## Related
+
+- `skills/gap-loop/SKILL.md` — full skill logic
+- `protocols/gap-loop-protocol.md` — the reusable methodology
+- `commands/quiesce.md` — the `/goal`-dependent session-quiescence sibling

--- a/protocols/gap-loop-protocol.md
+++ b/protocols/gap-loop-protocol.md
@@ -52,7 +52,7 @@ TERMINATION — keep looping until ALL true; do NOT stop early:
              AND ( agentic CONVERGENCE — >=2 dissenting positions reconciled into ONE synthesis + reject-log )
              AND ( autonomy_score >= 0.85, DERIVED + evidence-backed — §3 )
 
-BOUNDS: --autonomy=L2-unattended · --max-iterations=6 ·
+BOUNDS: autonomy-band=L2-unattended (set via --autonomy-threshold) · --max-iterations=6 ·
         --principles=[DRY,SSOT,KISS,YAGNI,ANTI-OVER-ENG,ANTI-THEATER,CONTINUITY,HAND-OFF,BOY-SCOUT] ·
         --principle-exception="documented justification (SDP)" · --meta-rule="BEING > law"
 

--- a/protocols/gap-loop-protocol.md
+++ b/protocols/gap-loop-protocol.md
@@ -1,0 +1,154 @@
+# Gap-Loop Protocol — Harness-Agnostic Convergence-Loop Methodology
+
+> **Shared reference / extracted methodology** for `skills/gap-loop` (its runnable embodiment) —
+> and a **citable vocabulary** that sibling orchestration skills (`quiesce`, `convergence-engine`,
+> `auto-pilot`, `enhance-pipeline`) MAY adopt without duplicating it.
+> **Version**: 1.0.0 (2026-06-29)
+> **Scope**: AAIF cross-vendor. Vendor-neutral; runs in cowork / Claude Code / SDK / Cursor / Codex / Gemini / Copilot.
+> **Lineage**: distilled (meta-concept extraction) from the operator's `--goal-n-loop` prompt; composes
+> `skills/converge` (5-act), `skills/convergence-engine` (master condition + economic stop),
+> `agents/perspective-trio` + `agents/persona-pipeline` (MoE breadth/depth), `agents/cascade-resolver`
+> (score formula + 12-role rotation), `agents/forge` (Forge + 33-Socratic), `skills/decision-capture` (ASH audit).
+> Complements `quiesce` (which composes the native `/goal` loop) by NOT depending on `/goal`.
+
+This document is the common methodology. Read it once; the skill references it instead of inlining
+the rationale, and siblings can cite a concept by name (e.g. "apply Gap-Loop §3 SCORE rule").
+
+---
+
+## §0 — BEING > Rules (foundational)
+
+The loop serves the goal, not the reverse. *"BEING > law; law serves the goal; any rule admits a
+justified exception (SDP — documented justification)."* This is the global §0 SER>Regras made
+loop-local; it is the `--principle-exception` escape and overrides any §below in genuine conflict.
+
+---
+
+## §1 — The 10 meta-concepts (the M.O.)
+
+Distilled from `--goal-n-loop`. ★ = net-new to the MAOS family; ○ = composes an existing primitive.
+
+1. ★ **Harness-Agnostic Declarative Condition-Loop** (§2) — the loop is expressed declaratively;
+   the agent self-evaluates the predicate each turn. No `/goal` slash-command dependency.
+2. ○ **Gap-Register-Driven Resolution** (§2) — a goal is decomposed into a deduplicated, IDed
+   gap-register (G1..Gn); each gap is *dispositioned*; full disposition is a termination condition.
+3. ○ **MoE Diverge→Converge per Gap** (§4) — >=2 diverse experts + 1 arbiter run the 5-act `converge`.
+4. ○ **Independent Validation (verifier != generator)** (§4) — the audit uses experts DIFFERENT
+   from the resolve step (the `convergence-engine` master condition).
+5. ★ **Anti-Gaming Derived Score** (§3) — `autonomy_score` is derived, per-dimension, names its binding constraint.
+6. ★ **Low-Score → New-Perspectives Re-Loop** (§3) — rotate the roster (same panel FORBIDDEN), NOT HITL.
+7. ★ **HITL-as-Problem Classification (SOFT vs HARD)** (§5).
+8. ○→★ **Socratic-Depth=N Gate** (§4) — question-bank from SSOT at parameterized depth; don't hardcode "33".
+9. ○ **Persist + Boy-Scout DoD** (§6) — decision-audit + reject-log + tickets + leave-cleaner + STAGE-only git.
+10. ○ **Principle-Exception meta-rule** (§0) — BEING > law; justified exception (SDP).
+
+---
+
+## §2 — The loop (declarative, self-driven)
+
+```text
+TERMINATION — keep looping until ALL true; do NOT stop early:
+  CONVERGED := ( every gap DISPOSITIONED — fix-applied | deferred-with-rationale | accepted-as-risk )
+             AND ( agentic CONVERGENCE — >=2 dissenting positions reconciled into ONE synthesis + reject-log )
+             AND ( autonomy_score >= 0.85, DERIVED + evidence-backed — §3 )
+
+BOUNDS: --autonomy=L2-unattended · --max-iterations=6 ·
+        --principles=[DRY,SSOT,KISS,YAGNI,ANTI-OVER-ENG,ANTI-THEATER,CONTINUITY,HAND-OFF,BOY-SCOUT] ·
+        --principle-exception="documented justification (SDP)" · --meta-rule="BEING > law"
+
+PHASES (per round):
+  0 DoR     precheck state; branch+worktree isolation (anti-conflict); SSOT targets reachable; abort-with-reason if unmet.
+  1 RECAP   from one state-source enumerate [purposes, plan, roadmap, open-problems, gaps, pending]
+            -> deduplicated IDed gap-register (G1..Gn). Inject prior HITL / low-score items as gaps. (no hallucination.)
+  2 RESOLVE per gap: >=2 DIVERSE experts (Forge if competency absent) + 1 arbiter; 5-act converge
+            [steelman -> critique -> compare -> synthesize -> reject-log];
+            output {decision, rationale, rejected-alternatives, residual-risk, confidence}.
+  3 VALIDATE independent audit (experts != Phase 2); Socratic gate (--socratic-depth=N); Sentinel audit;
+            any FAIL re-enters Phase 2 as a gap; compute autonomy_score (§3) -> drives the loop.
+  4 PERSIST decision-audit + convergence-report + reject-log + tickets + boy-scout (§6).
+```
+
+**Harness-agnostic**: on Claude Code MAY pair with `/goal --goal-aware` (free Stop-hook evaluator);
+on cowork/SDK/other the agent self-evaluates the predicate and emits ONE STOP marker per turn. The
+methodology never *requires* a slash-command — that is the seam it fills relative to `quiesce`.
+
+---
+
+## §3 — Anti-gaming SCORE rule + Low-score re-loop
+
+- `autonomy_score` is **DERIVED, never declared** — it MUST trace to dispositioned gaps + Phase-3
+  audit results. Each round emits a **per-dimension breakdown** (viability · security · usability ·
+  convergence-quality · residual-risk · ...) and **NAMES the binding constraint** (the dimension
+  dragging the score down). Score asserted without that trace = invalid (anti-theater R2).
+  Reuse `agents/cascade-resolver` autonomy_score formula + `convergence-engine` master condition + economic stop.
+- **Low-score → re-loop, NOT HITL** (while `iteration < max-iterations`): open a NEW round targeting
+  the binding constraint with NEW perspectives — **rotate the MoE roster (re-running the same panel
+  is FORBIDDEN)** · add a red-team seat · re-frame the weakest dimension · Forge a missing competency.
+  Escalate the whole goal only when `iteration >= max-iterations` AND score still `< threshold`
+  (park-state + SDP). If the binding constraint is a HARD gate (§5) → escalate THAT item only and
+  CONTINUE the loop on remaining gaps.
+
+---
+
+## §4 — RESOLVE (MoE) + VALIDATE (independent) + Socratic gate
+
+- **RESOLVE** (per gap): roster = >=2 DIVERSE experts (`perspective-trio`; Forge via `agents/forge`
+  if a competency is absent) + 1 arbiter; protocol = `converge` 5-act (steelman→critique→compare→
+  synthesize→reject-log). The reject-log is first-class (non-lossy).
+- **VALIDATE** (independent): experts DIFFERENT from RESOLVE (verifier != generator) — `persona-pipeline`
+  6-stage board + `sentinel` audit. Validate [plan, roadmap, tools, context, scope, viability,
+  implementability, usability, over-eng, theater, risks+mitigations, best-practices, security].
+- **Socratic gate**: `--socratic-depth=N`, drawn from SSOT (`agents/forge` §33-Socratic /
+  `skills/maos-concierge/references/socratic-33q.md`). **Do NOT hardcode "33"** — depth is parameterized.
+
+---
+
+## §5 — HITL-as-problem (SOFT vs HARD)
+
+Every HITL is an UNSOLVED PROBLEM; classify before escalating:
+- **SOFT** (deliberation can solve): low-confidence | resolvable ambiguity | missing context |
+  missing perspective | competency gap → re-inject as a gap; run a new-perspectives round (§3).
+  *Premise: the answer is usually latent in training — the job is to INVOKE it* (AI-as-PwD §3.3).
+  SOFT becomes a real HITL only after `max-iterations`.
+- **HARD** (authority boundary — looping cannot dissolve it): irreversible/high-cost authorization |
+  destructive op | credentials/secrets | safety → escalate IMMEDIATELY; never self-authorize.
+
+---
+
+## §6 — PERSIST + Boy-Scout DoD
+
+- per-decision → decision-audit (`skills/decision-capture` / `agentic-decide`).
+- convergence-report + reject-log → docs / Confluence.
+- gap-closures + residuals → tickets via `maos:postflight` P2.5 TICKET-SYNC (a capability-detected ticketing primitive, ref `ticket-as-prompt`; in-repo SSOT `skills/postflight/references/ticket-sync-protocol.md`).
+- boy-scout: leave touched artifacts cleaner than found (`maos:postflight` P1-SWEEP).
+- **STAGE-only git unless authorized** (EKO-66): never push/merge without explicit operator authorization.
+
+**DoD**: gap-register fully dispositioned · convergence synthesis + reject-log exist · Socratic gate
+passed · `autonomy_score >= 0.85` (evidence-backed) · artifacts persisted · every escalation classified
+(SOFT looped / HARD escalated) and logged.
+
+---
+
+## §7 — Adoption notes (for siblings — DRY)
+
+- `quiesce` MAY adopt §5 (SOFT/HARD) + §3 (derived score) to enrich its HITL handling; its outer loop
+  stays `/goal`-based, gap-loop's stays declarative.
+- `convergence-engine` already owns the master condition + economic stop; this protocol REUSES them
+  (it does not redefine them) — §3 cites them.
+- The methodology is cross-vendor; replace named primitives with the host's equivalents where absent.
+
+## §8 — Sunset (qualitative — not counter-based)
+
+Deprecate when ANY: a host makes a declarative condition-loop universal so `quiesce` covers cowork/SDK
+too (E1) · the family absorbs gap-loop into a unified loop entry (E6) · operator retraction (E4) ·
+>=3 false-positive runs (E5). Dormant-by-design otherwise.
+
+## §9 — Refs
+
+- `skills/gap-loop/SKILL.md` (runnable embodiment) · `commands/gap-loop.md`
+- `skills/quiesce` · `skills/convergence-engine` (+ `PRIOR-ART.md`) · `skills/converge` · `skills/pulse`
+- `agents/perspective-trio.md` · `agents/persona-pipeline.md` · `agents/cascade-resolver.md` · `agents/forge.md`
+- `skills/decision-capture` · `maos:postflight` P2.5 (ticketing, ref `ticket-as-prompt`) · `sentinel/detection_rules.md`
+- `protocols/agentic-tool-lifecycle.md` (shared-protocol precedent)
+- External grounding inherited from `skills/convergence-engine/PRIOR-ART.md` (Du et al. 2023 society-of-minds;
+  Madaan 2023 Self-Refine; Huang 2024 verifier>generator; multi-agent-debate).

--- a/skills/README.md
+++ b/skills/README.md
@@ -72,6 +72,12 @@ This folder contains reusable Agent Skills for the Multi-Agent OS framework. Ski
 - `agentic-tool-evaluator` — Behavioral eval-harness (with/without control + rubric); read-only score + report
 - `agentic-tool-trainer` — Reflect-loop improvement (trace→reflect→distill, Pareto-guarded) + distill-new-tool-from-trace
 
+### Orchestration / Convergence Skills
+
+> Driver/loop family — auto-discovered from `skills/*/SKILL.md` (not all listed in the table above; the catalog is being backfilled). Shared methodology: `protocols/gap-loop-protocol.md`.
+
+- `gap-loop` — **harness-agnostic** self-driven, self-scored 5-phase convergence loop (DoR → RECAP gap-register → RESOLVE MoE-per-gap → VALIDATE independent-audit → PERSIST); loops until [gaps dispositioned ∧ convergence ∧ autonomy_score ≥ 0.85]. Fills the seam left by `quiesce` (which needs the `/goal` slash-command); composes `converge`/`convergence-engine`/`perspective-trio`/`persona-pipeline`/`cascade-resolver`/`pulse` — reimplements nothing. Siblings (auto-discovered): `quiesce` · `auto-pilot` · `enhance-pipeline` · `convergence-engine` · `converge` · `pulse` · `work-compass`.
+
 ## Directory Structure
 
 ```

--- a/skills/gap-loop/SKILL.md
+++ b/skills/gap-loop/SKILL.md
@@ -3,22 +3,17 @@ name: gap-loop
 version: "0.1.0"
 description: |
   Harness-agnostic, self-driven, self-scored condition-loop that drives a GAP-REGISTER
-  (G1..Gn) to convergence — looping until [every gap dispositioned (fix | defer-with-rationale
-  | accept-as-risk) AND agentic convergence reached AND autonomy_score >= 0.85]. Five phases:
-  DoR precheck -> RECAP (build the gap-register) -> RESOLVE (MoE diverge->converge per gap) ->
-  VALIDATE (independent audit, experts != RESOLVE) -> PERSIST (decision-audit + reject-log +
-  tickets + boy-scout). Its defining novelty vs siblings: it expresses the condition-loop
-  DECLARATIVELY so the agent self-drives it in ANY harness (cowork / Code / SDK) — NO dependency
-  on the /goal slash-command. Adds an anti-gaming DERIVED score that names its binding
-  constraint, a low-score -> rotate-the-MoE-roster re-loop (NOT HITL), and a HITL-as-problem
-  SOFT/HARD classification. Thin preset — composes pulse + perspective-trio + converge +
-  persona-pipeline + cascade-resolver + convergence-engine + decision-capture; reimplements nothing.
-  Use when the operator wants a goal/gap-register driven to convergence in a harness WITHOUT /goal,
-  or wants the loop's score derived (not declared) and low-score handled by new perspectives
-  before any human ask: "gap-loop", "drive these gaps to convergence", "goal-n-loop",
-  "converge this without /goal", "self-scored convergence loop", "resolve the gap-register".
+  (G1..Gn) to convergence — loops until [every gap dispositioned (fix | defer | accept-risk)
+  AND agentic convergence AND autonomy_score >= 0.85]. Five phases: DoR -> RECAP (build the
+  gap-register) -> RESOLVE (MoE diverge->converge per gap) -> VALIDATE (independent audit,
+  experts != RESOLVE) -> PERSIST (decision-audit + reject-log + tickets + boy-scout). Defining
+  novelty: expresses the loop DECLARATIVELY so the agent self-drives it in ANY harness (cowork
+  / Code / SDK) — NO /goal dependency; an anti-gaming DERIVED score that names its binding
+  constraint; a low-score -> rotate-the-MoE-roster re-loop (NOT HITL). Thin preset: composes
+  pulse, perspective-trio, converge, persona-pipeline, cascade-resolver, convergence-engine,
+  decision-capture — reimplements nothing.
   Triggers: "gap-loop", "goal-n-loop", "drive gaps to convergence", "harness-agnostic loop",
-  "self-scored loop", "resolve gap-register", "loop until converged".
+  "self-scored loop", "loop until converged".
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 metadata:
   version: "0.1.0"
@@ -36,6 +31,13 @@ primitives and contributes only the parts the family lacks: a **declarative self
 loop** (no `/goal` dependency), an **anti-gaming derived score**, a **rotate-roster re-loop**,
 and a **SOFT/HARD HITL classification**. The shared methodology lives in
 `protocols/gap-loop-protocol.md` (citable by siblings).
+
+> **Provenance / lineage**: distilled (meta-concept extraction) from the operator's
+> `--goal-n-loop` declarative-orchestration prompt — the operator's own harness-agnostic
+> re-expression of `quiesce`'s `/goal` condition-loop. Named via the `anima` engine
+> (agent-register, 12-aspect): `gap-loop` (rejected `converge-loop` — collides with
+> `converge`/`convergence-engine`; `goal-loop` — `goal` is vendor-reserved). Authored by
+> Claude Opus 4.8 (1M) under operator `/quiesce` directive 2026-06-29; reviewed by @ekson73.
 
 ## Purpose
 
@@ -87,7 +89,7 @@ CONVERGED := ( every gap in the gap-register is DISPOSITIONED
 ## Bounds
 
 ```text
---autonomy=L2-unattended        (band; see --autonomy-threshold)
+autonomy-band: L2-unattended    (descriptive band — NOT a flag; set numerically via --autonomy-threshold)
 --max-iterations=6              (loop cap; then park-state + escalate)
 --principles=[DRY, SSOT, KISS, YAGNI, ANTI-OVER-ENG, ANTI-THEATER, CONTINUITY, HAND-OFF, BOY-SCOUT]
 --principle-exception="only with documented justification (SDP)"
@@ -176,12 +178,13 @@ cowork / SDK / other hosts it self-drives. Either way it emits exactly ONE STOP 
 | Flag | Default | Allowed / Notes |
 |---|---|---|
 | `"<instructions>"` (positional) | empty | extra free-text appended to the goal |
-| `--state-source` | `pulse` | where RECAP reads the goal/plan/gaps from (`pulse` \| ticket \| file \| free-text) |
+| `--state-source` | `pulse` | where RECAP reads the goal/plan/gaps from (`pulse` \| `ticket:<id>` \| `file` \| `free-text`) |
 | `--condition` | *(CONVERGED predicate above)* | override the termination predicate string |
 | `--autonomy-threshold` | `0.85` | `0.0`-`1.0` — the score gate (maps to band: >=0.85 L3, >=0.65 L2, else L1) |
 | `--max-iterations` | `6` | int — loop cap before park-state + escalate |
 | `--socratic-depth` | `N` (from SSOT) | int — Phase-3 question-bank depth; **never hardcode "33"** |
 | `--auto-merge` | `hold` | `authorized` \| `hold` \| `off` — default **hold** (EKO-66: STAGE-only, more conservative than quiesce) |
+| `--auto-merge-reason` | *(none)* | non-empty string — **required when `--auto-merge=authorized`** (auditability parity with `quiesce` + `auto-merge-standing-authorization` G8); ignored for `hold`/`off` |
 | `--driver` | self | self-driven; on Claude Code MAY delegate inner work to `auto-pilot` |
 
 ## Relationship to siblings
@@ -232,7 +235,7 @@ gap-loop "harden the auth gaps before we ship"
 gap-loop --state-source=ticket:VKS-1234 --max-iterations=4
 gap-loop --autonomy-threshold=0.9 --socratic-depth=12
 gap-loop --condition='every gap dispositioned AND no HARD gate open'
-gap-loop --auto-merge=authorized   # only when the operator authorizes (overrides EKO-66 default)
+gap-loop --auto-merge=authorized --auto-merge-reason="nightly convergence, green CI"   # reason required when authorized (overrides EKO-66 default)
 ```
 
 ## Quality Tests (6/6 self-validity — dogfooded)

--- a/skills/gap-loop/SKILL.md
+++ b/skills/gap-loop/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: gap-loop
+version: "0.1.0"
+description: |
+  Harness-agnostic, self-driven, self-scored condition-loop that drives a GAP-REGISTER
+  (G1..Gn) to convergence — looping until [every gap dispositioned (fix | defer-with-rationale
+  | accept-as-risk) AND agentic convergence reached AND autonomy_score >= 0.85]. Five phases:
+  DoR precheck -> RECAP (build the gap-register) -> RESOLVE (MoE diverge->converge per gap) ->
+  VALIDATE (independent audit, experts != RESOLVE) -> PERSIST (decision-audit + reject-log +
+  tickets + boy-scout). Its defining novelty vs siblings: it expresses the condition-loop
+  DECLARATIVELY so the agent self-drives it in ANY harness (cowork / Code / SDK) — NO dependency
+  on the /goal slash-command. Adds an anti-gaming DERIVED score that names its binding
+  constraint, a low-score -> rotate-the-MoE-roster re-loop (NOT HITL), and a HITL-as-problem
+  SOFT/HARD classification. Thin preset — composes pulse + perspective-trio + converge +
+  persona-pipeline + cascade-resolver + convergence-engine + decision-capture; reimplements nothing.
+  Use when the operator wants a goal/gap-register driven to convergence in a harness WITHOUT /goal,
+  or wants the loop's score derived (not declared) and low-score handled by new perspectives
+  before any human ask: "gap-loop", "drive these gaps to convergence", "goal-n-loop",
+  "converge this without /goal", "self-scored convergence loop", "resolve the gap-register".
+  Triggers: "gap-loop", "goal-n-loop", "drive gaps to convergence", "harness-agnostic loop",
+  "self-scored loop", "resolve gap-register", "loop until converged".
+allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
+metadata:
+  version: "0.1.0"
+  scope: AAIF cross-vendor
+  family: orchestration-convergence
+  cross_link_slug: gap-loop
+  dogfood_status: pending-first-cycle
+---
+
+# Gap-Loop
+
+Thin **harness-agnostic convergence-loop** preset. `gap-loop` does not re-implement
+orchestration, MoE resolution, convergence, audit, or scoring — it composes existing
+primitives and contributes only the parts the family lacks: a **declarative self-driven
+loop** (no `/goal` dependency), an **anti-gaming derived score**, a **rotate-roster re-loop**,
+and a **SOFT/HARD HITL classification**. The shared methodology lives in
+`protocols/gap-loop-protocol.md` (citable by siblings).
+
+## Purpose
+
+Drive a goal — decomposed into a **gap-register** — to convergence in ANY harness, by
+self-driving a 5-phase condition-loop until every gap is dispositioned, agentic convergence
+is reached, and the (derived, evidence-backed) `autonomy_score >= 0.85`. Fills the seam left
+by `quiesce`: where `quiesce` *composes the native `/goal` condition-loop* (a Claude Code
+slash-command), `gap-loop` expresses the loop **declaratively** so the agent drives it itself
+in cowork / SDK / any host with no slash-command.
+
+## When to use
+
+- The host has **no `/goal`** (claude-cowork, an SDK runner, a non-Claude vendor) but you want a
+  driven, scored, self-terminating convergence loop.
+- A goal has multiple open **gaps** that each need diverse-expert resolution + an independent audit.
+- You want the loop's stopping `autonomy_score` **derived from evidence** (not self-declared),
+  and a **low score handled by new perspectives** before any human is asked.
+
+## When **not** to use
+
+- Single-shot edit / single-file fix / typo — disproportionate ceremony.
+- Read-only Q&A — answer directly.
+- The host HAS `/goal` AND you want session-PR quiescence -> use `quiesce`.
+- ONE goal needs plain decompose+delegate (no per-gap MoE + audit) -> use `auto-pilot`.
+- Merging N existing proposals only -> use `converge` directly.
+- Destructive ops (force-push protected, drop prod) — always HITL.
+
+## Trigger Phrases
+
+- "gap-loop" / "goal-n-loop"
+- "drive these gaps to convergence" / "resolve the gap-register"
+- "converge this without /goal" / "harness-agnostic loop"
+- "self-scored loop" / "loop until converged"
+
+## Termination predicate (default `--condition`)
+
+```text
+CONVERGED := ( every gap in the gap-register is DISPOSITIONED
+                 dispositioned := fix-applied | deferred-with-rationale | accepted-as-risk )
+             AND ( agentic CONVERGENCE reached
+                 := >=2 dissenting expert positions reconciled into ONE synthesis + reject-log )
+             AND ( autonomy_score >= 0.85, DERIVED + evidence-backed — see SCORE rule )
+```
+
+> A gap **deferred-with-rationale** or **accepted-as-risk** is dispositioned — it does NOT keep
+> the loop open (capture-and-defer IS a resolution; Boy-Scout "don't lose it"). Only
+> *un-dispositioned* gaps keep looping.
+
+## Bounds
+
+```text
+--autonomy=L2-unattended        (band; see --autonomy-threshold)
+--max-iterations=6              (loop cap; then park-state + escalate)
+--principles=[DRY, SSOT, KISS, YAGNI, ANTI-OVER-ENG, ANTI-THEATER, CONTINUITY, HAND-OFF, BOY-SCOUT]
+--principle-exception="only with documented justification (SDP)"
+--meta-rule="BEING > rule; law serves the goal; any rule admits a justified exception"  (= §0 SER>Regras)
+```
+
+## The 5 phases
+
+```text
+PHASE 0 · DoR     precheck state (pulse / preflight); branch + worktree isolation (anti-conflict);
+                  verify SSOT targets reachable. Abort-with-reason if DoR unmet.
+PHASE 1 · RECAP   from <state-source> enumerate [purposes, plan, roadmap, open-problems, gaps,
+                  pending] -> ONE deduplicated, IDed gap-register (G1..Gn). Inject any prior
+                  HITL / low-score items from earlier rounds as gaps too. (no hallucination —
+                  single source.)
+PHASE 2 · RESOLVE per gap: roster := >=2 DIVERSE experts (Forge if competency absent) + 1 arbiter;
+                  protocol := converge 5-act [steelman -> critique -> compare -> synthesize ->
+                  reject-log]; output := {decision, rationale, rejected-alternatives,
+                  residual-risk, confidence}.
+PHASE 3 · VALIDATE independent audit — experts DIFFERENT from Phase 2 (verifier != generator).
+                  validate [plan, roadmap, participating tools, context, scope, viability,
+                  implementability, usability, over-eng, theater, risks+mitigations,
+                  best-practices, security]; SOCRATIC gate (--socratic-depth=N, from SSOT; do NOT
+                  hardcode "33"); run Sentinel audit; any FAIL re-enters Phase 2 as a gap; then
+                  compute autonomy_score (per SCORE rule) -> drives the loop.
+PHASE 4 · PERSIST per-decision -> decision-audit (agentic-decide); convergence-report +
+                  reject-log -> docs / Confluence; gap-closures + residuals -> tickets;
+                  boy-scout: leave touched artifacts cleaner than found. STAGE-only git unless
+                  authorized (see Auto-merge / EKO-66).
+```
+
+## Anti-gaming SCORE rule
+
+`autonomy_score` is **DERIVED, never declared** — it MUST trace to the dispositioned gaps + the
+Phase-3 audit results. Each round emits a **per-dimension breakdown** (viability · security ·
+usability · convergence-quality · residual-risk · ...) and **NAMES the binding constraint** — the
+single dimension dragging the score down. The binding constraint is the *target* of the next round
+(below). A score asserted without that trace is invalid (anti-theater R2).
+
+## Low-score -> re-loop (rotate roster, NOT HITL)
+
+If `autonomy_score < threshold` AND `iteration < max-iterations`: **do NOT escalate**. Open a NEW
+round targeting the **binding constraint** with NEW perspectives:
+- **rotate the MoE roster** — swap expert archetypes; **re-running the same panel is FORBIDDEN**
+  (it reproduces the same score);
+- add an explicit **red-team / adversarial** seat;
+- **re-frame** the weakest dimension (invert the question; attack it head-on);
+- **Forge a NEW expert** if the cause is a missing competency.
+
+If the binding constraint IS a HARD gate (below) -> escalate THAT item only, and CONTINUE the loop
+on remaining gaps. Escalate the WHOLE goal only if `iteration >= max-iterations` AND score still
+`< threshold` (park-state + SDP).
+
+## HITL-as-problem (SOFT vs HARD)
+
+Every HITL is an **UNSOLVED PROBLEM** — classify it before escalating:
+- **SOFT** (deliberation can solve it): low-confidence | resolvable ambiguity | missing context |
+  missing perspective | competency gap -> **re-inject as a gap**; run a new-perspectives round
+  (above). *Premise: the answer is usually latent in training — the job is to INVOKE it.* SOFT
+  becomes a real HITL only after `max-iterations` is exhausted.
+- **HARD** (authority boundary — looping cannot dissolve it): irreversible / high-cost
+  authorization | destructive op | credentials / secrets | safety -> **escalate IMMEDIATELY**;
+  never spend iterations trying to self-authorize.
+
+## Harness-agnostic note
+
+The OUTER loop is **declarative + self-driven**: the agent itself evaluates the termination
+predicate at the end of each turn and decides CONTINUE vs stop. **No `/goal` required.** On Claude
+Code the agent MAY pair with `/goal --goal-aware` (and its Stop-hook evaluator) for free; on
+cowork / SDK / other hosts it self-drives. Either way it emits exactly ONE STOP marker per turn.
+
+## Composition (the wiring — DRY; every phase lands on an existing primitive)
+
+| Phase | Composes (existing — reimplements nothing) |
+|---|---|
+| DoR | `maos:preflight` / `skills/pulse` + `skills/anti-conflict` + `skills/worktree-policy` |
+| RECAP | `skills/pulse` memory-refresh + gap enumeration -> gap-register |
+| RESOLVE | `maos:perspective-trio` (breadth) · `agents/forge.md` (Forge if competency absent) · `skills/converge` (5-act + reject-log) |
+| VALIDATE | `maos:persona-pipeline` (experts != RESOLVE) · `sentinel/detection_rules.md` audit · Socratic gate (`agents/forge.md` §33Q / `skills/maos-concierge/references/socratic-33q.md`) |
+| SCORE + re-loop | `agents/cascade-resolver.md` (autonomy_score formula + 12-role rotation) · `skills/convergence-engine` (master condition `verifier>generator` + economic stop) |
+| PERSIST | `skills/decision-capture` (`agentic-decide`) · `maos:postflight` P2.5 TICKET-SYNC (capability-detected ticketing primitive, ref `ticket-as-prompt`) + P1-SWEEP (boy-scout) |
+| OUTER loop | **this skill's own contribution** — declarative, harness-agnostic, self-scored |
+
+## Override parameters
+
+| Flag | Default | Allowed / Notes |
+|---|---|---|
+| `"<instructions>"` (positional) | empty | extra free-text appended to the goal |
+| `--state-source` | `pulse` | where RECAP reads the goal/plan/gaps from (`pulse` \| ticket \| file \| free-text) |
+| `--condition` | *(CONVERGED predicate above)* | override the termination predicate string |
+| `--autonomy-threshold` | `0.85` | `0.0`-`1.0` — the score gate (maps to band: >=0.85 L3, >=0.65 L2, else L1) |
+| `--max-iterations` | `6` | int — loop cap before park-state + escalate |
+| `--socratic-depth` | `N` (from SSOT) | int — Phase-3 question-bank depth; **never hardcode "33"** |
+| `--auto-merge` | `hold` | `authorized` \| `hold` \| `off` — default **hold** (EKO-66: STAGE-only, more conservative than quiesce) |
+| `--driver` | self | self-driven; on Claude Code MAY delegate inner work to `auto-pilot` |
+
+## Relationship to siblings
+
+| Tool | Scope | Drives | Needs `/goal`? |
+|---|---|---|---|
+| `gap-loop` (this) | a goal as a **gap-register** | declarative self-scored 5-phase loop (MoE-resolve + independent audit) | **NO** (harness-agnostic) |
+| `quiesce` | the SESSION | termination predicate over ALL open items -> steady state | YES (composes it) |
+| `auto-pilot` | ONE goal | decompose -> select -> spawn -> converge | no |
+| `enhance-pipeline` | ONE feature | EXPAND -> FILTER -> HARMONIZE -> DELIVER | no |
+| `convergence-engine` | result quality | REFINE / SELECT / DEFER by verifiability | no |
+| `converge` | N proposals | single-pass 5-act merge (invoked inside RESOLVE) | no |
+
+`gap-loop` MAY invoke `auto-pilot` for a gap's sub-work and `converge`/`perspective-trio`/
+`persona-pipeline` for RESOLVE/VALIDATE; it never re-implements them.
+
+## STOP-marker grammar (reused — emit exactly ONE as the last line of each turn)
+
+```text
+<!--ORCH-STATUS: STOP-DONE -->     CONVERGED — gap-register dispositioned, score >= threshold
+<!--ORCH-STATUS: STOP-HITL -->     HARD gate hit, OR SOFT exhausted at max-iterations (park-state + SDP)
+<!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (subagent / network / rate-limit)
+<!--ORCH-STATUS: CONTINUE -->      round done; gaps remain OR score < threshold; next round opens
+```
+
+## Protocol Rules (anti-loop invariants + bounds)
+
+- `--max-iterations` (default 6) caps loop rounds; same-panel re-run is FORBIDDEN (rotate or escalate).
+- Worktree discipline always on (`skills/worktree-policy`); never commit to main.
+- Delegation depth <= 2; Sentinel HIGH auto-blocks (`sentinel/config.json` authoritative).
+- VALIDATE experts MUST differ from RESOLVE experts (verifier != generator — `convergence-engine` master condition).
+- Exactly ONE STOP marker per turn.
+- HUMAN_DOMAIN + non-negotiable guardrails (secrets/PII, force-push protected, prod/irreversible,
+  cross-org) are HARD gates -> escalate IMMEDIATELY, never self-authorize.
+
+## DNA Geracional (inherited by every spawned agent)
+
+- **Dogfood**: validate the loop on its own artifacts before declaring CONVERGED.
+- **Persist-over-fail**: write-ahead-checkpoint each gap disposition BEFORE executing (mid-loop collapse is recoverable).
+- **DRY / KISS / YAGNI / SSOT** — compose primitives, never duplicate them.
+- **No self-destructive decisions** — nothing that boomerangs on a future session.
+- **Boy-Scout** — leave every artifact cleaner than found; STAGE-only unless authorized (EKO-66).
+
+## Examples
+
+```text
+gap-loop "harden the auth gaps before we ship"
+gap-loop --state-source=ticket:VKS-1234 --max-iterations=4
+gap-loop --autonomy-threshold=0.9 --socratic-depth=12
+gap-loop --condition='every gap dispositioned AND no HARD gate open'
+gap-loop --auto-merge=authorized   # only when the operator authorizes (overrides EKO-66 default)
+```
+
+## Quality Tests (6/6 self-validity — dogfooded)
+
+1. **Self-Application** — `gap-loop` could drive its OWN creation gaps (naming, structure, DRY) to convergence. PASS.
+2. **Non-Contradiction** — composes (not duplicates) quiesce/converge/convergence-engine/pulse; the loop + score + SOFT/HARD + rotate-roster are net-new. PASS.
+3. **Survival** — applied to itself it advocates a bounded, scored loop; it is itself bounded + scored. PASS.
+4. **Bounded-Responsibility** — `--max-iterations`, score gate, SOFT/HARD, depth<=2, STOP-marker, §DUED sunset. PASS.
+5. **Explicit-Exception** — When-not-to-use + HARD-gate escalation + `--principle-exception` (SDP) + §0 SER>Regras escape. PASS.
+6. **Utility-Sunset** — §DUED below. PASS.
+
+## §DUED Sunset (qualitative — not counter-based)
+
+Deprecate when ANY: a host makes `/goal` (or an equivalent declarative condition-loop) universally
+available so `quiesce` covers cowork/SDK too (E1) · the family absorbs `gap-loop` into a unified
+loop entry (E6) · operator retraction (E4) · >=3 false-positive runs (E5). Dormant-by-design otherwise.
+
+## Validation
+
+- `tests/validate-plugin.sh` enforces (generically): `skills/gap-loop/` contains `SKILL.md` with valid frontmatter.
+- `commands/gap-loop.md` carries matching `name: gap-loop` frontmatter.
+- `protocols/gap-loop-protocol.md` exists and is cross-linked from Related.
+- Satisfies the 10-item checklist in `skills/skill-writer/SKILL.md`.
+
+## Related
+
+- `commands/gap-loop.md` — operator-facing command surface
+- `protocols/gap-loop-protocol.md` — the extracted reusable methodology (citable by siblings)
+- `skills/quiesce/SKILL.md` — session-quiescence via `/goal` (sibling; the `/goal`-dependent cousin)
+- `skills/convergence-engine/SKILL.md` (+ `PRIOR-ART.md`) — quality regime-router + master condition + external grounding (inherited, DRY)
+- `skills/converge/SKILL.md` — 5-act proposal merge (used inside RESOLVE)
+- `skills/pulse/SKILL.md` — DoR/RECAP state source
+- `agents/perspective-trio.md` · `agents/persona-pipeline.md` · `agents/cascade-resolver.md` · `agents/forge.md` — RESOLVE/VALIDATE/SCORE/forge primitives
+- `skills/decision-capture/SKILL.md` — PERSIST decision-audit (`agentic-decide`)
+- `sentinel/config.json` + `sentinel/detection_rules.md` — anomaly thresholds (Phase-3 audit)
+- `protocols/agentic-tool-lifecycle.md` — family-protocol precedent
+
+## Versioning
+
+- v0.1.0 (initial) — harness-agnostic declarative 5-phase convergence loop; gap-register termination;
+  anti-gaming derived score (names binding constraint); low-score -> rotate-roster re-loop (not HITL);
+  HITL-as-problem SOFT/HARD classification; Socratic-depth=N gate; STOP-marker reuse; EKO-66 stage-only
+  default. Distilled from the operator's `--goal-n-loop` prompt. Composes existing primitives; reimplements nothing.
+
+## License
+
+MIT (matches multi-agent-os repo `LICENSE`).


### PR DESCRIPTION
## Summary

- Distills the operator's `--goal-n-loop` prompt into **`gap-loop`** — a generic, family-harmonic MAOS skill: the **harness-agnostic, self-driven, self-scored 5-phase convergence loop** (DoR → RECAP gap-register → RESOLVE MoE-per-gap → VALIDATE independent-audit → PERSIST).
- Fills the seam left by `quiesce` (which composes the native `/goal` slash-command and therefore can't run in cowork/SDK). Thin preset — **composes** `pulse`/`perspective-trio`/`converge`/`persona-pipeline`/`cascade-resolver`/`convergence-engine`/`decision-capture`/`postflight`; **reimplements nothing**.
- Extracts the prompt's reusable methodology into a citable protocol so siblings (`quiesce`/`convergence-engine`) can adopt the novel concepts DRY.

**Novel meta-concepts vs the family:** declarative harness-agnostic loop · anti-gaming **derived** score that *names its binding constraint* · low-score → **rotate-MoE-roster** re-loop (NOT HITL) · **HITL-as-problem SOFT/HARD** classification · **Socratic-depth=N** gate.

**Artifacts:** `skills/gap-loop/SKILL.md` (runnable, mirrors `quiesce`) · `commands/gap-loop.md` (`/slash` wrapper) · `protocols/gap-loop-protocol.md` (extracted methodology) · `skills/README.md` (minimal boy-scout catalog touch).

**Naming:** decided via `anima` (agent-register, 12-aspect) → `gap-loop` (rejected `converge-loop` — collides with `converge`/`convergence-engine`; `goal-loop` — `goal` is vendor-reserved).

## Type

- [x] feat (new functionality)

## AI Involvement

- [x] AI-generated draft reviewed by human (named reviewer: @ekson73 — operator)

`Co-Authored-By: Claude Opus 4.8 (1M context)` footer present in the commit.

## Runtime / Surface Impact

- [x] Claude Code (plugin runtime, hooks, agents, commands, skills)
- [x] Generic AI agents (AGENTS.md contract) — skill + protocol are AAIF cross-vendor

(No `plugin.json` change — skills auto-discover from `skills/*/SKILL.md`; no version bump required.)

## Files requiring follow-up governance update

- [x] `README.md` — `skills/README.md` catalog touched (new "Orchestration / Convergence Skills" subsection)

## Evidence

```bash
bash tests/validate-plugin.sh
#   ✓ skills/gap-loop/SKILL.md exists
#   ✓ gap-loop.md has frontmatter
#   Errors: 0   Status: ✓ PASSED

# frontmatter YAML valid + names match
#   skills/gap-loop/SKILL.md -> name=gap-loop ; commands/gap-loop.md -> name=gap-loop

# dangling-ref sweep: every cited in-repo primitive resolves
#   (fixed ticket-as-prompt -> family's "capability-detected ticketing primitive" pattern)
```

## Risks

- **Low.** Additive only (3 new files + 1 doc-line). No code path, no `plugin.json`, no hooks/CI changed. New skill auto-discovers; worst case it's an unused skill. Composes existing primitives — introduces no new runtime machinery.

## Rollback

- `git revert <merge-sha>` (or delete the 3 new files + revert the `skills/README.md` line). No state/migration to undo.

## Checklist

- [x] Worktree + branch used (no direct-main commits) — Conductor isolated branch `extract-meta-prompt-agentic-tool`
- [x] Conventional Commits + `Co-Authored-By:` footer
- [x] gitleaks clean (pre-commit passed)
- [x] Build / tests pass (`tests/validate-plugin.sh` PASSED)
- [x] No secrets, no PII, no Vek-specific content (Layer Purity — vendor-neutral AAIF)
- [ ] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated — N/A (no contract change)
- [ ] Version bump + CHANGELOG — N/A (no `plugin.json` change; skills auto-discover)

<!--
🤖 Opened by an automated agent under operator `/quiesce` directive.
Plan: ~/.claude/plans/system-instruction-you-are-working-gleaming-scroll.md
Driven by: skills/gap-loop (the skill this PR adds) + skills/quiesce.
-->
