### PR TITLE
feat(maos-hub): ISO universal tool-gating (WT3/S3) — summary pool + top-k promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — ISO universal tool-gating (WT3 / S3) — summary pool + top-k promotion (MCP-tax control)
+
+- **`mcp-tools/maos-mcp-hub/lib/gateway/iso.py`** — `IsoGate`: the WAVE-1 WT3 generalization of the
+  Atlassian-only progressive-discovery into a gateway-agnostic ISO layer (spec requirement
+  "ISO tool-gating (MCP-tax control)", `openspec/specs/maos-hub/spec.md`). Permanent summary pool
+  (≤60 tokens/tool) + top-k full-schema promotion — conflict C4's fix: with dozens of connected MCP
+  tools, full schemas cost 10k–60k tokens/turn; the pool keeps every tool discoverable at ≤60 tokens
+  while only the top-k pay full price.
+- **The two review-board-mandated definitions are now EXPLICIT** (else the threshold is incomputable):
+  the NORMATIVE tokenizer `iso_tokens(text) = ceil(len(text)/4)` (deterministic, dependency-free,
+  model-agnostic — the ≤60 threshold is *defined* in terms of this function) and
+  `ISO_DEFAULT_TOP_K = 5` with a budget-derived cap
+  (`k_effective = min(k_requested, budget_cap, allowed)`, greedy in rank order under an optional
+  `schema_token_budget`).
+- **Hard-filters-first composition:** an optional `PolicyResolver` (PR #180 seam, imported — never
+  reimplemented) eliminates denied candidates BEFORE promotion; a denied tool is never surfaced as a
+  top-k candidate (mirrors the CTS requirement). Denials carry `reason` + `conflicting_with`.
+- **DoD-gate honoured:** every acceptance is a *logged field* (`IsoSelection.to_report()` invariants:
+  `summaries_within_limit` · `promoted_lte_k` · `denied_never_promoted` · `budget_respected`) or a
+  *golden-fixture invariant* (`evals/fixtures/iso_inventory.yaml` — 12 real conflicts.yaml tool-ids,
+  4 turns: clean-topk / budget-bound / policy-gated / injection). Reproducible acceptance command:
+  `python -m evals.iso_gate_eval` (exit 0 ⇔ verdict green). **14 tests** (`tests/test_iso_gate.py`),
+  0-regression (error set identical to pristine main). Additive; no plugin version bump (ADR-003).
+
 ### Changed — bot-finding-arbiter v1.3.0 residual round (best-practices grounding · GitHub watch native · fire-point wiring)
 
 - **`skills/bot-finding-arbiter/SKILL.md` v1.2.1 → v1.3.0** — directive-triage verified the operator's "OODA the bot-caused failure + 9 dispositions + teach-the-bot" directive was ~85-90% already satisfied by v1.2.x; this closes the 3 verified residual gaps (docs-only; `bin/classify.sh` + `tests/` untouched, 7/7 green): (a) teach-the-bot edicts now MANDATE **best-practices grounding** — consult the bot's official current config docs AND the governance anchor, and cite BOTH in the edict PR; (b) **GitHub watch parity resolved with the native primitive** — `gh pr checks <pr> --watch --fail-fast --json name,bucket,…` (+ `gh run view --log-failed`) documented as the sibling of `bin/bb-pipeline-watch.sh`; probe confirmed structured diagnosis → no custom wrapper built (Gordian native-over-custom); (c) fire-point effectivation below.

--- a/mcp-tools/maos-mcp-hub/evals/fixtures/iso_inventory.yaml
+++ b/mcp-tools/maos-mcp-hub/evals/fixtures/iso_inventory.yaml
@@ -1,0 +1,148 @@
+# Golden inventory for the ISO universal gating eval (WT3 / S3).
+#
+# Invariants (asserted by tests/test_iso_gate.py — the DoD-gate):
+#   - every tool id is a REAL node of lib/gateway/conflicts.yaml (same
+#     discipline as routing_cases.yaml: never invented ids);
+#   - every summary is <=60 tokens under the NORMATIVE tokenizer
+#     (iso_tokens = ceil(len/4), see lib/gateway/iso.py);
+#   - every `profile` below is internally conflict-free UNLESS the turn is
+#     an `injection` turn (then the planted pair is the only signal).
+#
+# The inventory is larger than any turn budget — the exact spec scenario
+# "more tools are connected than fit a turn's budget".
+
+schema_version: iso-inventory/1.0.0
+
+inventory:
+  - id: openspec
+    summary: "Spec-driven change management: proposals, delta specs, strict validation (L1 spec model)."
+    schema:
+      resource: spec
+      operations: [propose, apply, archive, validate]
+      required: [change_id]
+      optional: {strict: "true", specs_dir: "openspec/"}
+  - id: spec-kit
+    summary: "Alternative L1 spec system (.specify/specs conventions); mutually exclusive with openspec."
+    schema:
+      resource: spec
+      operations: [specify, plan, tasks]
+      required: [feature]
+      optional: {dir: ".specify/"}
+  - id: mem0
+    summary: "Pluggable memory backend (vector store + entity memory) for cross-session agent recall (L8)."
+    schema:
+      resource: memory
+      operations: [add, search, get_all, delete]
+      required: [text]
+      optional: {user_id: "default", metadata: "null"}
+  - id: cognee
+    summary: "Graph memory backend; competes with mem0 for the default L8 slot (namespace pgvector)."
+    schema:
+      resource: memory
+      operations: [cognify, search, prune]
+      required: [dataset]
+      optional: {graph_model: "default"}
+  - id: letta
+    summary: "Agent runtime with built-in memory; runtime lock-in ('must use Letta') vs pluggable backends."
+    schema:
+      resource: agent
+      operations: [create, message, memory_get]
+      required: [agent_id]
+      optional: {model: "null"}
+  - id: gstack
+    summary: "Always-on L2 instruction layer: planning/QA/ship workflows plus browser skills."
+    schema:
+      resource: workflow
+      operations: [plan, qa, ship, browse]
+      required: [task]
+      optional: {mode: "interactive"}
+  - id: superpowers
+    summary: "Always-on L2 skill library: brainstorming, TDD, debugging, worktrees, plan execution."
+    schema:
+      resource: skill
+      operations: [invoke, list]
+      required: [skill_name]
+      optional: {args: "null"}
+  - id: ECC
+    summary: "CLAUDE.md manager + Pre/PostToolUse hook engine (L0); detects duplicate hooks."
+    schema:
+      resource: manager
+      operations: [audit, install_hooks]
+      required: [project_dir]
+      optional: {dry_run: "true"}
+  - id: open-design
+    summary: "Agent-native local-first design studio; applies design systems via od CLI + MCP (L6)."
+    schema:
+      resource: design
+      operations: [apply_system, list_systems, render]
+      required: [target]
+      optional: {system: "null", tier: "cli"}
+  - id: gsd-core
+    summary: "Fresh-subagent spec/execute lifecycle (GSD); competing SSOT of spec with openspec (L1)."
+    schema:
+      resource: lifecycle
+      operations: [new_project, plan_phase, execute_phase]
+      required: [phase]
+      optional: {autonomous: "false"}
+  - id: ruflo
+    summary: "Heavy meta-orchestrator (swarm runtime); overkill stacked on another L3 conductor."
+    schema:
+      resource: swarm
+      operations: [spawn, topology, converge]
+      required: [goal]
+      optional: {agents: "3"}
+  - id: notebooklm
+    summary: "Research/PKM expert: notebooks, sources, podcasts, reports via NotebookLM automation (L5)."
+    schema:
+      resource: notebook
+      operations: [create, add_source, generate]
+      required: [notebook_id]
+      optional: {artifact: "report"}
+
+# Each turn feeds IsoGate.select with a ranked candidate list. `profile: null`
+# means policy=None (passthrough). Expectations are INVARIANT names the eval
+# asserts — never prose.
+turns:
+  - name: clean-topk
+    profile: null
+    ranked: [openspec, mem0, notebooklm, open-design, gstack, superpowers, ECC, ruflo, gsd-core, cognee, letta, spec-kit]
+    k: 5
+    schema_token_budget: null
+    expect:
+      k_effective: 5
+      denied_count: 0
+      summarized_count: 7
+
+  - name: budget-bound
+    profile: null
+    ranked: [openspec, mem0, notebooklm, open-design, gstack]
+    k: 5
+    schema_token_budget: 100
+    expect:
+      k_effective_lt_requested: true
+      budget_respected: true
+
+  - name: policy-gated
+    # Internally conflict-free active profile (5 tools; ECC excluded — it
+    # carries a conflicts.yaml edge against superpowers). Ranked list includes
+    # out-of-profile tools -> denied (disabled-by-policy), never promoted.
+    profile: [openspec, mem0, notebooklm, open-design, superpowers]
+    ranked: [openspec, spec-kit, mem0, gsd-core, notebooklm, ruflo, open-design]
+    k: 4
+    schema_token_budget: null
+    expect:
+      denied_contains: [spec-kit, gsd-core, ruflo]
+      denied_never_promoted: true
+
+  - name: injection
+    # Planted mis-configuration: letta injected into a profile that already
+    # carries mem0 (conflicts.yaml L8 edge) -> BOTH endpoints deny with
+    # conflicting_with populated; neither is ever promoted.
+    profile: [mem0, letta, openspec, notebooklm]
+    ranked: [mem0, letta, openspec, notebooklm]
+    k: 4
+    schema_token_budget: null
+    expect:
+      denied_contains: [mem0, letta]
+      conflict_reason_names_peer: true
+      denied_never_promoted: true

--- a/mcp-tools/maos-mcp-hub/evals/iso_gate_eval.py
+++ b/mcp-tools/maos-mcp-hub/evals/iso_gate_eval.py
@@ -1,0 +1,163 @@
+"""
+ISO gating eval (WT3 / S3) — MEASURE the universal ISO layer, don't assume it.
+
+Exercises the REAL ``lib/gateway/iso.py::IsoGate`` (never a reimplementation)
+against the golden inventory ``fixtures/iso_inventory.yaml``, composing the
+REAL ``lib/gateway/policy.py::PolicyResolver`` (PR #180 seam) for the
+policy-gated and injection turns.
+
+Output is a single JSON object of LOGGED FIELDS (the DoD-gate: every
+acceptance is a logged field or golden-fixture invariant, never prose). Run::
+
+    python -m evals.iso_gate_eval               # prints JSON to stdout
+    python -m evals.iso_gate_eval --out r.json  # also writes the report
+
+Importable::
+
+    from evals.iso_gate_eval import run_eval
+    report = run_eval()
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from lib.gateway.iso import ISO_SUMMARY_TOKEN_LIMIT, IsoGate, iso_tokens
+from lib.gateway.policy import PolicyResolver, load_conflicts
+
+SCHEMA_VERSION = "iso-gate-eval/1.0.0"
+
+_HERE = Path(__file__).resolve().parent
+_GATEWAY = _HERE.parent / "lib" / "gateway"
+CONFLICTS_YAML = _GATEWAY / "conflicts.yaml"
+INVENTORY_YAML = _HERE / "fixtures" / "iso_inventory.yaml"
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+
+
+def _check_expectations(
+    expect: Dict[str, Any], report: Dict[str, Any]
+) -> Dict[str, bool]:
+    """Evaluate a turn's fixture expectations against its logged report."""
+    results: Dict[str, bool] = {}
+    denied_ids = {d["tool_id"] for d in report["denied"]}
+    for key, want in (expect or {}).items():
+        if key == "k_effective":
+            results[key] = report["k_effective"] == want
+        elif key == "denied_count":
+            results[key] = len(report["denied"]) == want
+        elif key == "summarized_count":
+            results[key] = len(report["summarized"]) == want
+        elif key == "k_effective_lt_requested":
+            results[key] = (report["k_effective"] < report["k_requested"]) is want
+        elif key == "budget_respected":
+            results[key] = report["invariants"]["budget_respected"] is want
+        elif key == "denied_contains":
+            results[key] = set(want).issubset(denied_ids)
+        elif key == "denied_never_promoted":
+            results[key] = report["invariants"]["denied_never_promoted"] is want
+        elif key == "conflict_reason_names_peer":
+            # every conflict-denied entry names its actual peer(s)
+            conflict_entries = [d for d in report["denied"] if d["conflicting_with"]]
+            results[key] = bool(conflict_entries) and all(
+                d["conflicting_with"] for d in conflict_entries
+            ) is want
+        else:
+            results[key] = False  # unknown expectation key fails loudly
+    return results
+
+
+def run_eval(
+    inventory_path: Path = INVENTORY_YAML,
+    conflicts_path: Path = CONFLICTS_YAML,
+) -> Dict[str, Any]:
+    """Run the full ISO-gate eval and return the report as a dict (logged fields)."""
+    fixture = _load_yaml(inventory_path)
+    inventory: List[Dict[str, Any]] = fixture["inventory"]
+    edges = load_conflicts(conflicts_path)
+
+    # Pool-level invariants (the spec's "<=60 tokens/tool" acceptance).
+    pool_tokens = {item["id"]: iso_tokens(item.get("summary", "")) for item in inventory}
+    summaries_within_limit = all(
+        t <= ISO_SUMMARY_TOKEN_LIMIT for t in pool_tokens.values()
+    )
+
+    turns_report: List[Dict[str, Any]] = []
+    all_expectations_pass = True
+
+    for turn in fixture.get("turns", []):
+        profile = turn.get("profile")
+        policy: Optional[PolicyResolver] = (
+            PolicyResolver(profile=profile, conflicts=edges) if profile else None
+        )
+        gate, _ = IsoGate.from_inventory(inventory, policy=policy)
+        selection = gate.select(
+            turn["ranked"],
+            k=turn.get("k"),
+            schema_token_budget=turn.get("schema_token_budget"),
+        )
+        report = selection.to_report()
+        checks = _check_expectations(turn.get("expect", {}), report)
+        all_expectations_pass = all_expectations_pass and all(checks.values())
+        turns_report.append(
+            {
+                "name": turn["name"],
+                "profile_size": len(profile) if profile else 0,
+                "report": report,
+                "expectations": checks,
+            }
+        )
+
+    verdict = {
+        # the spec scenario: rest of the inventory stays <=60-token summaries
+        "summaries_within_limit": summaries_within_limit,
+        "pool_size": len(inventory),
+        "pool_tokens_max": max(pool_tokens.values(), default=0),
+        # every turn honored its golden expectations
+        "all_turn_expectations_pass": all_expectations_pass,
+        # promotion is bounded on every turn (never the whole inventory)
+        "promotion_always_bounded": all(
+            t["report"]["k_effective"] <= t["report"]["k_requested"]
+            and t["report"]["k_effective"] < t["report"]["pool_size"]
+            for t in turns_report
+        ),
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "tokenizer": "ceil(len/4)",
+        "summary_token_limit": ISO_SUMMARY_TOKEN_LIMIT,
+        "turns": turns_report,
+        "verdict": verdict,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=None, help="also write JSON here")
+    args = parser.parse_args(argv)
+
+    report = run_eval()
+    text = json.dumps(report, indent=2, ensure_ascii=False)
+    print(text)
+    if args.out:
+        args.out.write_text(text + "\n", encoding="utf-8")
+
+    ok = (
+        report["verdict"]["summaries_within_limit"]
+        and report["verdict"]["all_turn_expectations_pass"]
+        and report["verdict"]["promotion_always_bounded"]
+    )
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
@@ -10,13 +10,27 @@ from .router import MetaToolRouter
 from .schema_registry import SchemaRegistry
 from .feedback import with_feedback
 from .discovery import build_discovery_response
+from .iso import (
+    ISO_DEFAULT_TOP_K,
+    ISO_SUMMARY_TOKEN_LIMIT,
+    IsoGate,
+    IsoSelection,
+    ToolSummary,
+    iso_tokens,
+)
 
 __all__ = [
     "ActionSchema",
     "AgentFeedback",
     "GatewayRequest",
+    "ISO_DEFAULT_TOP_K",
+    "ISO_SUMMARY_TOKEN_LIMIT",
+    "IsoGate",
+    "IsoSelection",
     "MetaToolRouter",
     "SchemaRegistry",
+    "ToolSummary",
     "build_discovery_response",
+    "iso_tokens",
     "with_feedback",
 ]

--- a/mcp-tools/maos-mcp-hub/lib/gateway/iso.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/iso.py
@@ -1,0 +1,299 @@
+"""
+IsoGate — universal ISO tool-gating (WT3 / S3): summary pool + top-k promotion.
+
+Spec contract (openspec/specs/maos-hub/spec.md → "ISO tool-gating (MCP-tax
+control)")::
+
+    The Hub SHALL keep a permanent summary pool (<=60 tokens/tool) and SHALL
+    promote a full tool schema only for the top-k gated candidates of a turn.
+
+This module generalizes the progressive-discovery pattern the Atlassian
+gateways already implement (SchemaRegistry levels 0-2) into a
+gateway-agnostic layer usable for ANY MCP tool inventory — the "MCP-tax"
+control (conflict C4 in 20260627-ATH-OODA-RECON.md): with dozens of connected
+tools, full schemas cost 10k-60k tokens/turn; the pool keeps every tool
+discoverable at <=60 tokens while only the top-k candidates pay full price.
+
+The two thresholds the review board required to be EXPLICIT (else the
+"<=60 tok/tool" acceptance is incomputable):
+
+NORMATIVE TOKENIZER
+    ``iso_tokens(text) = ceil(len(text) / 4)`` — the industry-standard
+    ~4-chars-per-token English heuristic. Deterministic, dependency-free,
+    model-agnostic. The ``<=60 tokens/tool`` threshold is DEFINED in terms of
+    this function: it does not drift when a vendor tokenizer changes, and any
+    harness can recompute it with one line of arithmetic.
+
+TOP-K
+    ``ISO_DEFAULT_TOP_K = 5`` — explicit default, overridable per call.
+    When a ``schema_token_budget`` is given, the effective k is additionally
+    capped by greedy rank-order promotion while the cumulative promoted
+    schema tokens fit the budget:
+    ``k_effective = min(k_requested, budget_cap, len(allowed_candidates))``.
+
+Composition (never reimplementation):
+  - Hard filters FIRST: an optional ``PolicyResolver`` (PR #180 gating seam)
+    eliminates denied candidates BEFORE promotion — a denied tool is never
+    surfaced as a top-k candidate (mirrors the CTS "hard-filters-first"
+    requirement).
+  - ``SchemaRegistry`` remains the per-gateway schema source; IsoGate stores
+    opaque schema dicts and only counts their serialized cost.
+
+Every selection emits LOGGED FIELDS (``IsoSelection.to_report()``) — the
+DoD-gate: acceptance is a logged field or golden-fixture invariant, never
+prose. See ``evals/iso_gate_eval.py`` + ``tests/test_iso_gate.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+from .policy import PolicyResolver
+
+SCHEMA_VERSION = "iso-gate/1.0.0"
+
+#: Normative per-tool summary budget (spec: "<=60 tokens/tool").
+ISO_SUMMARY_TOKEN_LIMIT = 60
+
+#: Explicit default top-k (review-board requirement: k must be defined).
+ISO_DEFAULT_TOP_K = 5
+
+
+def iso_tokens(text: str) -> int:
+    """NORMATIVE tokenizer for all ISO thresholds: ``ceil(len(text) / 4)``.
+
+    Deterministic, dependency-free, model-agnostic. The spec's
+    "<=60 tokens/tool" is defined in terms of THIS function (see module
+    docstring for rationale).
+    """
+    if not text:
+        return 0
+    return math.ceil(len(text) / 4)
+
+
+def _schema_tokens(schema: Optional[Dict[str, Any]]) -> int:
+    """Token cost of a full schema = iso_tokens of its canonical JSON form."""
+    if not schema:
+        return 0
+    return iso_tokens(json.dumps(schema, sort_keys=True, ensure_ascii=False))
+
+
+@dataclass(frozen=True)
+class ToolSummary:
+    """One permanent-pool entry: a tool id + its <=60-token summary."""
+
+    tool_id: str
+    text: str
+    tokens: int
+    truncated: bool = False
+
+    @classmethod
+    def build(cls, tool_id: str, text: str) -> "ToolSummary":
+        """Build a pool entry, deterministically truncating over-limit text.
+
+        Truncation is character-exact against the normative tokenizer:
+        the longest prefix whose ``iso_tokens`` is <= the limit
+        (= ``ISO_SUMMARY_TOKEN_LIMIT * 4`` characters).
+        """
+        text = (text or "").strip()
+        limit_chars = ISO_SUMMARY_TOKEN_LIMIT * 4
+        truncated = False
+        if iso_tokens(text) > ISO_SUMMARY_TOKEN_LIMIT:
+            text = text[:limit_chars].rstrip()
+            truncated = True
+        return cls(
+            tool_id=tool_id,
+            text=text,
+            tokens=iso_tokens(text),
+            truncated=truncated,
+        )
+
+
+@dataclass
+class IsoSelection:
+    """Result of one ``IsoGate.select`` turn — all fields loggable."""
+
+    k_requested: int
+    k_effective: int
+    pool_size: int
+    promoted: List[str] = field(default_factory=list)
+    summarized: List[str] = field(default_factory=list)
+    denied: List[Dict[str, Any]] = field(default_factory=list)
+    unknown: List[str] = field(default_factory=list)
+    schema_tokens_promoted: int = 0
+    schema_token_budget: Optional[int] = None
+    summary_tokens_total: int = 0
+    summary_tokens_max: int = 0
+
+    def to_report(self) -> Dict[str, Any]:
+        """Logged-fields report (the DoD-gate acceptance surface)."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "tokenizer": "ceil(len/4)",
+            "summary_token_limit": ISO_SUMMARY_TOKEN_LIMIT,
+            "k_requested": self.k_requested,
+            "k_effective": self.k_effective,
+            "pool_size": self.pool_size,
+            "promoted": list(self.promoted),
+            "summarized": list(self.summarized),
+            "denied": list(self.denied),
+            "unknown": list(self.unknown),
+            "schema_tokens_promoted": self.schema_tokens_promoted,
+            "schema_token_budget": self.schema_token_budget,
+            "summary_tokens_total": self.summary_tokens_total,
+            "summary_tokens_max": self.summary_tokens_max,
+            "invariants": {
+                "summaries_within_limit": self.summary_tokens_max
+                <= ISO_SUMMARY_TOKEN_LIMIT,
+                "promoted_lte_k": len(self.promoted) <= self.k_effective,
+                "denied_never_promoted": not (
+                    {d["tool_id"] for d in self.denied} & set(self.promoted)
+                ),
+                "budget_respected": (
+                    self.schema_token_budget is None
+                    or self.schema_tokens_promoted <= self.schema_token_budget
+                ),
+            },
+        }
+
+
+class IsoGate:
+    """Universal ISO gating layer: permanent summary pool + top-k promotion.
+
+    Usage::
+
+        gate = IsoGate(policy=resolver)          # policy optional (passthrough)
+        gate.register("openspec", "Spec-driven change management...", schema)
+        ...
+        sel = gate.select(ranked_ids, k=5, schema_token_budget=1200)
+        sel.promoted    # top-k tool ids whose FULL schema is loaded this turn
+        sel.summarized  # everything else — stays in the <=60-token pool
+    """
+
+    def __init__(
+        self,
+        k: int = ISO_DEFAULT_TOP_K,
+        policy: Optional[PolicyResolver] = None,
+    ) -> None:
+        if k < 1:
+            raise ValueError("k must be >= 1")
+        self.default_k = k
+        self.policy = policy
+        self._pool: Dict[str, ToolSummary] = {}
+        self._schemas: Dict[str, Optional[Dict[str, Any]]] = {}
+
+    # -- pool ---------------------------------------------------------------
+
+    def register(
+        self,
+        tool_id: str,
+        summary: str,
+        schema: Optional[Dict[str, Any]] = None,
+    ) -> ToolSummary:
+        """Add a tool to the permanent summary pool (idempotent by tool_id)."""
+        entry = ToolSummary.build(tool_id, summary)
+        self._pool[tool_id] = entry
+        self._schemas[tool_id] = schema
+        return entry
+
+    def pool(self) -> List[ToolSummary]:
+        """The permanent <=60-token/tool summary pool (sorted, deterministic)."""
+        return [self._pool[t] for t in sorted(self._pool)]
+
+    def schema_for(self, tool_id: str) -> Optional[Dict[str, Any]]:
+        return self._schemas.get(tool_id)
+
+    # -- selection ----------------------------------------------------------
+
+    def select(
+        self,
+        ranked_candidates: Sequence[str],
+        k: Optional[int] = None,
+        schema_token_budget: Optional[int] = None,
+    ) -> IsoSelection:
+        """Promote the top-k gated candidates; everything else stays summary.
+
+        Args:
+            ranked_candidates: tool ids in descending preference order (the
+                ranking itself comes from the caller — e.g. the CTS scorer).
+            k: per-turn override of the default top-k.
+            schema_token_budget: optional cumulative cap on promoted full
+                schema tokens (normative tokenizer); greedy in rank order.
+        """
+        k_requested = k if k is not None else self.default_k
+        if k_requested < 1:
+            raise ValueError("k must be >= 1")
+
+        promoted: List[str] = []
+        denied: List[Dict[str, Any]] = []
+        unknown: List[str] = []
+        seen: set = set()
+        spent = 0
+
+        for tool_id in ranked_candidates:
+            if tool_id in seen:
+                continue
+            seen.add(tool_id)
+            if tool_id not in self._pool:
+                unknown.append(tool_id)
+                continue
+            # Hard filter FIRST: a policy-denied tool is never promoted.
+            if self.policy is not None:
+                decision = self.policy.check(tool_id)
+                if not decision.allow:
+                    denied.append(
+                        {
+                            "tool_id": tool_id,
+                            "reason": decision.reason,
+                            "conflicting_with": list(decision.conflicting_with),
+                        }
+                    )
+                    continue
+            if len(promoted) >= k_requested:
+                continue  # rank exhausted the k slots; stays summarized
+            cost = _schema_tokens(self._schemas.get(tool_id))
+            if schema_token_budget is not None and spent + cost > schema_token_budget:
+                continue  # would bust the budget; stays summarized
+            promoted.append(tool_id)
+            spent += cost
+
+        promoted_set = set(promoted)
+        denied_set = {d["tool_id"] for d in denied}
+        summarized = [
+            t for t in sorted(self._pool) if t not in promoted_set and t not in denied_set
+        ]
+        pool_tokens = [s.tokens for s in self._pool.values()]
+
+        return IsoSelection(
+            k_requested=k_requested,
+            k_effective=len(promoted),
+            pool_size=len(self._pool),
+            promoted=promoted,
+            summarized=summarized,
+            denied=denied,
+            unknown=unknown,
+            schema_tokens_promoted=spent,
+            schema_token_budget=schema_token_budget,
+            summary_tokens_total=sum(pool_tokens),
+            summary_tokens_max=max(pool_tokens, default=0),
+        )
+
+    # -- construction helpers -------------------------------------------------
+
+    @classmethod
+    def from_inventory(
+        cls,
+        inventory: Iterable[Dict[str, Any]],
+        k: int = ISO_DEFAULT_TOP_K,
+        policy: Optional[PolicyResolver] = None,
+    ) -> Tuple["IsoGate", List[ToolSummary]]:
+        """Build a gate from an inventory (list of {id, summary, schema?})."""
+        gate = cls(k=k, policy=policy)
+        entries = [
+            gate.register(item["id"], item.get("summary", ""), item.get("schema"))
+            for item in inventory
+        ]
+        return gate, entries

--- a/mcp-tools/maos-mcp-hub/tests/test_iso_gate.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_iso_gate.py
@@ -181,6 +181,21 @@ def test_unknown_candidates_are_reported_not_promoted():
     assert sel.promoted == ["openspec"]
 
 
+def test_empty_pool_selection_does_not_crash():
+    """Regression lock for PR #197 review: ``max(pool_tokens, default=0)``
+    handles the empty pool by definition (PEP-defined ``default``) — an empty
+    gate selects cleanly with all invariants green and summary_tokens_max=0."""
+    gate = IsoGate()
+    sel = gate.select([], k=3)
+    assert sel.pool_size == 0
+    assert sel.summary_tokens_max == 0
+    report = sel.to_report()
+    assert all(report["invariants"].values())
+    # empty ranked list against a populated pool is equally safe
+    gate.register("openspec", "spec tool")
+    assert gate.select([], k=3).summarized == ["openspec"]
+
+
 def test_selection_is_deterministic():
     fixture = _fixture()
     gate, _ = IsoGate.from_inventory(fixture["inventory"])

--- a/mcp-tools/maos-mcp-hub/tests/test_iso_gate.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_iso_gate.py
@@ -1,0 +1,205 @@
+"""
+Tests for the universal ISO gating layer (WT3 / S3).
+
+Two layers, both DoD-gate compliant (every acceptance is a GOLDEN-FIXTURE
+invariant or a LOGGED FIELD — never prose):
+
+  A. CORPUS INTEGRITY — the golden inventory is honest: every id is a real
+     conflicts.yaml node (or the declared substrate tool), every summary fits
+     the normative <=60-token limit, every non-injection profile is internally
+     conflict-free, and the injection turn's planted pair has a real edge.
+  B. MEASURED OUTCOMES — feeding that corpus to the REAL IsoGate (composing
+     the REAL PolicyResolver) produces the logged fields the eval reports:
+     top-k bounded promotion, budget respected, denied-never-promoted,
+     normative-tokenizer truncation, determinism.
+"""
+
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, List, Set
+
+import yaml
+
+from lib.gateway.iso import (
+    ISO_DEFAULT_TOP_K,
+    ISO_SUMMARY_TOKEN_LIMIT,
+    IsoGate,
+    ToolSummary,
+    iso_tokens,
+)
+from lib.gateway.policy import PolicyResolver, load_conflicts
+from evals.iso_gate_eval import CONFLICTS_YAML, INVENTORY_YAML, run_eval
+
+
+# --------------------------------------------------------------------------- #
+# fixtures-as-data (loaded once)
+# --------------------------------------------------------------------------- #
+
+def _fixture() -> Dict[str, Any]:
+    return yaml.safe_load(Path(INVENTORY_YAML).read_text(encoding="utf-8"))
+
+
+def _edges() -> Set[FrozenSet[str]]:
+    return {frozenset(e) for e in load_conflicts(CONFLICTS_YAML)}
+
+
+def _conflict_nodes() -> Set[str]:
+    nodes: Set[str] = set()
+    for edge in _edges():
+        nodes |= set(edge)
+    return nodes
+
+
+# Substrate/expert tools that legitimately appear in the inventory without
+# carrying a conflict edge (same discipline as routing_cases.yaml).
+DECLARED_SUBSTRATE_TOOLS = {"notebooklm"}
+
+
+# --------------------------------------------------------------------------- #
+# A. corpus integrity — the golden inventory is honest
+# --------------------------------------------------------------------------- #
+
+def test_every_inventory_id_is_real():
+    """No invented/typo'd ids: every id is a conflict node or declared substrate."""
+    known = _conflict_nodes() | DECLARED_SUBSTRATE_TOOLS
+    for item in _fixture()["inventory"]:
+        assert item["id"] in known, f"invented id in fixture: {item['id']}"
+
+
+def test_every_summary_within_normative_limit():
+    """Spec acceptance: <=60 tokens/tool under iso_tokens (never prose-judged)."""
+    for item in _fixture()["inventory"]:
+        tokens = iso_tokens(item["summary"])
+        assert tokens <= ISO_SUMMARY_TOKEN_LIMIT, (
+            f"{item['id']} summary is {tokens} tokens (> {ISO_SUMMARY_TOKEN_LIMIT})"
+        )
+
+
+def test_non_injection_profiles_are_conflict_free():
+    edges = _edges()
+    for turn in _fixture()["turns"]:
+        if turn["name"] == "injection" or not turn.get("profile"):
+            continue
+        for a, b in combinations(turn["profile"], 2):
+            assert frozenset((a, b)) not in edges, (
+                f"turn {turn['name']} profile carries conflict {a}<->{b}"
+            )
+
+
+def test_injection_turn_plants_a_real_edge():
+    fixture = _fixture()
+    injection = next(t for t in fixture["turns"] if t["name"] == "injection")
+    planted = set(injection["expect"]["denied_contains"])
+    assert frozenset(planted) in _edges(), (
+        f"injection pair {planted} has no real conflicts.yaml edge"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# B. measured outcomes — the real IsoGate, logged fields
+# --------------------------------------------------------------------------- #
+
+def test_normative_tokenizer_is_ceil_len_over_4():
+    assert iso_tokens("") == 0
+    assert iso_tokens("abcd") == 1
+    assert iso_tokens("abcde") == 2
+    assert iso_tokens("x" * 240) == 60
+    assert iso_tokens("x" * 241) == 61
+
+
+def test_summary_truncation_is_deterministic_and_within_limit():
+    long_text = "word " * 200  # far beyond 60 tokens
+    entry = ToolSummary.build("openspec", long_text)
+    assert entry.truncated is True
+    assert entry.tokens <= ISO_SUMMARY_TOKEN_LIMIT
+    # deterministic: same input -> same truncation
+    assert ToolSummary.build("openspec", long_text) == entry
+
+
+def test_topk_promotion_bounded_and_rest_summarized():
+    """The spec scenario: only top-k full schemas; the rest stay summaries."""
+    fixture = _fixture()
+    gate, _ = IsoGate.from_inventory(fixture["inventory"])
+    ranked = [item["id"] for item in fixture["inventory"]]
+    sel = gate.select(ranked, k=ISO_DEFAULT_TOP_K)
+    assert sel.k_effective == ISO_DEFAULT_TOP_K
+    assert sel.promoted == ranked[:ISO_DEFAULT_TOP_K]
+    assert set(sel.promoted) | set(sel.summarized) == set(ranked)
+    assert sel.summary_tokens_max <= ISO_SUMMARY_TOKEN_LIMIT
+    report = sel.to_report()
+    assert report["invariants"]["summaries_within_limit"] is True
+    assert report["invariants"]["promoted_lte_k"] is True
+
+
+def test_budget_caps_promotion_greedily():
+    fixture = _fixture()
+    gate, _ = IsoGate.from_inventory(fixture["inventory"])
+    ranked = [item["id"] for item in fixture["inventory"]]
+    unbounded = gate.select(ranked, k=5)
+    assert unbounded.schema_tokens_promoted > 0
+    tight = unbounded.schema_tokens_promoted // 2
+    sel = gate.select(ranked, k=5, schema_token_budget=tight)
+    assert sel.schema_tokens_promoted <= tight
+    assert sel.k_effective < unbounded.k_effective
+    assert sel.to_report()["invariants"]["budget_respected"] is True
+
+
+def test_policy_denied_is_never_promoted():
+    """Hard-filter first: a denied tool never surfaces as a top-k candidate."""
+    fixture = _fixture()
+    turn = next(t for t in fixture["turns"] if t["name"] == "policy-gated")
+    policy = PolicyResolver(
+        profile=turn["profile"], conflicts=load_conflicts(CONFLICTS_YAML)
+    )
+    gate, _ = IsoGate.from_inventory(fixture["inventory"], policy=policy)
+    sel = gate.select(turn["ranked"], k=turn["k"])
+    denied_ids = {d["tool_id"] for d in sel.denied}
+    assert set(turn["expect"]["denied_contains"]) <= denied_ids
+    assert not denied_ids & set(sel.promoted)
+    assert not denied_ids & set(sel.summarized)  # denied is its own bucket
+
+
+def test_injection_denies_both_endpoints_with_named_peer():
+    fixture = _fixture()
+    turn = next(t for t in fixture["turns"] if t["name"] == "injection")
+    policy = PolicyResolver(
+        profile=turn["profile"], conflicts=load_conflicts(CONFLICTS_YAML)
+    )
+    gate, _ = IsoGate.from_inventory(fixture["inventory"], policy=policy)
+    sel = gate.select(turn["ranked"], k=turn["k"])
+    denied = {d["tool_id"]: d for d in sel.denied}
+    assert {"mem0", "letta"} <= set(denied)
+    assert denied["mem0"]["conflicting_with"] == ["letta"]
+    assert denied["letta"]["conflicting_with"] == ["mem0"]
+
+
+def test_unknown_candidates_are_reported_not_promoted():
+    gate = IsoGate()
+    gate.register("openspec", "spec tool")
+    sel = gate.select(["openspec", "not-a-tool"], k=2)
+    assert sel.unknown == ["not-a-tool"]
+    assert sel.promoted == ["openspec"]
+
+
+def test_selection_is_deterministic():
+    fixture = _fixture()
+    gate, _ = IsoGate.from_inventory(fixture["inventory"])
+    ranked = [item["id"] for item in fixture["inventory"]]
+    a = gate.select(ranked, k=4).to_report()
+    b = gate.select(ranked, k=4).to_report()
+    assert a == b
+
+
+def test_run_eval_verdict_all_green():
+    """The eval's own logged verdict — the reproducible acceptance command."""
+    report = run_eval()
+    verdict = report["verdict"]
+    assert verdict["summaries_within_limit"] is True
+    assert verdict["all_turn_expectations_pass"] is True
+    assert verdict["promotion_always_bounded"] is True
+    assert report["tokenizer"] == "ceil(len/4)"
+    assert report["summary_token_limit"] == ISO_SUMMARY_TOKEN_LIMIT
+
+
+def test_run_eval_is_deterministic():
+    assert run_eval() == run_eval()

--- a/openspec/specs/maos-hub/spec.md
+++ b/openspec/specs/maos-hub/spec.md
@@ -113,7 +113,10 @@ complement, never the sole control. Every enforcement decision SHALL be logged (
 
 ## Deferred (as-designed gaps — not yet built)
 
-- Universal ISO tool-gating beyond the Atlassian hub (WT3) · unified CTS scorer (WT4) · L8 memory substrate
+- ~~Universal ISO tool-gating beyond the Atlassian hub (WT3)~~ *(implemented — `lib/gateway/iso.py::IsoGate`:
+  ≤60-tok summary pool under the normative tokenizer `ceil(len/4)` + top-k promotion, `k=5` default with
+  budget-derived cap, PolicyResolver hard-filter first; acceptance = `python -m evals.iso_gate_eval` logged
+  verdict + golden fixture `evals/fixtures/iso_inventory.yaml`)* · unified CTS scorer (WT4) · L8 memory substrate
   (mem0 default; graphiti temporal DEFERRED until a measured workload) (WT5) · OTel exporter for Sentinel
   (WT6, DEFERRED — C3 severity LOW) · LiteLLM model-router (CUT — `os3pd` defers a runtime gateway until ≥3
   incidents and `slm-routing` is not a runtime router) · tool-registry YAML SSOT via auto-generation (WT8).


### PR DESCRIPTION
**[PR-as-Validation-Prompt]** — WAVE-1 **WT3** (story **S3**): universal ISO tool-gating — the MCP-tax control.

## Context
The WT0 eval (PR #187) measured weighted coverage at **~58% (not 70%)** with `half_the_plan_falls=false` → the gap-fill WAVE 1 remains justified. Conflict **C4** (OODA-RECON): the progressive-discovery/ISO pattern exists ONLY in the Atlassian hub; every other connected MCP tool pays the full "tools tax" (10k–60k tokens/turn). Spec contract: `openspec/specs/maos-hub/spec.md` → **"ISO tool-gating (MCP-tax control)"** — *summary pool ≤60 tokens/tool; full schema only for the top-k gated candidates of a turn*.

## What this adds
- `lib/gateway/iso.py` — **`IsoGate`**: permanent ≤60-tok/tool summary pool + top-k full-schema promotion. Composes (never reimplements): `PolicyResolver` (PR #180 seam) as **hard-filter-first** — a denied tool is never surfaced as a top-k candidate; denials carry `reason` + `conflicting_with`.
- **The two review-board-mandated definitions, now EXPLICIT** (the co-creation board flagged the threshold as *incomputable* without them):
  - **Normative tokenizer**: `iso_tokens(text) = ceil(len(text)/4)` — deterministic, dependency-free, model-agnostic; the ≤60 threshold is *defined in terms of this function* (no vendor-tokenizer drift).
  - **`k`**: `ISO_DEFAULT_TOP_K = 5` (explicit default) + budget-derived cap — `k_effective = min(k_requested, budget_cap, allowed)`, greedy in rank order under an optional `schema_token_budget`.
- `evals/iso_gate_eval.py` + `evals/fixtures/iso_inventory.yaml` — golden inventory (12 **real** `conflicts.yaml` tool-ids; same never-invented-ids discipline as S8), 4 turns: `clean-topk` · `budget-bound` · `policy-gated` · `injection` (planted mem0↔letta profile conflict → both endpoints denied naming their peer).
- `tests/test_iso_gate.py` (**14 tests**: corpus-integrity layer + measured-outcomes layer) · CHANGELOG · spec deferred-list updated (WT3 → implemented).

## 📊 Measured verdict (reproduce: `python -m evals.iso_gate_eval` — exit 0 ⇔ green)
| Field | Value |
|---|---|
| `summaries_within_limit` | **true** (pool max = 24 tok ≤ 60) |
| `all_turn_expectations_pass` | **true** (4/4 turns) |
| `promotion_always_bounded` | **true** (k_effective ≤ k, always < pool_size) |
| invariants per turn | `promoted_lte_k` · `denied_never_promoted` · `budget_respected` all true |

## Acceptance (DoD-gate — every item a logged field or golden-fixture invariant, never prose)
- [x] eval runs + emits the logged JSON report (`turns[].report` + `verdict`)
- [x] golden-fixture invariants asserted: every id is a real `conflicts.yaml` node (or declared substrate) · every summary ≤60 tok under the normative tokenizer · non-injection profiles internally conflict-free · injection pair has a real edge — **the corpus-integrity test caught a real fixture bug during development** (an ECC↔superpowers edge planted by accident) and forced the fix
- [x] measured outcomes asserted: top-k bounded · greedy budget cap (`k_effective < k_requested` when budget binds) · policy-denied never promoted · deterministic (`run_eval()==run_eval()`)
- [x] **14 new tests pass**; **0-regression** (failure/error sets byte-identical to pristine `main`: same 2 pre-existing `test_gateway_discover` fails + 9 pre-existing collection errors; 60→74 passing)
- [x] `validate-plugin.sh` PASSED (0 errors) · `gitleaks` clean on new files
- [x] CHANGELOG under `[Unreleased]` (no version bump per ADR-003) · spec §Deferred updated

## Risk + rollback
Purely additive (`lib/gateway/iso.py` is a new module; `__init__.py` only gains exports; no gateway/hub behaviour changes — `IsoGate` has zero callers in dispatch paths until WT4 wires it into the CTS scorer). Rollback = revert the single squash commit.

## Out of scope
WT4 (CTS scorer — will consume `IsoGate` as its ISO criterion) · WT5 (mem0) · wiring IsoGate into `hub.py` runtime (follows once CTS ranks candidates).

## Refs
ADR-006 · `openspec/specs/maos-hub/spec.md` (ISO requirement + Deferred) · `research/agentic-moe-2026/20260627-HANDOFF-claude-code.md` (WAVE 1 / WT3) · PR #187 (WT0 eval verdict) · PR #180 (PolicyResolver seam)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
