### PR TITLE
feat(maos-hub): unified CTS scorer (WT4/S2) — hard-filters-first multi-criteria ranking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — unified CTS scorer (WT4 / S2) — hard-filters-first multi-criteria ranking
+
+- **`mcp-tools/maos-mcp-hub/lib/gateway/cts.py`** — `CtsScorer`: the WAVE-1 WT4 unification of the
+  scattered prioritization logic (`protocols/action-priority.md` Eisenhower + `protocols/rbad.md`
+  4-dim rubric + the WT3 ISO layer) into ONE weighted scorer (spec requirement "CTS multi-criteria
+  scoring (hard-filters-first)", `openspec/specs/maos-hub/spec.md`).
+- **The review-board-mandated `risk=HIGH` predicate is now CONCRETE** (not "irreversible-ish"):
+  `RiskSignals` = enumerable boolean facts — HIGH iff ANY of {`irreversible`, `destructive`,
+  `credential_scope`, `prod_facing`, `cross_org`}; MEDIUM iff {`bulk_write`, `remote_write`};
+  LOW otherwise. Each signal is a verifiable property of the action, never a vibe.
+- **Hard filters BEFORE any weighted score** (spec scenario): `policy` (PolicyResolver, PR #180 seam)
+  → `open_source` → `auth` → `environment` → `data_class` → `risk_class` — the first hit eliminates
+  with a traced reason; a perfect-score candidate lacking authorization is NEVER scored. Above-ceiling
+  risk is `hitl_eligible` (HITL-routable), never a silent drop.
+- **Six explicit criteria weights (sum = 1.0, test-asserted)**: scope 0.30 · eisenhower 0.20 ·
+  risk 0.15 · reversibility 0.15 · iso 0.10 · methodology 0.10 — mapped to the RBAD 4-dim rubric
+  (Expert-fit / Authorization / Task-frame / Risk-frame). Deterministic (tool_id tie-break).
+- **The WT3↔WT4 seam composes**: `CtsRanking.ranked_ids()` is exactly `IsoGate.select`'s ranked
+  input — `iso_promoted == cts_rank prefix` asserted end-to-end.
+- **DoD-gate honoured:** acceptance = logged fields (`CtsRanking.to_report()` invariants:
+  `weights_sum_to_1` · `eliminated_never_ranked` · `scores_descending` · `every_elimination_reasoned`)
+  + golden fixture (`evals/fixtures/cts_cases.yaml`, real conflicts.yaml ids, 3 turns). Reproducible
+  acceptance command: `python -m evals.cts_eval` (exit 0 ⇔ verdict green). **12 tests**
+  (`tests/test_cts_scorer.py`), 0-regression. Additive; no plugin version bump (ADR-003).
+
 ### Added — ISO universal tool-gating (WT3 / S3) — summary pool + top-k promotion (MCP-tax control)
 
 - **`mcp-tools/maos-mcp-hub/lib/gateway/iso.py`** — `IsoGate`: the WAVE-1 WT3 generalization of the

--- a/mcp-tools/maos-mcp-hub/evals/cts_eval.py
+++ b/mcp-tools/maos-mcp-hub/evals/cts_eval.py
@@ -70,10 +70,10 @@ def _check_expectations(
             )
         elif key == "ruflo_hitl_eligible":
             results[key] = (
-                eliminated.get("ruflo", {}).get("hitl_eligible", False) is want
+                eliminated.get("ruflo", {}).get("hitl_eligible", False) == want
             )
         elif key == "eliminated_never_ranked":
-            results[key] = report["invariants"]["eliminated_never_ranked"] is want
+            results[key] = report["invariants"]["eliminated_never_ranked"] == want
         else:
             results[key] = False  # unknown expectation key fails loudly
     return results
@@ -114,7 +114,11 @@ def run_eval(
 
     # -- the WT3<->WT4 seam: the ranking IS IsoGate's ranked input -----------
     scorer = CtsScorer()
-    clean_turn = next(t for t in fixture["turns"] if t["name"] == "spec-task-clean")
+    clean_turn = next(
+        (t for t in fixture["turns"] if t["name"] == "spec-task-clean"), None
+    )
+    if clean_turn is None:
+        raise ValueError("required 'spec-task-clean' turn missing from fixture")
     ranking = scorer.rank(
         candidates,
         CtsTurn(

--- a/mcp-tools/maos-mcp-hub/evals/cts_eval.py
+++ b/mcp-tools/maos-mcp-hub/evals/cts_eval.py
@@ -1,0 +1,174 @@
+"""
+CTS scorer eval (WT4 / S2) — MEASURE the unified scorer, don't assume it.
+
+Exercises the REAL ``lib/gateway/cts.py::CtsScorer`` (never a reimplementation)
+against the golden corpus ``fixtures/cts_cases.yaml``, composing the REAL
+``PolicyResolver`` (PR #180 seam) for the policy turn and the REAL ``IsoGate``
+(WT3, PR #197) for the end-to-end seam check.
+
+Output is a single JSON object of LOGGED FIELDS (the DoD-gate: every
+acceptance is a logged field or golden-fixture invariant, never prose). Run::
+
+    python -m evals.cts_eval               # prints JSON to stdout
+    python -m evals.cts_eval --out r.json  # also writes the report
+
+Importable::
+
+    from evals.cts_eval import run_eval
+    report = run_eval()
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from lib.gateway.cts import (
+    CTS_WEIGHTS,
+    CtsScorer,
+    CtsTurn,
+    RiskClass,
+    candidates_from_fixture,
+)
+from lib.gateway.iso import IsoGate
+from lib.gateway.policy import PolicyResolver, load_conflicts
+
+SCHEMA_VERSION = "cts-eval/1.0.0"
+
+_HERE = Path(__file__).resolve().parent
+_GATEWAY = _HERE.parent / "lib" / "gateway"
+CONFLICTS_YAML = _GATEWAY / "conflicts.yaml"
+CASES_YAML = _HERE / "fixtures" / "cts_cases.yaml"
+
+
+def _load_yaml(path: Path) -> Dict[str, Any]:
+    return yaml.safe_load(Path(path).read_text(encoding="utf-8")) or {}
+
+
+def _check_expectations(
+    expect: Dict[str, Any], report: Dict[str, Any]
+) -> Dict[str, bool]:
+    """Evaluate a turn's fixture expectations against its logged report."""
+    results: Dict[str, bool] = {}
+    ranked_ids = [r["tool_id"] for r in report["ranked"]]
+    eliminated = {e["tool_id"]: e for e in report["eliminated"]}
+    for key, want in (expect or {}).items():
+        if key == "top1":
+            results[key] = bool(ranked_ids) and ranked_ids[0] == want
+        elif key == "ranked_contains":
+            results[key] = set(want).issubset(set(ranked_ids))
+        elif key == "eliminated_contains":
+            results[key] = all(
+                item["tool_id"] in eliminated
+                and eliminated[item["tool_id"]]["filter"] == item["filter"]
+                for item in want
+            )
+        elif key == "ruflo_hitl_eligible":
+            results[key] = (
+                eliminated.get("ruflo", {}).get("hitl_eligible", False) is want
+            )
+        elif key == "eliminated_never_ranked":
+            results[key] = report["invariants"]["eliminated_never_ranked"] is want
+        else:
+            results[key] = False  # unknown expectation key fails loudly
+    return results
+
+
+def run_eval(
+    cases_path: Path = CASES_YAML,
+    conflicts_path: Path = CONFLICTS_YAML,
+) -> Dict[str, Any]:
+    """Run the full CTS eval and return the report as a dict (logged fields)."""
+    fixture = _load_yaml(cases_path)
+    candidates = candidates_from_fixture(fixture["candidates"])
+    edges = load_conflicts(conflicts_path)
+
+    turns_report: List[Dict[str, Any]] = []
+    all_expectations_pass = True
+
+    for turn_spec in fixture.get("turns", []):
+        profile = turn_spec.get("profile")
+        policy: Optional[PolicyResolver] = (
+            PolicyResolver(profile=profile, conflicts=edges) if profile else None
+        )
+        scorer = CtsScorer(policy=policy)
+        turn = CtsTurn(
+            granted_scopes=frozenset(turn_spec.get("granted_scopes", [])),
+            allowed_data_classes=frozenset(
+                turn_spec.get("allowed_data_classes", [])
+            ),
+            max_risk=RiskClass[turn_spec.get("max_risk", "HIGH")],
+        )
+        ranking = scorer.rank(candidates, turn)
+        report = ranking.to_report()
+        checks = _check_expectations(turn_spec.get("expect", {}), report)
+        all_expectations_pass = all_expectations_pass and all(checks.values())
+        turns_report.append(
+            {"name": turn_spec["name"], "report": report, "expectations": checks}
+        )
+
+    # -- the WT3<->WT4 seam: the ranking IS IsoGate's ranked input -----------
+    scorer = CtsScorer()
+    clean_turn = next(t for t in fixture["turns"] if t["name"] == "spec-task-clean")
+    ranking = scorer.rank(
+        candidates,
+        CtsTurn(
+            granted_scopes=frozenset(clean_turn["granted_scopes"]),
+            max_risk=RiskClass[clean_turn["max_risk"]],
+        ),
+    )
+    gate, _ = IsoGate.from_inventory(
+        [
+            {"id": c.tool_id, "summary": f"{c.tool_id} expert", "schema": c.schema}
+            for c in candidates
+        ]
+    )
+    selection = gate.select(ranking.ranked_ids(), k=3)
+    seam = {
+        "cts_rank": ranking.ranked_ids(),
+        "iso_promoted": selection.promoted,
+        "promoted_is_rank_prefix": selection.promoted
+        == ranking.ranked_ids()[: len(selection.promoted)],
+    }
+
+    verdict = {
+        "weights_sum_to_1": abs(sum(CTS_WEIGHTS.values()) - 1.0) < 1e-9,
+        "all_turn_expectations_pass": all_expectations_pass,
+        "hard_filters_precede_scoring": all(
+            t["report"]["invariants"]["eliminated_never_ranked"]
+            and t["report"]["invariants"]["every_elimination_reasoned"]
+            for t in turns_report
+        ),
+        "iso_seam_composes": seam["promoted_is_rank_prefix"],
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "weights": dict(CTS_WEIGHTS),
+        "turns": turns_report,
+        "iso_seam": seam,
+        "verdict": verdict,
+    }
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", type=Path, default=None, help="also write JSON here")
+    args = parser.parse_args(argv)
+
+    report = run_eval()
+    text = json.dumps(report, indent=2, ensure_ascii=False)
+    print(text)
+    if args.out:
+        args.out.write_text(text + "\n", encoding="utf-8")
+
+    return 0 if all(report["verdict"].values()) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mcp-tools/maos-mcp-hub/evals/fixtures/cts_cases.yaml
+++ b/mcp-tools/maos-mcp-hub/evals/fixtures/cts_cases.yaml
@@ -1,0 +1,109 @@
+# Golden corpus for the CTS scorer eval (WT4 / S2).
+#
+# Invariants (asserted by tests/test_cts_scorer.py — the DoD-gate):
+#   - every tool id is a REAL node of lib/gateway/conflicts.yaml (or a
+#     declared substrate tool) — never invented ids;
+#   - every `risk` block uses ONLY RiskSignals field names (enumerable
+#     booleans — the concrete risk predicate's inputs);
+#   - every turn's expectations are INVARIANT names, never prose.
+#
+# Candidate scoring facts model a "spec-change task" turn: openspec is the
+# domain expert (high expert_fit, Q1); the others are progressively less fit.
+
+schema_version: cts-cases/1.0.0
+
+candidates:
+  - id: openspec
+    expert_fit: 0.95
+    methodology_fit: 0.9
+    eisenhower_q: 1
+    reversibility: 1.0
+    required_scopes: [repo.write]
+    schema: {resource: spec, operations: [propose, apply, archive, validate], required: [change_id]}
+  - id: spec-kit
+    expert_fit: 0.85
+    methodology_fit: 0.8
+    eisenhower_q: 1
+    reversibility: 1.0
+    required_scopes: [repo.write]
+    schema: {resource: spec, operations: [specify, plan, tasks], required: [feature]}
+  - id: mem0
+    expert_fit: 0.35
+    methodology_fit: 0.4
+    eisenhower_q: 2
+    reversibility: 0.9
+    required_scopes: [memory.write]
+    schema: {resource: memory, operations: [add, search], required: [text]}
+  - id: notebooklm
+    expert_fit: 0.3
+    methodology_fit: 0.5
+    eisenhower_q: 2
+    reversibility: 1.0
+    required_scopes: [research.read]
+    schema: {resource: notebook, operations: [create, add_source, generate], required: [notebook_id]}
+  - id: gstack
+    # Perfect-looking scores BUT requires a scope the turn does not grant:
+    # the auth HARD FILTER must eliminate it BEFORE scoring (spec scenario).
+    expert_fit: 1.0
+    methodology_fit: 1.0
+    eisenhower_q: 1
+    reversibility: 1.0
+    required_scopes: [browser.control]
+    schema: {resource: workflow, operations: [plan, qa, ship], required: [task]}
+  - id: ruflo
+    # HIGH-risk by the concrete predicate: prod_facing + bulk_write.
+    expert_fit: 0.7
+    methodology_fit: 0.6
+    eisenhower_q: 1
+    reversibility: 0.2
+    required_scopes: [repo.write]
+    risk: {prod_facing: true, bulk_write: true}
+    schema: {resource: swarm, operations: [spawn, topology, converge], required: [goal]}
+  - id: open-design
+    expert_fit: 0.2
+    methodology_fit: 0.3
+    eisenhower_q: 3
+    reversibility: 1.0
+    required_scopes: []
+    schema: {resource: design, operations: [apply_system, render], required: [target]}
+
+turns:
+  - name: spec-task-clean
+    # Everything the clean candidates need is granted; ruflo exceeds the
+    # MEDIUM risk ceiling; gstack lacks browser.control.
+    profile: null
+    granted_scopes: [repo.write, memory.write, research.read]
+    allowed_data_classes: []
+    max_risk: MEDIUM
+    expect:
+      top1: openspec
+      eliminated_contains:
+        - {tool_id: gstack, filter: auth}
+        - {tool_id: ruflo, filter: risk_class}
+      ruflo_hitl_eligible: true
+      eliminated_never_ranked: true
+
+  - name: high-risk-allowed
+    # Same turn but the ceiling is HIGH: ruflo now passes the risk filter and
+    # is SCORED (low risk criterion value), not eliminated.
+    profile: null
+    granted_scopes: [repo.write, memory.write, research.read]
+    allowed_data_classes: []
+    max_risk: HIGH
+    expect:
+      ranked_contains: [ruflo]
+      top1: openspec
+
+  - name: policy-conflict
+    # Injection: spec-kit planted into a profile that already carries
+    # openspec (conflicts.yaml L1 edge) -> policy hard filter eliminates
+    # BOTH endpoints before any scoring.
+    profile: [openspec, spec-kit, mem0, notebooklm]
+    granted_scopes: [repo.write, memory.write, research.read]
+    allowed_data_classes: []
+    max_risk: HIGH
+    expect:
+      eliminated_contains:
+        - {tool_id: openspec, filter: policy}
+        - {tool_id: spec-kit, filter: policy}
+      eliminated_never_ranked: true

--- a/mcp-tools/maos-mcp-hub/evals/iso_gate_eval.py
+++ b/mcp-tools/maos-mcp-hub/evals/iso_gate_eval.py
@@ -57,19 +57,20 @@ def _check_expectations(
         elif key == "summarized_count":
             results[key] = len(report["summarized"]) == want
         elif key == "k_effective_lt_requested":
-            results[key] = (report["k_effective"] < report["k_requested"]) is want
+            results[key] = (report["k_effective"] < report["k_requested"]) == want
         elif key == "budget_respected":
-            results[key] = report["invariants"]["budget_respected"] is want
+            results[key] = report["invariants"]["budget_respected"] == want
         elif key == "denied_contains":
             results[key] = set(want).issubset(denied_ids)
         elif key == "denied_never_promoted":
-            results[key] = report["invariants"]["denied_never_promoted"] is want
+            results[key] = report["invariants"]["denied_never_promoted"] == want
         elif key == "conflict_reason_names_peer":
             # every conflict-denied entry names its actual peer(s)
             conflict_entries = [d for d in report["denied"] if d["conflicting_with"]]
-            results[key] = bool(conflict_entries) and all(
-                d["conflicting_with"] for d in conflict_entries
-            ) is want
+            results[key] = (
+                bool(conflict_entries)
+                and all(d["conflicting_with"] for d in conflict_entries)
+            ) == want
         else:
             results[key] = False  # unknown expectation key fails loudly
     return results

--- a/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
@@ -18,19 +18,37 @@ from .iso import (
     ToolSummary,
     iso_tokens,
 )
+from .cts import (
+    CTS_WEIGHTS,
+    CtsCandidate,
+    CtsRanking,
+    CtsScorer,
+    CtsTurn,
+    RiskClass,
+    RiskSignals,
+    risk_class,
+)
 
 __all__ = [
     "ActionSchema",
     "AgentFeedback",
+    "CTS_WEIGHTS",
+    "CtsCandidate",
+    "CtsRanking",
+    "CtsScorer",
+    "CtsTurn",
     "GatewayRequest",
     "ISO_DEFAULT_TOP_K",
     "ISO_SUMMARY_TOKEN_LIMIT",
     "IsoGate",
     "IsoSelection",
     "MetaToolRouter",
+    "RiskClass",
+    "RiskSignals",
     "SchemaRegistry",
     "ToolSummary",
     "build_discovery_response",
     "iso_tokens",
+    "risk_class",
     "with_feedback",
 ]

--- a/mcp-tools/maos-mcp-hub/lib/gateway/cts.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/cts.py
@@ -1,0 +1,350 @@
+"""
+CtsScorer — unified CTS multi-criteria scoring (WT4 / S2): hard-filters-first.
+
+Spec contract (openspec/specs/maos-hub/spec.md → "CTS multi-criteria scoring
+(hard-filters-first)")::
+
+    The Hub SHALL apply hard filters (open-source/policy, auth, environment,
+    data-class, risk-class) BEFORE a weighted score over ISO x Eisenhower x
+    risk x scope x methodology x reversibility (the 4-dim rubric
+    Expert-fit/Authorization/Task-frame/Risk-frame from `rbad` +
+    `action-priority`).
+
+Before this module the prioritization logic existed but was SCATTERED
+(OODA-RECON critique: "action-priority + rbad + agent-select, but no single
+weighted scorer"). This composes the three sources into ONE scorer:
+
+  - ``protocols/action-priority.md`` -> the Eisenhower criterion (Q1..Q4);
+  - ``protocols/rbad.md``            -> the 4-dim rubric mapping (below);
+  - ``lib/gateway/iso.py``           -> the ISO cost criterion (normative
+    tokenizer) AND the downstream consumer: ``CtsRanking.ranked_ids()`` is
+    exactly the ``ranked_candidates`` input of ``IsoGate.select``.
+
+THE CONCRETE ``risk=HIGH`` PREDICATE (review-board mandate — "not
+'irreversible-ish'"): risk is derived from ``RiskSignals``, a fixed set of
+ENUMERABLE BOOLEAN FACTS about the candidate action::
+
+    HIGH   iff ANY of {irreversible, destructive, credential_scope,
+                       prod_facing, cross_org}
+    MEDIUM iff (not HIGH) and ANY of {bulk_write, remote_write}
+    LOW    otherwise (read-only / locally-reversible)
+
+Each signal is a verifiable property of the action — never a vibe:
+  irreversible     no single-command undo (force-push, secret rotation, drop)
+  destructive      deletes data/branches/resources without a backup path
+  credential_scope reads or writes secrets/credentials
+  prod_facing      mutates production-facing state (deploy, DNS, billing)
+  cross_org        writes/egress beyond the org boundary (public post, 3rd party)
+  bulk_write       mutates many resources in one call
+  remote_write     any single-target reversible remote mutation
+
+RBAD 4-dim rubric mapping (spec parenthetical):
+  Expert-fit     -> ``expert_fit`` + ``methodology_fit`` criteria
+  Authorization  -> the ``auth`` HARD FILTER (never a weighted criterion —
+                    a tool you cannot authorize must not score at all)
+  Task-frame     -> the ``eisenhower`` criterion (Q1..Q4 mapping)
+  Risk-frame     -> the ``risk`` + ``reversibility`` criteria (+ the
+                    ``risk-class`` hard ceiling)
+
+Every ranking emits LOGGED FIELDS (``CtsRanking.to_report()``) — the
+DoD-gate: acceptance is a logged field or golden-fixture invariant, never
+prose. See ``evals/cts_eval.py`` + ``tests/test_cts_scorer.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields as dc_fields
+from enum import IntEnum
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Sequence
+
+from .iso import _schema_tokens
+from .policy import PolicyResolver
+
+SCHEMA_VERSION = "cts-scorer/1.0.0"
+
+#: Schema cost (normative iso_tokens) at/above which the ISO criterion is 0.0.
+ISO_COST_CEILING = 600
+
+#: Explicit criterion weights (spec: ISO x Eisenhower x risk x scope x
+#: methodology x reversibility). MUST sum to 1.0 (asserted by tests).
+CTS_WEIGHTS: Dict[str, float] = {
+    "scope": 0.30,          # RBAD Expert-fit (domain/scope match)
+    "eisenhower": 0.20,     # RBAD Task-frame (action-priority Q1..Q4)
+    "risk": 0.15,           # RBAD Risk-frame (derived RiskClass)
+    "reversibility": 0.15,  # RBAD Risk-frame (undo-ability)
+    "iso": 0.10,            # ISO schema-cost frugality (normative tokenizer)
+    "methodology": 0.10,    # RBAD Expert-fit (methodology/task-style match)
+}
+
+#: Eisenhower quadrant -> criterion value (Q1 do-now ... Q4 eliminate).
+EISENHOWER_VALUE: Dict[int, float] = {1: 1.0, 2: 0.75, 3: 0.40, 4: 0.0}
+
+
+class RiskClass(IntEnum):
+    """Ordered risk classes (comparable: LOW < MEDIUM < HIGH)."""
+
+    LOW = 0
+    MEDIUM = 1
+    HIGH = 2
+
+
+@dataclass(frozen=True)
+class RiskSignals:
+    """Enumerable boolean facts — the concrete risk predicate's inputs."""
+
+    irreversible: bool = False
+    destructive: bool = False
+    credential_scope: bool = False
+    prod_facing: bool = False
+    cross_org: bool = False
+    bulk_write: bool = False
+    remote_write: bool = False
+
+    HIGH_SIGNALS = (
+        "irreversible",
+        "destructive",
+        "credential_scope",
+        "prod_facing",
+        "cross_org",
+    )
+    MEDIUM_SIGNALS = ("bulk_write", "remote_write")
+
+    def active(self) -> List[str]:
+        return [f.name for f in dc_fields(self) if getattr(self, f.name)]
+
+
+def risk_class(signals: RiskSignals) -> RiskClass:
+    """The CONCRETE ``risk=HIGH`` predicate (see module docstring)."""
+    if any(getattr(signals, name) for name in RiskSignals.HIGH_SIGNALS):
+        return RiskClass.HIGH
+    if any(getattr(signals, name) for name in RiskSignals.MEDIUM_SIGNALS):
+        return RiskClass.MEDIUM
+    return RiskClass.LOW
+
+
+#: RiskClass -> criterion value (lower risk scores higher).
+RISK_VALUE: Dict[RiskClass, float] = {
+    RiskClass.LOW: 1.0,
+    RiskClass.MEDIUM: 0.6,
+    RiskClass.HIGH: 0.2,
+}
+
+
+@dataclass(frozen=True)
+class CtsCandidate:
+    """One tool candidate: hard-filter facts + scoring facts."""
+
+    tool_id: str
+    # -- hard-filter facts ---------------------------------------------------
+    open_source_ok: bool = True
+    required_scopes: FrozenSet[str] = frozenset()
+    env_ok: bool = True
+    data_classes: FrozenSet[str] = frozenset()
+    risk: RiskSignals = RiskSignals()
+    # -- scoring facts (0..1 unless noted) ------------------------------------
+    expert_fit: float = 0.0
+    methodology_fit: float = 0.0
+    eisenhower_q: int = 2  # quadrant of the task this candidate serves (1..4)
+    reversibility: float = 1.0
+    schema: Optional[Dict[str, Any]] = None  # for the ISO cost criterion
+
+
+@dataclass(frozen=True)
+class CtsTurn:
+    """The turn context hard filters evaluate against."""
+
+    granted_scopes: FrozenSet[str] = frozenset()
+    allowed_data_classes: FrozenSet[str] = frozenset()
+    max_risk: RiskClass = RiskClass.HIGH  # inclusive ceiling
+    require_open_source: bool = True
+
+
+@dataclass
+class CtsRanking:
+    """Result of one ``CtsScorer.rank`` turn — all fields loggable."""
+
+    ranked: List[Dict[str, Any]] = field(default_factory=list)
+    eliminated: List[Dict[str, Any]] = field(default_factory=list)
+
+    def ranked_ids(self) -> List[str]:
+        """The ``ranked_candidates`` input for ``IsoGate.select`` (the seam)."""
+        return [entry["tool_id"] for entry in self.ranked]
+
+    def to_report(self) -> Dict[str, Any]:
+        """Logged-fields report (the DoD-gate acceptance surface)."""
+        eliminated_ids = {e["tool_id"] for e in self.eliminated}
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "weights": dict(CTS_WEIGHTS),
+            "hard_filter_order": list(HARD_FILTER_ORDER),
+            "ranked": list(self.ranked),
+            "eliminated": list(self.eliminated),
+            "invariants": {
+                "weights_sum_to_1": abs(sum(CTS_WEIGHTS.values()) - 1.0) < 1e-9,
+                "eliminated_never_ranked": not (
+                    eliminated_ids & {r["tool_id"] for r in self.ranked}
+                ),
+                "scores_descending": all(
+                    self.ranked[i]["score"] >= self.ranked[i + 1]["score"]
+                    for i in range(len(self.ranked) - 1)
+                ),
+                "every_elimination_reasoned": all(
+                    e.get("filter") and e.get("reason") for e in self.eliminated
+                ),
+            },
+        }
+
+
+#: Hard filters run IN THIS ORDER; the first hit eliminates (reason traced).
+HARD_FILTER_ORDER = (
+    "policy",
+    "open_source",
+    "auth",
+    "environment",
+    "data_class",
+    "risk_class",
+)
+
+
+class CtsScorer:
+    """Unified CTS scorer: hard filters FIRST, weighted score second.
+
+    Usage::
+
+        scorer = CtsScorer(policy=resolver)          # policy optional
+        ranking = scorer.rank(candidates, turn)
+        gate.select(ranking.ranked_ids(), ...)       # feed IsoGate (WT3)
+    """
+
+    def __init__(self, policy: Optional[PolicyResolver] = None) -> None:
+        self.policy = policy
+
+    # -- hard filters (spec: BEFORE any weighted score) -----------------------
+
+    def _hard_filter(
+        self, candidate: CtsCandidate, turn: CtsTurn
+    ) -> Optional[Dict[str, Any]]:
+        """Return the elimination record for the FIRST failing filter, or None."""
+        if self.policy is not None:
+            decision = self.policy.check(candidate.tool_id)
+            if not decision.allow:
+                return {
+                    "tool_id": candidate.tool_id,
+                    "filter": "policy",
+                    "reason": decision.reason,
+                    "conflicting_with": list(decision.conflicting_with),
+                    "hitl_eligible": False,
+                }
+        if turn.require_open_source and not candidate.open_source_ok:
+            return {
+                "tool_id": candidate.tool_id,
+                "filter": "open_source",
+                "reason": "candidate fails the open-source/policy requirement",
+                "hitl_eligible": False,
+            }
+        missing = candidate.required_scopes - turn.granted_scopes
+        if missing:
+            return {
+                "tool_id": candidate.tool_id,
+                "filter": "auth",
+                "reason": f"missing authorization scope(s): {sorted(missing)}",
+                "hitl_eligible": False,
+            }
+        if not candidate.env_ok:
+            return {
+                "tool_id": candidate.tool_id,
+                "filter": "environment",
+                "reason": "candidate cannot run in the current environment",
+                "hitl_eligible": False,
+            }
+        disallowed = candidate.data_classes - turn.allowed_data_classes
+        if disallowed:
+            return {
+                "tool_id": candidate.tool_id,
+                "filter": "data_class",
+                "reason": f"touches disallowed data class(es): {sorted(disallowed)}",
+                "hitl_eligible": False,
+            }
+        rc = risk_class(candidate.risk)
+        if rc > turn.max_risk:
+            # Never a silent drop: above-ceiling risk is HITL-routable
+            # (spec: "HITL on irreversible / high-risk").
+            return {
+                "tool_id": candidate.tool_id,
+                "filter": "risk_class",
+                "reason": (
+                    f"risk={rc.name} exceeds the turn ceiling {turn.max_risk.name} "
+                    f"(active signals: {candidate.risk.active()})"
+                ),
+                "hitl_eligible": True,
+            }
+        return None
+
+    # -- weighted score --------------------------------------------------------
+
+    @staticmethod
+    def _criteria(candidate: CtsCandidate) -> Dict[str, float]:
+        cost = _schema_tokens(candidate.schema)
+        return {
+            "scope": max(0.0, min(1.0, candidate.expert_fit)),
+            "eisenhower": EISENHOWER_VALUE.get(candidate.eisenhower_q, 0.0),
+            "risk": RISK_VALUE[risk_class(candidate.risk)],
+            "reversibility": max(0.0, min(1.0, candidate.reversibility)),
+            "iso": max(0.0, 1.0 - min(1.0, cost / ISO_COST_CEILING)),
+            "methodology": max(0.0, min(1.0, candidate.methodology_fit)),
+        }
+
+    @classmethod
+    def score(cls, candidate: CtsCandidate) -> Dict[str, Any]:
+        criteria = cls._criteria(candidate)
+        total = sum(CTS_WEIGHTS[name] * value for name, value in criteria.items())
+        return {
+            "tool_id": candidate.tool_id,
+            "score": round(total, 6),
+            "criteria": {k: round(v, 6) for k, v in criteria.items()},
+            "risk_class": risk_class(candidate.risk).name,
+        }
+
+    # -- the seam contract ------------------------------------------------------
+
+    def rank(
+        self, candidates: Iterable[CtsCandidate], turn: CtsTurn
+    ) -> CtsRanking:
+        """Hard-filter then score+sort. Deterministic (ties break on tool_id)."""
+        ranking = CtsRanking()
+        seen: set = set()
+        for candidate in candidates:
+            if candidate.tool_id in seen:
+                continue
+            seen.add(candidate.tool_id)
+            elimination = self._hard_filter(candidate, turn)
+            if elimination is not None:
+                ranking.eliminated.append(elimination)
+                continue
+            ranking.ranked.append(self.score(candidate))
+        ranking.ranked.sort(key=lambda e: (-e["score"], e["tool_id"]))
+        return ranking
+
+
+def candidates_from_fixture(
+    items: Sequence[Dict[str, Any]],
+) -> List[CtsCandidate]:
+    """Build candidates from a fixture list (evals/tests helper)."""
+    out: List[CtsCandidate] = []
+    for item in items:
+        out.append(
+            CtsCandidate(
+                tool_id=item["id"],
+                open_source_ok=item.get("open_source_ok", True),
+                required_scopes=frozenset(item.get("required_scopes", [])),
+                env_ok=item.get("env_ok", True),
+                data_classes=frozenset(item.get("data_classes", [])),
+                risk=RiskSignals(**item.get("risk", {})),
+                expert_fit=item.get("expert_fit", 0.0),
+                methodology_fit=item.get("methodology_fit", 0.0),
+                eisenhower_q=item.get("eisenhower_q", 2),
+                reversibility=item.get("reversibility", 1.0),
+                schema=item.get("schema"),
+            )
+        )
+    return out

--- a/mcp-tools/maos-mcp-hub/lib/gateway/cts.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/cts.py
@@ -290,7 +290,7 @@ class CtsScorer:
             "eisenhower": EISENHOWER_VALUE.get(candidate.eisenhower_q, 0.0),
             "risk": RISK_VALUE[risk_class(candidate.risk)],
             "reversibility": max(0.0, min(1.0, candidate.reversibility)),
-            "iso": max(0.0, 1.0 - min(1.0, cost / ISO_COST_CEILING)),
+            "iso": max(0.0, 1.0 - min(1.0, cost / max(ISO_COST_CEILING, 1))),
             "methodology": max(0.0, min(1.0, candidate.methodology_fit)),
         }
 

--- a/mcp-tools/maos-mcp-hub/tests/test_cts_scorer.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_cts_scorer.py
@@ -72,7 +72,10 @@ def test_risk_blocks_use_only_enumerable_signals():
 
 
 def test_policy_conflict_turn_plants_a_real_edge():
-    turn = next(t for t in _fixture()["turns"] if t["name"] == "policy-conflict")
+    turn = next(
+        (t for t in _fixture()["turns"] if t["name"] == "policy-conflict"), None
+    )
+    assert turn is not None, "required 'policy-conflict' turn missing from fixture"
     planted = {e["tool_id"] for e in turn["expect"]["eliminated_contains"]}
     assert frozenset(planted) in _edges()
 
@@ -168,7 +171,10 @@ def test_cts_rank_feeds_iso_gate_as_prefix():
     """The WT3<->WT4 seam: IsoGate promotes exactly the CTS rank prefix."""
     fixture = _fixture()
     candidates = candidates_from_fixture(fixture["candidates"])
-    turn_spec = next(t for t in fixture["turns"] if t["name"] == "spec-task-clean")
+    turn_spec = next(
+        (t for t in fixture["turns"] if t["name"] == "spec-task-clean"), None
+    )
+    assert turn_spec is not None, "required 'spec-task-clean' turn missing from fixture"
     scorer = CtsScorer()
     ranking = scorer.rank(
         candidates,

--- a/mcp-tools/maos-mcp-hub/tests/test_cts_scorer.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_cts_scorer.py
@@ -1,0 +1,192 @@
+"""
+Tests for the unified CTS scorer (WT4 / S2).
+
+Two layers, both DoD-gate compliant (every acceptance is a GOLDEN-FIXTURE
+invariant or a LOGGED FIELD — never prose):
+
+  A. CORPUS INTEGRITY — the golden corpus is honest: every id is a real
+     conflicts.yaml node (or declared substrate), every risk block uses only
+     RiskSignals field names, the policy-conflict turn plants a real edge.
+  B. MEASURED OUTCOMES — feeding that corpus to the REAL CtsScorer produces
+     the logged fields the eval reports: hard-filters-first (a perfect-score
+     candidate failing auth is never scored), the concrete risk=HIGH
+     predicate, weight normalization, determinism, and the WT3<->WT4 seam
+     (CTS rank is IsoGate's ranked input).
+"""
+
+from dataclasses import fields as dc_fields
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, Set
+
+import yaml
+
+from lib.gateway.cts import (
+    CTS_WEIGHTS,
+    CtsCandidate,
+    CtsScorer,
+    CtsTurn,
+    RiskClass,
+    RiskSignals,
+    candidates_from_fixture,
+    risk_class,
+)
+from lib.gateway.iso import IsoGate
+from lib.gateway.policy import PolicyResolver, load_conflicts
+from evals.cts_eval import CASES_YAML, CONFLICTS_YAML, run_eval
+
+
+def _fixture() -> Dict[str, Any]:
+    return yaml.safe_load(Path(CASES_YAML).read_text(encoding="utf-8"))
+
+
+def _edges() -> Set[FrozenSet[str]]:
+    return {frozenset(e) for e in load_conflicts(CONFLICTS_YAML)}
+
+
+def _conflict_nodes() -> Set[str]:
+    nodes: Set[str] = set()
+    for edge in _edges():
+        nodes |= set(edge)
+    return nodes
+
+
+DECLARED_SUBSTRATE_TOOLS = {"notebooklm"}
+
+
+# --------------------------------------------------------------------------- #
+# A. corpus integrity
+# --------------------------------------------------------------------------- #
+
+def test_every_candidate_id_is_real():
+    known = _conflict_nodes() | DECLARED_SUBSTRATE_TOOLS
+    for item in _fixture()["candidates"]:
+        assert item["id"] in known, f"invented id in fixture: {item['id']}"
+
+
+def test_risk_blocks_use_only_enumerable_signals():
+    signal_names = {f.name for f in dc_fields(RiskSignals)}
+    for item in _fixture()["candidates"]:
+        assert set(item.get("risk", {})) <= signal_names, (
+            f"{item['id']} risk block uses non-signal keys"
+        )
+
+
+def test_policy_conflict_turn_plants_a_real_edge():
+    turn = next(t for t in _fixture()["turns"] if t["name"] == "policy-conflict")
+    planted = {e["tool_id"] for e in turn["expect"]["eliminated_contains"]}
+    assert frozenset(planted) in _edges()
+
+
+# --------------------------------------------------------------------------- #
+# B. measured outcomes
+# --------------------------------------------------------------------------- #
+
+def test_weights_sum_to_one():
+    assert abs(sum(CTS_WEIGHTS.values()) - 1.0) < 1e-9
+    assert set(CTS_WEIGHTS) == {
+        "scope", "eisenhower", "risk", "reversibility", "iso", "methodology",
+    }  # the spec's six criteria, exactly
+
+
+def test_risk_high_predicate_is_concrete_per_signal():
+    """Each HIGH signal alone flips the class — enumerable, never vibes."""
+    assert risk_class(RiskSignals()) is RiskClass.LOW
+    for name in RiskSignals.HIGH_SIGNALS:
+        assert risk_class(RiskSignals(**{name: True})) is RiskClass.HIGH, name
+    for name in RiskSignals.MEDIUM_SIGNALS:
+        assert risk_class(RiskSignals(**{name: True})) is RiskClass.MEDIUM, name
+    # a MEDIUM signal never masks a HIGH one
+    assert (
+        risk_class(RiskSignals(bulk_write=True, prod_facing=True)) is RiskClass.HIGH
+    )
+
+
+def test_hard_filter_eliminates_before_scoring():
+    """Spec scenario: perfect-score candidate lacking auth is NEVER scored."""
+    scorer = CtsScorer()
+    perfect_but_unauth = CtsCandidate(
+        tool_id="gstack",
+        expert_fit=1.0,
+        methodology_fit=1.0,
+        eisenhower_q=1,
+        required_scopes=frozenset({"browser.control"}),
+    )
+    ranking = scorer.rank(
+        [perfect_but_unauth], CtsTurn(granted_scopes=frozenset({"repo.write"}))
+    )
+    assert ranking.ranked == []
+    assert ranking.eliminated[0]["filter"] == "auth"
+    assert "browser.control" in ranking.eliminated[0]["reason"]
+
+
+def test_risk_ceiling_elimination_is_hitl_eligible_not_silent():
+    scorer = CtsScorer()
+    risky = CtsCandidate(
+        tool_id="ruflo", expert_fit=0.9, risk=RiskSignals(prod_facing=True)
+    )
+    ranking = scorer.rank([risky], CtsTurn(max_risk=RiskClass.MEDIUM))
+    entry = ranking.eliminated[0]
+    assert entry["filter"] == "risk_class"
+    assert entry["hitl_eligible"] is True
+    assert "prod_facing" in entry["reason"]
+    # ceiling raised -> the same candidate is scored instead
+    ranking_high = scorer.rank([risky], CtsTurn(max_risk=RiskClass.HIGH))
+    assert ranking_high.ranked and ranking_high.eliminated == []
+
+
+def test_data_class_filter():
+    scorer = CtsScorer()
+    pii_tool = CtsCandidate(tool_id="mem0", data_classes=frozenset({"pii"}))
+    ranking = scorer.rank([pii_tool], CtsTurn())
+    assert ranking.eliminated[0]["filter"] == "data_class"
+    ok = scorer.rank(
+        [pii_tool], CtsTurn(allowed_data_classes=frozenset({"pii"}))
+    )
+    assert ok.ranked
+
+
+def test_ranking_is_deterministic_with_tool_id_tiebreak():
+    scorer = CtsScorer()
+    twin_a = CtsCandidate(tool_id="mem0", expert_fit=0.5)
+    twin_b = CtsCandidate(tool_id="cognee", expert_fit=0.5)
+    ranking = scorer.rank([twin_a, twin_b], CtsTurn())
+    assert [r["tool_id"] for r in ranking.ranked] == ["cognee", "mem0"]
+    again = scorer.rank([twin_a, twin_b], CtsTurn())
+    assert ranking.to_report() == again.to_report()
+
+
+def test_golden_turns_all_pass():
+    report = run_eval()
+    for turn in report["turns"]:
+        assert all(turn["expectations"].values()), (
+            turn["name"],
+            turn["expectations"],
+        )
+
+
+def test_cts_rank_feeds_iso_gate_as_prefix():
+    """The WT3<->WT4 seam: IsoGate promotes exactly the CTS rank prefix."""
+    fixture = _fixture()
+    candidates = candidates_from_fixture(fixture["candidates"])
+    turn_spec = next(t for t in fixture["turns"] if t["name"] == "spec-task-clean")
+    scorer = CtsScorer()
+    ranking = scorer.rank(
+        candidates,
+        CtsTurn(
+            granted_scopes=frozenset(turn_spec["granted_scopes"]),
+            max_risk=RiskClass[turn_spec["max_risk"]],
+        ),
+    )
+    gate, _ = IsoGate.from_inventory(
+        [{"id": c.tool_id, "summary": f"{c.tool_id} expert", "schema": c.schema}
+         for c in candidates]
+    )
+    selection = gate.select(ranking.ranked_ids(), k=3)
+    assert selection.promoted == ranking.ranked_ids()[:3]
+    assert selection.to_report()["invariants"]["promoted_lte_k"] is True
+
+
+def test_run_eval_verdict_all_green_and_deterministic():
+    report = run_eval()
+    assert all(report["verdict"].values()), report["verdict"]
+    assert run_eval() == run_eval()

--- a/openspec/specs/maos-hub/spec.md
+++ b/openspec/specs/maos-hub/spec.md
@@ -116,7 +116,12 @@ complement, never the sole control. Every enforcement decision SHALL be logged (
 - ~~Universal ISO tool-gating beyond the Atlassian hub (WT3)~~ *(implemented — `lib/gateway/iso.py::IsoGate`:
   ≤60-tok summary pool under the normative tokenizer `ceil(len/4)` + top-k promotion, `k=5` default with
   budget-derived cap, PolicyResolver hard-filter first; acceptance = `python -m evals.iso_gate_eval` logged
-  verdict + golden fixture `evals/fixtures/iso_inventory.yaml`)* · unified CTS scorer (WT4) · L8 memory substrate
+  verdict + golden fixture `evals/fixtures/iso_inventory.yaml`)* · ~~unified CTS scorer (WT4)~~ *(implemented —
+  `lib/gateway/cts.py::CtsScorer`: hard-filters-first [policy → open_source → auth → environment → data_class →
+  risk_class] before the 6-criteria weighted score [scope 0.30 · eisenhower 0.20 · risk 0.15 · reversibility 0.15 ·
+  iso 0.10 · methodology 0.10]; `risk=HIGH` = the concrete `RiskSignals` predicate [any of irreversible ·
+  destructive · credential_scope · prod_facing · cross_org]; acceptance = `python -m evals.cts_eval` logged
+  verdict + golden fixture `evals/fixtures/cts_cases.yaml`)* · L8 memory substrate
   (mem0 default; graphiti temporal DEFERRED until a measured workload) (WT5) · OTel exporter for Sentinel
   (WT6, DEFERRED — C3 severity LOW) · LiteLLM model-router (CUT — `os3pd` defers a runtime gateway until ≥3
   incidents and `slm-routing` is not a runtime router) · tool-registry YAML SSOT via auto-generation (WT8).


### PR DESCRIPTION
**[PR-as-Validation-Prompt]** — WAVE-1 **WT4** (story **S2**): the unified CTS scorer — hard-filters-first.

## Context
OODA-RECON critique (c): *"a lógica de priorização existe espalhada (action-priority + rbad + agent-select) mas não há um scorer único"*. The WT0 eval (#187) logged `risk_gating_enforced=false` — the seam is risk-agnostic; risk gating was explicitly deferred to WT4. Spec contract: `openspec/specs/maos-hub/spec.md` → **"CTS multi-criteria scoring (hard-filters-first)"** — *hard filters (open-source/policy, auth, environment, data-class, risk-class) BEFORE a weighted score over ISO × Eisenhower × risk × scope × methodology × reversibility*.

## What this adds
- `lib/gateway/cts.py` — **`CtsScorer`**: composes (never reimplements) `protocols/action-priority.md` (Eisenhower Q1–Q4 criterion) + `protocols/rbad.md` (4-dim rubric mapping: Expert-fit / **Authorization = hard filter, never a weighted criterion** / Task-frame / Risk-frame) + the WT3 ISO layer (#197, normative-tokenizer schema cost).
- **The review-board-mandated `risk=HIGH` predicate, now CONCRETE** (the board rejected "irreversible-ish"): `RiskSignals` = enumerable boolean facts —
  `HIGH ⇔ any{irreversible · destructive · credential_scope · prod_facing · cross_org}` · `MEDIUM ⇔ any{bulk_write · remote_write}` · `LOW` otherwise. Each signal is a verifiable property of the action.
- **Hard filters in a fixed traced order** (`policy → open_source → auth → environment → data_class → risk_class`); the first hit eliminates with a reason. A perfect-score candidate lacking authorization is **never scored** (the spec scenario, test-asserted). Above-ceiling risk is `hitl_eligible` — HITL-routable, never a silent drop (spec: "HITL on irreversible / high-risk").
- **Six explicit weights, sum = 1.0 (test-asserted)**: scope 0.30 · eisenhower 0.20 · risk 0.15 · reversibility 0.15 · iso 0.10 · methodology 0.10.
- **The WT3↔WT4 seam composes**: `CtsRanking.ranked_ids()` is exactly `IsoGate.select`'s ranked input; `iso_promoted == cts_rank prefix` asserted end-to-end (eval `iso_seam.promoted_is_rank_prefix=true`).
- `evals/cts_eval.py` + `evals/fixtures/cts_cases.yaml` (real conflicts.yaml ids; 3 turns: `spec-task-clean` · `high-risk-allowed` · `policy-conflict` injection) · `tests/test_cts_scorer.py` (**12 tests**) · CHANGELOG · spec deferred-list updated (WT4 → implemented).

## 📊 Measured verdict (reproduce: `python -m evals.cts_eval` — exit 0 ⇔ green)
| Field | Value |
|---|---|
| `weights_sum_to_1` | **true** |
| `all_turn_expectations_pass` | **true** (3/3 turns) |
| `hard_filters_precede_scoring` | **true** (`eliminated_never_ranked` + `every_elimination_reasoned` on every turn) |
| `iso_seam_composes` | **true** (IsoGate promotes exactly the CTS rank prefix) |

## Acceptance (DoD-gate — every item a logged field or golden-fixture invariant, never prose)
- [x] eval runs + emits the logged JSON report (`turns[].report` + `iso_seam` + `verdict`)
- [x] golden-fixture invariants asserted: every id real · risk blocks use only `RiskSignals` field names · the policy-conflict turn plants a real `openspec↔spec-kit` edge
- [x] measured outcomes asserted: per-signal risk predicate (each HIGH signal alone flips the class; MEDIUM never masks HIGH) · auth-before-score · `hitl_eligible` ceiling · data-class filter · deterministic with `tool_id` tie-break
- [x] **12 new tests pass** (27 with WT3's suite); **0-regression** (same pre-existing 2 fails + 9 collection errors as pristine main)
- [x] `validate-plugin.sh` PASSED (0 errors) · `gitleaks` clean
- [x] CHANGELOG under `[Unreleased]` (no version bump per ADR-003) · spec §Deferred updated

## Risk + rollback
Purely additive (new module + exports; zero dispatch-path changes — `CtsScorer` has no runtime callers until the hub wires rank→select). Rollback = revert the squash commit.

## Out of scope
WT5 (mem0 substrate) · wiring rank→select into `hub.py` runtime · calibrating per-domain `expert_fit`/`methodology_fit` sources (future: tool-registry WT8 frontmatter).

## Refs
ADR-006 · `openspec/specs/maos-hub/spec.md` (CTS requirement + Deferred) · handoff WAVE 1 / WT4 · PR #187 (`risk_gating_enforced=false`) · PR #197 (WT3 IsoGate) · PR #180 (PolicyResolver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
