### PR TITLE
feat(maos-hub): L8 memory substrate (WT5/S4) — mem0 default, file/seed degradation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — L8 memory substrate (WT5 / S4) — mem0 default, file/seed degradation
+
+- **`docs/adoption/mem0-2026-07-01.md`** — the `agentic-tool-intake` dossier for mem0 (verdict:
+  **ADAPT — adapter-first, optional dependency**; research DRY-cited from
+  `research/agentic-moe-2026/20260627-01a-substrates.md` §L8). Alternatives recorded: letta
+  REJECTED (runtime lock-in), cognee = graph-first alternative, **graphiti DEFERRED** until a
+  measured temporal workload (handoff WAVE-1: no gold-plating).
+- **`mcp-tools/maos-mcp-hub/lib/memory/substrate.py`** — `MemorySubstrate`: resolves **mem0-first**
+  (lazy import; any init/reach failure degrades) → `FileSeedBackend` (append-only JSONL — the
+  file/seed mechanism postflight seeds already rely on). The spec scenario ("Substrate-first
+  activation" → *memory backend unavailable*) implemented verbatim: degrade, **continue (never
+  blocks, never fabricates — every response names the answering backend)**, and record
+  **`l8_substrate{backend, degraded, reason}`** through the `on_trace` L9 hook. Mid-call outages
+  degrade + retry on the fallback; a failing trace hook never blocks the substrate.
+- **DoD-gate honoured:** acceptance = the logged field + golden behaviors asserted by **10 tests**
+  (`tests/test_memory_substrate.py`), incl. torn-JSONL tolerance and no-false-degradation with a
+  healthy client. 0-regression. Additive; no plugin version bump (ADR-003).
+
 ### Added — unified CTS scorer (WT4 / S2) — hard-filters-first multi-criteria ranking
 
 - **`mcp-tools/maos-mcp-hub/lib/gateway/cts.py`** — `CtsScorer`: the WAVE-1 WT4 unification of the

--- a/docs/adoption/mem0-2026-07-01.md
+++ b/docs/adoption/mem0-2026-07-01.md
@@ -1,0 +1,68 @@
+# Adoption verdict — mem0 (L8 memory substrate default)
+
+> **Produced by**: the `agentic-tool-intake` discipline · WAVE-1 WT5 (story S4) · 2026-07-01.
+> **Candidate**: `github.com/mem0ai/mem0` · PyPI `mem0ai` · trigger: ADR-006 gap roadmap (artifact (e), conflict C5).
+> **Research base (DRY — cited, not re-run)**: `research/agentic-moe-2026/20260627-01a-substrates.md` §L8
+> (mem0 · letta · cognee · graphiti · agentmemory, first-hand comparative evidence incl. the
+> agentmemory README "vs Competitors" table) + `20260627-02-ntree-moe.md` §2.7 (L8 conflict edges).
+
+## VERDICT: **ADAPT** (adapter-first, optional dependency) — mem0 is the DEFAULT L8 backend; it is NEVER a hard dependency.
+
+*Not a blanket INSTALL (the hub must keep working — and its tests must run — on machines without
+`mem0ai` or a reachable store), not ABANDON (the C5 gap is real: file/seed memory alone is fragile
+for cross-session routing at scale). The deciding spec constraint — "degrades to file/seed memory,
+continues (never blocks, never fabricates)" — REQUIRES the adapter shape, so adapter-first IS the
+verdict, not a compromise.*
+
+## 1. UNDERSTAND
+mem0 ("universal memory layer for AI agents", YC S24) retains User/Session/Agent-level memory with
+semantic + BM25 + entity retrieval. Three deploy modes (library / self-hosted server / cloud).
+The hub needs it as the L8 substrate behind `MemorySubstrate` so routing decisions can recall
+cross-session facts (conflict **C5**: "memória ausente — roteamento entre sessões sem backend
+semântico").
+
+## 2. CLAIM AUDIT (from the 20260627 research run — primary sources)
+| Claim | Verified (2026-06-27 run) | Note |
+|---|---|---|
+| maturity | 58.2k★ · 331 releases · arXiv 2504.19413 | high; benchmark framework is itself open-source (`memory-benchmarks`) |
+| license | **Apache-2.0** (exact, README+LICENSE) | permissive, patent-grant ✓ |
+| security | auth-on-by-default self-hosted, `ADMIN_API_KEY` | agent memory treated as sensitive data first-class |
+| retrieval quality | LoCoMo 91.6 · LongMemEval 94.8 (April 2026 algorithm) | reproducible via the open benchmark framework — the reason it beat MemPalace for the default slot |
+
+## 3. COMPARE / CROSS (why mem0 and not the siblings — decision recorded, alternatives rejected)
+| Alternative | Verdict | Reason (research §L8) |
+|---|---|---|
+| **letta** | **REJECT** | categorially different: a full agent RUNTIME, not a pluggable layer — "High (must use Letta)" lock-in; a rival harness, not a backend |
+| **cognee** | keep as ALTERNATIVE | pluggable + Apache-2.0, but graph-native control-plane; competes for the same default slot (conflicts.yaml `mem0<->cognee` edge) — choose when a use case needs relation reasoning |
+| **graphiti** (temporal) | **DEFER** | until a MEASURED temporal workload exists (handoff WAVE-1: "sem gold-plating"; os3pd anti-over-engineering) |
+| **agentmemory** | not adopted | overlapping engine; mem0's auditable benchmark + ecosystem breadth win the default |
+
+## 4. VALIDATE — the decisive spec constraint (CASC)
+`openspec/specs/maos-hub/spec.md` → "Substrate-first activation" scenario: *WHEN the L8 backend
+(default mem0) is unreachable THEN the Hub degrades to file/seed memory, continues (never blocks,
+never fabricates), and records the degradation in the L9 trace.* ⇒ the integration MUST be an
+adapter with a stdlib-only fallback and a logged degradation field. Security/CASC green:
+Apache-2.0, self-host-able (data control), no secrets in the adapter, fully reversible (delete the
+module; the file/seed fallback is what exists today).
+
+## 5. DECIDE — ADAPT (adapter-first, optional dependency)
+- `mcp-tools/maos-mcp-hub/lib/memory/substrate.py` — `MemorySubstrate`: resolves **mem0-first**
+  (lazy import; any init/reach failure ⇒ degrade), falls back to `FileSeedBackend` (append-only
+  JSONL — the same file/seed mechanism postflight seeds + memory journals already rely on).
+- Every resolution/degradation emits the logged field `l8_substrate{backend, degraded, reason}`
+  through an `on_trace` hook (the caller appends it to the L9/Sentinel trace — the substrate does
+  not invent its own observability channel).
+- **Honesty clause (never fabricates)**: the fallback is an AVAILABILITY tier, not parity — naive
+  substring/recency search, and every response carries the answering backend's name.
+- Installing/configuring the actual mem0 service (library vs self-hosted vs cloud) is an
+  **operator deployment decision** (HUMAN_DOMAIN: cost + data residency) — out of this verdict's
+  scope; the adapter works with whichever is provided (or none).
+
+## Acceptance (DoD-gate)
+`tests/test_memory_substrate.py` asserts the spec scenario as logged fields + golden behavior:
+mem0-unavailable ⇒ `l8_substrate.degraded=true` with reason, add/search continue on file/seed,
+mid-call outage degrades without raising, trace hook receives the degradation event, and a
+provided healthy client is used (`degraded=false`).
+
+---
+*Agent: Claude-Dev-quiesce-wt5 | 2026-07-01 | WAVE-1 WT5 (S4) — ADR-006 · maos-hub spec "Substrate-first activation"*

--- a/mcp-tools/maos-mcp-hub/lib/memory/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/memory/__init__.py
@@ -1,0 +1,21 @@
+"""
+L8 memory substrate (WT5 / S4) — mem0 default, file/seed degradation.
+
+See ``substrate.py`` for the full contract.
+"""
+
+from .substrate import (
+    FileSeedBackend,
+    Mem0Backend,
+    MemoryRecord,
+    MemorySubstrate,
+    SCHEMA_VERSION,
+)
+
+__all__ = [
+    "FileSeedBackend",
+    "Mem0Backend",
+    "MemoryRecord",
+    "MemorySubstrate",
+    "SCHEMA_VERSION",
+]

--- a/mcp-tools/maos-mcp-hub/lib/memory/substrate.py
+++ b/mcp-tools/maos-mcp-hub/lib/memory/substrate.py
@@ -40,6 +40,7 @@ name so downstream consumers can see which quality tier answered.
 from __future__ import annotations
 
 import json
+import logging
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
@@ -99,6 +100,8 @@ class FileSeedBackend:
                     item = json.loads(raw)
                 except json.JSONDecodeError:
                     continue  # a torn line never blocks recall
+                if not isinstance(item, dict):
+                    continue  # valid-JSON-but-not-an-object fragment (torn line)
                 if item.get("user_id") != user_id:
                     continue
                 if needle and needle not in str(item.get("text", "")).casefold():
@@ -205,7 +208,11 @@ class MemorySubstrate:
             try:
                 self._on_trace({"event": event, **self.status()})
             except Exception:
-                pass  # observability must never block the substrate
+                # observability must never block the substrate — but a broken
+                # hook should still be visible to whoever reads debug logs
+                logging.getLogger(__name__).debug(
+                    "on_trace hook failed for event %r", event, exc_info=True
+                )
 
     def status(self) -> Dict[str, Any]:
         """The logged field: ``l8_substrate{backend, degraded, reason}``."""

--- a/mcp-tools/maos-mcp-hub/lib/memory/substrate.py
+++ b/mcp-tools/maos-mcp-hub/lib/memory/substrate.py
@@ -1,0 +1,243 @@
+"""
+MemorySubstrate — the L8 memory substrate (WT5 / S4): mem0 default,
+file/seed degradation, never blocks.
+
+Spec contract (openspec/specs/maos-hub/spec.md → "Substrate-first
+activation")::
+
+    Scenario: memory backend unavailable
+    - WHEN the L8 backend (default mem0) is unreachable
+    - THEN the Hub degrades to file/seed memory, continues (never blocks,
+      never fabricates), and records the degradation in the L9 trace.
+
+Adoption verdict (``docs/adoption/mem0-2026-07-01.md``, via the
+``agentic-tool-intake`` discipline): **ADAPT (adapter-first, optional
+dependency)** — mem0 is the DEFAULT backend but NEVER a hard dependency:
+
+  - ``mem0ai`` is imported lazily; when the package is absent OR the client
+    cannot be constructed/reached, the substrate DEGRADES to the file/seed
+    backend (the mechanism postflight seeds + memory journals already rely
+    on) instead of failing.
+  - graphiti (temporal graph memory) is DEFERRED until a measured temporal
+    workload exists (no gold-plating — handoff WAVE 1 / os3pd).
+  - letta was REJECTED at intake (runtime lock-in: "must use Letta");
+    cognee remains the graph-first alternative (see the dossier).
+
+Every resolution and degradation is a LOGGED FIELD (the DoD-gate)::
+
+    l8_substrate{backend, degraded, reason}
+
+emitted through an optional ``on_trace`` callback so the caller can append
+it to the L9 trace (Sentinel JSONL) — the substrate does not invent its own
+observability channel.
+
+HONESTY NOTE (never fabricates): the file/seed backend is an AVAILABILITY
+fallback, not a parity implementation — search is naive substring/recency
+over an append-only JSONL, and every search response carries the backend
+name so downstream consumers can see which quality tier answered.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+SCHEMA_VERSION = "l8-substrate/1.0.0"
+
+TraceHook = Optional[Callable[[Dict[str, Any]], None]]
+
+
+@dataclass(frozen=True)
+class MemoryRecord:
+    """One memory item (the substrate's common currency across backends)."""
+
+    text: str
+    user_id: str = "default"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    ts: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+
+class FileSeedBackend:
+    """Append-only JSONL file/seed memory — the degradation target.
+
+    Always available (stdlib only). Search is honest-but-naive: case-folded
+    substring match, most-recent-first.
+    """
+
+    name = "file-seed"
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def add(self, record: MemoryRecord) -> Dict[str, Any]:
+        line = json.dumps(record.to_dict(), ensure_ascii=False, sort_keys=True)
+        with self._path.open("a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+        return {"backend": self.name, "stored": True}
+
+    def search(
+        self, query: str, user_id: str = "default", limit: int = 5
+    ) -> List[Dict[str, Any]]:
+        if not self._path.exists():
+            return []
+        needle = (query or "").casefold()
+        hits: List[Dict[str, Any]] = []
+        for raw in self._path.read_text(encoding="utf-8").splitlines():
+            if not raw.strip():
+                continue
+            try:
+                item = json.loads(raw)
+            except json.JSONDecodeError:
+                continue  # a torn line never blocks recall
+            if item.get("user_id") != user_id:
+                continue
+            if needle and needle not in str(item.get("text", "")).casefold():
+                continue
+            hits.append(item)
+        hits.sort(key=lambda i: i.get("ts", 0.0), reverse=True)
+        return hits[: max(0, limit)]
+
+
+class Mem0Backend:
+    """The DEFAULT L8 backend — a thin adapter over the ``mem0ai`` client.
+
+    The import is LAZY and every failure mode raises ``RuntimeError`` so the
+    substrate (not the caller) decides to degrade. This class is deliberately
+    minimal: it adapts, it does not re-model mem0's API.
+    """
+
+    name = "mem0"
+
+    def __init__(self, client: Optional[Any] = None) -> None:
+        if client is None:
+            try:
+                from mem0 import Memory  # type: ignore[import-not-found]
+            except Exception as exc:  # ImportError or transitive init errors
+                raise RuntimeError(f"mem0 unavailable: {exc!r}") from exc
+            try:
+                client = Memory()
+            except Exception as exc:
+                raise RuntimeError(f"mem0 client init failed: {exc!r}") from exc
+        self._client = client
+
+    def add(self, record: MemoryRecord) -> Dict[str, Any]:
+        try:
+            self._client.add(
+                record.text, user_id=record.user_id, metadata=record.metadata
+            )
+        except Exception as exc:
+            raise RuntimeError(f"mem0 add failed: {exc!r}") from exc
+        return {"backend": self.name, "stored": True}
+
+    def search(
+        self, query: str, user_id: str = "default", limit: int = 5
+    ) -> List[Dict[str, Any]]:
+        try:
+            results = self._client.search(query, user_id=user_id, limit=limit)
+        except Exception as exc:
+            raise RuntimeError(f"mem0 search failed: {exc!r}") from exc
+        # normalize to the substrate's record-dict shape
+        out: List[Dict[str, Any]] = []
+        for item in results or []:
+            if isinstance(item, dict):
+                out.append(item)
+        return out
+
+
+class MemorySubstrate:
+    """Resolve mem0-first, degrade to file/seed, never block, always trace.
+
+    Usage::
+
+        substrate = MemorySubstrate(seed_path=Path(".claude/memory/seed.jsonl"),
+                                    on_trace=sentinel_append)
+        substrate.add("operator prefers squash merges")
+        hits = substrate.search("squash")
+        substrate.status()   # -> l8_substrate{backend, degraded, reason}
+    """
+
+    def __init__(
+        self,
+        seed_path: Path,
+        mem0_factory: Optional[Callable[[], Any]] = None,
+        on_trace: TraceHook = None,
+        clock: Callable[[], float] = time.time,
+    ) -> None:
+        self._fallback = FileSeedBackend(seed_path)
+        self._on_trace = on_trace
+        self._clock = clock
+        self._degraded = False
+        self._reason: Optional[str] = None
+        self._backend: Any = self._fallback
+        factory = mem0_factory if mem0_factory is not None else Mem0Backend
+        try:
+            self._backend = factory()
+        except Exception as exc:
+            self._degrade(f"resolve: {exc}")
+        self._trace("l8_substrate_resolved")
+
+    # -- degradation (the spec scenario) --------------------------------------
+
+    def _degrade(self, reason: str) -> None:
+        self._degraded = True
+        self._reason = reason
+        self._backend = self._fallback
+
+    def _trace(self, event: str) -> None:
+        if self._on_trace is not None:
+            try:
+                self._on_trace({"event": event, **self.status()})
+            except Exception:
+                pass  # observability must never block the substrate
+
+    def status(self) -> Dict[str, Any]:
+        """The logged field: ``l8_substrate{backend, degraded, reason}``."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "l8_substrate": {
+                "backend": getattr(self._backend, "name", "unknown"),
+                "degraded": self._degraded,
+                "reason": self._reason,
+            },
+        }
+
+    # -- the substrate API (never blocks) -------------------------------------
+
+    def add(
+        self,
+        text: str,
+        user_id: str = "default",
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        record = MemoryRecord(
+            text=text,
+            user_id=user_id,
+            metadata=dict(metadata or {}),
+            ts=self._clock(),
+        )
+        try:
+            result = self._backend.add(record)
+        except RuntimeError as exc:
+            # mid-call outage: degrade NOW, retry once on the fallback
+            self._degrade(f"add: {exc}")
+            self._trace("l8_substrate_degraded")
+            result = self._fallback.add(record)
+        return {**result, **self.status()}
+
+    def search(
+        self, query: str, user_id: str = "default", limit: int = 5
+    ) -> Dict[str, Any]:
+        try:
+            hits = self._backend.search(query, user_id=user_id, limit=limit)
+        except RuntimeError as exc:
+            self._degrade(f"search: {exc}")
+            self._trace("l8_substrate_degraded")
+            hits = self._fallback.search(query, user_id=user_id, limit=limit)
+        return {"hits": hits, **self.status()}

--- a/mcp-tools/maos-mcp-hub/lib/memory/substrate.py
+++ b/mcp-tools/maos-mcp-hub/lib/memory/substrate.py
@@ -89,18 +89,21 @@ class FileSeedBackend:
             return []
         needle = (query or "").casefold()
         hits: List[Dict[str, Any]] = []
-        for raw in self._path.read_text(encoding="utf-8").splitlines():
-            if not raw.strip():
-                continue
-            try:
-                item = json.loads(raw)
-            except json.JSONDecodeError:
-                continue  # a torn line never blocks recall
-            if item.get("user_id") != user_id:
-                continue
-            if needle and needle not in str(item.get("text", "")).casefold():
-                continue
-            hits.append(item)
+        # stream line-by-line: the append-only file grows unboundedly and must
+        # never be loaded whole into memory (crash-risk on large seeds)
+        with self._path.open("r", encoding="utf-8") as fh:
+            for raw in fh:
+                if not raw.strip():
+                    continue
+                try:
+                    item = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue  # a torn line never blocks recall
+                if item.get("user_id") != user_id:
+                    continue
+                if needle and needle not in str(item.get("text", "")).casefold():
+                    continue
+                hits.append(item)
         hits.sort(key=lambda i: i.get("ts", 0.0), reverse=True)
         return hits[: max(0, limit)]
 
@@ -143,11 +146,18 @@ class Mem0Backend:
             results = self._client.search(query, user_id=user_id, limit=limit)
         except Exception as exc:
             raise RuntimeError(f"mem0 search failed: {exc!r}") from exc
-        # normalize to the substrate's record-dict shape
+        # normalize to the substrate's record-dict shape — the mem0 SDK returns
+        # a dict envelope ({"results": [...]}) on v1.1+, a bare list on older
+        # versions; each hit carries the memory text under "memory"
+        if isinstance(results, dict):
+            results = results.get("results", [])
         out: List[Dict[str, Any]] = []
         for item in results or []:
-            if isinstance(item, dict):
-                out.append(item)
+            if not isinstance(item, dict):
+                continue
+            if "text" not in item and "memory" in item:
+                item = {**item, "text": item["memory"]}
+            out.append(item)
         return out
 
 
@@ -224,8 +234,9 @@ class MemorySubstrate:
         )
         try:
             result = self._backend.add(record)
-        except RuntimeError as exc:
-            # mid-call outage: degrade NOW, retry once on the fallback
+        except Exception as exc:
+            # ANY backend failure (not just Mem0Backend's RuntimeError wrapper —
+            # injected backends may raise anything) degrades instead of blocking
             self._degrade(f"add: {exc}")
             self._trace("l8_substrate_degraded")
             result = self._fallback.add(record)
@@ -236,7 +247,7 @@ class MemorySubstrate:
     ) -> Dict[str, Any]:
         try:
             hits = self._backend.search(query, user_id=user_id, limit=limit)
-        except RuntimeError as exc:
+        except Exception as exc:
             self._degrade(f"search: {exc}")
             self._trace("l8_substrate_degraded")
             hits = self._fallback.search(query, user_id=user_id, limit=limit)

--- a/mcp-tools/maos-mcp-hub/tests/test_memory_substrate.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_memory_substrate.py
@@ -169,6 +169,54 @@ def test_trace_hook_failure_never_blocks_the_substrate(tmp_path):
     assert sub.add("still works")["stored"] is True
 
 
+def test_non_runtime_error_from_injected_backend_still_degrades(tmp_path):
+    """PR #199 review (amazon-q + Copilot): the never-blocks contract must
+    hold for ANY exception type, not just Mem0Backend's RuntimeError wrapper."""
+
+    class RaisesConnectionError:
+        name = "mem0"
+
+        def add(self, record: MemoryRecord):
+            raise ConnectionError("socket closed")
+
+        def search(self, query, user_id="default", limit=5):
+            raise TimeoutError("backend hung")
+
+    sub = _substrate(tmp_path, mem0_factory=RaisesConnectionError)
+    result = sub.add("survives non-RuntimeError outage", user_id="op")
+    assert result["stored"] is True
+    assert result["l8_substrate"]["degraded"] is True
+    assert sub.search("survives", user_id="op")["hits"]
+
+
+def test_mem0_backend_normalizes_dict_envelope_and_memory_field():
+    """PR #199 review (Copilot): the mem0 SDK v1.1+ returns
+    {"results": [...]} with the text under "memory" — both shapes normalize."""
+    from lib.memory import Mem0Backend
+
+    class DictEnvelopeClient:
+        def search(self, query, user_id="default", limit=5):
+            return {
+                "results": [
+                    {"id": "m1", "memory": "squash merges preferred"},
+                    "not-a-dict-is-skipped",
+                ]
+            }
+
+    hits = Mem0Backend(client=DictEnvelopeClient()).search("squash")
+    assert hits == [
+        {"id": "m1", "memory": "squash merges preferred",
+         "text": "squash merges preferred"}
+    ]
+
+    class BareListClient:
+        def search(self, query, user_id="default", limit=5):
+            return [{"text": "already normalized"}]
+
+    hits = Mem0Backend(client=BareListClient()).search("already")
+    assert hits == [{"text": "already normalized"}]
+
+
 def test_substrate_is_deterministic_given_fixed_clock(tmp_path):
     sub = _substrate(tmp_path, mem0_factory=_unreachable_factory)
     sub.add("alpha", user_id="op")

--- a/mcp-tools/maos-mcp-hub/tests/test_memory_substrate.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_memory_substrate.py
@@ -1,0 +1,177 @@
+"""
+Tests for the L8 memory substrate (WT5 / S4).
+
+The acceptance IS the spec scenario (openspec/specs/maos-hub/spec.md →
+"Substrate-first activation" / "memory backend unavailable"), asserted as
+LOGGED FIELDS — never prose:
+
+    WHEN the L8 backend (default mem0) is unreachable
+    THEN the Hub degrades to file/seed memory, continues (never blocks,
+    never fabricates), and records the degradation in the L9 trace.
+"""
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+from lib.memory import FileSeedBackend, MemoryRecord, MemorySubstrate
+
+
+def _unreachable_factory():
+    raise RuntimeError("mem0 unavailable: simulated outage")
+
+
+def _substrate(tmp_path: Path, **kwargs) -> MemorySubstrate:
+    return MemorySubstrate(
+        seed_path=tmp_path / "seed.jsonl",
+        clock=lambda: 1000.0,
+        **kwargs,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# the spec scenario: backend unavailable -> degrade, continue, trace
+# --------------------------------------------------------------------------- #
+
+def test_unreachable_mem0_degrades_to_file_seed_with_logged_reason(tmp_path):
+    sub = _substrate(tmp_path, mem0_factory=_unreachable_factory)
+    status = sub.status()["l8_substrate"]
+    assert status["backend"] == "file-seed"
+    assert status["degraded"] is True
+    assert "simulated outage" in status["reason"]
+
+
+def test_degraded_substrate_continues_add_and_search(tmp_path):
+    """Never blocks: add + recall keep working on the file/seed tier."""
+    sub = _substrate(tmp_path, mem0_factory=_unreachable_factory)
+    result = sub.add("operator prefers squash merges", user_id="op")
+    assert result["stored"] is True
+    assert result["l8_substrate"]["backend"] == "file-seed"
+
+    found = sub.search("squash", user_id="op")
+    assert [h["text"] for h in found["hits"]] == ["operator prefers squash merges"]
+    # never fabricates: the answering backend is named in every response
+    assert found["l8_substrate"]["backend"] == "file-seed"
+
+
+def test_degradation_is_recorded_in_the_trace(tmp_path):
+    """The L9 hook receives l8_substrate{backend, degraded, reason}."""
+    events: List[Dict[str, Any]] = []
+    sub = _substrate(
+        tmp_path, mem0_factory=_unreachable_factory, on_trace=events.append
+    )
+    assert events, "resolution must emit a trace event"
+    resolved = events[0]
+    assert resolved["event"] == "l8_substrate_resolved"
+    assert resolved["l8_substrate"]["degraded"] is True
+    assert resolved["l8_substrate"]["reason"]
+    assert sub.status()["schema_version"] == "l8-substrate/1.0.0"
+
+
+def test_mid_call_outage_degrades_without_raising(tmp_path):
+    """A backend that dies AFTER resolution still never blocks the caller."""
+
+    class DiesOnFirstUse:
+        name = "mem0"
+
+        def add(self, record: MemoryRecord):
+            raise RuntimeError("mem0 add failed: connection reset")
+
+        def search(self, query, user_id="default", limit=5):
+            raise RuntimeError("mem0 search failed: connection reset")
+
+    events: List[Dict[str, Any]] = []
+    sub = _substrate(
+        tmp_path, mem0_factory=DiesOnFirstUse, on_trace=events.append
+    )
+    assert sub.status()["l8_substrate"]["degraded"] is False  # resolved fine
+
+    result = sub.add("fact survives the outage")
+    assert result["stored"] is True
+    assert result["l8_substrate"]["backend"] == "file-seed"
+    assert result["l8_substrate"]["degraded"] is True
+    assert any(e["event"] == "l8_substrate_degraded" for e in events)
+
+    # the retried write actually landed in the fallback store
+    hits = sub.search("survives")["hits"]
+    assert len(hits) == 1
+
+
+def test_healthy_injected_client_is_used_not_degraded(tmp_path):
+    """With a working backend the substrate does NOT degrade."""
+
+    class HealthyStub:
+        name = "mem0"
+
+        def __init__(self):
+            self.items: List[MemoryRecord] = []
+
+        def add(self, record: MemoryRecord):
+            self.items.append(record)
+            return {"backend": self.name, "stored": True}
+
+        def search(self, query, user_id="default", limit=5):
+            return [
+                r.to_dict()
+                for r in self.items
+                if query in r.text and r.user_id == user_id
+            ][:limit]
+
+    sub = _substrate(tmp_path, mem0_factory=HealthyStub)
+    status = sub.add("remember the tokenizer is ceil(len/4)")["l8_substrate"]
+    assert status == {"backend": "mem0", "degraded": False, "reason": None}
+    assert sub.search("tokenizer")["hits"]
+
+
+def test_default_factory_degrades_cleanly_when_mem0ai_not_installed(tmp_path):
+    """On a machine without the optional dependency, resolution degrades
+    (never raises) — the exact CI environment this suite runs in."""
+    sub = MemorySubstrate(seed_path=tmp_path / "seed.jsonl")
+    status = sub.status()["l8_substrate"]
+    assert status["backend"] in ("mem0", "file-seed")
+    if status["backend"] == "file-seed":
+        assert status["degraded"] is True
+        assert status["reason"]
+
+
+# --------------------------------------------------------------------------- #
+# file/seed backend honesty + robustness
+# --------------------------------------------------------------------------- #
+
+def test_file_seed_search_is_user_scoped_and_recency_ordered(tmp_path):
+    backend = FileSeedBackend(tmp_path / "seed.jsonl")
+    backend.add(MemoryRecord(text="older squash note", user_id="op", ts=1.0))
+    backend.add(MemoryRecord(text="newer squash note", user_id="op", ts=2.0))
+    backend.add(MemoryRecord(text="squash but other user", user_id="x", ts=3.0))
+    hits = backend.search("squash", user_id="op")
+    assert [h["text"] for h in hits] == ["newer squash note", "older squash note"]
+
+
+def test_file_seed_tolerates_torn_lines(tmp_path):
+    path = tmp_path / "seed.jsonl"
+    backend = FileSeedBackend(path)
+    backend.add(MemoryRecord(text="good record", user_id="op", ts=1.0))
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write('{"torn": \n')  # a crashed writer's partial line
+    assert [h["text"] for h in backend.search("good", user_id="op")] == [
+        "good record"
+    ]
+
+
+def test_trace_hook_failure_never_blocks_the_substrate(tmp_path):
+    def broken_hook(_event):
+        raise ValueError("observability sink down")
+
+    sub = _substrate(
+        tmp_path, mem0_factory=_unreachable_factory, on_trace=broken_hook
+    )
+    assert sub.add("still works")["stored"] is True
+
+
+def test_substrate_is_deterministic_given_fixed_clock(tmp_path):
+    sub = _substrate(tmp_path, mem0_factory=_unreachable_factory)
+    sub.add("alpha", user_id="op")
+    a = sub.search("alpha", user_id="op")
+    b = sub.search("alpha", user_id="op")
+    assert a == b

--- a/mcp-tools/maos-mcp-hub/tests/test_memory_substrate.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_memory_substrate.py
@@ -169,6 +169,44 @@ def test_trace_hook_failure_never_blocks_the_substrate(tmp_path):
     assert sub.add("still works")["stored"] is True
 
 
+def test_search_only_mid_call_outage_degrades_and_switches_backend(tmp_path):
+    """PR #199 review (CodeRabbit): a resolved-healthy backend whose FIRST
+    failure is on search() (add never failed) must still degrade + switch."""
+
+    class HealthyAddDeadSearch:
+        name = "mem0"
+
+        def add(self, record: MemoryRecord):
+            return {"backend": self.name, "stored": True}
+
+        def search(self, query, user_id="default", limit=5):
+            raise RuntimeError("mem0 search failed: connection reset")
+
+    sub = _substrate(tmp_path, mem0_factory=HealthyAddDeadSearch)
+    assert sub.add("fact", user_id="op")["l8_substrate"]["degraded"] is False
+
+    result = sub.search("fact", user_id="op")
+    assert result["l8_substrate"]["backend"] == "file-seed"
+    assert result["l8_substrate"]["degraded"] is True
+    # subsequent calls stay on the switched fallback backend
+    assert sub.status()["l8_substrate"]["backend"] == "file-seed"
+
+
+def test_file_seed_tolerates_valid_json_non_dict_lines(tmp_path):
+    """PR #199 review (CodeRabbit): a torn line that decodes to a bare
+    number/string (valid JSON, not an object) must not raise AttributeError."""
+    path = tmp_path / "seed.jsonl"
+    backend = FileSeedBackend(path)
+    backend.add(MemoryRecord(text="good record", user_id="op", ts=1.0))
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("123\n")           # bare number fragment
+        fh.write('"orphan str"\n')  # bare string fragment
+        fh.write("[1, 2]\n")        # array fragment
+    assert [h["text"] for h in backend.search("good", user_id="op")] == [
+        "good record"
+    ]
+
+
 def test_non_runtime_error_from_injected_backend_still_degrades(tmp_path):
     """PR #199 review (amazon-q + Copilot): the never-blocks contract must
     hold for ANY exception type, not just Mem0Backend's RuntimeError wrapper."""

--- a/openspec/specs/maos-hub/spec.md
+++ b/openspec/specs/maos-hub/spec.md
@@ -121,7 +121,11 @@ complement, never the sole control. Every enforcement decision SHALL be logged (
   risk_class] before the 6-criteria weighted score [scope 0.30 · eisenhower 0.20 · risk 0.15 · reversibility 0.15 ·
   iso 0.10 · methodology 0.10]; `risk=HIGH` = the concrete `RiskSignals` predicate [any of irreversible ·
   destructive · credential_scope · prod_facing · cross_org]; acceptance = `python -m evals.cts_eval` logged
-  verdict + golden fixture `evals/fixtures/cts_cases.yaml`)* · L8 memory substrate
-  (mem0 default; graphiti temporal DEFERRED until a measured workload) (WT5) · OTel exporter for Sentinel
+  verdict + golden fixture `evals/fixtures/cts_cases.yaml`)* · ~~L8 memory substrate
+  (mem0 default) (WT5)~~ *(implemented — `lib/memory/substrate.py::MemorySubstrate`: mem0-first lazy
+  resolution with file/seed degradation per the "memory backend unavailable" scenario; logged field
+  `l8_substrate{backend, degraded, reason}` via the on_trace L9 hook; intake dossier
+  `docs/adoption/mem0-2026-07-01.md`; graphiti temporal remains DEFERRED until a measured workload)* ·
+  OTel exporter for Sentinel
   (WT6, DEFERRED — C3 severity LOW) · LiteLLM model-router (CUT — `os3pd` defers a runtime gateway until ≥3
   incidents and `slm-routing` is not a runtime router) · tool-registry YAML SSOT via auto-generation (WT8).


### PR DESCRIPTION
**[PR-as-Validation-Prompt]** — WAVE-1 **WT5** (story **S4**): the L8 memory substrate — mem0 default, file/seed degradation.

## Context
Conflict **C5** (OODA-RECON): *"memória ausente — roteamento entre sessões sem backend semântico; os seeds/postflight mitigam parcialmente"*. Spec contract: `openspec/specs/maos-hub/spec.md` → **"Substrate-first activation"**, scenario *"memory backend unavailable"*: WHEN the L8 backend (default mem0) is unreachable THEN the Hub **degrades to file/seed memory, continues (never blocks, never fabricates), and records the degradation in the L9 trace**. Handoff WAVE-1 mandate: **UM backend só — mem0 (default) via `/agentic-tool-intake`; graphiti ADIADO** até haver workload temporal medido.

## What this adds
- **`docs/adoption/mem0-2026-07-01.md`** — the intake dossier (same convention as `codegraph-2026-06-18.md`): UNDERSTAND → CLAIM AUDIT → COMPARE/CROSS → VALIDATE → **DECIDE: ADAPT (adapter-first, optional dependency)**. Research base DRY-cited from `20260627-01a-substrates.md` §L8 (never re-run): mem0 58.2k★ · Apache-2.0 · auditable open benchmark (the reason it beat MemPalace for the default slot). Alternatives recorded: **letta REJECTED** (runtime lock-in — "must use Letta"), **cognee = graph-first alternative** (real `mem0↔cognee` conflicts.yaml edge), **graphiti DEFERRED** (no gold-plating).
- **`lib/memory/substrate.py`** — `MemorySubstrate`: resolves **mem0-first** (lazy import; ANY init/reach failure ⇒ degrade) → `FileSeedBackend` (append-only JSONL — the same file/seed mechanism postflight seeds already rely on). Mid-call outages degrade + retry on the fallback — the caller **never blocks**.
- **The logged field** (the spec's acceptance): `l8_substrate{backend, degraded, reason}` — emitted on resolution AND degradation through an `on_trace` hook the caller wires to the L9/Sentinel trace (the substrate does not invent its own observability channel). A failing trace hook never blocks the substrate.
- **Honesty clause (never fabricates)**: the file/seed tier is an AVAILABILITY fallback, not parity — naive substring/recency search, and **every response names the answering backend** so consumers see which quality tier answered.
- Deploying the actual mem0 service (library / self-hosted / cloud) is an operator deployment decision (cost + data residency) — out of scope; the adapter works with whichever is provided (or none — the CI environment itself runs degraded, which is test-asserted).

## Acceptance (DoD-gate — every item a logged field or golden behavior, never prose)
- [x] spec scenario asserted verbatim: unreachable mem0 ⇒ `l8_substrate.degraded=true` + reason · add/search continue on file/seed · degradation event received by the trace hook
- [x] mid-call outage (backend dies AFTER healthy resolution) degrades without raising; the retried write lands in the fallback store
- [x] healthy injected client ⇒ `{backend: mem0, degraded: false, reason: null}` (no false degradation)
- [x] robustness: torn JSONL lines tolerated · user-scoped recency-ordered recall · deterministic under a fixed clock
- [x] **10 tests pass** (`tests/test_memory_substrate.py`); **0-regression** (same pre-existing 2 fails + 9 collection errors as pristine main)
- [x] `validate-plugin.sh` PASSED · `gitleaks` clean · CHANGELOG under `[Unreleased]` · spec §Deferred updated (WT5 → implemented)

## Risk + rollback
Purely additive (`lib/memory/` is a new package with zero runtime callers until the hub wires substrate-first activation). Rollback = revert the squash commit; the file/seed mechanism it falls back to is what exists today.

## Out of scope
Wiring substrate-first activation into `hub.py` startup · mem0 service deployment (operator HUMAN_DOMAIN) · graphiti temporal memory (deferred until measured workload) · linking `decision-capture`/`agentic-session-harness` writers (follow-up once the hub consumes the substrate).

## Refs
ADR-006 · `openspec/specs/maos-hub/spec.md` ("Substrate-first activation" + Deferred) · handoff WAVE-1 / WT5 · `research/agentic-moe-2026/20260627-01a-substrates.md` §L8 · `docs/adoption/codegraph-2026-06-18.md` (dossier convention precedent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
