### PR TITLE
feat(maos-hub): auto-generated tool-registry SSOT (WT8/S1) — derived from SchemaRegistry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — auto-generated tool-registry SSOT (WT8 / S1) — derived, never hand-maintained
+
+- **`mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py`** — `ToolRegistry`: every `ToolRecord`
+  is DERIVED from live `MetaToolRouter` instances (`SchemaRegistry` schemas + registered handlers +
+  governance) — the WAVE-2 keystone that lifts the tool contract out of the gateways' divergent
+  wiring (handoff: *"registry AUTO-GERADO … NÃO YAML hand-maintained que dá drift"*; spec anchor:
+  `maos-hub-registry` → "Records are derived, not hand-maintained"). Provenance IS the acceptance:
+  `derived_from` names the real handler (unwrapped past `@with_feedback`), checked by
+  `report().invariants.all_records_derived` — a logged field, not prose.
+- **WAVE-1 seams closed**: `to_iso_inventory()` = the exact `{id, summary, schema}` input of
+  `IsoGate.from_inventory` (WT3); `to_cts_candidates()` = `CtsCandidate` rows with risk from a
+  **deterministic, documented verb→`RiskSignals` map** (destructive→HIGH · write→MEDIUM · read→LOW,
+  WT4). `to_yaml()` emits the generated YAML projection stamped `AUTO-GENERATED — DO NOT EDIT`.
+- **DoD-gate honoured:** 8 tests (`tests/test_tool_registry.py`) incl. end-to-end seam proofs
+  (registry→IsoGate selection · registry→CtsScorer rank with HIGH filtered traced) + a **golden
+  derivation over the hub's REAL gateways** (confluence+compass+common, loss-free vs
+  `router.action_count`; skip-graceful where gateway deps are absent). Additive; no plugin version
+  bump (ADR-003).
+
 ### Added — L8 memory substrate (WT5 / S4) — mem0 default, file/seed degradation
 
 - **`docs/adoption/mem0-2026-07-01.md`** — the `agentic-tool-intake` dossier for mem0 (verdict:

--- a/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/__init__.py
@@ -8,6 +8,12 @@ and governance feedback injection in every response.
 from .types import GatewayRequest, ActionSchema, AgentFeedback
 from .router import MetaToolRouter
 from .schema_registry import SchemaRegistry
+from .tool_registry import (
+    REGISTRY_SCHEMA_VERSION,
+    ToolRecord,
+    ToolRegistry,
+    risk_signals_for_operation,
+)
 from .feedback import with_feedback
 from .discovery import build_discovery_response
 from .iso import (
@@ -43,12 +49,16 @@ __all__ = [
     "IsoGate",
     "IsoSelection",
     "MetaToolRouter",
+    "REGISTRY_SCHEMA_VERSION",
     "RiskClass",
     "RiskSignals",
     "SchemaRegistry",
+    "ToolRecord",
+    "ToolRegistry",
     "ToolSummary",
     "build_discovery_response",
     "iso_tokens",
     "risk_class",
+    "risk_signals_for_operation",
     "with_feedback",
 ]

--- a/mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py
@@ -133,7 +133,9 @@ class ToolRegistry:
         """Walk one router's schema registry and derive its records."""
         derived: List[ToolRecord] = []
         gateway = getattr(router, "tool_name", "") or "unknown-gateway"
-        schema_registry = router.registry
+        schema_registry = getattr(router, "registry", None)
+        if schema_registry is None:
+            return derived  # not a router surface — nothing derivable
         handlers: Dict[str, Dict[str, Any]] = getattr(router, "_handlers", {})
         governance = tuple(getattr(router, "governance", ()) or ())
         for resource in schema_registry.resources():
@@ -278,7 +280,9 @@ def _provenance(
     via ``__wrapped__`` when present so provenance names the REAL handler.
     """
     fn = handler
-    while fn is not None and hasattr(fn, "__wrapped__"):
+    seen: set = set()
+    while fn is not None and hasattr(fn, "__wrapped__") and id(fn) not in seen:
+        seen.add(id(fn))  # guards pathological circular __wrapped__ chains
         fn = fn.__wrapped__
     if fn is None:
         # schema without a live handler — still derived (from the registry),

--- a/mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py
@@ -28,14 +28,15 @@ Seams (the WAVE-1 contract this registry feeds):
   - ``to_yaml()``           → the generated YAML *projection* (a build
     artifact stamped AUTO-GENERATED; editing it is the anti-pattern).
 
-Deterministic verb → risk mapping (falsifiable, documented):
-  - DESTRUCTIVE_VERBS (delete/remove/purge/drop/decline)
+Deterministic verb → risk mapping (falsifiable, documented, FAIL-CLOSED):
+  - DESTRUCTIVE_VERBS (delete/remove/purge/drop/decline/clear/…)
       → RiskSignals(destructive=True, remote_write=True)  → HIGH
-  - WRITE_VERBS (create/update/edit/add/set/transition/trigger/stop/merge/
-    approve/post/upload/move/publish/assign/link/comment)
+  - READ_VERBS (get/list/search/check/…)  → RiskSignals() → LOW
+  - everything else — known write verbs AND unknown verbs —
       → RiskSignals(remote_write=True)                    → MEDIUM
-  - everything else (get/list/search/check/…) → RiskSignals() → LOW
 The verb is the first ``_``-separated token of the operation name.
+UNKNOWN verbs default to MEDIUM (never LOW): a verb the map has not seen
+must not slip under a risk ceiling (fail-closed per PR #200 review).
 """
 
 from __future__ import annotations
@@ -49,24 +50,34 @@ from .iso import iso_tokens
 
 REGISTRY_SCHEMA_VERSION = "tool-registry/1.0.0"
 
-DESTRUCTIVE_VERBS = frozenset({"delete", "remove", "purge", "drop", "decline"})
-WRITE_VERBS = frozenset(
+DESTRUCTIVE_VERBS = frozenset(
     {
-        "create", "update", "edit", "add", "set", "transition", "trigger",
-        "stop", "merge", "approve", "post", "upload", "move", "publish",
-        "assign", "link", "comment", "request",
+        "delete", "remove", "purge", "drop", "decline", "clear", "destroy",
+        "truncate", "wipe", "revoke", "reset",
+    }
+)
+READ_VERBS = frozenset(
+    {
+        "get", "list", "search", "check", "find", "read", "show", "view",
+        "describe", "count", "fetch", "query", "discover", "resolve",
+        "lookup", "compare", "diff", "validate", "preview",
     }
 )
 
 
 def risk_signals_for_operation(operation: str) -> RiskSignals:
-    """The deterministic verb→RiskSignals map (module docstring contract)."""
+    """The deterministic verb→RiskSignals map (module docstring contract).
+
+    FAIL-CLOSED: only enumerated READ_VERBS map to LOW; an UNKNOWN verb is
+    treated as a remote write (MEDIUM) so it can never slip under a turn's
+    risk ceiling just because the map hasn't met it yet.
+    """
     verb = (operation or "").split("_", 1)[0].lower()
     if verb in DESTRUCTIVE_VERBS:
         return RiskSignals(destructive=True, remote_write=True)
-    if verb in WRITE_VERBS:
-        return RiskSignals(remote_write=True)
-    return RiskSignals()
+    if verb in READ_VERBS:
+        return RiskSignals()
+    return RiskSignals(remote_write=True)
 
 
 @dataclass(frozen=True)
@@ -163,6 +174,13 @@ class ToolRegistry:
                     risk=risk_class(risk_signals_for_operation(operation)),
                     derived_from=_provenance(handler, gateway, resource, operation),
                 )
+                if record.tool_id in self._records:
+                    # silent overwrite would break the loss-free invariant
+                    raise ValueError(
+                        f"tool_id collision: {record.tool_id!r} already "
+                        f"derived from "
+                        f"{self._records[record.tool_id].derived_from!r}"
+                    )
                 self._records[record.tool_id] = record
                 derived.append(record)
         return derived
@@ -200,11 +218,15 @@ class ToolRegistry:
         expert_fit: float = 0.0,
         methodology_fit: float = 0.0,
         eisenhower_q: int = 2,
+        reversibility: float = 1.0,
     ) -> List[CtsCandidate]:
         """CtsCandidate rows with the derived RiskSignals (WT4 seam).
 
-        Fit/eisenhower facts are TURN-scoped (the caller's judgment), not
-        registry facts — passed through, defaulted neutrally.
+        Fit/eisenhower/reversibility facts are TURN-scoped (the caller's
+        judgment), not registry facts — passed through, defaulted neutrally.
+        Reversibility is NOT derived from risk: risk already drives both a
+        hard ceiling and a weighted criterion in CtsScorer; deriving
+        reversibility from it would double-count (PR #200 review).
         """
         return [
             CtsCandidate(
@@ -213,7 +235,7 @@ class ToolRegistry:
                 expert_fit=expert_fit,
                 methodology_fit=methodology_fit,
                 eisenhower_q=eisenhower_q,
-                reversibility=1.0 if r.risk is RiskClass.LOW else 0.4,
+                reversibility=reversibility,
                 schema=r.schema_dict(),
             )
             for r in self.records()

--- a/mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/tool_registry.py
@@ -1,0 +1,291 @@
+"""
+ToolRegistry — the AUTO-GENERATED tool-registry SSOT (WT8 / S1, backlog P2-d).
+
+The keystone that lifts the tool contract out of the gateways' divergent
+wiring: every record is DERIVED from a live ``MetaToolRouter`` (its
+``SchemaRegistry`` schemas + registered handlers + governance tags) — NEVER
+hand-maintained YAML, which drifts (handoff WAVE-2 mandate: *"registry
+AUTO-GERADO (derivado por decorator do SchemaRegistry, NÃO YAML
+hand-maintained que dá drift)"*).
+
+Spec anchors:
+  - ``openspec/specs/maos-hub-registry/spec.md`` → "Records are derived,
+    not hand-maintained" (mirrors ``SchemaRegistry`` auto-gen).
+  - ``openspec/specs/maos-hub/spec.md`` §Deferred → "tool-registry YAML SSOT
+    via auto-generation (WT8)".
+
+Provenance IS the acceptance (the DoD-gate): every ``ToolRecord`` carries
+``derived_from`` = the handler's module-qualified name, so "derived, not
+hand-maintained" is a checkable field, not prose. ``ToolRegistry.report()``
+exposes the invariants as logged fields.
+
+Seams (the WAVE-1 contract this registry feeds):
+  - ``to_iso_inventory()``  → the exact ``{id, summary, schema}`` items
+    ``IsoGate.from_inventory`` consumes (WT3).
+  - ``to_cts_candidates()`` → ``CtsCandidate`` rows with the derived
+    ``RiskSignals`` (WT4) — risk comes from a DETERMINISTIC, documented
+    verb→signals map (below), never a vibe.
+  - ``to_yaml()``           → the generated YAML *projection* (a build
+    artifact stamped AUTO-GENERATED; editing it is the anti-pattern).
+
+Deterministic verb → risk mapping (falsifiable, documented):
+  - DESTRUCTIVE_VERBS (delete/remove/purge/drop/decline)
+      → RiskSignals(destructive=True, remote_write=True)  → HIGH
+  - WRITE_VERBS (create/update/edit/add/set/transition/trigger/stop/merge/
+    approve/post/upload/move/publish/assign/link/comment)
+      → RiskSignals(remote_write=True)                    → MEDIUM
+  - everything else (get/list/search/check/…) → RiskSignals() → LOW
+The verb is the first ``_``-separated token of the operation name.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from .cts import CtsCandidate, RiskClass, RiskSignals, risk_class
+from .iso import iso_tokens
+
+REGISTRY_SCHEMA_VERSION = "tool-registry/1.0.0"
+
+DESTRUCTIVE_VERBS = frozenset({"delete", "remove", "purge", "drop", "decline"})
+WRITE_VERBS = frozenset(
+    {
+        "create", "update", "edit", "add", "set", "transition", "trigger",
+        "stop", "merge", "approve", "post", "upload", "move", "publish",
+        "assign", "link", "comment", "request",
+    }
+)
+
+
+def risk_signals_for_operation(operation: str) -> RiskSignals:
+    """The deterministic verb→RiskSignals map (module docstring contract)."""
+    verb = (operation or "").split("_", 1)[0].lower()
+    if verb in DESTRUCTIVE_VERBS:
+        return RiskSignals(destructive=True, remote_write=True)
+    if verb in WRITE_VERBS:
+        return RiskSignals(remote_write=True)
+    return RiskSignals()
+
+
+@dataclass(frozen=True)
+class ToolRecord:
+    """One derived tool record — the registry's unit of truth."""
+
+    tool_id: str            # "<gateway>.<resource>.<operation>"
+    gateway: str            # MetaToolRouter.tool_name
+    resource: str
+    operation: str
+    summary: str            # ActionSchema.description (docstring-derived)
+    summary_tokens: int     # iso_tokens(summary) — the WT3 currency
+    required_params: Tuple[str, ...] = ()
+    optional_params: Tuple[Tuple[str, str], ...] = ()
+    governance: Tuple[str, ...] = ()
+    risk: RiskClass = RiskClass.LOW
+    derived_from: str = ""  # provenance: handler module.qualname (NEVER empty
+    #                         for a derived record — the DoD-gate field)
+
+    def schema_dict(self) -> Dict[str, Any]:
+        """The {required, optional} schema shape ISO/CTS consume."""
+        return {
+            "required": list(self.required_params),
+            "optional": dict(self.optional_params),
+        }
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool_id": self.tool_id,
+            "gateway": self.gateway,
+            "resource": self.resource,
+            "operation": self.operation,
+            "summary": self.summary,
+            "summary_tokens": self.summary_tokens,
+            "required_params": list(self.required_params),
+            "optional_params": dict(self.optional_params),
+            "governance": list(self.governance),
+            "risk": self.risk.name,
+            "derived_from": self.derived_from,
+        }
+
+
+class ToolRegistry:
+    """Auto-derived registry over one or more ``MetaToolRouter`` instances."""
+
+    def __init__(self) -> None:
+        self._records: Dict[str, ToolRecord] = {}
+
+    # -- derivation (the ONLY way records enter; no hand-maintained path) -----
+
+    @classmethod
+    def from_routers(cls, routers: Iterable[Any]) -> "ToolRegistry":
+        """Derive every record from live routers (SchemaRegistry + handlers).
+
+        Accepts any object with the ``MetaToolRouter`` surface:
+        ``tool_name`` · ``registry`` (SchemaRegistry) · ``_handlers``.
+        """
+        reg = cls()
+        for router in routers:
+            reg.derive_router(router)
+        return reg
+
+    def derive_router(self, router: Any) -> List[ToolRecord]:
+        """Walk one router's schema registry and derive its records."""
+        derived: List[ToolRecord] = []
+        gateway = getattr(router, "tool_name", "") or "unknown-gateway"
+        schema_registry = router.registry
+        handlers: Dict[str, Dict[str, Any]] = getattr(router, "_handlers", {})
+        governance = tuple(getattr(router, "governance", ()) or ())
+        for resource in schema_registry.resources():
+            for operation in schema_registry.operations(resource):
+                schema = schema_registry.get_schema(resource, operation)
+                handler = handlers.get(resource, {}).get(operation)
+                record = ToolRecord(
+                    tool_id=f"{gateway}.{resource}.{operation}",
+                    gateway=gateway,
+                    resource=resource,
+                    operation=operation,
+                    summary=schema.description if schema else "",
+                    summary_tokens=iso_tokens(
+                        schema.description if schema else ""
+                    ),
+                    required_params=tuple(
+                        schema.required_params if schema else ()
+                    ),
+                    optional_params=tuple(
+                        sorted((schema.optional_params or {}).items())
+                    )
+                    if schema
+                    else (),
+                    governance=governance,
+                    risk=risk_class(risk_signals_for_operation(operation)),
+                    derived_from=_provenance(handler, gateway, resource, operation),
+                )
+                self._records[record.tool_id] = record
+                derived.append(record)
+        return derived
+
+    # -- queries ---------------------------------------------------------------
+
+    def records(self) -> List[ToolRecord]:
+        return [self._records[k] for k in sorted(self._records)]
+
+    def get(self, tool_id: str) -> Optional[ToolRecord]:
+        return self._records.get(tool_id)
+
+    def gateways(self) -> List[str]:
+        return sorted({r.gateway for r in self._records.values()})
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    # -- seams (the keystone contract) ------------------------------------------
+
+    def to_iso_inventory(self) -> List[Dict[str, Any]]:
+        """Exactly the ``{id, summary, schema}`` items IsoGate.from_inventory
+        consumes (WT3 seam)."""
+        return [
+            {
+                "id": r.tool_id,
+                "summary": r.summary,
+                "schema": r.schema_dict(),
+            }
+            for r in self.records()
+        ]
+
+    def to_cts_candidates(
+        self,
+        expert_fit: float = 0.0,
+        methodology_fit: float = 0.0,
+        eisenhower_q: int = 2,
+    ) -> List[CtsCandidate]:
+        """CtsCandidate rows with the derived RiskSignals (WT4 seam).
+
+        Fit/eisenhower facts are TURN-scoped (the caller's judgment), not
+        registry facts — passed through, defaulted neutrally.
+        """
+        return [
+            CtsCandidate(
+                tool_id=r.tool_id,
+                risk=risk_signals_for_operation(r.operation),
+                expert_fit=expert_fit,
+                methodology_fit=methodology_fit,
+                eisenhower_q=eisenhower_q,
+                reversibility=1.0 if r.risk is RiskClass.LOW else 0.4,
+                schema=r.schema_dict(),
+            )
+            for r in self.records()
+        ]
+
+    # -- projections + acceptance ------------------------------------------------
+
+    def to_yaml(self) -> str:
+        """The generated YAML projection of the SSOT (a BUILD ARTIFACT).
+
+        Stdlib-only emission (values JSON-encoded — valid YAML subset).
+        Editing this output by hand is the drift anti-pattern the registry
+        exists to kill; the header says so.
+        """
+        lines = [
+            "# AUTO-GENERATED by lib/gateway/tool_registry.py — DO NOT EDIT.",
+            "# Derived from live MetaToolRouter SchemaRegistry instances;",
+            "# regenerate instead of editing (hand-maintained YAML drifts).",
+            f"schema_version: {json.dumps(REGISTRY_SCHEMA_VERSION)}",
+            "tools:",
+        ]
+        for r in self.records():
+            lines.append(f"  - tool_id: {json.dumps(r.tool_id)}")
+            for key, value in r.to_dict().items():
+                if key == "tool_id":
+                    continue
+                lines.append(f"    {key}: {json.dumps(value, sort_keys=True)}")
+        return "\n".join(lines) + "\n"
+
+    def report(self) -> Dict[str, Any]:
+        """Logged-field invariants (the DoD-gate surface)."""
+        records = self.records()
+        return {
+            "schema_version": REGISTRY_SCHEMA_VERSION,
+            "total_tools": len(records),
+            "per_gateway": {
+                gw: sum(1 for r in records if r.gateway == gw)
+                for gw in self.gateways()
+            },
+            "risk_distribution": {
+                level.name: sum(1 for r in records if r.risk is level)
+                for level in RiskClass
+            },
+            "invariants": {
+                # every record carries handler provenance → derived, never hand-made
+                "all_records_derived": all(r.derived_from for r in records),
+                # tool_ids are namespaced by their gateway (no cross-wiring)
+                "ids_namespaced_by_gateway": all(
+                    r.tool_id.startswith(r.gateway + ".") for r in records
+                ),
+                # the ISO seam is loss-free (one inventory item per record)
+                "iso_inventory_complete": len(self.to_iso_inventory())
+                == len(records),
+            },
+        }
+
+
+def _provenance(
+    handler: Any, gateway: str, resource: str, operation: str
+) -> str:
+    """Module-qualified handler name — the derived-not-hand-maintained proof.
+
+    ``MetaToolRouter.register`` wraps handlers with @with_feedback; unwrap
+    via ``__wrapped__`` when present so provenance names the REAL handler.
+    """
+    fn = handler
+    while fn is not None and hasattr(fn, "__wrapped__"):
+        fn = fn.__wrapped__
+    if fn is None:
+        # schema without a live handler — still derived (from the registry),
+        # provenance names the schema slot
+        return f"schema:{gateway}.{resource}.{operation}"
+    module = getattr(fn, "__module__", "") or "unknown"
+    qualname = getattr(fn, "__qualname__", None) or getattr(
+        fn, "__name__", "unknown"
+    )
+    return f"{module}.{qualname}"

--- a/mcp-tools/maos-mcp-hub/tests/test_tool_registry.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_tool_registry.py
@@ -92,6 +92,38 @@ def test_verb_risk_mapping_is_deterministic(registry):
     )
 
 
+def test_unknown_verb_is_fail_closed_medium_and_clear_is_destructive():
+    """PR #200 review (qodo): an unknown verb must NEVER default to LOW
+    (fail-closed → MEDIUM); `clear` is destructive → HIGH."""
+    from lib.gateway.cts import risk_class
+
+    assert risk_class(risk_signals_for_operation("frobnicate_cache")) is (
+        RiskClass.MEDIUM
+    )
+    assert risk_class(risk_signals_for_operation("clear_cache")) is RiskClass.HIGH
+    assert risk_class(risk_signals_for_operation("list_items")) is RiskClass.LOW
+
+
+def test_tool_id_collision_raises_instead_of_silent_overwrite():
+    """PR #200 review (Copilot + qodo): deriving the same router twice (or
+    two routers sharing a tool_name) must raise, never silently overwrite."""
+    reg = ToolRegistry()
+    router = _demo_router()
+    reg.derive_router(router)
+    with pytest.raises(ValueError, match="tool_id collision"):
+        reg.derive_router(router)
+
+
+def test_reversibility_is_turn_scoped_not_derived():
+    """PR #200 review (Copilot): reversibility is a caller fact — never
+    derived from risk (which would double-count in CtsScorer)."""
+    reg = ToolRegistry.from_routers([_demo_router()])
+    cands = reg.to_cts_candidates()
+    assert all(c.reversibility == 1.0 for c in cands)
+    cands = reg.to_cts_candidates(reversibility=0.3)
+    assert all(c.reversibility == 0.3 for c in cands)
+
+
 def test_multi_router_merge_stays_namespaced():
     other = MetaToolRouter("demo_other")
     other.register("thing", "list", get_widget)
@@ -178,11 +210,15 @@ def test_yaml_projection_is_generated_and_deterministic(registry):
 def _real_routers():
     routers = []
     for gw in ("confluence", "compass", "common"):
+        # env-specific IMPORT failures (missing gateway deps; py<3.10 raises
+        # TypeError evaluating `X | None` signature defaults at def-time) are
+        # a legitimate skip; a runtime failure in build_router() is NOT — it
+        # runs OUTSIDE the try so real regressions fail the test (PR #200).
         try:
             mod = __import__(f"gateways.{gw}.actions", fromlist=["build_router"])
-            routers.append(mod.build_router())
-        except Exception:  # missing deps / py-version syntax — env-specific
-            pass
+        except (ImportError, SyntaxError, TypeError):
+            continue
+        routers.append(mod.build_router())
     return routers
 
 

--- a/mcp-tools/maos-mcp-hub/tests/test_tool_registry.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_tool_registry.py
@@ -101,6 +101,35 @@ def test_multi_router_merge_stays_namespaced():
     assert reg.report()["invariants"]["ids_namespaced_by_gateway"] is True
 
 
+def test_non_router_object_derives_nothing_without_crashing():
+    """PR #200 review (amazon-q): an object without a `registry` surface
+    yields zero records — never AttributeError."""
+
+    class NotARouter:
+        tool_name = "bogus"
+
+    reg = ToolRegistry()
+    assert reg.derive_router(NotARouter()) == []
+    assert len(reg) == 0
+
+
+def test_circular_wrapped_chain_does_not_infinite_loop():
+    """PR #200 review (amazon-q): a pathological circular __wrapped__ chain
+    terminates via the visited-id guard."""
+    from lib.gateway.tool_registry import _provenance
+
+    def a():
+        """A."""
+
+    def b():
+        """B."""
+
+    a.__wrapped__ = b
+    b.__wrapped__ = a  # cycle
+    result = _provenance(a, "gw", "res", "op")
+    assert result  # terminated and produced a name
+
+
 # --------------------------------------------------------------------------- #
 # the keystone seams: registry → IsoGate (WT3) → CtsScorer (WT4)
 # --------------------------------------------------------------------------- #

--- a/mcp-tools/maos-mcp-hub/tests/test_tool_registry.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_tool_registry.py
@@ -1,0 +1,173 @@
+"""
+Tests for the auto-generated ToolRegistry (WT8 / S1, backlog P2-d).
+
+The acceptance IS the spec scenario (openspec/specs/maos-hub-registry/spec.md
+→ "Records are derived, not hand-maintained"), asserted as LOGGED FIELDS +
+golden derivation over the hub's REAL gateways — never prose:
+
+    WHEN records are needed
+    THEN they are DERIVED from live MetaToolRouter SchemaRegistry instances
+    (provenance field names the real handler) and the WAVE-1 seams
+    (IsoGate / CtsScorer) consume them loss-free.
+"""
+
+import pytest
+
+from lib.gateway.cts import CtsScorer, CtsTurn, RiskClass
+from lib.gateway.iso import IsoGate
+from lib.gateway.router import MetaToolRouter
+from lib.gateway.tool_registry import (
+    REGISTRY_SCHEMA_VERSION,
+    ToolRegistry,
+    risk_signals_for_operation,
+)
+
+
+# --------------------------------------------------------------------------- #
+# synthetic router (always runs — no gateway deps)
+# --------------------------------------------------------------------------- #
+
+async def get_widget(widget_id: str, verbose: bool = False):
+    """Fetch one widget by id."""
+    return {"widget_id": widget_id}
+
+
+async def create_widget(name: str):
+    """Create a widget."""
+    return {"name": name}
+
+
+async def delete_widget(widget_id: str):
+    """Delete a widget permanently."""
+    return {"deleted": widget_id}
+
+
+def _demo_router() -> MetaToolRouter:
+    router = MetaToolRouter("demo_widgets", governance=["worktree-first"])
+    router.register("widget", "get", get_widget)
+    router.register("widget", "create", create_widget)
+    router.register("widget", "delete", delete_widget)
+    return router
+
+
+@pytest.fixture()
+def registry() -> ToolRegistry:
+    return ToolRegistry.from_routers([_demo_router()])
+
+
+# --------------------------------------------------------------------------- #
+# derivation: the derived-not-hand-maintained contract
+# --------------------------------------------------------------------------- #
+
+def test_records_are_derived_with_real_handler_provenance(registry):
+    """Provenance names the REAL handler (unwrapped past @with_feedback)."""
+    record = registry.get("demo_widgets.widget.get")
+    assert record is not None
+    assert record.derived_from.endswith(".get_widget")
+    assert record.summary == "Fetch one widget by id."
+    assert record.required_params == ("widget_id",)
+    assert dict(record.optional_params) == {"verbose": "False"}
+    assert record.governance == ("worktree-first",)
+
+
+def test_report_invariants_are_logged_fields(registry):
+    report = registry.report()
+    assert report["schema_version"] == REGISTRY_SCHEMA_VERSION
+    assert report["total_tools"] == 3
+    assert report["per_gateway"] == {"demo_widgets": 3}
+    inv = report["invariants"]
+    assert inv["all_records_derived"] is True
+    assert inv["ids_namespaced_by_gateway"] is True
+    assert inv["iso_inventory_complete"] is True
+
+
+def test_verb_risk_mapping_is_deterministic(registry):
+    """delete→HIGH · create→MEDIUM · get→LOW (documented verb map)."""
+    assert registry.get("demo_widgets.widget.delete").risk is RiskClass.HIGH
+    assert registry.get("demo_widgets.widget.create").risk is RiskClass.MEDIUM
+    assert registry.get("demo_widgets.widget.get").risk is RiskClass.LOW
+    # the map is pure — same operation, same signals
+    assert risk_signals_for_operation("delete_x") == risk_signals_for_operation(
+        "delete_y"
+    )
+
+
+def test_multi_router_merge_stays_namespaced():
+    other = MetaToolRouter("demo_other")
+    other.register("thing", "list", get_widget)
+    reg = ToolRegistry.from_routers([_demo_router(), other])
+    assert len(reg) == 4
+    assert reg.gateways() == ["demo_other", "demo_widgets"]
+    assert reg.report()["invariants"]["ids_namespaced_by_gateway"] is True
+
+
+# --------------------------------------------------------------------------- #
+# the keystone seams: registry → IsoGate (WT3) → CtsScorer (WT4)
+# --------------------------------------------------------------------------- #
+
+def test_iso_seam_end_to_end(registry):
+    """to_iso_inventory() IS IsoGate.from_inventory's input — loss-free."""
+    inventory = registry.to_iso_inventory()
+    gate, entries = IsoGate.from_inventory(inventory, k=2)
+    assert len(entries) == len(registry)
+    selection = gate.select(
+        ranked_candidates=[r.tool_id for r in registry.records()]
+    )
+    report = selection.to_report()
+    assert report["invariants"]["promoted_lte_k"] is True
+    assert report["invariants"]["summaries_within_limit"] is True
+
+
+def test_cts_seam_end_to_end(registry):
+    """to_cts_candidates() ranks under CtsScorer with derived risk."""
+    turn = CtsTurn(max_risk=RiskClass.MEDIUM)
+    ranking = CtsScorer().rank(registry.to_cts_candidates(expert_fit=0.8), turn)
+    ranked = ranking.ranked_ids()
+    # HIGH-risk delete is filtered above the turn ceiling — never silently:
+    assert "demo_widgets.widget.delete" not in ranked
+    assert "demo_widgets.widget.get" in ranked
+    assert "demo_widgets.widget.create" in ranked
+
+
+# --------------------------------------------------------------------------- #
+# YAML projection: generated artifact, deterministic, self-declaring
+# --------------------------------------------------------------------------- #
+
+def test_yaml_projection_is_generated_and_deterministic(registry):
+    yaml_text = registry.to_yaml()
+    assert yaml_text.startswith("# AUTO-GENERATED")
+    assert "DO NOT EDIT" in yaml_text
+    assert '"demo_widgets.widget.delete"' in yaml_text
+    assert registry.to_yaml() == yaml_text  # deterministic
+
+
+# --------------------------------------------------------------------------- #
+# GOLDEN: derivation over the hub's REAL gateways (skip-graceful when the
+# gateway deps / Python version aren't available in this environment)
+# --------------------------------------------------------------------------- #
+
+def _real_routers():
+    routers = []
+    for gw in ("confluence", "compass", "common"):
+        try:
+            mod = __import__(f"gateways.{gw}.actions", fromlist=["build_router"])
+            routers.append(mod.build_router())
+        except Exception:  # missing deps / py-version syntax — env-specific
+            pass
+    return routers
+
+
+def test_golden_derivation_over_real_gateways():
+    routers = _real_routers()
+    if not routers:
+        pytest.skip("no real gateway importable in this environment")
+    reg = ToolRegistry.from_routers(routers)
+    # loss-free: registry size == the routers' own action counts
+    assert len(reg) == sum(r.action_count for r in routers)
+    report = reg.report()
+    assert report["invariants"]["all_records_derived"] is True
+    assert report["invariants"]["ids_namespaced_by_gateway"] is True
+    assert report["invariants"]["iso_inventory_complete"] is True
+    # the ISO seam holds over the real surface too
+    gate, entries = IsoGate.from_inventory(reg.to_iso_inventory(), k=5)
+    assert len(entries) == len(reg)

--- a/openspec/specs/maos-hub/spec.md
+++ b/openspec/specs/maos-hub/spec.md
@@ -128,4 +128,9 @@ complement, never the sole control. Every enforcement decision SHALL be logged (
   `docs/adoption/mem0-2026-07-01.md`; graphiti temporal remains DEFERRED until a measured workload)* ·
   OTel exporter for Sentinel
   (WT6, DEFERRED — C3 severity LOW) · LiteLLM model-router (CUT — `os3pd` defers a runtime gateway until ≥3
-  incidents and `slm-routing` is not a runtime router) · tool-registry YAML SSOT via auto-generation (WT8).
+  incidents and `slm-routing` is not a runtime router) · ~~tool-registry YAML SSOT via auto-generation (WT8)~~ *(implemented —
+  `lib/gateway/tool_registry.py::ToolRegistry`: records derived from live `MetaToolRouter`
+  SchemaRegistry instances with handler provenance (`derived_from`); seams `to_iso_inventory()` →
+  IsoGate (WT3) + `to_cts_candidates()` → CtsScorer (WT4); YAML = generated projection stamped
+  AUTO-GENERATED; acceptance = `report()` invariants + `tests/test_tool_registry.py` golden over
+  real gateways)*.


### PR DESCRIPTION
# [PR-as-Prompt] WT8 (S1) — auto-generated tool-registry SSOT

**Purpose-tag**: `[PR-as-Prompt]` · WAVE 2 keystone of the ATH→MAOS Hub handoff (`research/agentic-moe-2026/20260627-HANDOFF-claude-code.md`), backlog **P2-d / S1**.

## Context

The gateways wire their tool contracts divergently (bitbucket imports a handler dict; jira builds its own client class). The handoff mandates: *"registry AUTO-GERADO (derivado por decorator do SchemaRegistry, NÃO YAML hand-maintained que dá drift). É o keystone que tira o contrato do wiring divergente dos gateways."* Spec anchor: `openspec/specs/maos-hub-registry/spec.md` → **"Records are derived, not hand-maintained"** (mirrors SchemaRegistry auto-gen).

## Objectives

1. `ToolRegistry.from_routers()` — every `ToolRecord` derived from live `MetaToolRouter` instances (SchemaRegistry schemas + registered handlers + governance tags). No hand-maintained entry path exists.
2. **Provenance as acceptance**: `derived_from` names the REAL handler (unwrapped past `@with_feedback`); `report().invariants.all_records_derived` is the logged field.
3. **WAVE-1 seams closed**: `to_iso_inventory()` = exact input of `IsoGate.from_inventory` (WT3, #197) · `to_cts_candidates()` = `CtsCandidate` rows with a **deterministic documented verb→`RiskSignals` map** (destructive→HIGH · write→MEDIUM · read→LOW) (WT4, #198).
4. `to_yaml()` = generated projection stamped `AUTO-GENERATED — DO NOT EDIT` (editing it is the drift anti-pattern this registry kills).

## Acceptance (DoD-GATE: logged fields + golden fixtures, zero prose)

- [x] `report()` invariants: `all_records_derived` · `ids_namespaced_by_gateway` · `iso_inventory_complete`
- [x] End-to-end seam proofs: registry→`IsoGate.select` (invariants green) · registry→`CtsScorer.rank` (HIGH-risk delete filtered above turn ceiling, traced not silent)
- [x] **Golden derivation over the hub's REAL gateways** (confluence + compass + common): loss-free vs `router.action_count`; skip-graceful where gateway deps absent
- [x] 8/8 tests green · validate-plugin PASSED · gitleaks clean
- [x] CHANGELOG entry + spec §Deferred strike (WT8 → implemented)

## Risk + rollback

Additive module (no gateway touched; hub wiring unchanged). Rollback = revert single commit. No plugin version bump (ADR-003).

## Out of scope

WAVE-5 registry/console (ADR-007 — skill/agent frontmatter records, activation gating, license/provenance fields): that is the `maos-hub-registry` spec's full surface, gated behind WAVE 5 T1. WT6 OTel = DEFERRED · WT7 LiteLLM = CUT (handoff).

## Refs

Closes the WT8 line of the WAVE-2 plan · seams: #197 (WT3) · #198 (WT4) · sibling: #199 (WT5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
