### PR TITLE
docs(status-map): declare SKILL.md<->statusmap/ SSOT relationship (KRDR #160)

### DIFF
--- a/skills/status-map/SKILL.md
+++ b/skills/status-map/SKILL.md
@@ -10,6 +10,12 @@ version: 1.0.0
 
 Generate ASCII-based visualizations for human observability of AI agent sessions. Complements Sentinel Protocol (JSON-based) by providing quick, scannable status information.
 
+> **SSOT declaration** (2026-07-02, KRDR #160 Phase-B item #7): this file is the **condensed, invocable skill**
+> Claude Code actually loads/executes. `../../statusmap/` (README + `inference.md` + `templates/statusmap_templates.md`,
+> ~1850 lines) is the **detailed reference source** this skill's abbreviated template catalog + inference rules
+> are distilled from — a source-doc pack, not dead duplication. Update both together when either changes;
+> `statusmap/` for full rule/template detail, this file for the compact runtime summary.
+
 ## When to Use
 
 - Every response (PULSE template)

--- a/statusmap/README.md
+++ b/statusmap/README.md
@@ -2,6 +2,11 @@
 
 Sistema padronizado de visualizacoes ASCII para observabilidade humana em sessoes multi-agent.
 
+> **SSOT declaration** (2026-07-02, KRDR #160 Phase-B item #7): this directory is the **detailed reference
+> source** (full 8-template library + inference rules). The **actual invocable skill** Claude Code loads is
+> `skills/status-map/SKILL.md` — a condensed distillation of this source. Not a dead/orphaned duplicate; update
+> both together when either changes.
+
 ## Proposito
 
 Status Maps sao **visualizacoes estruturadas** projetadas para:


### PR DESCRIPTION
[PR-as-Documentation-Prompt]

## Context
KRDR #160 Phase-B item #7: "status-map skill <-> statusmap/ dir SSOT declaration."

## Recon
`skills/status-map/SKILL.md` (90 lines, invocable — this is what Claude Code loads for the skill) ends with
"*Skill based on Status Map System v1.0 | multi-agent-os*" but has zero pointer to where that source lives.
`statusmap/` (README + `inference.md` + `templates/statusmap_templates.md`, ~1850 lines combined) is that
source — a much richer template/inference-rule pack — but has zero pointer back to the skill that consumes it.

**Verdict**: not dead duplication — a real distill/detail relationship with an undeclared SSOT direction. Given
I don't yet have full confidence that consolidating (deleting one side) wouldn't lose real content, this PR
closes the *declaration* gap the issue asked for, without forcing a premature merge/deletion.

## What changed
- `skills/status-map/SKILL.md` — SSOT blockquote pointing to `statusmap/` as the detailed source.
- `statusmap/README.md` — reciprocal blockquote pointing to `SKILL.md` as the actual invocable artifact.

## Test plan
- [x] `gitleaks detect` clean
- [x] Both blockquotes added, zero content removed

## Risk + rollback
Trivial docs-only addition, fully reversible, no HUMAN_DOMAIN.

## Refs
Part of ekson73/akasha-claude#160 Phase-B item #7.
