### PR TITLE
feat(maos-hub): hub-registry SSOT (T1/WAVE-5) — plugin-level registry, derived not hand-maintained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — hub-registry SSOT (T1 / WAVE 5) — plugin-level registry, derived not hand-maintained
+
+- **`mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py`** — `HubRegistry`: the plugin-level
+  registry SSOT of `openspec/specs/maos-hub-registry/spec.md` (the SSOT the WAVE-5 console and the
+  WAVE-6 integrator read). Records DERIVED from the repo's own sources — `skills/*/SKILL.md` +
+  `agents/*.md` frontmatter (own tools), `evals/fixtures/intake_verdicts.yaml` (third-party:
+  license/provenance/verdict→activation), `lib/gateway/conflicts.yaml` (WAVE-0 Phase-2
+  incompatibilities, round-tripped), `plugin-scripts/governance/lib/conductors.txt` (RULE-011).
+  Full spec field set per record (`activation` · `license_spdx` · `provenance` · `ttl` +
+  `last_validated` · `rollback` · `conflicts_with` · `recipes` · `security_status` …) +
+  `derived_from` (provenance of the derivation itself — the checkable "not hand-maintained" field).
+- **`mcp-tools/maos-mcp-hub/lib/gateway/recipes.yaml`** — the Phase-2 §4 composition recipes
+  promoted into structured data (one-time curated promotion, sibling of `conflicts.yaml`; source
+  cited): 6 use-case stacks the registry projects into each record's `recipes[]`.
+- **Spec scenarios as logged fields (DoD-gate honoured):** "a new skill ships" (synthetic-repo
+  regeneration test) · "third-party proposed as always-on" (`request_activation` refuses on
+  `license_spdx=NONE` / `conflicts_with` edge / non-vetted, reason recorded in `gate_decisions`) ·
+  "two conductors selected" (`conflicts_roundtrip` invariant: registry graph == conflicts.yaml,
+  every endpoint resolves to a record) · "upstream goes stale" (`eject_candidates(today)` flags
+  past-TTL records — the GSD/MemPalace lesson). Deterministic verdict→activation map documented
+  in the module docstring (EXCLUDED/ABANDON→excluded · SUB-AGENT/DEFER→opt-in ·
+  INSTALL/ADAPT/ABSORB→default-on-for-context capped by license/conductor/conflict gates;
+  `always-on` never granted to third-party at derivation).
+- **`mcp-tools/maos-mcp-hub/tests/test_hub_registry.py`** — 20 tests incl. golden derivation over
+  the REAL repo (62 skills · 32 intake entries) + CLI contract
+  (`python -m lib.registry.hub_registry` → `verdict: pass`, exit 1 on any invariant violation).
+  Additive; no plugin version bump (ADR-003). Local pre-existing env failures (py<3.10 unions,
+  absent gateway deps) unchanged vs pristine main — zero regression.
+
+
 ### Removed — Layer-Purity: corp-overlay rules removed (KRDR #160 Phase-B item #1)
 
 - **`rules/agent-delegation.md` [C14], `rules/exit-hygiene.md` [C13], `rules/forge-agent-design.md`

--- a/mcp-tools/maos-mcp-hub/lib/gateway/recipes.yaml
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/recipes.yaml
@@ -1,0 +1,96 @@
+# Curated composition-recipe list for the MoE hub registry (T1 / WAVE 5).
+#
+# Source (one-time promotion, like conflicts.yaml):
+#   research/agentic-moe-2026/20260627-02-ntree-moe.md
+#   §4 "RECEITAS DE COMPOSIÇÃO (substrate-first)" — the 6 use-case stacks.
+#
+# Schema: a list of recipes. Each recipe:
+#   id        — kebab-case recipe identifier
+#   use_case  — the human use-case name (pt-BR, as in the source)
+#   stack     — ORDERED tool ids (substrates L0+L8+L9 first, then pipeline).
+#               Ids are canonical intake ids (evals/fixtures/intake_verdicts.yaml);
+#               alternatives within a slot are nested as a list [a, b] = "a OR b".
+#   why       — one-line rationale (from the source table)
+#   hitl      — where the human gate is recommended
+#
+# Consumed by lib/registry/hub_registry.py (HubRegistry derives each record's
+# `recipes[]` membership from these stacks). Editing the DERIVED registry
+# projection is the anti-pattern; editing THIS curated promotion is fine.
+
+recipes:
+  - id: new-idea-to-mvp
+    use_case: "Nova ideia → MVP"
+    stack:
+      - karpathy-claude-md
+      - mem0
+      - langfuse
+      - seed
+      - [spec-kit, openspec]
+      - superpowers
+      - open-codesign
+      - frontend-slides
+    why: "Substrato leve; seed estrutura a ideia; spec-kit p/ rigor (ou openspec p/ leve); superpowers garante TDD; studio enxuto+seguro p/ UI; deck p/ pitch."
+    hitl: "escolha spec-kit vs openspec (mutuamente exclusivos) + aprovação do plano (clarify)"
+
+  - id: legacy-refactor
+    use_case: "Refactor de legado"
+    stack:
+      - karpathy-claude-md
+      - base
+      - cognee
+      - langfuse
+      - understand-anything
+      - graphify
+      - openspec
+      - superpowers
+    why: "Legado exige compreensão antes de mudar (understand→graphify); cognee mapeia relações; openspec é brownfield-first; review gates obrigatórios."
+    hitl: "code-review com severidade (Critical blocks); não commitar grafo com segredos"
+
+  - id: enterprise-feature
+    use_case: "Feature enterprise"
+    stack:
+      - karpathy-claude-md
+      - graphiti
+      - langfuse
+      - graphify
+      - spec-kit
+      - [gstack, superpowers]
+      - open-design
+      - slidev
+    why: "spec-kit é o canônico p/ governança/constitution; graphiti dá auditoria temporal; langfuse região HIPAA; gstack traz /cso (OWASP+STRIDE) + coverage gate."
+    hitl: "gates de compliance (/speckit.analyze, /cso); não empilhar gstack+ECC"
+
+  - id: production-deploy
+    use_case: "Deploy de produção"
+    stack:
+      - base
+      - mem0
+      - langfuse
+      - [gsd-core, gstack]
+      - impeccable
+    why: "gsd-core e gstack têm verify-before-ship + PR auto; impeccable é linter determinístico plugável em CI; langfuse evals como gate."
+    hitl: "aprovação do PR + canary; se gsd-core: usar SÓ o fork open-gsd (npm original é perigoso)"
+
+  - id: codebase-onboarding
+    use_case: "Onboarding de codebase"
+    stack:
+      - karpathy-claude-md
+      - cognee
+      - langfuse
+      - understand-anything
+      - graphify
+      - obsidian-skills
+    why: "understand-anything é 'graphs that teach' (onboarding); graphify exporta vault; obsidian-skills deixa o agente enriquecer o vault → loop L4↔L5."
+    hitl: "opcional na revisão do tour/domínio extraído (read-mostly, risco baixo)"
+
+  - id: long-session-memory
+    use_case: "Sessão longa com memória"
+    stack:
+      - karpathy-claude-md
+      - [letta, mem0]
+      - graphiti
+      - langfuse
+      - [ECC, gsd-core]
+      - ruflo
+    why: "Sessão longa precisa de memória que sobrevive a sessões: letta (self-edit) ou mem0+graphiti; ECC/gsd-core persistem STATE/SQLite; ruflo adiciona learning-loop."
+    hitl: "decisão letta-vs-mem0 (letta = lock-in de runtime); ruflo é over-kill se solo/budget-limitado"

--- a/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
@@ -1,0 +1,13 @@
+"""lib.registry — the MAOS Hub plugin-level registry SSOT (T1 / WAVE 5).
+
+Sibling of ``lib.gateway.tool_registry`` (WT8 — MCP-gateway-scoped records):
+this package derives records for EVERY MAOS-routable tool — own skills/agents
++ integrated third-party experts — per ``openspec/specs/maos-hub-registry/spec.md``.
+"""
+
+from .hub_registry import (  # noqa: F401
+    ACTIVATION_TIERS,
+    HUB_REGISTRY_SCHEMA_VERSION,
+    HubRecord,
+    HubRegistry,
+)

--- a/mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py
@@ -1,0 +1,525 @@
+"""
+HubRegistry — the plugin-level registry SSOT (T1 / WAVE 5, ADR-006/ADR-007).
+
+The SSOT both the console (WAVE 5) and the integrator (WAVE 6) read: one
+machine-readable record per MAOS-routable tool — own skills + own agents +
+integrated third-party experts — per ``openspec/specs/maos-hub-registry/spec.md``.
+
+Derivation sources (records are DERIVED, never hand-maintained — the spec's
+first requirement, mirroring WT8 ``lib.gateway.tool_registry``):
+
+  - own skills   → ``skills/*/SKILL.md`` frontmatter (name/description/version)
+  - own agents   → ``agents/*.md`` frontmatter (name/description)
+  - third-party  → ``evals/fixtures/intake_verdicts.yaml`` (WT10 — verdicts,
+                   license, provenance repo, flags, conditions, TTL dates)
+  - conflicts    → ``lib/gateway/conflicts.yaml`` (WAVE-0 — the Phase-2
+                   incompatibilities, already promoted; round-tripped here)
+  - recipes      → ``lib/gateway/recipes.yaml`` (T1 — the Phase-2 §4
+                   composition recipes, promoted like conflicts.yaml)
+  - conductors   → ``plugin-scripts/governance/lib/conductors.txt`` (RULE-011)
+
+Spec scenarios implemented as CHECKABLE fields (the DoD-gate — no prose):
+
+  - "a new skill ships"            → ``HubRegistry.derive`` regenerates the
+    record from frontmatter alone (test adds a synthetic skill to a tmp repo).
+  - "third-party proposed as always-on" → ``request_activation(id, "always-on")``
+    refuses when ``license_spdx == "NONE"`` OR a ``conflicts_with`` edge exists,
+    records the reason in ``gate_decisions`` (a logged field).
+  - "two conductors selected"      → the ``conflicts_with`` graph round-trips
+    ``conflicts.yaml`` exactly (``report().invariants.conflicts_roundtrip``).
+  - "upstream goes stale/abandoned" → ``eject_candidates(today)`` flags records
+    whose ``ttl`` deadline has passed (the GSD/MemPalace lesson).
+
+Deterministic activation derivation (documented, fail-closed):
+
+  third-party (by intake verdict):
+    EXCLUDED | ABANDON  → excluded
+    SUB-AGENT | DEFER   → opt-in
+    INSTALL | ADAPT | ABSORB
+      → default-on-for-context, UNLESS license_spdx == "NONE" OR the id is in
+        the conductor class OR it has a conflicts_with edge → opt-in (reason
+        recorded). ``always-on`` is NEVER granted at derivation time — only
+        via ``request_activation`` and only when every gate passes.
+  own tools:
+    skills → default-on-for-context (context-loaded plugin surface)
+    agents → opt-in (spawned on demand)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
+
+import yaml
+
+HUB_REGISTRY_SCHEMA_VERSION = "hub-registry/1.0.0"
+
+ACTIVATION_TIERS = ("always-on", "default-on-for-context", "opt-in", "excluded")
+
+#: Verdict → activation tier (third-party derivation; module docstring contract).
+_VERDICT_ACTIVATION = {
+    "EXCLUDED": "excluded",
+    "ABANDON": "excluded",
+    "SUB-AGENT": "opt-in",
+    "DEFER": "opt-in",
+    "INSTALL": "default-on-for-context",
+    "ADAPT": "default-on-for-context",
+    "ABSORB": "default-on-for-context",
+}
+
+#: conflicts.yaml endpoints that are VARIANTS of a canonical intake id.
+CONFLICT_ALIASES = {
+    "ECC-browser-mcp": "ECC",
+    "bmad-as-co-runtime": "bmad-method",
+}
+
+_OWN_REPO = "ekson73/multi-agent-os"
+_OWN_LICENSE = "MIT"
+_FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.S)
+
+
+@dataclass(frozen=True)
+class HubRecord:
+    """One registry record — the exact field set of the spec's Tool record."""
+
+    id: str
+    owner_repo: str
+    layer: str
+    role: str
+    category: str
+    harness_coverage: Tuple[str, ...]
+    requires: Tuple[str, ...]
+    conflicts_with: Tuple[str, ...]
+    guardrails: str
+    impact: str
+    recipes: Tuple[str, ...]
+    activation: str
+    license_spdx: str
+    provenance: str
+    ttl: Optional[str]            # deadline date (ISO) after which re-validation is due
+    last_validated: Optional[str]
+    rollback: str
+    security_status: str
+    derived_from: str             # provenance of the DERIVATION itself (checkable)
+    activation_reason: str = ""   # why the tier was capped/granted (logged field)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "owner_repo": self.owner_repo,
+            "layer": self.layer,
+            "role": self.role,
+            "category": self.category,
+            "harness_coverage": list(self.harness_coverage),
+            "requires": list(self.requires),
+            "conflicts_with": list(self.conflicts_with),
+            "guardrails": self.guardrails,
+            "impact": self.impact,
+            "recipes": list(self.recipes),
+            "activation": self.activation,
+            "license_spdx": self.license_spdx,
+            "provenance": self.provenance,
+            "ttl": self.ttl,
+            "last_validated": self.last_validated,
+            "rollback": self.rollback,
+            "security_status": self.security_status,
+            "derived_from": self.derived_from,
+            "activation_reason": self.activation_reason,
+        }
+
+
+def _parse_frontmatter(path: Path) -> Optional[Dict[str, Any]]:
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return None
+    try:
+        data = yaml.safe_load(m.group(1))
+    except yaml.YAMLError:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _flatten_stack(stack: Iterable[Any]) -> List[str]:
+    """Flatten a recipe stack; nested lists mean 'a OR b' alternatives."""
+    out: List[str] = []
+    for item in stack:
+        if isinstance(item, list):
+            out.extend(str(x) for x in item)
+        else:
+            out.append(str(item))
+    return out
+
+
+class HubRegistry:
+    """Plugin-level registry derived from the repo's own sources of truth."""
+
+    def __init__(self) -> None:
+        self._records: Dict[str, HubRecord] = {}
+        self._conflict_edges: Set[FrozenSet[str]] = set()
+        self._gate_decisions: List[Dict[str, str]] = []
+        self._conductors: Set[str] = set()
+
+    # ------------------------------------------------------------ derive ---
+    @classmethod
+    def derive(cls, repo_root: Path, as_of: str) -> "HubRegistry":
+        """Derive the full registry from a repo checkout.
+
+        ``as_of`` (ISO date) stamps ``last_validated`` on OWN records —
+        derivation IS validation for first-party tools (they are re-derived
+        from the live checkout every build). Third-party records keep the
+        intake fixture's ``decided``/``revisit`` dates.
+        """
+        reg = cls()
+        hub_dir = repo_root / "mcp-tools" / "maos-mcp-hub"
+
+        reg._conductors = _load_conductors(
+            repo_root / "plugin-scripts" / "governance" / "lib" / "conductors.txt"
+        )
+        conflicts_by_id = reg._load_conflicts(hub_dir / "lib" / "gateway" / "conflicts.yaml")
+        recipes_by_id = _load_recipes(hub_dir / "lib" / "gateway" / "recipes.yaml")
+
+        reg._derive_own_skills(repo_root, as_of, conflicts_by_id, recipes_by_id)
+        reg._derive_own_agents(repo_root, as_of, conflicts_by_id, recipes_by_id)
+        reg._derive_third_party(
+            hub_dir / "evals" / "fixtures" / "intake_verdicts.yaml",
+            conflicts_by_id,
+            recipes_by_id,
+        )
+        return reg
+
+    def _load_conflicts(self, path: Path) -> Dict[str, Set[str]]:
+        by_id: Dict[str, Set[str]] = {}
+        if not path.is_file():
+            return by_id
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        for edge in data.get("conflicts", []):
+            if isinstance(edge, dict):
+                a, b = str(edge.get("a")), str(edge.get("b"))
+            else:  # 2-item sequence
+                a, b = str(edge[0]), str(edge[1])
+            a = CONFLICT_ALIASES.get(a, a)
+            b = CONFLICT_ALIASES.get(b, b)
+            self._conflict_edges.add(frozenset((a, b)))
+            by_id.setdefault(a, set()).add(b)
+            by_id.setdefault(b, set()).add(a)
+        return by_id
+
+    def _derive_own_skills(
+        self,
+        repo_root: Path,
+        as_of: str,
+        conflicts: Dict[str, Set[str]],
+        recipes: Dict[str, List[str]],
+    ) -> None:
+        for skill_md in sorted((repo_root / "skills").glob("*/SKILL.md")):
+            fm = _parse_frontmatter(skill_md)
+            if not fm or "name" not in fm:
+                continue
+            sid = str(fm["name"])
+            rel = skill_md.relative_to(repo_root).as_posix()
+            self._add(
+                HubRecord(
+                    id=sid,
+                    owner_repo=_OWN_REPO,
+                    layer="L2",
+                    role="pipeline",
+                    category="skill",
+                    harness_coverage=("claude-code",),
+                    requires=(),
+                    conflicts_with=tuple(sorted(conflicts.get(sid, ()))),
+                    guardrails="",
+                    impact=str(fm.get("description", "")).strip()[:200],
+                    recipes=tuple(recipes.get(sid, ())),
+                    activation="default-on-for-context",
+                    license_spdx=_OWN_LICENSE,
+                    provenance=f"repo:{_OWN_REPO}@{rel}",
+                    ttl=None,
+                    last_validated=as_of,
+                    rollback="git revert the introducing commit; plugin re-install",
+                    security_status="first-party",
+                    derived_from=rel,
+                )
+            )
+
+    def _derive_own_agents(
+        self,
+        repo_root: Path,
+        as_of: str,
+        conflicts: Dict[str, Set[str]],
+        recipes: Dict[str, List[str]],
+    ) -> None:
+        for agent_md in sorted((repo_root / "agents").glob("*.md")):
+            fm = _parse_frontmatter(agent_md)
+            if not fm or "name" not in fm:
+                continue  # README / policy docs without frontmatter
+            aid = str(fm["name"])
+            if aid in self._records:  # a skill already claimed the id
+                continue
+            rel = agent_md.relative_to(repo_root).as_posix()
+            self._add(
+                HubRecord(
+                    id=aid,
+                    owner_repo=_OWN_REPO,
+                    layer="L3",
+                    role="amplifier",
+                    category="agent",
+                    harness_coverage=("claude-code",),
+                    requires=(),
+                    conflicts_with=tuple(sorted(conflicts.get(aid, ()))),
+                    guardrails="",
+                    impact=str(fm.get("description", "")).strip()[:200],
+                    recipes=tuple(recipes.get(aid, ())),
+                    activation="opt-in",
+                    license_spdx=_OWN_LICENSE,
+                    provenance=f"repo:{_OWN_REPO}@{rel}",
+                    ttl=None,
+                    last_validated=as_of,
+                    rollback="git revert the introducing commit; plugin re-install",
+                    security_status="first-party",
+                    derived_from=rel,
+                )
+            )
+
+    def _derive_third_party(
+        self,
+        fixture: Path,
+        conflicts: Dict[str, Set[str]],
+        recipes: Dict[str, List[str]],
+    ) -> None:
+        if not fixture.is_file():
+            return
+        data = yaml.safe_load(fixture.read_text(encoding="utf-8")) or {}
+        decided = str(data.get("decided", "")) or None
+        revisit = str(data.get("revisit", "")) or None
+        rel = "mcp-tools/maos-mcp-hub/evals/fixtures/intake_verdicts.yaml"
+        for entry in data.get("entries", []):
+            tid = str(entry.get("id"))
+            verdict = str(entry.get("verdict", "")).upper()
+            license_raw = str(entry.get("license", "") or "none")
+            license_spdx = "NONE" if license_raw.lower() in ("none", "null", "") else license_raw
+            edges = tuple(sorted(conflicts.get(tid, ())))
+            activation, reason = self._third_party_activation(tid, verdict, license_spdx, edges)
+            flags = [str(f) for f in entry.get("flags", [])]
+            if entry.get("blocked") or verdict == "EXCLUDED":
+                security = "supply-chain-veto"
+            elif "license-none" in flags:
+                security = "license-risk"
+            else:
+                security = "vetted"
+            conditions = [str(c) for c in entry.get("conditions", [])]
+            self._add(
+                HubRecord(
+                    id=tid,
+                    owner_repo=str(entry.get("repo", "")),
+                    layer=str(entry.get("layer", "")),
+                    role=str(entry.get("role", "")).strip()[:200],
+                    category="third-party",
+                    harness_coverage=(),
+                    requires=(),
+                    conflicts_with=edges,
+                    guardrails="; ".join(conditions),
+                    impact=str(entry.get("rationale", "")).strip()[:200],
+                    recipes=tuple(recipes.get(tid, ())),
+                    activation=activation,
+                    license_spdx=license_spdx,
+                    provenance=f"intake:{rel}#{tid} (verdict={verdict})",
+                    ttl=revisit,
+                    last_validated=decided,
+                    rollback="disable in the enablement profile; remove slot-adapter (WAVE-6 T7 recipe)",
+                    security_status=security,
+                    derived_from=rel,
+                    activation_reason=reason,
+                )
+            )
+
+    def _third_party_activation(
+        self, tid: str, verdict: str, license_spdx: str, edges: Tuple[str, ...]
+    ) -> Tuple[str, str]:
+        tier = _VERDICT_ACTIVATION.get(verdict, "opt-in")
+        reason = f"verdict={verdict}"
+        if tier == "default-on-for-context":
+            if license_spdx == "NONE":
+                tier, reason = "opt-in", "gate: license_spdx=NONE (HF2 — not license-clean)"
+            elif tid in self._conductors:
+                tier, reason = "opt-in", "gate: conductor class (RULE-011 single-conductor)"
+            elif edges:
+                tier, reason = "opt-in", f"gate: conflicts_with={','.join(edges)}"
+        self._gate_decisions.append({"id": tid, "activation": tier, "reason": reason})
+        return tier, reason
+
+    def _add(self, record: HubRecord) -> None:
+        self._records[record.id] = record
+
+    # ------------------------------------------------------------ queries ---
+    def records(self) -> List[HubRecord]:
+        return sorted(self._records.values(), key=lambda r: r.id)
+
+    def get(self, rid: str) -> Optional[HubRecord]:
+        return self._records.get(rid)
+
+    def __len__(self) -> int:
+        return len(self._records)
+
+    @property
+    def gate_decisions(self) -> List[Dict[str, str]]:
+        return list(self._gate_decisions)
+
+    def conflict_edges(self) -> Set[FrozenSet[str]]:
+        return set(self._conflict_edges)
+
+    def edges_from_records(self) -> Set[FrozenSet[str]]:
+        out: Set[FrozenSet[str]] = set()
+        for rec in self._records.values():
+            for other in rec.conflicts_with:
+                out.add(frozenset((rec.id, other)))
+        return out
+
+    def request_activation(self, rid: str, requested: str) -> Dict[str, str]:
+        """Spec scenario 'third-party proposed as always-on' — a logged gate.
+
+        ``always-on`` is granted to a third-party record ONLY when license-clean
+        (SPDX present, not NONE) AND conflict-free AND not supply-chain-vetoed.
+        Refusals keep the derived tier and record the reason.
+        """
+        rec = self._records.get(rid)
+        if rec is None:
+            raise KeyError(rid)
+        if requested not in ACTIVATION_TIERS:
+            raise ValueError(f"unknown activation tier: {requested}")
+        decision = {"id": rid, "requested": requested, "granted": rec.activation, "reason": ""}
+        if requested == "always-on" and rec.category == "third-party":
+            if rec.license_spdx == "NONE":
+                decision["reason"] = "refused: license_spdx=NONE (license-clean gate)"
+            elif rec.conflicts_with:
+                decision["reason"] = (
+                    f"refused: conflicts_with={','.join(rec.conflicts_with)} (conflict-free gate)"
+                )
+            elif rec.security_status != "vetted":
+                decision["reason"] = f"refused: security_status={rec.security_status}"
+            else:
+                decision["granted"] = "always-on"
+                decision["reason"] = "granted: license-clean + conflict-free + vetted"
+        elif requested == "always-on":
+            decision["granted"] = "always-on"
+            decision["reason"] = "granted: first-party"
+        else:
+            decision["granted"] = requested
+            decision["reason"] = "granted: non-privileged tier"
+        self._gate_decisions.append(
+            {"id": rid, "activation": decision["granted"], "reason": decision["reason"]}
+        )
+        return decision
+
+    def eject_candidates(self, today: str) -> List[str]:
+        """Freshness invariant: ttl deadline passed → eject-candidate (HITL)."""
+        out = []
+        for rec in self.records():
+            if rec.ttl and today > rec.ttl:
+                out.append(rec.id)
+        return out
+
+    # ------------------------------------------------------------ outputs ---
+    def to_yaml(self) -> str:
+        header = (
+            "# AUTO-GENERATED by lib/registry/hub_registry.py — DO NOT EDIT.\n"
+            f"# schema: {HUB_REGISTRY_SCHEMA_VERSION}\n"
+        )
+        body = yaml.safe_dump(
+            {"records": [r.to_dict() for r in self.records()]},
+            sort_keys=False,
+            allow_unicode=True,
+        )
+        return header + body
+
+    def report(self, today: Optional[str] = None) -> Dict[str, Any]:
+        """The logged-field acceptance surface (DoD-gate — never prose)."""
+        recs = self.records()
+        required_ok = all(
+            all(k in r.to_dict() for k in (
+                "id", "owner_repo", "layer", "role", "category", "harness_coverage",
+                "requires", "conflicts_with", "guardrails", "impact", "recipes",
+                "activation", "license_spdx", "provenance", "ttl", "last_validated",
+                "rollback", "security_status",
+            ))
+            for r in recs
+        )
+        vocab_ok = all(r.activation in ACTIVATION_TIERS for r in recs)
+        roundtrip = self.conflict_edges() == self.edges_from_records()
+        third_party_always_on = [
+            r.id for r in recs if r.category == "third-party" and r.activation == "always-on"
+        ]
+        invariants = {
+            "schema_version": HUB_REGISTRY_SCHEMA_VERSION,
+            "total_records": len(recs),
+            "all_required_fields_present": required_ok,
+            "activation_vocab_valid": vocab_ok,
+            "conflicts_roundtrip": roundtrip,
+            "third_party_always_on": third_party_always_on,
+        }
+        if today:
+            invariants["eject_candidates"] = self.eject_candidates(today)
+        ok = required_ok and vocab_ok and roundtrip and not third_party_always_on
+        return {
+            "verdict": "pass" if ok else "fail",
+            "invariants": invariants,
+            "gate_decisions": self.gate_decisions,
+        }
+
+
+def _load_conductors(path: Path) -> Set[str]:
+    if not path.is_file():
+        return set()
+    out: Set[str] = set()
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if line and not line.startswith("#"):
+            out.add(line)
+    return out
+
+
+def _load_recipes(path: Path) -> Dict[str, List[str]]:
+    by_id: Dict[str, List[str]] = {}
+    if not path.is_file():
+        return by_id
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    for recipe in data.get("recipes", []):
+        rid = str(recipe.get("id"))
+        for tool in _flatten_stack(recipe.get("stack", [])):
+            by_id.setdefault(tool, []).append(rid)
+    return by_id
+
+
+def _main(argv: List[str]) -> int:
+    """CLI: derive over the live repo and print the report (exit 1 on fail)."""
+    here = Path(__file__).resolve()
+    repo_root = here.parents[4]  # lib/registry/x.py -> lib -> maos-mcp-hub -> mcp-tools -> ROOT
+    as_of = "1970-01-01"
+    today = None
+    args = list(argv)
+    while args:
+        a = args.pop(0)
+        if a == "--repo-root" and args:
+            repo_root = Path(args.pop(0)).resolve()
+        elif a == "--as-of" and args:
+            as_of = args.pop(0)
+        elif a == "--today" and args:
+            today = args.pop(0)
+    if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson)
+        print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
+        return 1
+    reg = HubRegistry.derive(repo_root, as_of=as_of)
+    report = reg.report(today=today)
+    print(json.dumps(report, indent=2, ensure_ascii=False))
+    return 0 if report["verdict"] == "pass" else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_main(sys.argv[1:]))

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registry.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registry.py
@@ -1,0 +1,213 @@
+"""Tests — HubRegistry (T1 / WAVE 5): the spec's Scenarios as logged fields.
+
+Spec: openspec/specs/maos-hub-registry/spec.md — each test names the
+Requirement/Scenario it reproduces (the DoD-gate: no prose-judged acceptance).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lib.registry import ACTIVATION_TIERS, HubRecord, HubRegistry
+
+_HERE = Path(__file__).resolve()
+_HUB_DIR = _HERE.parents[1]           # mcp-tools/maos-mcp-hub
+_REPO_ROOT = _HERE.parents[3]         # repo root
+
+AS_OF = "2026-07-02"
+
+
+@pytest.fixture(scope="module")
+def registry() -> HubRegistry:
+    assert (_REPO_ROOT / "skills").is_dir(), "repo-root resolution broke (Qodo lesson)"
+    return HubRegistry.derive(_REPO_ROOT, as_of=AS_OF)
+
+
+# --- Requirement: Records are derived, not hand-maintained -----------------
+
+def test_golden_derivation_over_real_repo(registry: HubRegistry) -> None:
+    cats = {r.category for r in registry.records()}
+    assert {"skill", "agent", "third-party"} <= cats
+    skills = [r for r in registry.records() if r.category == "skill"]
+    third = [r for r in registry.records() if r.category == "third-party"]
+    assert len(skills) >= 40          # the repo ships 60+ skills
+    assert len(third) == 32           # 26 INCLUDED + graphiti + 5 EXCLUDED (WT10 fixture)
+
+
+def test_every_record_is_derived_with_provenance(registry: HubRegistry) -> None:
+    for rec in registry.records():
+        assert rec.derived_from, rec.id
+        assert rec.provenance, rec.id
+
+
+def test_scenario_a_new_skill_ships(tmp_path: Path) -> None:
+    """Scenario: a new skill ships -> its record is (re)generated."""
+    skills = tmp_path / "skills" / "brand-new-skill"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text(
+        "---\nname: brand-new-skill\ndescription: synthetic\nversion: 0.0.1\n---\n# X\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "agents").mkdir()
+    reg = HubRegistry.derive(tmp_path, as_of=AS_OF)
+    rec = reg.get("brand-new-skill")
+    assert rec is not None
+    assert rec.category == "skill"
+    assert rec.last_validated == AS_OF
+    assert rec.derived_from == "skills/brand-new-skill/SKILL.md"
+
+
+# --- Requirement: schema completeness + vocabulary --------------------------
+
+def test_all_required_spec_fields_present(registry: HubRegistry) -> None:
+    report = registry.report()
+    assert report["invariants"]["all_required_fields_present"] is True
+
+
+def test_activation_vocabulary_valid(registry: HubRegistry) -> None:
+    for rec in registry.records():
+        assert rec.activation in ACTIVATION_TIERS, (rec.id, rec.activation)
+
+
+# --- Requirement: Activation gating -----------------------------------------
+
+def test_excluded_verdicts_are_excluded(registry: HubRegistry) -> None:
+    """The supply-chain vetoes (GSD rug-pull, MemPalace) can never route."""
+    for rid in ("gsd-build-get-shit-done", "mempalace"):
+        rec = registry.get(rid)
+        assert rec is not None
+        assert rec.activation == "excluded"
+        assert rec.security_status == "supply-chain-veto"
+
+
+def test_no_third_party_is_always_on_at_derivation(registry: HubRegistry) -> None:
+    report = registry.report()
+    assert report["invariants"]["third_party_always_on"] == []
+
+
+def test_conductor_class_never_default_on(registry: HubRegistry) -> None:
+    """RULE-011: a conductor-class third-party is capped at opt-in/excluded."""
+    for rid in ("base", "superpowers", "gstack", "ECC", "ruflo", "bmad-method"):
+        rec = registry.get(rid)
+        assert rec is not None, rid
+        assert rec.activation in ("opt-in", "excluded"), (rid, rec.activation)
+        assert rec.activation_reason, rid
+
+
+def test_scenario_third_party_always_on_refused_license_none(registry: HubRegistry) -> None:
+    """Scenario: license_spdx=NONE -> always-on refused, reason recorded."""
+    decision = registry.request_activation("karpathy-claude-md", "always-on")
+    assert decision["granted"] != "always-on"
+    assert "license" in decision["reason"]
+
+
+def test_scenario_third_party_always_on_refused_conflict_edge(registry: HubRegistry) -> None:
+    """Scenario: a conflicts_with edge -> always-on refused (mem0 x letta/cognee)."""
+    rec = registry.get("mem0")
+    assert rec is not None and rec.conflicts_with  # Apache-2.0, but conflicted
+    decision = registry.request_activation("mem0", "always-on")
+    assert decision["granted"] != "always-on"
+    assert "conflict" in decision["reason"]
+
+
+def test_third_party_clean_always_on_grant_path(registry: HubRegistry) -> None:
+    """A license-clean, conflict-free, vetted third-party CAN pass the gate."""
+    clean = [
+        r for r in registry.records()
+        if r.category == "third-party" and r.license_spdx != "NONE"
+        and not r.conflicts_with and r.security_status == "vetted"
+    ]
+    assert clean, "fixture should contain at least one gate-clean third-party"
+    decision = registry.request_activation(clean[0].id, "always-on")
+    assert decision["granted"] == "always-on"
+
+
+# --- Requirement: Incompatibility is queryable -------------------------------
+
+def test_conflicts_roundtrip_phase2(registry: HubRegistry) -> None:
+    """The conflicts_with graph round-trips conflicts.yaml exactly."""
+    assert registry.conflict_edges(), "conflicts.yaml must load"
+    assert registry.conflict_edges() == registry.edges_from_records()
+    report = registry.report()
+    assert report["invariants"]["conflicts_roundtrip"] is True
+
+
+def test_every_conflict_endpoint_resolves_to_a_record(registry: HubRegistry) -> None:
+    """Scenario 'two conductors selected' presupposes both endpoints exist."""
+    ids = {r.id for r in registry.records()}
+    for edge in registry.conflict_edges():
+        for endpoint in edge:
+            assert endpoint in ids, f"conflict endpoint without record: {endpoint}"
+
+
+# --- Requirement: Real license + provenance ----------------------------------
+
+def test_license_classified_never_assumed(registry: HubRegistry) -> None:
+    for rec in registry.records():
+        assert rec.license_spdx, rec.id          # never empty
+    assert registry.get("karpathy-claude-md").license_spdx == "NONE"   # not "MIT-assumed"
+    assert registry.get("mem0").license_spdx == "Apache-2.0"
+
+
+# --- Requirement: Freshness + rollback ---------------------------------------
+
+def test_scenario_upstream_goes_stale(registry: HubRegistry) -> None:
+    """Scenario: now - last_validated > ttl -> eject-candidate."""
+    fresh = registry.eject_candidates("2026-08-01")   # before revisit 2026-09-27
+    stale = registry.eject_candidates("2026-12-01")   # after revisit
+    third = [r.id for r in registry.records() if r.category == "third-party"]
+    assert fresh == []
+    assert set(stale) == set(third)                   # every fixture record shares the TTL
+    report = registry.report(today="2026-12-01")
+    assert set(report["invariants"]["eject_candidates"]) == set(third)
+
+
+def test_every_record_has_rollback(registry: HubRegistry) -> None:
+    for rec in registry.records():
+        assert rec.rollback, rec.id
+
+
+# --- Requirement: recipes (Phase-2 promotion) --------------------------------
+
+def test_recipes_derived_from_promotion(registry: HubRegistry) -> None:
+    rec = registry.get("mem0")
+    assert rec is not None
+    assert "new-idea-to-mvp" in rec.recipes
+    assert "production-deploy" in rec.recipes
+
+
+def test_recipe_stack_ids_resolve(registry: HubRegistry) -> None:
+    """Every tool id named by a recipe stack resolves to a registry record."""
+    import yaml as _yaml
+    data = _yaml.safe_load(
+        (_HUB_DIR / "lib" / "gateway" / "recipes.yaml").read_text(encoding="utf-8")
+    )
+    ids = {r.id for r in registry.records()}
+    for recipe in data["recipes"]:
+        for item in recipe["stack"]:
+            for tool in (item if isinstance(item, list) else [item]):
+                assert tool in ids, f"recipe {recipe['id']} names unknown tool: {tool}"
+
+
+# --- Outputs ------------------------------------------------------------------
+
+def test_yaml_projection_is_stamped_auto_generated(registry: HubRegistry) -> None:
+    out = registry.to_yaml()
+    assert out.startswith("# AUTO-GENERATED")
+    assert "records:" in out
+
+
+def test_cli_contract() -> None:
+    proc = subprocess.run(
+        [sys.executable, "-m", "lib.registry.hub_registry",
+         "--repo-root", str(_REPO_ROOT), "--as-of", AS_OF],
+        cwd=_HUB_DIR, capture_output=True, text=True, timeout=120,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    assert payload["verdict"] == "pass"


### PR DESCRIPTION
**[PR-as-Prompt]**

## Context
**WAVE 5 / T1** (`openspec/changes/maos-hub-console/tasks.md`; tracking issue #204; GO do operador na sessão /quiesce de 2026-07-02). T1 é o keystone da WAVE 5 — o registry SSOT que a console (T2–T6) e o integrator (WAVE 6) leem. Ordem obrigatória: **T1 → T2 primeiro**.

## What
`HubRegistry` (`lib/registry/hub_registry.py`) — the **plugin-level** registry SSOT per `openspec/specs/maos-hub-registry/spec.md`, sibling of WT8's gateway-scoped `ToolRegistry` (#200):

- **Derived, never hand-maintained**: records auto-derived from `skills/*/SKILL.md` + `agents/*.md` frontmatter (own), `evals/fixtures/intake_verdicts.yaml` (third-party — license/provenance/verdict), `lib/gateway/conflicts.yaml` (WAVE-0 Phase-2 incompatibilities) and `conductors.txt` (RULE-011). `derived_from` on every record = the checkable field.
- **`recipes.yaml`** — Phase-2 §4 composition recipes promoted into structured data (one-time curated promotion, sibling of `conflicts.yaml`, source-cited).
- **Full spec schema** per record: `activation` · `license_spdx` · `provenance` · `ttl`+`last_validated` · `rollback` · `conflicts_with` · `recipes` · `security_status` · …
- **Activation gate** (deterministic, documented): EXCLUDED/ABANDON→`excluded` · SUB-AGENT/DEFER→`opt-in` · INSTALL/ADAPT/ABSORB→`default-on-for-context` capped to `opt-in` on license-NONE / conductor-class / conflict-edge. `always-on` for third-party ONLY via `request_activation` passing license-clean + conflict-free + vetted (refusal reason logged in `gate_decisions`).

## Acceptance (tasks.md T1 + spec Scenarios — logged fields, not prose)
| Scenario | Checkable field / test |
|---|---|
| registry validates against the spec | `report().invariants.all_required_fields_present == true` |
| `conflicts_with` round-trips Phase-2 | `invariants.conflicts_roundtrip == true` + endpoint-resolution test |
| a new skill ships → record regenerated | synthetic-repo test (`test_scenario_a_new_skill_ships`) |
| third-party always-on refused (license NONE / conflict) | `request_activation` tests (karpathy-claude-md · mem0) |
| upstream stale → eject-candidate | `eject_candidates("2026-12-01")` == all 32 fixture records |

```bash
cd mcp-tools/maos-mcp-hub && python3 -m pytest tests/test_hub_registry.py -q   # 20 passed
python3 -m lib.registry.hub_registry --as-of 2026-07-02                        # verdict: pass, exit 0
```

## Test plan / regression
- 20 new tests green; full local suite delta vs pristine main = **identical** pre-existing env failures (py<3.10 union syntax + absent gateway deps) — zero regression; CI is the authoritative gate.
- `tests/validate-plugin.sh` ✓ PASSED · gitleaks clean.

## Risk + rollback
Additive (new package + one curated YAML; nothing existing modified). Rollback = revert squash commit. No plugin version bump (ADR-003).

## Refs
Issue #204 (WAVE 5 T1) · `openspec/specs/maos-hub-registry/spec.md` · ADR-006/ADR-007 · WT8 #200 (gateway sibling) · WT10 #201 (intake fixture source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
