### PR TITLE
feat(maos-hub): profile-as-gating-input (T2/WAVE-5) — persisted enablement profile wired into gateway routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — profile-as-gating-input (T2 / WAVE 5) — the persisted enablement profile the hub honors
+
+- **`mcp-tools/maos-mcp-hub/lib/gateway/profile.py`** — `HubProfile` + `load_profile()` (resolution:
+  arg > `$MAOS_HUB_PROFILE` > `<hub>/profile.yaml` > None) + `resolver_from_profile()` — the
+  persisted enablement-profile SSOT the WAVE-0 gating seam was waiting for (*"the active profile
+  comes from OUTSIDE"*). Absent profile / `mode: advisory` / empty ⇒ `None` ⇒ passthrough
+  (pre-WAVE-5 behaviour, 0-regression); a PRESENT-but-invalid profile raises `ProfileError`
+  (fail-closed — never silently disables gating). `validate_profile(profile, registry)` refuses a
+  profile enabling an `activation=excluded` id (supply-chain vetoes can't be re-enabled via YAML).
+- **`hub.py` wiring** — ONE shared profile-derived `PolicyResolver` attached to every gateway
+  router at mount (`router.policy = _hub_policy`); stderr banner when a profile is ENFORCED or
+  loaded advisory-only.
+- **`lib/gateway/policy.py`** — every DENY is now a **logged field**: recorded in
+  `PolicyResolver.decisions` (bounded ring, `DECISION_LOG_MAXLEN=200`) + mirrored to
+  `logging` (`maos_hub.policy` warning). Additive — decision semantics unchanged.
+- **`profile.yaml.example`** — documented template (copy to `profile.yaml` to activate).
+- **tasks.md T2 acceptance as logged fields (DoD-gate):** disabled tool → dispatch returns the
+  structured `Blocked by policy` envelope AND `resolver.decisions[-1]` carries
+  `{tool_id, allow: false, reason}`; conflicting tool → denied with `conflicting_with` populated
+  (11 tests in `tests/test_gateway_profile.py`; ring-bound proof; registry fail-closed proof).
+  Local suite delta vs pristine main = identical pre-existing env failures — zero regression.
+
+
 ### Added — hub-registry SSOT (T1 / WAVE 5) — plugin-level registry, derived not hand-maintained
 
 - **`mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py`** — `HubRegistry`: the plugin-level

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -303,6 +303,26 @@ try:
         "common": "gateways.common.gateway",
     }
 
+    # T2 (WAVE-5): profile-as-gating-input — ONE shared resolver derived from
+    # the persisted enablement profile (lib/gateway/profile.py), attached to
+    # every gateway router below. No profile file / mode=advisory / empty
+    # profile => None => passthrough (the pre-WAVE-5 behaviour, 0-regression).
+    # A PRESENT-but-invalid profile fails LOUDLY (fail-closed): silently
+    # falling back to passthrough would disable gating without notice.
+    from lib.gateway.profile import load_profile, resolver_from_profile
+
+    _hub_profile = load_profile()          # ProfileError propagates (fail-closed)
+    _hub_policy = resolver_from_profile(_hub_profile)
+    if _hub_policy is not None:
+        sys.stderr.write(
+            f"  \U0001F512 gating profile ENFORCED: "
+            f"{len(_hub_profile.enabled)} enabled ids ({_hub_profile.source})\n"
+        )
+    elif _hub_profile is not None:
+        sys.stderr.write(
+            f"  \U0001F513 gating profile loaded ADVISORY-only ({_hub_profile.source})\n"
+        )
+
     gateway_errors: List[str] = []
 
     for gw_name, actions_module_path in _GATEWAY_MODULES.items():
@@ -329,6 +349,8 @@ try:
                 actions_mod = importlib.import_module(actions_module_path)
                 build_router_fn = getattr(actions_mod, "build_router")
                 router = build_router_fn()
+                # T2 (WAVE-5): the profile-derived policy gates every dispatch.
+                router.policy = _hub_policy
                 action_count = router.action_count
 
                 def _register_gateway(r, tn, desc):

--- a/mcp-tools/maos-mcp-hub/lib/gateway/policy.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/policy.py
@@ -28,11 +28,18 @@ but callers/tests may inject their own edge-list or profile.
 
 from __future__ import annotations
 
+import logging
+from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
+from typing import Deque, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
 
 import yaml
+
+logger = logging.getLogger("maos_hub.policy")
+
+#: Bounded ring of recorded deny decisions (memory-safe on a hot path).
+DECISION_LOG_MAXLEN = 200
 
 
 @dataclass
@@ -68,6 +75,9 @@ class PolicyResolver:
         self._conflicts: Dict[str, Set[str]] = {}
         for a, b in conflicts or []:
             self._add_edge(a, b)
+        # T2 (WAVE-5): every DENY is recorded here (the "decision is logged"
+        # acceptance — a checkable field, not prose) + mirrored to `logging`.
+        self._decisions: Deque[Dict[str, object]] = deque(maxlen=DECISION_LOG_MAXLEN)
 
     # -- construction helpers ------------------------------------------------
 
@@ -105,8 +115,8 @@ class PolicyResolver:
 
         # Disabled: the tool is not part of the active profile.
         if tool_id not in self._profile:
-            return PolicyDecision(
-                allow=False,
+            return self._deny(
+                tool_id,
                 reason=(
                     f"Tool '{tool_id}' is not enabled in the active profile "
                     f"(disabled by policy)."
@@ -116,8 +126,8 @@ class PolicyResolver:
         # Conflict: the tool clashes with something already active.
         clashes = sorted(self._conflicts.get(tool_id, set()) & self._profile)
         if clashes:
-            return PolicyDecision(
-                allow=False,
+            return self._deny(
+                tool_id,
                 reason=(
                     f"Tool '{tool_id}' conflicts with active tool(s): "
                     f"{', '.join(clashes)}."
@@ -126,6 +136,30 @@ class PolicyResolver:
             )
 
         return PolicyDecision(allow=True)
+
+    def _deny(
+        self,
+        tool_id: str,
+        reason: str,
+        conflicting_with: Optional[List[str]] = None,
+    ) -> PolicyDecision:
+        """Record + log a deny (T2: the routing decision is a logged field)."""
+        record: Dict[str, object] = {
+            "tool_id": tool_id,
+            "allow": False,
+            "reason": reason,
+            "conflicting_with": list(conflicting_with or []),
+        }
+        self._decisions.append(record)
+        logger.warning("policy deny: %s — %s", tool_id, reason)
+        return PolicyDecision(
+            allow=False, reason=reason, conflicting_with=list(conflicting_with or [])
+        )
+
+    @property
+    def decisions(self) -> List[Dict[str, object]]:
+        """The recorded deny decisions (bounded ring, oldest first)."""
+        return list(self._decisions)
 
     # -- loading -------------------------------------------------------------
 

--- a/mcp-tools/maos-mcp-hub/lib/gateway/profile.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/profile.py
@@ -1,0 +1,142 @@
+"""
+HubProfile — the persisted enablement-profile SSOT (T2 / WAVE 5, ADR-006/007).
+
+The WAVE-0 gating seam (``lib/gateway/policy.py``) is deliberately dumb: the
+active profile "comes from OUTSIDE — the resolver does not discover or compute
+it". THIS module is that outside: it persists/loads the operator's enablement
+profile and turns it into the ``PolicyResolver`` the hub attaches to every
+gateway router (``openspec/changes/maos-hub-console/tasks.md`` T2: *"persist an
+enablement profile SSOT; wire the MAOS Hub gating to honor it"*).
+
+Profile file schema (YAML)::
+
+    schema_version: hub-profile/1.0.0
+    mode: enforce            # enforce | advisory
+    enabled:                 # the ids the operator turned ON
+      - get_issue
+      - list_pages
+
+Resolution order (first hit wins)::
+
+    explicit ``path`` arg  >  $MAOS_HUB_PROFILE  >  <hub dir>/profile.yaml  >  None
+
+Safety posture (all fail-safe toward today's behaviour):
+
+  - **Absent profile => passthrough.** ``load_profile()`` returns ``None`` and
+    ``resolver_from_profile(None)`` returns ``None`` => ``router.policy=None``
+    => the pre-WAVE-5 zero-gating behaviour. Nothing changes until an operator
+    persists a profile with ``mode: enforce``.
+  - **advisory mode => loaded but NOT enforced** (the console can display it;
+    routing is untouched).
+  - **Fail-closed vs the registry** (spec ``maos-hub-registry`` → Activation
+    gating): ``validate_profile(profile, registry)`` rejects a profile that
+    enables an id the HubRegistry classifies ``activation=excluded`` — a
+    supply-chain veto cannot be re-enabled by editing YAML.
+  - **Denials are LOGGED fields**: the resolver built here records every deny
+    in ``PolicyResolver.decisions`` (bounded ring) and emits a
+    ``logging`` warning — the T2 acceptance ("the decision is logged").
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, List, Optional, Tuple
+
+import yaml
+
+from .policy import PolicyResolver
+
+PROFILE_SCHEMA_VERSION = "hub-profile/1.0.0"
+PROFILE_ENV_VAR = "MAOS_HUB_PROFILE"
+PROFILE_MODES = ("enforce", "advisory")
+
+_HUB_DIR = Path(__file__).resolve().parents[2]  # lib/gateway/x.py -> lib -> hub dir
+DEFAULT_PROFILE_PATH = _HUB_DIR / "profile.yaml"
+
+
+class ProfileError(ValueError):
+    """A profile file exists but is invalid — fail loudly, never half-load."""
+
+
+@dataclass(frozen=True)
+class HubProfile:
+    """The parsed enablement profile (the SSOT record, not the resolver)."""
+
+    enabled: Tuple[str, ...]
+    mode: str
+    source: str
+    schema_version: str = PROFILE_SCHEMA_VERSION
+
+    def to_dict(self) -> dict:
+        return {
+            "schema_version": self.schema_version,
+            "mode": self.mode,
+            "enabled": list(self.enabled),
+            "source": self.source,
+        }
+
+
+def load_profile(path: Optional[Path] = None) -> Optional[HubProfile]:
+    """Load the profile SSOT, or ``None`` when no profile is persisted.
+
+    Resolution order: ``path`` arg > ``$MAOS_HUB_PROFILE`` > the default
+    ``<hub>/profile.yaml``. A missing file at the resolved location => None
+    (passthrough). A PRESENT-but-invalid file raises ``ProfileError``.
+    """
+    resolved: Optional[Path]
+    if path is not None:
+        resolved = Path(path)
+    elif os.environ.get(PROFILE_ENV_VAR):
+        resolved = Path(os.environ[PROFILE_ENV_VAR])
+    else:
+        resolved = DEFAULT_PROFILE_PATH
+    if not resolved.is_file():
+        return None
+
+    try:
+        raw = yaml.safe_load(resolved.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ProfileError(f"profile is not valid YAML: {resolved}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ProfileError(f"profile must be a mapping: {resolved}")
+
+    mode = str(raw.get("mode", "enforce"))
+    if mode not in PROFILE_MODES:
+        raise ProfileError(f"profile mode must be one of {PROFILE_MODES}, got: {mode!r}")
+    enabled_raw = raw.get("enabled", [])
+    if not isinstance(enabled_raw, list):
+        raise ProfileError(f"profile 'enabled' must be a list: {resolved}")
+    enabled = tuple(str(x) for x in enabled_raw)
+    schema = str(raw.get("schema_version", PROFILE_SCHEMA_VERSION))
+    return HubProfile(enabled=enabled, mode=mode, source=str(resolved), schema_version=schema)
+
+
+def validate_profile(profile: HubProfile, registry: Any) -> List[str]:
+    """Fail-closed guard vs the HubRegistry (spec: Activation gating).
+
+    Returns a list of violations (empty == valid). ``registry`` is a
+    ``lib.registry.HubRegistry`` (duck-typed: needs ``get(id)``).
+    """
+    errors: List[str] = []
+    for tid in profile.enabled:
+        rec = registry.get(tid)
+        if rec is not None and rec.activation == "excluded":
+            errors.append(
+                f"profile enables '{tid}' but the registry classifies it "
+                f"activation=excluded ({rec.security_status}) — refused (fail-closed)"
+            )
+    return errors
+
+
+def resolver_from_profile(
+    profile: Optional[HubProfile],
+    conflicts_path: Optional[Path] = None,
+) -> Optional[PolicyResolver]:
+    """Build the enforcing resolver, or ``None`` (passthrough) when there is
+    nothing to enforce: no profile, ``mode: advisory``, or an empty profile.
+    """
+    if profile is None or profile.mode != "enforce" or not profile.enabled:
+        return None
+    return PolicyResolver.from_yaml(path=conflicts_path, profile=profile.enabled)

--- a/mcp-tools/maos-mcp-hub/profile.yaml.example
+++ b/mcp-tools/maos-mcp-hub/profile.yaml.example
@@ -1,0 +1,28 @@
+# MAOS Hub enablement profile — the persisted gating-input SSOT (T2 / WAVE 5).
+#
+# COPY to `profile.yaml` (same directory) — or point $MAOS_HUB_PROFILE at a
+# path — to activate. NO profile file => passthrough (nothing is gated).
+#
+# mode:
+#   enforce   — the hub attaches a PolicyResolver to every gateway router:
+#               an operation NOT in `enabled` (or conflicting per
+#               lib/gateway/conflicts.yaml) is refused pre-dispatch with a
+#               structured error envelope; every deny is a logged field
+#               (PolicyResolver.decisions + logging warning).
+#   advisory  — the profile is loaded (console can display it) but routing
+#               is untouched.
+#
+# Fail-closed notes:
+#   - a present-but-invalid profile aborts hub startup (never silently
+#     falls back to passthrough);
+#   - the console (T3) validates a profile against the hub-registry before
+#     persisting it: ids with activation=excluded are refused
+#     (lib/gateway/profile.py::validate_profile).
+
+schema_version: hub-profile/1.0.0
+mode: enforce
+enabled:
+  # gateway operation ids to allow, e.g.:
+  # - get_issue
+  # - search_issues
+  # - list_pages

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_profile.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_profile.py
@@ -1,0 +1,171 @@
+"""Tests — HubProfile + profile-as-gating-input wiring (T2 / WAVE 5).
+
+tasks.md T2 acceptance, as logged fields (the DoD-gate):
+  "a disabled/conflicting tool is not routed; the decision is logged."
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from lib.gateway.policy import PolicyResolver
+from lib.gateway.profile import (
+    PROFILE_ENV_VAR,
+    HubProfile,
+    ProfileError,
+    load_profile,
+    resolver_from_profile,
+    validate_profile,
+)
+from lib.gateway.router import MetaToolRouter
+from lib.gateway.types import GatewayRequest
+
+_HUB_DIR = Path(__file__).resolve().parents[1]
+_REPO_ROOT = _HUB_DIR.parents[1]
+
+
+# ---------------------------------------------------------------------- helpers
+
+async def _mock_get_issue(issue_key: str) -> Dict[str, Any]:
+    return {"key": issue_key}
+
+
+async def _mock_create_issue(project_key: str, summary: str) -> Dict[str, Any]:
+    return {"key": f"{project_key}-1", "summary": summary}
+
+
+def _build_router(policy=None) -> MetaToolRouter:
+    router = MetaToolRouter(tool_name="atlassian_jira", policy=policy)
+    router.register("issue", "get", _mock_get_issue, description="Get issue")
+    router.register("issue", "create", _mock_create_issue, description="Create issue")
+    return router
+
+
+def _write_profile(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "profile.yaml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ------------------------------------------------------------------ load_profile
+
+def test_absent_profile_is_none_and_passthrough(tmp_path: Path) -> None:
+    assert load_profile(tmp_path / "missing.yaml") is None
+    assert resolver_from_profile(None) is None
+
+
+def test_profile_parses_schema(tmp_path: Path) -> None:
+    p = _write_profile(
+        tmp_path,
+        "schema_version: hub-profile/1.0.0\nmode: enforce\nenabled: [get]\n",
+    )
+    prof = load_profile(p)
+    assert prof is not None
+    assert prof.mode == "enforce"
+    assert prof.enabled == ("get",)
+    assert prof.source == str(p)
+
+
+def test_env_var_resolution(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    p = _write_profile(tmp_path, "mode: enforce\nenabled: [x]\n")
+    monkeypatch.setenv(PROFILE_ENV_VAR, str(p))
+    prof = load_profile()
+    assert prof is not None and prof.enabled == ("x",)
+
+
+def test_invalid_profile_fails_loudly(tmp_path: Path) -> None:
+    p = _write_profile(tmp_path, "mode: bogus\nenabled: []\n")
+    with pytest.raises(ProfileError):
+        load_profile(p)
+    p2 = _write_profile(tmp_path, "- not\n- a\n- mapping\n")
+    with pytest.raises(ProfileError):
+        load_profile(p2)
+
+
+def test_advisory_mode_is_not_enforced(tmp_path: Path) -> None:
+    p = _write_profile(tmp_path, "mode: advisory\nenabled: [get]\n")
+    prof = load_profile(p)
+    assert prof is not None and prof.mode == "advisory"
+    assert resolver_from_profile(prof) is None
+
+
+def test_empty_enabled_is_not_enforced(tmp_path: Path) -> None:
+    p = _write_profile(tmp_path, "mode: enforce\nenabled: []\n")
+    assert resolver_from_profile(load_profile(p)) is None
+
+
+# --------------------------------------------- acceptance: not routed + logged
+
+def test_disabled_tool_is_not_routed_and_decision_logged(tmp_path: Path) -> None:
+    """T2 acceptance (half 1): a DISABLED tool is not routed; deny is logged."""
+    p = _write_profile(tmp_path, "mode: enforce\nenabled: [get]\n")
+    resolver = resolver_from_profile(load_profile(p))
+    assert isinstance(resolver, PolicyResolver)
+    router = _build_router(policy=resolver)
+
+    result = asyncio.run(
+        router.dispatch(GatewayRequest(resource="issue", operation="create",
+                                       params={"project_key": "X", "summary": "s"}))
+    )
+    assert "error" in result and "Blocked by policy" in result["error"]
+
+    allowed = asyncio.run(
+        router.dispatch(GatewayRequest(resource="issue", operation="get",
+                                       params={"issue_key": "X-1"}))
+    )
+    assert allowed.get("key") == "X-1"
+
+    # The decision is a LOGGED FIELD (not prose):
+    denies = resolver.decisions
+    assert denies and denies[-1]["tool_id"] == "create"
+    assert denies[-1]["allow"] is False
+    assert "disabled by policy" in str(denies[-1]["reason"])
+
+
+def test_conflicting_tool_is_denied_and_decision_logged() -> None:
+    """T2 acceptance (half 2): a CONFLICTING tool is denied; deny is logged."""
+    resolver = PolicyResolver(profile=["ECC", "gstack"], conflicts=[("ECC", "gstack")])
+    decision = resolver.check("gstack")
+    assert not decision.allow
+    assert decision.conflicting_with == ["ECC"]
+    denies = resolver.decisions
+    assert denies[-1]["tool_id"] == "gstack"
+    assert denies[-1]["conflicting_with"] == ["ECC"]
+
+
+def test_decision_log_is_bounded() -> None:
+    resolver = PolicyResolver(profile=["only"])
+    for i in range(500):
+        resolver.check(f"nope-{i}")
+    assert len(resolver.decisions) == 200  # DECISION_LOG_MAXLEN ring
+
+
+# --------------------------------------------- fail-closed vs the hub-registry
+
+def test_profile_enabling_excluded_id_is_refused() -> None:
+    """Spec (maos-hub-registry → Activation gating): supply-chain vetoes cannot
+    be re-enabled by editing a YAML profile."""
+    from lib.registry import HubRegistry
+
+    registry = HubRegistry.derive(_REPO_ROOT, as_of="2026-07-02")
+    bad = HubProfile(enabled=("mempalace", "get"), mode="enforce", source="test")
+    errors = validate_profile(bad, registry)
+    assert errors and "mempalace" in errors[0] and "excluded" in errors[0]
+
+    clean = HubProfile(enabled=("get",), mode="enforce", source="test")
+    assert validate_profile(clean, registry) == []
+
+
+# --------------------------------------------- regression: passthrough intact
+
+def test_no_policy_router_unchanged() -> None:
+    router = _build_router(policy=None)
+    result = asyncio.run(
+        router.dispatch(GatewayRequest(resource="issue", operation="create",
+                                       params={"project_key": "X", "summary": "s"}))
+    )
+    assert result.get("key") == "X-1"


### PR DESCRIPTION
**[PR-as-Prompt]**

## Context
**WAVE 5 / T2** (`openspec/changes/maos-hub-console/tasks.md`; issue #204; sequência obrigatória T1→T2 — T1 merged em #209). A costura WAVE-0 (#180) deixou o gating em `policy=None` de propósito: *"the active profile comes from OUTSIDE — the resolver does not discover or compute it"*. T2 é esse outside.

## What
- **`lib/gateway/profile.py`** — `HubProfile` (schema `hub-profile/1.0.0`: `mode: enforce|advisory` + `enabled[]`) + `load_profile()` (arg > `$MAOS_HUB_PROFILE` > `<hub>/profile.yaml` > None) + `resolver_from_profile()` + `validate_profile(profile, registry)` (fail-closed: id `activation=excluded` no hub-registry (T1) não pode ser re-habilitado por YAML).
- **`hub.py`** — um resolver compartilhado derivado do profile, anexado a TODOS os gateway routers no mount. Sem profile / advisory / vazio ⇒ passthrough (comportamento pré-WAVE-5, zero regressão). Profile presente-mas-inválido ⇒ aborta o startup (fail-closed, nunca degrada silenciosamente para passthrough).
- **`lib/gateway/policy.py`** (aditivo) — todo DENY vira **campo logado**: `PolicyResolver.decisions` (ring bounded, 200) + `logging` warning (`maos_hub.policy`).
- **`profile.yaml.example`** — template documentado.

## Acceptance (tasks.md T2 — logged fields, not prose)
> *"a disabled/conflicting tool is not routed; the decision is logged"*

| Proof | Test |
|---|---|
| disabled op → dispatch blocked (`Blocked by policy` envelope), handler NOT invoked | `test_disabled_tool_is_not_routed_and_decision_logged` |
| deny recorded: `decisions[-1] == {tool_id, allow: false, reason}` | idem |
| conflicting tool denied with `conflicting_with` populated + logged | `test_conflicting_tool_is_denied_and_decision_logged` |
| decision ring bounded (500 denies → 200 kept) | `test_decision_log_is_bounded` |
| excluded registry id in profile → refused (fail-closed) | `test_profile_enabling_excluded_id_is_refused` |
| passthrough regression intact (no profile ⇒ pre-WAVE-5 behaviour) | `test_no_policy_router_unchanged` + suite |

```bash
cd mcp-tools/maos-mcp-hub && python3 -m pytest tests/test_gateway_profile.py -q  # 11 passed
```
Full local suite: 161 passed; delta vs pristine main = identical pre-existing env failures (py<3.10 unions / absent gateway deps) — zero regression. `validate-plugin` ✓ · gitleaks clean.

## Risk + rollback
Additive; default path is byte-identical behaviour (no profile file ships active). Rollback = revert squash commit (or delete `profile.yaml` to return to passthrough at runtime).

## Refs
Issue #204 (WAVE 5 T2) · #209 (T1 registry — the fail-closed source) · #180 (WAVE-0 seam) · `openspec/specs/maos-hub-registry/spec.md` · ADR-006/007.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
