### PR TITLE
fix(maos-hub): profile bot-finding remediation — env-path hardening (CWE-22), schema fail-closed, real example ids (#210 PDCA)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — profile bot-finding remediation (post-merge PDCA of #210)
+
+- **amazon-q 🛑 (CWE-22)**: `$MAOS_HUB_PROFILE` is now normalized (`expanduser().resolve()`) and
+  restricted to `.yaml`/`.yml` targets — the hub can only be pointed at profile-shaped files
+  (raise `ProfileError` otherwise). Operator-set env remains the trust model; this removes the
+  raw-path read.
+- **Copilot: schema fail-closed** — an unsupported `schema_version` (≠ `hub-profile/1.x`) now
+  raises `ProfileError` instead of half-loading.
+- **Copilot ×2: example ids corrected** — docstring + `profile.yaml.example` now use the REAL
+  gateway operation tokens (`get`/`create`/`transition` …), with a pointer to level-1 discovery;
+  the previous `get_issue`-style examples would have produced a deny-everything profile.
+- Unused `dataclasses.field` import removed. +2 regression tests (13 green in the profile suite).
+
+
 ### Fixed — hub-registry bot-finding remediation (post-merge PDCA of #209)
 
 - **F2 (High — Copilot + Qodo): conductor gate was inert** — `_load_conductors()` stored the raw

--- a/mcp-tools/maos-mcp-hub/lib/gateway/profile.py
+++ b/mcp-tools/maos-mcp-hub/lib/gateway/profile.py
@@ -12,9 +12,9 @@ Profile file schema (YAML)::
 
     schema_version: hub-profile/1.0.0
     mode: enforce            # enforce | advisory
-    enabled:                 # the ids the operator turned ON
-      - get_issue
-      - list_pages
+    enabled:                 # gateway OPERATION tokens (the ids the router
+      - get                  # dispatches, e.g. issue/get, page/list -> the
+      - list                 # short operation name is what the policy checks)
 
 Resolution order (first hit wins)::
 
@@ -40,7 +40,7 @@ Safety posture (all fail-safe toward today's behaviour):
 from __future__ import annotations
 
 import os
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Iterable, List, Optional, Tuple
 
@@ -89,7 +89,14 @@ def load_profile(path: Optional[Path] = None) -> Optional[HubProfile]:
     if path is not None:
         resolved = Path(path)
     elif os.environ.get(PROFILE_ENV_VAR):
-        resolved = Path(os.environ[PROFILE_ENV_VAR])
+        # Hardening (PR #210 amazon-q, CWE-22): the env var is operator-set,
+        # but never feed it raw into filesystem reads — normalize and require
+        # a YAML suffix so the hub can only be pointed at profile-shaped files.
+        resolved = Path(os.environ[PROFILE_ENV_VAR]).expanduser().resolve()
+        if resolved.suffix.lower() not in (".yaml", ".yml"):
+            raise ProfileError(
+                f"${PROFILE_ENV_VAR} must point to a .yaml/.yml profile, got: {resolved}"
+            )
     else:
         resolved = DEFAULT_PROFILE_PATH
     if not resolved.is_file():
@@ -110,6 +117,12 @@ def load_profile(path: Optional[Path] = None) -> Optional[HubProfile]:
         raise ProfileError(f"profile 'enabled' must be a list: {resolved}")
     enabled = tuple(str(x) for x in enabled_raw)
     schema = str(raw.get("schema_version", PROFILE_SCHEMA_VERSION))
+    # Fail-closed (PR #210 Copilot): an unknown/incompatible schema line must
+    # not half-load — only the hub-profile/1.x contract is accepted.
+    if not schema.startswith("hub-profile/1."):
+        raise ProfileError(
+            f"unsupported profile schema_version {schema!r} (expected hub-profile/1.x): {resolved}"
+        )
     return HubProfile(enabled=enabled, mode=mode, source=str(resolved), schema_version=schema)
 
 

--- a/mcp-tools/maos-mcp-hub/profile.yaml.example
+++ b/mcp-tools/maos-mcp-hub/profile.yaml.example
@@ -22,7 +22,10 @@
 schema_version: hub-profile/1.0.0
 mode: enforce
 enabled:
-  # gateway operation ids to allow, e.g.:
-  # - get_issue
-  # - search_issues
-  # - list_pages
+  # gateway OPERATION tokens to allow — the short operation names the routers
+  # register (resource/operation), e.g. for atlassian_jira `issue`:
+  # - get
+  # - create
+  # - transition
+  # (discover the real tokens via the gateway's level-1 discovery:
+  #  atlassian_jira {resource: "issue"} lists its operations)

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_profile.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_profile.py
@@ -169,3 +169,23 @@ def test_no_policy_router_unchanged() -> None:
                                        params={"project_key": "X", "summary": "s"}))
     )
     assert result.get("key") == "X-1"
+
+
+# --- PR #210 bot-finding regressions ------------------------------------------
+
+def test_env_var_requires_yaml_suffix(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """amazon-q CWE-22 hardening: $MAOS_HUB_PROFILE only accepts .yaml/.yml."""
+    evil = tmp_path / "passwd"
+    evil.write_text("mode: enforce\nenabled: [x]\n", encoding="utf-8")
+    monkeypatch.setenv(PROFILE_ENV_VAR, str(evil))
+    with pytest.raises(ProfileError):
+        load_profile()
+
+
+def test_unknown_schema_version_fails_closed(tmp_path: Path) -> None:
+    """Copilot: an unsupported schema_version must raise, never half-load."""
+    p = _write_profile(
+        tmp_path, "schema_version: hub-profile/9.0.0\nmode: enforce\nenabled: [get]\n"
+    )
+    with pytest.raises(ProfileError):
+        load_profile(p)


### PR DESCRIPTION
**[PR-as-Correction-Prompt]**

Post-merge PDCA of #210. Triage: 4 real findings, all fixed.

| Finding | Severity | Fix |
|---|---|---|
| amazon-q: `$MAOS_HUB_PROFILE` raw path read (CWE-22) | 🛑 | normalize + `.yaml/.yml` suffix allowlist (ProfileError otherwise). Rationale: env is operator-set (local trust model), but no raw path should reach filesystem reads |
| Copilot: `schema_version` accepted unvalidated | High | only `hub-profile/1.x` accepted — fail-closed |
| Copilot ×2: example ids (`get_issue`) don't match real operation tokens → deny-everything profile | Med | examples now use real tokens (`get`/`create`/`transition`) + level-1 discovery pointer |
| amazon-q: unused `field` import | Low | removed |

+2 regression tests (env suffix rejection · unknown schema rejection); 13 green. validate-plugin ✓ · gitleaks clean.

Refs: #210 · issue #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)