### PR TITLE
feat(maos-hub): console setup/config modes (WAVE5/T3) — 6 registry views + HITL-gated profile write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`hub-profile/1.x`).
 - **`maos-concierge` v1.1.0**: +2 modes — `setup` (hub console) and `config` (profile SSOT
   inspect/validate) — composing T1+T2; reimplements nothing.
-- Tests: `tests/test_hub_console.py` — 21 tests (golden safe-mode fixture, byte-stability,
+- Tests: `tests/test_hub_console.py` — 28 tests (golden safe-mode fixture, byte-stability,
   conflict/excluded/confirm gates, T2 round-trip, live-repo CLI smoke).
+- **Pre-merge bot-finding remediation (PDCA on #214)**: atomic profile write (tmp+replace —
+  a truncated YAML would brick the fail-closed hub startup); empty selection refused
+  (`reason: empty_selection` — an empty enforce-profile is a silent passthrough); `mode`
+  vocabulary enforced at API level (not only CLI); `recipes.yaml` type-guards (malformed
+  root/items never crash a view); unknown CLI flags error instead of silently no-oping;
+  `validate_profile` (T2 SSOT) actually invoked before every write; token-plane surfacing —
+  enforce-profiles built from registry TOOL ids emit `warning: enforce_profile_gates_operations`
+  (the runtime gate checks gateway OPERATION tokens; plane unification tracked as T4–T6 design).
 
 ### Fixed — profile bot-finding remediation (post-merge PDCA of #210)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — hub console setup/config modes (WAVE 5 / T3, ADR-006 + ADR-007)
+
+- **`lib/registry/console.py`** (`mcp-tools/maos-mcp-hub`): `HubConsole` — deterministic ASCII
+  renderer + HITL-gated profile writer over the T1 `HubRegistry` and the T2 profile SSOT.
+  6 views (`preset · category · use-case · context-aware · prose-intent · safe-mode`), all
+  byte-stable projections of the DERIVED registry + the curated `recipes.yaml` catalog;
+  `--help` / `--safe-mode` CLI flags; optional `--html` artifact (ASCII first-class).
+  `context-aware`/`prose-intent` are registry-rendered scaffolds — engines land in T4/T5
+  (each view says so).
+- **Selection gates (logged fields, per the DoD-gate)**: `select --ids …` is conflict-checked
+  against BOTH edge sources (curated conflicts.yaml ∪ per-record `conflicts_with`) →
+  `verdict: refused` + `conflicts: [[a,b]]`; `activation=excluded` ids refused fail-closed;
+  **no `--confirm` → `written: false, reason: confirmation_required`** — the profile is NEVER
+  auto-applied. Confirmed writes round-trip through `lib.gateway.profile.load_profile`
+  (`hub-profile/1.x`).
+- **`maos-concierge` v1.1.0**: +2 modes — `setup` (hub console) and `config` (profile SSOT
+  inspect/validate) — composing T1+T2; reimplements nothing.
+- Tests: `tests/test_hub_console.py` — 21 tests (golden safe-mode fixture, byte-stability,
+  conflict/excluded/confirm gates, T2 round-trip, live-repo CLI smoke).
+
 ### Fixed — profile bot-finding remediation (post-merge PDCA of #210)
 
 - **amazon-q 🛑 (CWE-22)**: `$MAOS_HUB_PROFILE` is now normalized (`expanduser().resolve()`) and

--- a/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
@@ -11,3 +11,9 @@ from .hub_registry import (  # noqa: F401
     HubRecord,
     HubRegistry,
 )
+from .console import (  # noqa: F401
+    VIEWS,
+    HubConsole,
+    Recipe,
+    load_recipe_catalog,
+)

--- a/mcp-tools/maos-mcp-hub/lib/registry/console.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/console.py
@@ -14,12 +14,28 @@ Design position in the WAVE-5 chain (compose, don't reimplement):
     — every view is a projection of registry records + the curated
     ``recipes.yaml`` catalog. The console NEVER hand-maintains tool data.
   - **Writes** the enablement-profile SSOT (T2, ``lib/gateway/profile.py``)
-    — and ONLY after (a) conflict-check vs ``registry.conflict_edges()``,
-    (b) fail-closed ``validate_profile`` (excluded ids refused), and
-    (c) an explicit ``--confirm`` (the HITL gate). Without ``--confirm`` the
-    console emits the DRAFT it *would* write plus the logged field
-    ``{"written": false, "reason": "confirmation_required"}`` — it never
-    auto-applies (same posture T5 mandates for prose-intent).
+    — and ONLY after (a) conflict-check vs the UNION of both edge sources
+    (curated conflicts.yaml + per-record ``conflicts_with``), (b) fail-closed
+    refusal of ``activation=excluded`` ids (cross-checked with the T2
+    ``validate_profile`` guard before any write), (c) refusal of an EMPTY
+    selection (an empty ``enabled`` list silently disables enforcement —
+    ``resolver_from_profile`` treats it as passthrough), and (d) an explicit
+    ``--confirm`` (the HITL gate). Without ``--confirm`` the console emits the
+    DRAFT it *would* write plus the logged field ``{"written": false,
+    "reason": "confirmation_required"}`` — it never auto-applies (same
+    posture T5 mandates for prose-intent). Writes are ATOMIC (tmp + replace):
+    the hub loads the profile fail-closed at startup, so a truncated file
+    must be impossible.
+
+Token planes (honest boundary — surfaced, not hidden): the T2 profile's
+``enabled`` list is checked by the runtime gate per gateway OPERATION token
+(``get``, ``create`` … — see ``profile.yaml.example``), while the console's
+views/selection speak registry TOOL ids. Selecting registry ids under
+``mode: enforce`` therefore gates gateway operations OFF unless operation
+tokens are also enabled — ``select()`` emits the logged field
+``warning: enforce_profile_gates_operations`` whenever that applies. The
+plane unification (tool-tier gating riding the registry vs operation gating
+riding the profile) is a T4-T6/WAVE-6 design decision, tracked on the PR.
 
 Determinism contract (DoD-GATE): every view is byte-stable for the same
 registry input — records sorted by (tier-rank, id) or (category, id); no
@@ -47,11 +63,23 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import yaml
 
-# Package-relative first (hub runtime), path-injected fallback (pytest / CLI).
+# Package-relative first (hub runtime), path-injected fallback (direct CLI run:
+# `python3 lib/registry/console.py …` has no parent package — inject the hub
+# dir so `lib.*` absolute imports resolve).
 try:  # pragma: no cover - import plumbing
     from .hub_registry import ACTIVATION_TIERS, HubRecord, HubRegistry, _flatten_stack
+    from ..gateway.profile import PROFILE_MODES, HubProfile, validate_profile
 except ImportError:  # pragma: no cover
-    from hub_registry import ACTIVATION_TIERS, HubRecord, HubRegistry, _flatten_stack  # type: ignore
+    _HUB_ROOT = str(Path(__file__).resolve().parents[2])  # lib/registry -> lib -> hub dir
+    if _HUB_ROOT not in sys.path:
+        sys.path.insert(0, _HUB_ROOT)
+    from lib.registry.hub_registry import (  # type: ignore
+        ACTIVATION_TIERS,
+        HubRecord,
+        HubRegistry,
+        _flatten_stack,
+    )
+    from lib.gateway.profile import PROFILE_MODES, HubProfile, validate_profile  # type: ignore
 
 VIEWS = ("preset", "category", "use-case", "context-aware", "prose-intent", "safe-mode")
 
@@ -80,8 +108,15 @@ def load_recipe_catalog(path: Path) -> List[Recipe]:
     if not path.is_file():
         return []
     data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):  # malformed root (list/str) never crashes a view
+        return []
+    raw_recipes = data.get("recipes", [])
+    if not isinstance(raw_recipes, list):
+        return []
     out: List[Recipe] = []
-    for raw in data.get("recipes", []):
+    for raw in raw_recipes:
+        if not isinstance(raw, dict):
+            continue
         rid = str(raw.get("id") or "").strip()
         if not rid:
             continue
@@ -283,6 +318,8 @@ class HubConsole:
 
     def profile_draft(self, ids: Sequence[str], mode: str = "enforce") -> str:
         """The exact YAML the console WOULD write (shown pre-confirmation)."""
+        if mode not in PROFILE_MODES:  # API-level guard, not only the CLI (Qodo #3)
+            raise ValueError(f"profile mode must be one of {PROFILE_MODES}, got: {mode!r}")
         check = self.check_selection(ids)
         doc = {
             "schema_version": "hub-profile/1.0.0",
@@ -300,9 +337,25 @@ class HubConsole:
     ) -> Dict[str, Any]:
         """The T3 acceptance path: conflict-checked + HITL-confirmed BEFORE
         any profile write. Returns logged fields only."""
+        if mode not in PROFILE_MODES:  # API-level guard, not only the CLI (Qodo #3)
+            raise ValueError(f"profile mode must be one of {PROFILE_MODES}, got: {mode!r}")
         result = self.check_selection(ids)
         result["mode"] = mode
+        if not result["ids"]:
+            # An empty enforce-profile is a silent passthrough (Qodo #5) —
+            # never a valid thing to persist from a selection flow.
+            result["verdict"] = "refused"
+            result["written"] = False
+            result["reason"] = "empty_selection"
+            result["draft"] = ""
+            return result
         result["draft"] = self.profile_draft(ids, mode=mode)
+        known_registry_ids = [i for i in result["ids"] if self.registry.get(i) is not None]
+        if mode == "enforce" and known_registry_ids:
+            # Token-plane surfacing (Qodo #1): the runtime gate checks gateway
+            # OPERATION tokens; registry TOOL ids in an enforce profile do not
+            # enable operations by themselves.
+            result["warning"] = "enforce_profile_gates_operations"
         if result["verdict"] == "refused":
             result["written"] = False
             result["reason"] = "selection_refused"
@@ -317,9 +370,30 @@ class HubConsole:
             result["written"] = False
             result["reason"] = "no_write_path"
             return result
+        # Belt-and-braces (Copilot #1): re-run the T2 fail-closed guard on the
+        # exact profile about to be persisted — the SSOT of the excluded-id
+        # rule lives in lib.gateway.profile.validate_profile.
+        draft_profile = HubProfile(
+            enabled=tuple(result["ids"]), mode=mode, source="<console-draft>"
+        )
+        violations = validate_profile(draft_profile, self.registry)
+        if violations:
+            result["verdict"] = "refused"
+            result["written"] = False
+            result["reason"] = "validate_profile_refused"
+            result["violations"] = violations
+            return result
         write_path = Path(write_path)
         write_path.parent.mkdir(parents=True, exist_ok=True)
-        write_path.write_text(result["draft"], encoding="utf-8")
+        # Atomic write (Qodo #2): the hub loads this file fail-closed at
+        # startup — a truncated YAML must be impossible.
+        tmp = write_path.with_suffix(write_path.suffix + ".tmp")
+        try:
+            tmp.write_text(result["draft"], encoding="utf-8")
+            tmp.replace(write_path)
+        except BaseException:
+            tmp.unlink(missing_ok=True)
+            raise
         result["written"] = True
         result["path"] = str(write_path)
         return result
@@ -352,8 +426,12 @@ usage:
 
 views: preset | category | use-case | context-aware | prose-intent | safe-mode
 
-Selection is conflict-checked (registry conflict edges) + fail-closed
-(activation=excluded refused) and NEVER writes without --confirm (HITL gate).
+Selection is conflict-checked against BOTH edge sources (curated
+conflicts.yaml UNION per-record conflicts_with), fail-closed
+(activation=excluded refused; empty selection refused) and NEVER writes
+without --confirm (HITL gate). NOTE: the runtime gate checks gateway
+OPERATION tokens (see profile.yaml.example) — enforce-profiles built from
+registry TOOL ids emit `warning: enforce_profile_gates_operations`.
 """
 
 
@@ -403,6 +481,11 @@ def _main(argv: List[str]) -> int:
             confirm = True
         elif a == "--safe-mode":
             cmd, view_name = "view", "safe-mode"
+        else:
+            # Unknown flags never silently no-op (Copilot #3) — a typo must
+            # not run the console with unintended defaults.
+            print(json.dumps({"verdict": "fail", "error": f"unknown argument: {a}"}))
+            return 2
 
     if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson, T1)
         print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))

--- a/mcp-tools/maos-mcp-hub/lib/registry/console.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/console.py
@@ -1,0 +1,433 @@
+"""
+HubConsole — the maos-concierge ``setup``/``config`` rendering + selection
+engine (T3 / WAVE 5, ADR-006/007).
+
+``openspec/changes/maos-hub-console/tasks.md`` T3: *"maos-concierge
+setup/config modes: views preset · category · use-case · context-aware ·
+prose-intent · safe-mode; --help, --safe-mode. ASCII first-class; optional
+HTML artifact. Acceptance: each view renders from the registry; selection is
+conflict-checked + HITL-confirmed before it writes the profile."*
+
+Design position in the WAVE-5 chain (compose, don't reimplement):
+
+  - **Reads** the derived ``HubRegistry`` (T1, ``lib/registry/hub_registry.py``)
+    — every view is a projection of registry records + the curated
+    ``recipes.yaml`` catalog. The console NEVER hand-maintains tool data.
+  - **Writes** the enablement-profile SSOT (T2, ``lib/gateway/profile.py``)
+    — and ONLY after (a) conflict-check vs ``registry.conflict_edges()``,
+    (b) fail-closed ``validate_profile`` (excluded ids refused), and
+    (c) an explicit ``--confirm`` (the HITL gate). Without ``--confirm`` the
+    console emits the DRAFT it *would* write plus the logged field
+    ``{"written": false, "reason": "confirmation_required"}`` — it never
+    auto-applies (same posture T5 mandates for prose-intent).
+
+Determinism contract (DoD-GATE): every view is byte-stable for the same
+registry input — records sorted by (tier-rank, id) or (category, id); no
+timestamps, no randomness. Golden-fixture tested in
+``tests/test_hub_console.py``.
+
+Two of the six views are structurally scaffolded here and gain their engines
+in later worktrees (honest placeholders, still rendered FROM the registry):
+
+  - ``context-aware`` — v1 deterministic default ranking (tier-rank, id);
+    the work-compass signal engine lands in T4 (the view says so).
+  - ``prose-intent``  — the bounded ≤3-question interview scaffold whose
+    answer domains come from the live registry; the prose→profile mapping
+    engine lands in T5 (the view says so).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import dataclass
+from html import escape
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import yaml
+
+# Package-relative first (hub runtime), path-injected fallback (pytest / CLI).
+try:  # pragma: no cover - import plumbing
+    from .hub_registry import ACTIVATION_TIERS, HubRecord, HubRegistry, _flatten_stack
+except ImportError:  # pragma: no cover
+    from hub_registry import ACTIVATION_TIERS, HubRecord, HubRegistry, _flatten_stack  # type: ignore
+
+VIEWS = ("preset", "category", "use-case", "context-aware", "prose-intent", "safe-mode")
+
+_OWN_REPO = "ekson73/multi-agent-os"
+_WIDTH = 78
+
+# Higher rank = more trusted/always available. Mirrors ACTIVATION_TIERS order
+# (["always-on", "default-on-for-context", "opt-in", "excluded"]).
+_TIER_RANK = {tier: i for i, tier in enumerate(ACTIVATION_TIERS)}
+
+
+@dataclass(frozen=True)
+class Recipe:
+    """One curated composition recipe (the recipes.yaml catalog entry)."""
+
+    id: str
+    use_case: str
+    stack: Tuple[str, ...]
+    why: str
+    hitl: str
+
+
+def load_recipe_catalog(path: Path) -> List[Recipe]:
+    """Load the FULL recipe objects (hub_registry._load_recipes only builds
+    the inverted tool→recipes map; the console needs the catalog itself)."""
+    if not path.is_file():
+        return []
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    out: List[Recipe] = []
+    for raw in data.get("recipes", []):
+        rid = str(raw.get("id") or "").strip()
+        if not rid:
+            continue
+        out.append(
+            Recipe(
+                id=rid,
+                use_case=str(raw.get("use_case") or ""),
+                stack=tuple(
+                    t.strip()
+                    for t in _flatten_stack(raw.get("stack", []))
+                    if t.strip() and t.strip().lower() != "none"
+                ),
+                why=str(raw.get("why") or ""),
+                hitl=str(raw.get("hitl") or ""),
+            )
+        )
+    return sorted(out, key=lambda r: r.id)
+
+
+def _rule(char: str = "-") -> str:
+    return char * _WIDTH
+
+
+def _sorted_records(registry: HubRegistry) -> List[HubRecord]:
+    return sorted(registry.records(), key=lambda r: (_TIER_RANK[r.activation], r.id))
+
+
+def _record_line(rec: HubRecord) -> str:
+    return f"  {rec.id:<28} {rec.activation:<24} {rec.license_spdx:<12} {rec.owner_repo}"
+
+
+def _record_header() -> List[str]:
+    return [
+        f"  {'id':<28} {'activation':<24} {'license':<12} owner_repo",
+        "  " + _rule()[:76],
+    ]
+
+
+class HubConsole:
+    """Deterministic ASCII renderer + HITL-gated profile writer over the
+    T1 registry and the T2 profile SSOT."""
+
+    def __init__(self, registry: HubRegistry, recipes: Sequence[Recipe]) -> None:
+        self.registry = registry
+        self.recipes = sorted(recipes, key=lambda r: r.id)
+
+    # ------------------------------------------------------------------ views
+
+    def render(self, view: str) -> str:
+        if view not in VIEWS:
+            raise ValueError(f"unknown view {view!r} (expected one of {VIEWS})")
+        body = {
+            "preset": self._view_preset,
+            "category": self._view_category,
+            "use-case": self._view_use_case,
+            "context-aware": self._view_context_aware,
+            "prose-intent": self._view_prose_intent,
+            "safe-mode": self._view_safe_mode,
+        }[view]()
+        head = [
+            _rule("="),
+            f" MAOS Hub console — view: {view}  (registry: {len(self.registry)} records)",
+            _rule("="),
+        ]
+        return "\n".join(head + body) + "\n"
+
+    def _tier_of(self, tool_id: str) -> str:
+        rec = self.registry.get(tool_id)
+        return rec.activation if rec is not None else "(not in registry)"
+
+    def _view_preset(self) -> List[str]:
+        """Curated presets = the recipe stacks as ready-to-select bundles,
+        each tool annotated with its DERIVED activation tier."""
+        lines: List[str] = []
+        if not self.recipes:
+            return [" (no recipes promoted — lib/gateway/recipes.yaml absent/empty)"]
+        for r in self.recipes:
+            lines.append(f" preset: {r.id}  [{r.use_case}]")
+            for tool in r.stack:
+                lines.append(f"   - {tool:<28} tier: {self._tier_of(tool)}")
+            lines.append(f"   HITL: {r.hitl}")
+            lines.append(_rule())
+        lines.append(
+            " select a preset: console.py select --ids <stack,ids> --confirm --write <profile.yaml>"
+        )
+        return lines
+
+    def _view_category(self) -> List[str]:
+        lines: List[str] = []
+        by_cat: Dict[str, List[HubRecord]] = {}
+        for rec in self.registry.records():
+            by_cat.setdefault(rec.category, []).append(rec)
+        for cat in sorted(by_cat):
+            lines.append(f" category: {cat}  ({len(by_cat[cat])})")
+            lines.extend(_record_header())
+            for rec in sorted(by_cat[cat], key=lambda r: r.id):
+                lines.append(_record_line(rec))
+            lines.append(_rule())
+        return lines or [" (registry empty)"]
+
+    def _view_use_case(self) -> List[str]:
+        lines: List[str] = []
+        if not self.recipes:
+            return [" (no recipes promoted — lib/gateway/recipes.yaml absent/empty)"]
+        for r in self.recipes:
+            lines.append(f" use-case: {r.use_case}  (recipe: {r.id})")
+            lines.append(f"   why : {r.why}")
+            lines.append(f"   HITL: {r.hitl}")
+            lines.append(f"   stack ({len(r.stack)}): {', '.join(r.stack)}")
+            lines.append(_rule())
+        return lines
+
+    def _view_context_aware(self) -> List[str]:
+        lines = [
+            " context-aware ranking v1 — DEFAULT deterministic ordering",
+            " (tier-rank, id). The work-compass project-signal engine lands in T4;",
+            " until then this view shows the registry's trust-ordered baseline.",
+            _rule(),
+        ]
+        lines.extend(_record_header())
+        for rec in _sorted_records(self.registry):
+            lines.append(_record_line(rec))
+        return lines
+
+    def _view_prose_intent(self) -> List[str]:
+        cats = sorted({rec.category for rec in self.registry.records()})
+        lines = [
+            " prose-intent — bounded interview (<=3 questions) -> profile DRAFT.",
+            " The prose->profile mapping engine lands in T5; the answer domains",
+            " below are derived LIVE from the registry. A draft NEVER auto-applies.",
+            _rule(),
+            " Q1. What are you building? (maps to a use-case recipe)",
+        ]
+        for r in self.recipes:
+            lines.append(f"      - {r.id}: {r.use_case}")
+        lines.append(" Q2. Which capability categories do you need?")
+        for cat in cats:
+            lines.append(f"      - {cat}")
+        lines.append(" Q3. Enforcement posture? (enforce | advisory)")
+        return lines
+
+    def _view_safe_mode(self) -> List[str]:
+        """Conservative floor: always-on records + FIRST-PARTY
+        default-on-for-context. Third-party opt-in/excluded hidden."""
+        safe = [
+            rec
+            for rec in _sorted_records(self.registry)
+            if rec.activation == "always-on"
+            or (rec.activation == "default-on-for-context" and rec.owner_repo == _OWN_REPO)
+        ]
+        lines = [
+            " safe-mode — the conservative floor (always-on substrates +",
+            f" first-party default-on-for-context; {len(safe)} of {len(self.registry)} records).",
+            _rule(),
+        ]
+        lines.extend(_record_header())
+        lines.extend(_record_line(rec) for rec in safe)
+        return lines
+
+    # -------------------------------------------------------------- selection
+
+    def check_selection(self, ids: Sequence[str]) -> Dict[str, Any]:
+        """Conflict-check + fail-closed activation check for a selection.
+
+        Returns a LOGGED-FIELD dict (never prose-judged):
+          verdict          — "ok" | "refused"
+          conflicts        — [[a, b], ...] pairs inside the selection that the
+                             registry marks mutually exclusive
+          excluded         — ids whose derived activation == excluded
+          unknown          — ids not present in the registry (allowed: the T2
+                             profile also carries gateway operation tokens the
+                             registry does not model; surfaced for the human)
+        """
+        chosen = sorted(dict.fromkeys(str(i).strip() for i in ids if str(i).strip()))
+        chosen_set = set(chosen)
+        # Both edge sources: the curated conflicts.yaml promotion (loaded at
+        # derive-time) AND the per-record conflicts_with fields — a pair is
+        # mutually exclusive if EITHER source says so (fail-closed union).
+        all_edges = self.registry.conflict_edges() | self.registry.edges_from_records()
+        conflicts = sorted(
+            sorted(edge)
+            for edge in all_edges
+            if len(edge) == 2 and edge <= chosen_set
+        )
+        excluded = sorted(
+            tid
+            for tid in chosen
+            if (rec := self.registry.get(tid)) is not None and rec.activation == "excluded"
+        )
+        unknown = sorted(tid for tid in chosen if self.registry.get(tid) is None)
+        verdict = "ok" if not conflicts and not excluded else "refused"
+        return {
+            "verdict": verdict,
+            "ids": chosen,
+            "conflicts": [list(pair) for pair in conflicts],
+            "excluded": excluded,
+            "unknown": unknown,
+        }
+
+    def profile_draft(self, ids: Sequence[str], mode: str = "enforce") -> str:
+        """The exact YAML the console WOULD write (shown pre-confirmation)."""
+        check = self.check_selection(ids)
+        doc = {
+            "schema_version": "hub-profile/1.0.0",
+            "mode": mode,
+            "enabled": check["ids"],
+        }
+        return yaml.safe_dump(doc, sort_keys=False, allow_unicode=True)
+
+    def select(
+        self,
+        ids: Sequence[str],
+        mode: str = "enforce",
+        write_path: Optional[Path] = None,
+        confirm: bool = False,
+    ) -> Dict[str, Any]:
+        """The T3 acceptance path: conflict-checked + HITL-confirmed BEFORE
+        any profile write. Returns logged fields only."""
+        result = self.check_selection(ids)
+        result["mode"] = mode
+        result["draft"] = self.profile_draft(ids, mode=mode)
+        if result["verdict"] == "refused":
+            result["written"] = False
+            result["reason"] = "selection_refused"
+            return result
+        if not confirm:
+            # The HITL gate: rendering the draft is free; APPLYING requires
+            # the explicit human confirmation flag.
+            result["written"] = False
+            result["reason"] = "confirmation_required"
+            return result
+        if write_path is None:
+            result["written"] = False
+            result["reason"] = "no_write_path"
+            return result
+        write_path = Path(write_path)
+        write_path.parent.mkdir(parents=True, exist_ok=True)
+        write_path.write_text(result["draft"], encoding="utf-8")
+        result["written"] = True
+        result["path"] = str(write_path)
+        return result
+
+    # ------------------------------------------------------------------- html
+
+    def render_html(self, view: str) -> str:
+        """Optional HTML artifact — a minimal wrapper around the ASCII
+        first-class rendering (tasks.md: 'ASCII first-class; optional HTML')."""
+        ascii_body = self.render(view)
+        return (
+            "<!DOCTYPE html>\n<html><head><meta charset=\"utf-8\">"
+            f"<title>MAOS Hub console — {escape(view)}</title></head>\n"
+            "<body style=\"background:#111;color:#ddd\">"
+            f"<pre>{escape(ascii_body)}</pre></body></html>\n"
+        )
+
+
+# ----------------------------------------------------------------------- CLI
+
+
+_USAGE = """\
+MAOS Hub console (T3) — render registry views / write the enablement profile.
+
+usage:
+  console.py view <name> [--repo-root P] [--as-of DATE] [--html OUT.html]
+  console.py select --ids a,b,c [--mode enforce|advisory] [--write PROFILE.yaml] [--confirm]
+  console.py --safe-mode            # shortcut for: view safe-mode
+  console.py --help
+
+views: preset | category | use-case | context-aware | prose-intent | safe-mode
+
+Selection is conflict-checked (registry conflict edges) + fail-closed
+(activation=excluded refused) and NEVER writes without --confirm (HITL gate).
+"""
+
+
+def _build_console(repo_root: Path, as_of: str) -> HubConsole:
+    registry = HubRegistry.derive(repo_root, as_of=as_of)
+    recipes = load_recipe_catalog(
+        repo_root / "mcp-tools" / "maos-mcp-hub" / "lib" / "gateway" / "recipes.yaml"
+    )
+    return HubConsole(registry, recipes)
+
+
+def _main(argv: List[str]) -> int:
+    here = Path(__file__).resolve()
+    repo_root = here.parents[4]  # lib/registry/x.py -> lib -> maos-mcp-hub -> mcp-tools -> ROOT
+    as_of = "1970-01-01"
+    args = list(argv)
+    if not args or "--help" in args or "-h" in args:
+        print(_USAGE)
+        return 0
+    if args == ["--safe-mode"]:
+        args = ["view", "safe-mode"]
+
+    cmd = args.pop(0)
+    view_name: Optional[str] = None
+    html_out: Optional[Path] = None
+    ids: List[str] = []
+    mode = "enforce"
+    write_path: Optional[Path] = None
+    confirm = False
+    if cmd == "view" and args and not args[0].startswith("--"):
+        view_name = args.pop(0)
+    while args:
+        a = args.pop(0)
+        if a == "--repo-root" and args:
+            repo_root = Path(args.pop(0)).resolve()
+        elif a == "--as-of" and args:
+            as_of = args.pop(0)
+        elif a == "--html" and args:
+            html_out = Path(args.pop(0))
+        elif a == "--ids" and args:
+            ids = [s for s in args.pop(0).split(",") if s.strip()]
+        elif a == "--mode" and args:
+            mode = args.pop(0)
+        elif a == "--write" and args:
+            write_path = Path(args.pop(0))
+        elif a == "--confirm":
+            confirm = True
+        elif a == "--safe-mode":
+            cmd, view_name = "view", "safe-mode"
+
+    if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson, T1)
+        print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
+        return 1
+    console = _build_console(repo_root, as_of)
+
+    if cmd == "view":
+        if view_name not in VIEWS:
+            print(_USAGE)
+            return 1
+        print(console.render(view_name), end="")
+        if html_out is not None:
+            html_out.write_text(console.render_html(view_name), encoding="utf-8")
+            print(f"[html artifact] {html_out}")
+        return 0
+    if cmd == "select":
+        if mode not in ("enforce", "advisory"):
+            print(json.dumps({"verdict": "fail", "error": f"invalid mode: {mode}"}))
+            return 1
+        result = console.select(ids, mode=mode, write_path=write_path, confirm=confirm)
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+        return 0 if result["verdict"] == "ok" else 1
+    print(_USAGE)
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_main(sys.argv[1:]))

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
@@ -250,3 +250,92 @@ def test_cli_help_flag(tmp_path: Path) -> None:
     out = subprocess.run([sys.executable, str(script), "--help"],
                          capture_output=True, text=True, check=True)
     assert "views: preset | category | use-case" in out.stdout
+
+
+# ------------------- PR #214 bot-finding regressions (pre-merge fix-forward)
+
+
+def test_empty_selection_is_refused(console: HubConsole, tmp_path: Path) -> None:
+    """Qodo #5: an empty enforce-profile is a silent passthrough — refused."""
+    target = tmp_path / "p.yaml"
+    result = console.select([], write_path=target, confirm=True)
+    assert result["verdict"] == "refused"
+    assert result["reason"] == "empty_selection"
+    assert not target.exists()
+    result2 = console.select(["", "  "], write_path=target, confirm=True)
+    assert result2["reason"] == "empty_selection"
+
+
+def test_invalid_mode_raises_at_api_level(console: HubConsole) -> None:
+    """Qodo #3: mode vocabulary is enforced in the API, not only the CLI."""
+    with pytest.raises(ValueError):
+        console.select(["guard"], mode="yolo", confirm=True)
+    with pytest.raises(ValueError):
+        console.profile_draft(["guard"], mode="YOLO")
+
+
+def test_profile_write_is_atomic_no_tmp_left_behind(
+    console: HubConsole, tmp_path: Path
+) -> None:
+    """Qodo #2: write goes through tmp+replace; no .tmp residue on success."""
+    target = tmp_path / "nested" / "profile.yaml"
+    result = console.select(["guard"], write_path=target, confirm=True)
+    assert result["written"] is True
+    assert target.exists()
+    assert not target.with_suffix(target.suffix + ".tmp").exists()
+
+
+def test_malformed_recipes_yaml_never_crashes(tmp_path: Path) -> None:
+    """Qodo #4: list/str YAML root or non-dict items -> empty catalog, no crash."""
+    f = tmp_path / "recipes.yaml"
+    f.write_text("- just\n- a\n- list\n", encoding="utf-8")
+    assert load_recipe_catalog(f) == []
+    f.write_text("recipes: notalist\n", encoding="utf-8")
+    assert load_recipe_catalog(f) == []
+    f.write_text("recipes:\n  - notadict\n  - id: ok\n    stack: [x]\n", encoding="utf-8")
+    assert [r.id for r in load_recipe_catalog(f)] == ["ok"]
+
+
+def test_enforce_with_registry_ids_emits_token_plane_warning(
+    console: HubConsole, tmp_path: Path
+) -> None:
+    """Qodo #1 (mitigation): enforce-mode selection of registry TOOL ids warns
+    that the runtime gate checks OPERATION tokens (logged field, not prose)."""
+    result = console.select(["guard"], write_path=tmp_path / "p.yaml", confirm=True)
+    assert result["warning"] == "enforce_profile_gates_operations"
+    ops_only = console.select(["get", "create"], write_path=tmp_path / "q.yaml", confirm=True)
+    assert "warning" not in ops_only
+    advisory = console.select(["guard"], mode="advisory",
+                              write_path=tmp_path / "r.yaml", confirm=True)
+    assert "warning" not in advisory
+
+
+def test_select_write_reuses_t2_validate_profile_guard(
+    console: HubConsole, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Copilot #1: the T2 validate_profile SSOT actually runs before a write —
+    if it grows new checks, the console inherits them."""
+    import lib.registry.console as console_mod
+    target = tmp_path / "p.yaml"
+
+    def _always_refuse(profile, registry):  # a future validate_profile check
+        return ["synthetic violation"]
+
+    monkeypatch.setattr(console_mod, "validate_profile", _always_refuse)
+    result = console.select(["guard"], write_path=target, confirm=True)
+    assert result["verdict"] == "refused"
+    assert result["reason"] == "validate_profile_refused"
+    assert result["violations"] == ["synthetic violation"]
+    assert not target.exists()
+
+
+def test_cli_unknown_argument_is_an_error(tmp_path: Path) -> None:
+    """Copilot #3: a typo'd flag never silently no-ops."""
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    out = subprocess.run(
+        [sys.executable, str(script), "view", "safe-mode", "--reop-root", str(_REPO_ROOT)],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 2
+    payload = json.loads(out.stdout.splitlines()[-1])
+    assert payload["error"] == "unknown argument: --reop-root"

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
@@ -1,0 +1,252 @@
+"""Tests — HubConsole (T3 / WAVE 5): console setup/config modes.
+
+tasks.md T3 acceptance, as logged fields / golden fixtures (the DoD-gate):
+  "each view renders from the registry; selection is conflict-checked +
+   HITL-confirmed before it writes the profile."
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lib.gateway.profile import load_profile
+from lib.registry import VIEWS, HubConsole, HubRecord, HubRegistry, Recipe, load_recipe_catalog
+
+_HERE = Path(__file__).resolve()
+_HUB_DIR = _HERE.parents[1]           # mcp-tools/maos-mcp-hub
+_REPO_ROOT = _HERE.parents[3]         # repo root
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+def _mk_record(rid: str, **kw) -> HubRecord:
+    base = dict(
+        id=rid, owner_repo="acme/tools", layer="L2", role="r", category="skill",
+        harness_coverage=(), requires=(), conflicts_with=(), guardrails="g",
+        impact="i", recipes=(), activation="opt-in", license_spdx="MIT",
+        provenance="p", ttl=None, last_validated="2026-07-02",
+        rollback="rb", security_status="vetted", derived_from="d",
+    )
+    base.update(kw)
+    return HubRecord(**base)
+
+
+@pytest.fixture()
+def registry() -> HubRegistry:
+    """A small synthetic registry covering every tier + one conflict edge."""
+    reg = HubRegistry()
+    reg._add(_mk_record("guard", activation="always-on", category="substrate",
+                        owner_repo="ekson73/multi-agent-os"))
+    reg._add(_mk_record("memory", activation="default-on-for-context", category="substrate",
+                        owner_repo="ekson73/multi-agent-os"))
+    reg._add(_mk_record("alpha", activation="opt-in", conflicts_with=("beta",)))
+    reg._add(_mk_record("beta", activation="opt-in", conflicts_with=("alpha",),
+                        category="third-party"))
+    reg._add(_mk_record("mallory", activation="excluded", category="third-party",
+                        security_status="rejected"))
+    reg._add(_mk_record("vendor-default", activation="default-on-for-context",
+                        category="third-party"))
+    return reg
+
+
+@pytest.fixture()
+def recipes() -> list:
+    return [
+        Recipe(id="quick-start", use_case="Quick start", stack=("guard", "memory", "alpha"),
+               why="minimal stack", hitl="approve the plan"),
+        Recipe(id="full-stack", use_case="Full stack", stack=("guard", "beta"),
+               why="broader", hitl="pick alpha vs beta"),
+    ]
+
+
+@pytest.fixture()
+def console(registry: HubRegistry, recipes: list) -> HubConsole:
+    return HubConsole(registry, recipes)
+
+
+# --------------------------------------------------- views render from registry
+
+
+def test_every_view_renders_from_registry(console: HubConsole) -> None:
+    """T3 acceptance: each of the 6 views renders (non-empty, header present)."""
+    for view in VIEWS:
+        out = console.render(view)
+        assert f"view: {view}" in out
+        assert "registry: 6 records" in out
+
+
+def test_views_are_byte_stable(console: HubConsole) -> None:
+    """DoD determinism: same input -> byte-identical rendering."""
+    for view in VIEWS:
+        assert console.render(view) == console.render(view)
+
+
+def test_unknown_view_is_refused(console: HubConsole) -> None:
+    with pytest.raises(ValueError):
+        console.render("dashboard")
+
+
+def test_category_view_groups_all_records(console: HubConsole) -> None:
+    out = console.render("category")
+    for cat in ("skill", "substrate", "third-party"):
+        assert f"category: {cat}" in out
+    for rid in ("guard", "memory", "alpha", "beta", "mallory", "vendor-default"):
+        assert rid in out
+
+
+def test_preset_view_annotates_tiers_from_registry(console: HubConsole) -> None:
+    """Preset stacks show the DERIVED tier per tool (renders FROM the registry)."""
+    out = console.render("preset")
+    assert "preset: quick-start" in out
+    assert "guard" in out and "always-on" in out
+    assert "HITL: approve the plan" in out
+
+
+def test_use_case_view_lists_recipes(console: HubConsole) -> None:
+    out = console.render("use-case")
+    assert "use-case: Quick start  (recipe: quick-start)" in out
+    assert "why : minimal stack" in out
+
+
+def test_context_aware_view_is_tier_ordered_and_names_t4(console: HubConsole) -> None:
+    out = console.render("context-aware")
+    assert "lands in T4" in out
+    # deterministic ordering: always-on first, excluded last
+    assert out.index("guard") < out.index("alpha") < out.index("mallory")
+
+
+def test_prose_intent_view_scaffolds_3_questions_from_registry(console: HubConsole) -> None:
+    out = console.render("prose-intent")
+    questions = [ln for ln in out.splitlines() if ln.lstrip().startswith("Q")]
+    assert len(questions) == 3  # the interview is BOUNDED (<=3 Qs)
+    assert "quick-start" in out and "third-party" in out
+    assert "NEVER auto-applies" in out
+
+
+def test_safe_mode_view_hides_third_party_opt_in_and_excluded(console: HubConsole) -> None:
+    out = console.render("safe-mode")
+    body = out.split("owner_repo", 1)[1]  # only the record table
+    assert "guard" in body and "memory" in body
+    for hidden in ("alpha", "beta", "mallory", "vendor-default"):
+        assert hidden not in body
+
+
+def test_golden_safe_mode_fixture(console: HubConsole) -> None:
+    """Golden fixture (DoD-gate): the safe-mode record lines, byte-exact."""
+    out = console.render("safe-mode")
+    lines = [ln for ln in out.splitlines() if ln.startswith("  guard") or ln.startswith("  memory")]
+    assert lines == [
+        "  guard                        always-on                MIT          ekson73/multi-agent-os",
+        "  memory                       default-on-for-context   MIT          ekson73/multi-agent-os",
+    ]
+
+
+def test_html_artifact_wraps_ascii(console: HubConsole) -> None:
+    html = console.render_html("category")
+    assert html.startswith("<!DOCTYPE html>")
+    assert "view: category" in html
+
+
+# --------------------------------------- selection: conflict-check + HITL gate
+
+
+def test_selection_conflict_pair_is_refused(console: HubConsole) -> None:
+    """T3 acceptance: selection is conflict-checked (logged field, not prose)."""
+    result = console.select(["alpha", "beta"], confirm=True, write_path=None)
+    assert result["verdict"] == "refused"
+    assert result["conflicts"] == [["alpha", "beta"]]
+    assert result["written"] is False
+    assert result["reason"] == "selection_refused"
+
+
+def test_selection_excluded_id_is_refused_fail_closed(console: HubConsole) -> None:
+    result = console.select(["guard", "mallory"], confirm=True)
+    assert result["verdict"] == "refused"
+    assert result["excluded"] == ["mallory"]
+    assert result["written"] is False
+
+
+def test_selection_without_confirm_never_writes(console: HubConsole, tmp_path: Path) -> None:
+    """T3 acceptance: HITL-confirmed BEFORE it writes the profile."""
+    target = tmp_path / "profile.yaml"
+    result = console.select(["guard", "memory"], write_path=target, confirm=False)
+    assert result["verdict"] == "ok"
+    assert result["written"] is False
+    assert result["reason"] == "confirmation_required"
+    assert not target.exists()
+    assert "enabled:" in result["draft"]  # the draft is SHOWN, not applied
+
+
+def test_confirmed_selection_writes_t2_loadable_profile(
+    console: HubConsole, tmp_path: Path
+) -> None:
+    """Integration with T2: the written profile round-trips through
+    lib.gateway.profile.load_profile (schema hub-profile/1.x)."""
+    target = tmp_path / "profile.yaml"
+    result = console.select(["guard", "memory"], write_path=target, confirm=True)
+    assert result["written"] is True and result["path"] == str(target)
+    prof = load_profile(target)
+    assert prof is not None
+    assert prof.mode == "enforce"
+    assert prof.enabled == ("guard", "memory")
+
+
+def test_confirmed_selection_without_path_does_not_write(console: HubConsole) -> None:
+    result = console.select(["guard"], confirm=True, write_path=None)
+    assert result["written"] is False and result["reason"] == "no_write_path"
+
+
+def test_unknown_ids_are_surfaced_but_allowed(console: HubConsole, tmp_path: Path) -> None:
+    """Gateway operation tokens (`get`, `create`) are not registry records —
+    they must pass selection but be SURFACED for the human (logged field)."""
+    result = console.select(["guard", "get"], write_path=tmp_path / "p.yaml", confirm=True)
+    assert result["verdict"] == "ok"
+    assert result["unknown"] == ["get"]
+    assert result["written"] is True
+
+
+def test_selection_dedupes_and_sorts_ids(console: HubConsole) -> None:
+    result = console.check_selection(["memory", "guard", "memory", " guard "])
+    assert result["ids"] == ["guard", "memory"]
+
+
+# -------------------------------------------------------------- catalog + CLI
+
+
+def test_recipe_catalog_loads_live_recipes_yaml() -> None:
+    catalog = load_recipe_catalog(_HUB_DIR / "lib" / "gateway" / "recipes.yaml")
+    ids = [r.id for r in catalog]
+    assert "new-idea-to-mvp" in ids and len(ids) == 6
+    assert ids == sorted(ids)  # deterministic ordering
+
+
+def test_cli_view_renders_and_select_gates(tmp_path: Path) -> None:
+    """CLI smoke over the LIVE repo: view renders; unconfirmed select refuses."""
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    view = subprocess.run(
+        [sys.executable, str(script), "view", "safe-mode", "--repo-root", str(_REPO_ROOT)],
+        capture_output=True, text=True, check=True,
+    )
+    assert "view: safe-mode" in view.stdout
+    sel = subprocess.run(
+        [sys.executable, str(script), "select", "--ids", "get,create",
+         "--write", str(tmp_path / "p.yaml"), "--repo-root", str(_REPO_ROOT)],
+        capture_output=True, text=True,
+    )
+    payload = json.loads(sel.stdout)
+    assert payload["written"] is False
+    assert payload["reason"] == "confirmation_required"
+    assert not (tmp_path / "p.yaml").exists()
+
+
+def test_cli_help_flag(tmp_path: Path) -> None:
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    out = subprocess.run([sys.executable, str(script), "--help"],
+                         capture_output=True, text=True, check=True)
+    assert "views: preset | category | use-case" in out.stdout

--- a/skills/maos-concierge/SKILL.md
+++ b/skills/maos-concierge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maos-concierge
-version: "1.0.0"
+version: "1.1.0"
 description: |
   Concierge / onboarding / guide / router / capability-detector / governance-anchor for the
   ENTIRE Multi-Agent OS (MAOS) framework — its agents, skills, commands, protocols, and governances
@@ -9,10 +9,13 @@ description: |
   Use when a human or agent wants to LEARN MAOS, ONBOARD onto it, find WHICH tool/agent/command/protocol
   to use for an intent, get a PLAYBOOK/RUNBOOK/WALKTHROUGH, AUDIT a project's MAOS usage, or re-find a
   CANONICAL decision that drifted across sessions. It ROUTES + TEACHES + ANCHORS — it never reimplements
-  an agent/skill/protocol and never wraps an existing tool. 6 modes: explain (default — teach the
+  an agent/skill/protocol and never wraps an existing tool. 8 modes: explain (default — teach the
   framework + landscape), onboard (guided ramp for a newcomer), guide (intent → right tool + playbook),
   audit (read-only compliance vs MAOS protocols), anchor (surface canonical decisions, flag drift),
-  dashboard (ASCII onboarding-map; optional HTML companion). Vendor-neutral (AAIF cross-vendor) —
+  dashboard (ASCII onboarding-map; optional HTML companion), setup (MAOS Hub console — render the
+  derived registry views preset/category/use-case/context-aware/prose-intent/safe-mode and write the
+  enablement profile, conflict-checked + HITL-confirmed), config (inspect/adjust the persisted
+  hub profile SSOT). Vendor-neutral (AAIF cross-vendor) —
   portable across Claude Code, Cursor, Codex, Gemini CLI, Copilot.
 allowed-tools: Read, Glob, Grep, Bash, WebFetch
 evals:
@@ -23,6 +26,8 @@ evals:
     - "Audit whether this project follows the Anti-Conflict + worktree protocol"
     - "What does the Sentinel Protocol do and when does it auto-block?"
     - "Show me an onboarding dashboard of the MAOS framework"
+    - "Set up the MAOS Hub — show me the expert presets and enable a stack for this project"
+    - "Which hub tools are safe to enable? Show safe-mode and write my profile"
     - "Someone bypassed hierarchical-merge and merged a subtask branch to main — is that allowed?"
     - "How does The Forge decide whether to create a new agent?"
   should_not_trigger:
@@ -82,9 +87,9 @@ Detect which MAOS surfaces are present before orienting. Degrade gracefully + em
 | **Session lifecycle (recap / re-orient / quiesce)** | `morning-briefing` · `pulse` · `quiesce` skills | — | session hygiene |
 | **Startup / founder lifecycle guidance** | `founder-playbook` + `founder-stage-*` skills | — | domain advisory, not MAOS-core |
 
-## The 6 Modes
+## The 8 Modes
 
-Invoke with `--mode=<explain|onboard|guide|audit|anchor|dashboard>` (default `explain`).
+Invoke with `--mode=<explain|onboard|guide|audit|anchor|dashboard|setup|config>` (default `explain`).
 
 ### `--mode=explain` (default)
 Teach MAOS: what it is (an orchestration "OS" for AI agents), the agent/skill/command catalogs, the protocol set, and **when to reach for what / what to SKIP**. Source of truth = [`AWARENESS-REGISTRY.md`](./AWARENESS-REGISTRY.md). Reduce surface — tell the user which tool NOT to use for their intent.
@@ -103,6 +108,22 @@ Surface the canonical MAOS decisions (from [`CANON.md`](./CANON.md)) on demand s
 
 ### `--mode=dashboard`
 Render an **ASCII/markdown onboarding-map** (the default): framework landscape + adoption-progress checklist + next-step pointer, in the `status-map` house style. On request, also emit the self-contained **[`dashboard.html`](./dashboard.html)** companion (open in a browser) for a richer onboarding/playbook view. No web service, no build step — a single static file.
+
+### `--mode=setup` (hub console — T3, ADR-006/007)
+Render the **MAOS Hub console** views over the DERIVED registry (T1 SSOT — never hand-maintained data) and, on selection, write the enablement-profile SSOT (T2) — **conflict-checked + HITL-confirmed, never auto-applied**. Engine = `mcp-tools/maos-mcp-hub/lib/registry/console.py` (ASCII first-class; `--html` optional artifact):
+
+```bash
+python3 mcp-tools/maos-mcp-hub/lib/registry/console.py view <preset|category|use-case|context-aware|prose-intent|safe-mode>
+python3 mcp-tools/maos-mcp-hub/lib/registry/console.py --safe-mode           # conservative floor
+python3 mcp-tools/maos-mcp-hub/lib/registry/console.py select --ids a,b,c \
+        --write mcp-tools/maos-mcp-hub/profile.yaml            # DRAFT only (refuses to write)
+# … review the emitted draft + logged fields, then the HUMAN adds:  --confirm
+```
+
+Gates (logged fields, not prose): conflicting pair in the selection → `verdict: refused` + `conflicts: [[a,b]]`; `activation=excluded` id → refused fail-closed; no `--confirm` → `written: false, reason: confirmation_required`. The `context-aware` and `prose-intent` views are registry-rendered scaffolds whose engines land in T4 (work-compass signals) and T5 (prose→profile interview).
+
+### `--mode=config` (profile SSOT inspect/adjust)
+Inspect the persisted hub profile (`mcp-tools/maos-mcp-hub/profile.yaml` / `$MAOS_HUB_PROFILE`): show `mode` (enforce|advisory), the `enabled` list, and validate it against the registry (`lib.gateway.profile.validate_profile` — excluded ids are refused). Adjustments go through the same `select … --confirm` path as setup (never hand-edit advice that bypasses the conflict/HITL gates).
 
 ## Governance layer (what I enforce when orienting)
 
@@ -139,4 +160,5 @@ Render an **ASCII/markdown onboarding-map** (the default): framework landscape +
 - Sibling concierges (cross-vendor pattern): `claude-code-concierge` (the Claude-Code platform) · `walkthrough-concierge` (ASH) · `specdd-concierge` · `vek-concierge` (Vek layer) · `atlassian-concierge`
 
 ## Changelog
+- 2026-07-02 — v1.1.0 — T3 (WAVE 5, ADR-006/007): +2 modes `setup` (hub console — 6 registry views + conflict-checked, HITL-confirmed profile write via `lib/registry/console.py`) and `config` (profile SSOT inspect/validate). Composes T1 HubRegistry + T2 HubProfile; reimplements nothing.
 - 2026-05-28 — v1.0.0 — Bootstrap. Concierge/onboarding/guide/router/governance-anchor over the whole MAOS framework. 6 modes (explain/onboard/guide/audit/anchor/dashboard) + Landscape Decision Matrix + governance layer + AWARENESS-REGISTRY + CANON + self-executed 33Q + ASCII/HTML dashboard. Vendor-neutral (MIT, layer-pure — no corporate content). Anti-over-engineering: orients over existing tools, reimplements NOTHING. Origin: operator /enhance 2026-05-28 (concierge family — sibling of atlassian-concierge/specdd-concierge).


### PR DESCRIPTION
[PR-as-Prompt] **WAVE 5 / T3 — hub console `setup`/`config` modes** (ADR-006 MoE hub · ADR-007 front-door)

## Context
`openspec/changes/maos-hub-console/tasks.md` T3: *"maos-concierge setup/config modes: views preset · category · use-case · context-aware · prose-intent · safe-mode; --help, --safe-mode. ASCII first-class; optional HTML artifact."* Third leg of WAVE 5, composing the two already-merged primitives: T1 registry SSOT (#209 + #211) and T2 profile-as-gating-input (#210 + #212).

## Objectives
- `lib/registry/console.py` — **HubConsole**: 6 deterministic ASCII views, ALL projections of the derived `HubRegistry` + curated `recipes.yaml` (never hand-maintained data). `--help` / `--safe-mode`; optional `--html` artifact.
- **Selection path = the T3 acceptance**: `select --ids …` → conflict-check (curated conflicts.yaml ∪ per-record `conflicts_with`, fail-closed union) → `activation=excluded` refused fail-closed → **HITL gate**: without `--confirm` the console emits the DRAFT + `{written: false, reason: confirmation_required}` and never touches disk. Confirmed writes produce a `hub-profile/1.x` file that round-trips through `lib.gateway.profile.load_profile` (T2 integration test).
- `maos-concierge` v1.1.0 — +2 modes `setup`/`config` (routes to the engine; reimplements nothing).
- `context-aware`/`prose-intent` views are registry-rendered scaffolds; their engines land in T4/T5 (each view states this — no fake capability).

## Acceptance (logged fields / golden fixtures — DoD-gate)
- [x] each of the 6 views renders from the registry — `test_every_view_renders_from_registry` + golden safe-mode fixture + byte-stability test
- [x] conflicting pair refused — `verdict: refused, conflicts: [["alpha","beta"]]`
- [x] excluded id refused fail-closed — `excluded: ["mallory"]`
- [x] no `--confirm` ⇒ no write — `written: false, reason: confirmation_required` (file absent asserted)
- [x] confirmed write loads via T2 `load_profile` (schema `hub-profile/1.x`)
- [x] `bash tests/validate-plugin.sh` PASS · gitleaks clean · 61/61 W5 suites green locally

## Risk + rollback
Additive module + additive SKILL.md modes; hub runtime untouched (console is CLI/skill-invoked only). Rollback = revert the squash commit.

## Cross-links
ADR-006 · ADR-007 · issue #204 (T3 checkbox) · spec `openspec/specs/maos-hub-registry/spec.md` · PRs #209/#210/#211/#212 (composed primitives)

Signed: Claude-Dev-moe-t3 · 2026-07-02T12:03:00-03:00
