### PR TITLE
feat(maos-hub): context-aware ranking v1 (WAVE5/T4) — deterministic work-compass signal ranking, why emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — context-aware ranking v1 (WAVE 5 / T4, ADR-006 + ADR-007)
+
+- **`lib/registry/context_rank.py`** (`mcp-tools/maos-mcp-hub`): deterministic ranking of registry
+  records by **work-compass project signals** (`bin/work-compass-aggregate.py --json` snapshot as
+  INPUT — the collector is composed, never re-collected). Signal extraction ignores volatile
+  fields (`generated_utc`, `last_ts`, `status`) so two snapshots of the same project state yield
+  identical tokens; scoring is pure integers; total order `(-score, tier-rank, id)` —
+  **same input → same ranking, byte-stable** (asserted at engine, view, and CLI surfaces).
+- **The "why" is emitted** (T4 acceptance): every ranked entry carries `why: […]` — one reason per
+  scoring contribution (`signal 'legacy' matches recipe 'legacy-refactor' (+1)` …); zero-score
+  entries say so explicitly. `activation=excluded` records are never ranked.
+- **Console integration**: the T3 `context-aware` scaffold now runs the engine when the CLI gets
+  `--signals COMPASS.json` (malformed/missing snapshot degrades to the tier-ordered baseline,
+  fail-safe + stderr diagnostic). `refactor`/`legacy` deliberately NOT stopwords (intent signals).
+- Tests: `tests/test_context_rank.py` — 15 tests (golden ranking fixture, volatile-field
+  invariance, byte-stability at CLI via double-run diff, excluded-never-ranked, fail-safe
+  degradation).
+
+
 ### Added — hub console setup/config modes (WAVE 5 / T3, ADR-006 + ADR-007)
 
 - **`lib/registry/console.py`** (`mcp-tools/maos-mcp-hub`): `HubConsole` — deterministic ASCII

--- a/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
@@ -17,3 +17,9 @@ from .console import (  # noqa: F401
     Recipe,
     load_recipe_catalog,
 )
+from .context_rank import (  # noqa: F401
+    extract_signals,
+    load_signals_file,
+    rank,
+    render_ranking,
+)

--- a/mcp-tools/maos-mcp-hub/lib/registry/console.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/console.py
@@ -68,6 +68,8 @@ import yaml
 # dir so `lib.*` absolute imports resolve).
 try:  # pragma: no cover - import plumbing
     from .hub_registry import ACTIVATION_TIERS, HubRecord, HubRegistry, _flatten_stack
+    from .context_rank import load_signals_file, render_ranking
+    from .context_rank import rank as rank_by_signals
     from ..gateway.profile import PROFILE_MODES, HubProfile, validate_profile
 except ImportError:  # pragma: no cover
     _HUB_ROOT = str(Path(__file__).resolve().parents[2])  # lib/registry -> lib -> hub dir
@@ -79,6 +81,8 @@ except ImportError:  # pragma: no cover
         HubRegistry,
         _flatten_stack,
     )
+    from lib.registry.context_rank import load_signals_file, render_ranking  # type: ignore
+    from lib.registry.context_rank import rank as rank_by_signals  # type: ignore
     from lib.gateway.profile import PROFILE_MODES, HubProfile, validate_profile  # type: ignore
 
 VIEWS = ("preset", "category", "use-case", "context-aware", "prose-intent", "safe-mode")
@@ -159,9 +163,15 @@ class HubConsole:
     """Deterministic ASCII renderer + HITL-gated profile writer over the
     T1 registry and the T2 profile SSOT."""
 
-    def __init__(self, registry: HubRegistry, recipes: Sequence[Recipe]) -> None:
+    def __init__(
+        self,
+        registry: HubRegistry,
+        recipes: Sequence[Recipe],
+        signals: Sequence[str] = (),
+    ) -> None:
         self.registry = registry
         self.recipes = sorted(recipes, key=lambda r: r.id)
+        self.signals: Tuple[str, ...] = tuple(sorted(set(signals)))
 
     # ------------------------------------------------------------------ views
 
@@ -230,10 +240,16 @@ class HubConsole:
         return lines
 
     def _view_context_aware(self) -> List[str]:
+        if self.signals:
+            # T4 engine: deterministic ranking by work-compass signals,
+            # reasons ("why") emitted per record (lib/registry/context_rank.py).
+            ranking = rank_by_signals(self.registry, self.signals)
+            return render_ranking(ranking, self.signals)
         lines = [
             " context-aware ranking v1 — DEFAULT deterministic ordering",
-            " (tier-rank, id). The work-compass project-signal engine lands in T4;",
-            " until then this view shows the registry's trust-ordered baseline.",
+            " (tier-rank, id): no work-compass snapshot provided. Pass a",
+            " `bin/work-compass-aggregate.py --json` snapshot via --signals to",
+            " rank by project signals with per-record reasoning (T4 engine).",
             _rule(),
         ]
         lines.extend(_record_header())
@@ -420,6 +436,7 @@ MAOS Hub console (T3) — render registry views / write the enablement profile.
 
 usage:
   console.py view <name> [--repo-root P] [--as-of DATE] [--html OUT.html]
+                  [--signals COMPASS.json]   # work-compass --json snapshot (T4 ranking)
   console.py select --ids a,b,c [--mode enforce|advisory] [--write PROFILE.yaml] [--confirm]
   console.py --safe-mode            # shortcut for: view safe-mode
   console.py --help
@@ -435,12 +452,14 @@ registry TOOL ids emit `warning: enforce_profile_gates_operations`.
 """
 
 
-def _build_console(repo_root: Path, as_of: str) -> HubConsole:
+def _build_console(
+    repo_root: Path, as_of: str, signals: Sequence[str] = ()
+) -> HubConsole:
     registry = HubRegistry.derive(repo_root, as_of=as_of)
     recipes = load_recipe_catalog(
         repo_root / "mcp-tools" / "maos-mcp-hub" / "lib" / "gateway" / "recipes.yaml"
     )
-    return HubConsole(registry, recipes)
+    return HubConsole(registry, recipes, signals=signals)
 
 
 def _main(argv: List[str]) -> int:
@@ -461,6 +480,7 @@ def _main(argv: List[str]) -> int:
     mode = "enforce"
     write_path: Optional[Path] = None
     confirm = False
+    signals: Tuple[str, ...] = ()
     if cmd == "view" and args and not args[0].startswith("--"):
         view_name = args.pop(0)
     while args:
@@ -471,6 +491,13 @@ def _main(argv: List[str]) -> int:
             as_of = args.pop(0)
         elif a == "--html" and args:
             html_out = Path(args.pop(0))
+        elif a == "--signals" and args:
+            # A work-compass --json snapshot file (T4). Malformed/missing
+            # degrades to the tier-ordered baseline (fail-safe, logged below).
+            sig_path = Path(args.pop(0))
+            signals = load_signals_file(sig_path)
+            if not signals:
+                print(f"[signals] no usable tokens from {sig_path} — baseline order", file=sys.stderr)
         elif a == "--ids" and args:
             ids = [s for s in args.pop(0).split(",") if s.strip()]
         elif a == "--mode" and args:
@@ -490,7 +517,7 @@ def _main(argv: List[str]) -> int:
     if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson, T1)
         print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
         return 1
-    console = _build_console(repo_root, as_of)
+    console = _build_console(repo_root, as_of, signals=signals)
 
     if cmd == "view":
         if view_name not in VIEWS:

--- a/mcp-tools/maos-mcp-hub/lib/registry/context_rank.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/context_rank.py
@@ -1,0 +1,183 @@
+"""
+ContextRank — deterministic context-aware ranking v1 (T4 / WAVE 5, ADR-006/007).
+
+``openspec/changes/maos-hub-console/tasks.md`` T4: *"deterministic ranking by
+`work-compass` project signals, reasoning shown. Acceptance: same input →
+same ranking (byte-stable); the 'why' is emitted."*
+
+Position in the WAVE-5 chain (compose, don't reimplement):
+
+  - **Signals come from `work-compass`** (`bin/work-compass-aggregate.py
+    --json` — the CPT §9.5 consumer that aggregates sessions · worktrees ·
+    branches · GitHub · Jira into one graph). This module consumes that
+    graph as a SNAPSHOT input; it never re-collects (the collector already
+    exists and is itself deterministic per its own contract).
+  - **Ranking is over the derived T1 ``HubRegistry``** + the curated recipe
+    catalog — the same data plane every console view projects.
+  - **The console's `context-aware` view** (T3 scaffold — "engine lands in
+    T4") upgrades to this engine when a signals snapshot is provided, and
+    keeps the tier-ordered baseline when none is.
+
+Determinism contract (DoD-GATE — "same input → same ranking, byte-stable"):
+
+  - Signal extraction ignores volatile fields (``meta.generated_utc``,
+    timestamps) — only stable content (item ids, titles, domains, refs)
+    becomes tokens.
+  - Tokens, matches, and reasons are SORTED; scoring is pure integer
+    arithmetic; the final order is the total order ``(-score, tier-rank,
+    id)`` — no floats, no randomness, no clock.
+
+The "why" contract: every ranked entry carries ``why: [str, ...]`` — one
+human-readable reason per scoring contribution (which signal token matched
+which field, plus the activation-tier prior). An entry that scored 0 says so
+explicitly (``no signal match; activation-tier baseline``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Sequence, Set, Tuple
+
+# Package-relative first (hub runtime), path-injected fallback (direct CLI /
+# pytest — same plumbing as console.py).
+try:  # pragma: no cover - import plumbing
+    from .hub_registry import ACTIVATION_TIERS, HubRegistry
+except ImportError:  # pragma: no cover
+    _HUB_ROOT = str(Path(__file__).resolve().parents[2])
+    if _HUB_ROOT not in sys.path:
+        sys.path.insert(0, _HUB_ROOT)
+    from lib.registry.hub_registry import ACTIVATION_TIERS, HubRegistry  # type: ignore
+
+_TIER_RANK = {tier: i for i, tier in enumerate(ACTIVATION_TIERS)}
+
+# Tier prior: substrates that are always-on deserve to surface first at equal
+# signal relevance (they are the floor every recipe stands on).
+_TIER_PRIOR = {"always-on": 2, "default-on-for-context": 1}
+
+_TOKEN_RE = re.compile(r"[a-z0-9]{3,}")
+
+# Ubiquitous repo/workflow words that carry no project-signal meaning.
+_STOPWORDS = frozenset(
+    (
+        # NOTE: "refactor"/"legacy" are NOT stopwords — a `refactor/…` branch
+        # is exactly the intent signal that should surface `legacy-refactor`.
+        "the and for with from feat fix chore docs test tests main master "
+        "branch worktree session issue merge merged open closed done wip pull "
+        "request unknown none null true false"
+    ).split()
+)
+
+
+def _tokens(text: str) -> Set[str]:
+    return {t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOPWORDS}
+
+
+def extract_signals(compass_graph: Any) -> Tuple[str, ...]:
+    """Deterministic signal-token bag from a work-compass ``--json`` graph.
+
+    Only STABLE content contributes (item ``id``/``title``/``domain`` + the
+    values of ``refs``); volatile fields (``meta.generated_utc``, ``last_ts``,
+    ``status``) are ignored so two snapshots of the same project state yield
+    the same tokens. Malformed input degrades to an empty bag (fail-safe:
+    the console then renders the tier-ordered baseline)."""
+    if not isinstance(compass_graph, dict):
+        return ()
+    items = compass_graph.get("items", [])
+    if not isinstance(items, list):
+        return ()
+    bag: Set[str] = set()
+    for it in items:
+        if not isinstance(it, dict):
+            continue
+        for field in ("id", "title", "domain"):
+            bag |= _tokens(str(it.get(field) or ""))
+        refs = it.get("refs")
+        if isinstance(refs, dict):
+            for v in refs.values():
+                bag |= _tokens(str(v or ""))
+    return tuple(sorted(bag))
+
+
+def rank(
+    registry: HubRegistry,
+    signals: Sequence[str],
+    top: int = 0,
+) -> List[Dict[str, Any]]:
+    """Rank registry records by signal relevance — reasons ("why") emitted.
+
+    Scoring (pure integers, documented so the "why" is checkable):
+      +2  per distinct signal token found in the record's TOOL ID
+      +1  per distinct signal token found in one of the record's RECIPE ids
+      +1  per distinct signal token equal to the record's CATEGORY
+      +2/+1 activation-tier prior (always-on / default-on-for-context)
+    ``activation=excluded`` records are NEVER ranked (they are not offerable).
+
+    Total order: ``(-score, tier-rank, id)`` — byte-stable for equal input.
+    """
+    sig = sorted(set(signals))
+    out: List[Dict[str, Any]] = []
+    for rec in registry.records():
+        if rec.activation == "excluded":
+            continue
+        score = 0
+        why: List[str] = []
+        id_tokens = _tokens(rec.id)
+        recipe_tokens = {r: _tokens(r) for r in rec.recipes}
+        for token in sig:
+            if token in id_tokens:
+                score += 2
+                why.append(f"signal '{token}' matches tool id '{rec.id}' (+2)")
+            for rid in sorted(recipe_tokens):
+                if token in recipe_tokens[rid]:
+                    score += 1
+                    why.append(f"signal '{token}' matches recipe '{rid}' (+1)")
+            if token == rec.category.lower():
+                score += 1
+                why.append(f"signal '{token}' matches category (+1)")
+        prior = _TIER_PRIOR.get(rec.activation, 0)
+        if prior:
+            score += prior
+            why.append(f"activation-tier prior: {rec.activation} (+{prior})")
+        if not why:
+            why.append("no signal match; activation-tier baseline")
+        out.append(
+            {
+                "id": rec.id,
+                "score": score,
+                "activation": rec.activation,
+                "category": rec.category,
+                "why": why,
+            }
+        )
+    out.sort(key=lambda e: (-e["score"], _TIER_RANK[e["activation"]], e["id"]))
+    return out[:top] if top else out
+
+
+def load_signals_file(path: Path) -> Tuple[str, ...]:
+    """Load a work-compass ``--json`` snapshot file → signal tokens.
+    Malformed JSON degrades to an empty bag (fail-safe, never crashes a view)."""
+    try:
+        return extract_signals(json.loads(Path(path).read_text(encoding="utf-8")))
+    except (OSError, json.JSONDecodeError):
+        return ()
+
+
+def render_ranking(ranking: List[Dict[str, Any]], signals: Sequence[str]) -> List[str]:
+    """ASCII lines for the console's context-aware view (reasons inline)."""
+    lines = [
+        f" context-aware ranking v1 — {len(signals)} project signal token(s)"
+        f" (work-compass snapshot), {len(ranking)} rankable record(s).",
+        " order: (-score, tier-rank, id) — deterministic; excluded ids never ranked.",
+        "-" * 78,
+    ]
+    for pos, entry in enumerate(ranking, start=1):
+        lines.append(
+            f" {pos:>2}. {entry['id']:<28} score: {entry['score']:<4}"
+            f" tier: {entry['activation']}"
+        )
+        for reason in entry["why"]:
+            lines.append(f"       why: {reason}")
+    return lines

--- a/mcp-tools/maos-mcp-hub/tests/test_context_rank.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_context_rank.py
@@ -1,0 +1,209 @@
+"""Tests — ContextRank (T4 / WAVE 5): context-aware ranking v1.
+
+tasks.md T4 acceptance, as logged fields / golden fixtures (the DoD-gate):
+  "same input → same ranking (byte-stable); the 'why' is emitted."
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from lib.registry import HubConsole, HubRecord, HubRegistry
+from lib.registry.context_rank import (
+    extract_signals,
+    load_signals_file,
+    rank,
+    render_ranking,
+)
+
+_HERE = Path(__file__).resolve()
+_HUB_DIR = _HERE.parents[1]
+_REPO_ROOT = _HERE.parents[3]
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+def _mk_record(rid: str, **kw) -> HubRecord:
+    base = dict(
+        id=rid, owner_repo="acme/tools", layer="L2", role="r", category="skill",
+        harness_coverage=(), requires=(), conflicts_with=(), guardrails="g",
+        impact="i", recipes=(), activation="opt-in", license_spdx="MIT",
+        provenance="p", ttl=None, last_validated="2026-07-02",
+        rollback="rb", security_status="vetted", derived_from="d",
+    )
+    base.update(kw)
+    return HubRecord(**base)
+
+
+@pytest.fixture()
+def registry() -> HubRegistry:
+    reg = HubRegistry()
+    reg._add(_mk_record("guard", activation="always-on", category="substrate"))
+    reg._add(_mk_record("cognee", activation="opt-in",
+                        recipes=("legacy-refactor", "codebase-onboarding")))
+    reg._add(_mk_record("spec-kit", activation="opt-in", recipes=("new-idea-to-mvp",)))
+    reg._add(_mk_record("mallory", activation="excluded", security_status="rejected"))
+    return reg
+
+
+def _compass_graph(generated_utc: str = "2026-07-02T12:00:00+00:00") -> dict:
+    """A synthetic work-compass --json snapshot: a legacy-refactor project."""
+    return {
+        "meta": {"count": 2, "scope": "current", "generated_utc": generated_utc},
+        "by_domain": {},
+        "items": [
+            {"id": "git:refactor/legacy-billing", "domain": "branch",
+             "title": "Refactor legacy billing module", "status": "open",
+             "last_ts": generated_utc, "refs": {"pr": "acme/app#7"}, "flags": []},
+            {"id": "jira:APP-12", "domain": "ticket",
+             "title": "Characterize legacy behavior with cognee",
+             "status": "in-progress", "last_ts": generated_utc, "refs": {}, "flags": []},
+        ],
+    }
+
+
+# ------------------------------------------------------ signal extraction
+
+
+def test_signals_are_sorted_and_stable() -> None:
+    sig = extract_signals(_compass_graph())
+    assert sig == tuple(sorted(set(sig)))
+    assert "legacy" in sig and "cognee" in sig and "billing" in sig
+
+
+def test_volatile_fields_do_not_change_signals() -> None:
+    """DoD byte-stability: only stable content contributes — two snapshots of
+    the same project state (different generated_utc) yield identical tokens."""
+    assert extract_signals(_compass_graph("2026-07-02T12:00:00+00:00")) == \
+        extract_signals(_compass_graph("2027-01-01T00:00:00+00:00"))
+
+
+def test_malformed_graph_degrades_to_empty(tmp_path: Path) -> None:
+    assert extract_signals(["not", "a", "dict"]) == ()
+    assert extract_signals({"items": "notalist"}) == ()
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ truncated", encoding="utf-8")
+    assert load_signals_file(bad) == ()
+    assert load_signals_file(tmp_path / "absent.json") == ()
+
+
+def test_stopwords_filtered_but_refactor_is_a_signal() -> None:
+    sig = extract_signals(_compass_graph())
+    assert "refactor" in sig            # intent signal, deliberately NOT a stopword
+    assert "open" not in sig            # status noise
+    assert "branch" not in sig          # domain-plumbing noise
+
+
+# ---------------------------------------------------------------- ranking
+
+
+def test_ranking_is_byte_stable_same_input_same_output(registry: HubRegistry) -> None:
+    """T4 acceptance: same input → same ranking (byte-stable)."""
+    sig = extract_signals(_compass_graph())
+    r1 = json.dumps(rank(registry, sig), sort_keys=True)
+    r2 = json.dumps(rank(registry, extract_signals(_compass_graph())), sort_keys=True)
+    assert r1 == r2
+
+
+def test_golden_ranking_order_and_scores(registry: HubRegistry) -> None:
+    """Golden fixture: the legacy-refactor snapshot must surface cognee first
+    (tool-id match +2 AND recipe matches), guard next (tier prior)."""
+    ranking = rank(registry, extract_signals(_compass_graph()))
+    assert [e["id"] for e in ranking] == ["cognee", "guard", "spec-kit"]
+    by_id = {e["id"]: e for e in ranking}
+    # cognee: 'cognee' id match (+2) + 'legacy'/'refactor' → recipe legacy-refactor (+1+1)
+    assert by_id["cognee"]["score"] >= 4
+    assert by_id["guard"]["score"] == 2          # tier prior only
+    assert by_id["spec-kit"]["score"] == 0       # nothing matches
+
+
+def test_why_is_emitted_for_every_entry(registry: HubRegistry) -> None:
+    """T4 acceptance: the 'why' is emitted — every entry, even zero-score."""
+    ranking = rank(registry, extract_signals(_compass_graph()))
+    for entry in ranking:
+        assert entry["why"], f"empty why for {entry['id']}"
+    by_id = {e["id"]: e for e in ranking}
+    assert any("matches tool id 'cognee'" in w for w in by_id["cognee"]["why"])
+    assert any("recipe 'legacy-refactor'" in w for w in by_id["cognee"]["why"])
+    assert by_id["spec-kit"]["why"] == ["no signal match; activation-tier baseline"]
+
+
+def test_excluded_records_are_never_ranked(registry: HubRegistry) -> None:
+    ranking = rank(registry, ("mallory",))
+    assert "mallory" not in [e["id"] for e in ranking]
+
+
+def test_empty_signals_rank_is_tier_ordered_baseline(registry: HubRegistry) -> None:
+    ranking = rank(registry, ())
+    assert [e["id"] for e in ranking] == ["guard", "cognee", "spec-kit"]
+    assert ranking[0]["why"] == ["activation-tier prior: always-on (+2)"]
+
+
+def test_top_parameter_truncates(registry: HubRegistry) -> None:
+    assert len(rank(registry, (), top=2)) == 2
+
+
+# ------------------------------------------------------- console integration
+
+
+def test_console_context_aware_view_uses_engine_when_signals_present(
+    registry: HubRegistry,
+) -> None:
+    sig = extract_signals(_compass_graph())
+    console = HubConsole(registry, [], signals=sig)
+    out = console.render("context-aware")
+    assert "why:" in out
+    assert out.index("cognee") < out.index("spec-kit")
+    assert console.render("context-aware") == out  # byte-stable through the view
+
+
+def test_console_context_aware_baseline_without_signals(registry: HubRegistry) -> None:
+    out = HubConsole(registry, []).render("context-aware")
+    assert "no work-compass snapshot provided" in out
+    assert "why:" not in out
+
+
+def test_rendered_ranking_lines_carry_positions_and_reasons() -> None:
+    lines = render_ranking(
+        [{"id": "x", "score": 3, "activation": "opt-in", "category": "skill",
+          "why": ["signal 'x' matches tool id 'x' (+2)"]}],
+        ("x",),
+    )
+    assert any(ln.startswith("  1. x") for ln in lines)
+    assert any("why: signal 'x'" in ln for ln in lines)
+
+
+# ------------------------------------------------------------------- CLI
+
+
+def test_cli_signals_flag_ranks_with_reasons(tmp_path: Path) -> None:
+    """CLI smoke over the LIVE repo: a snapshot naming a real recipe token
+    produces a ranked view with reasons; run twice → byte-identical."""
+    snap = tmp_path / "compass.json"
+    snap.write_text(json.dumps(_compass_graph()), encoding="utf-8")
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    argv = [sys.executable, str(script), "view", "context-aware",
+            "--signals", str(snap), "--repo-root", str(_REPO_ROOT)]
+    run1 = subprocess.run(argv, capture_output=True, text=True, check=True)
+    run2 = subprocess.run(argv, capture_output=True, text=True, check=True)
+    assert "why:" in run1.stdout
+    assert run1.stdout == run2.stdout  # T4 acceptance at the CLI surface
+
+
+def test_cli_malformed_signals_degrades_to_baseline(tmp_path: Path) -> None:
+    snap = tmp_path / "broken.json"
+    snap.write_text("{ nope", encoding="utf-8")
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    out = subprocess.run(
+        [sys.executable, str(script), "view", "context-aware",
+         "--signals", str(snap), "--repo-root", str(_REPO_ROOT)],
+        capture_output=True, text=True, check=True,
+    )
+    assert "no usable tokens" in out.stderr
+    assert "no work-compass snapshot provided" in out.stdout

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
@@ -115,8 +115,9 @@ def test_use_case_view_lists_recipes(console: HubConsole) -> None:
 
 
 def test_context_aware_view_is_tier_ordered_and_names_t4(console: HubConsole) -> None:
+    """Baseline (no signals): tier-ordered + points to the T4 --signals engine."""
     out = console.render("context-aware")
-    assert "lands in T4" in out
+    assert "T4 engine" in out and "--signals" in out
     # deterministic ordering: always-on first, excluded last
     assert out.index("guard") < out.index("alpha") < out.index("mallory")
 


### PR DESCRIPTION
[PR-as-Prompt] **WAVE 5 / T4 — context-aware ranking v1** (ADR-006 MoE hub · ADR-007 front-door)

## Context
`openspec/changes/maos-hub-console/tasks.md` T4: *"deterministic ranking by `work-compass` project signals, **reasoning shown**. Acceptance: same input → same ranking (byte-stable); the 'why' is emitted."* Fills the engine slot the T3 console scaffold (#214) declared ("engine lands in T4"). Composes: work-compass (`bin/work-compass-aggregate.py --json`, the CPT §9.5 signal collector) → T1 registry (#209) → T3 console view.

## Objectives
- `lib/registry/context_rank.py` — `extract_signals()` (volatile fields ignored: `generated_utc`/`last_ts`/`status` never become tokens) + `rank()` (pure-integer scoring: +2 tool-id · +1 recipe · +1 category · +2/+1 tier prior; `excluded` never ranked; total order `(-score, tier-rank, id)`) + `render_ranking()` (ASCII, reasons inline).
- Console `context-aware` view runs the engine when `--signals COMPASS.json` is given; keeps the tier-ordered baseline otherwise (fail-safe on malformed snapshot + stderr diagnostic).
- Stopword design note: `refactor`/`legacy` are deliberately intent-signals (a `refactor/…` branch must surface the `legacy-refactor` recipe); `session`/`branch`/status words are noise.

## Acceptance (logged fields / golden fixtures — DoD-gate)
- [x] **same input → same ranking (byte-stable)** — asserted at 3 surfaces: engine (`json` double-run), view (`render` twice), CLI (subprocess double-run stdout diff)
- [x] volatile-field invariance — two snapshots differing only in `generated_utc` ⇒ identical tokens
- [x] **the "why" is emitted** — every entry carries `why: […]` per scoring contribution; zero-score entries say `no signal match; activation-tier baseline`
- [x] golden ranking fixture — legacy-refactor snapshot ⇒ `[cognee, guard, spec-kit]` with checked scores
- [x] excluded ids never ranked; malformed/missing snapshot degrades to baseline
- [x] 15 new tests; 83/83 W5 suites green · validate-plugin PASS · gitleaks clean

## Risk + rollback
Additive module + view upgrade behind the `--signals` flag (no flag ⇒ prior behavior minus scaffold text). Rollback = revert the squash commit.

## Cross-links
ADR-006 · ADR-007 · issue #204 (T4) · PR #214 (T3) · `skills/work-compass/SKILL.md` · CPT §9.5

Signed: Claude-Dev-moe-t4 · 2026-07-02T12:47:00-03:00
