### PR TITLE
feat(maos-hub): prose-intent engine (WAVE5/T5) — bounded interview, shown mapping, DRAFT never auto-applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — prose-intent engine (WAVE 5 / T5, ADR-006 + ADR-007)
+
+- **`lib/registry/prose_intent.py`** (`mcp-tools/maos-mcp-hub`): prose need → **bounded interview
+  (≤3 Qs)** → custom profile **DRAFT** (HITL). Deterministic pure-integer token-overlap vs the
+  curated recipe catalog (tokenizer reused from T4 `context_rank` — one tokenizer, one behavior).
+- **The mapping is SHOWN** (T5 acceptance): logged fields — `mapping[]` with per-token reasons
+  (`prose 'legado' matches use-case …`), `draft_ids`, the exact draft YAML, `open_questions`.
+- **Never auto-applies** (T5 acceptance): `applied: false` always; the module has NO write
+  capability — applying routes through the ONE gated path (`console.py select … --confirm`, T3).
+- Fail-closed at DRAFT time: `activation=excluded` ids are dropped + surfaced
+  (`excluded_dropped`); intra-stack OR-alternatives (e.g. `spec-kit` vs `openspec`) become
+  `open_questions` echoing the recipe's own HITL note — never a silent pick. Unmatched prose ⇒
+  the ≤3-Q interview (answer domains from live data) — no fabricated mapping (anti-theater).
+- Tests: `tests/test_prose_intent.py` — 13 tests (shown-mapping, never-applies incl. no-write-API
+  assertion, determinism double-run at engine+CLI, excluded-dropped, conflict-as-open-question,
+  bounded-interview).
+
+
 ### Added — context-aware ranking v1 (WAVE 5 / T4, ADR-006 + ADR-007)
 
 - **`lib/registry/context_rank.py`** (`mcp-tools/maos-mcp-hub`): deterministic ranking of registry

--- a/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/__init__.py
@@ -23,3 +23,8 @@ from .context_rank import (  # noqa: F401
     rank,
     render_ranking,
 )
+from .prose_intent import (  # noqa: F401
+    interview_questions,
+    map_prose,
+    render_mapping,
+)

--- a/mcp-tools/maos-mcp-hub/lib/registry/console.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/console.py
@@ -49,7 +49,7 @@ in later worktrees (honest placeholders, still rendered FROM the registry):
     the work-compass signal engine lands in T4 (the view says so).
   - ``prose-intent``  — the bounded ≤3-question interview scaffold whose
     answer domains come from the live registry; the prose→profile mapping
-    engine lands in T5 (the view says so).
+    engine is ``lib/registry/prose_intent.py`` (T5).
 """
 
 from __future__ import annotations
@@ -261,8 +261,9 @@ class HubConsole:
         cats = sorted({rec.category for rec in self.registry.records()})
         lines = [
             " prose-intent — bounded interview (<=3 questions) -> profile DRAFT.",
-            " The prose->profile mapping engine lands in T5; the answer domains",
-            " below are derived LIVE from the registry. A draft NEVER auto-applies.",
+            " Engine: lib/registry/prose_intent.py --prose '<need>' (T5) — emits the",
+            " shown prose->profile mapping; the answer domains below are derived",
+            " LIVE from the registry. A draft NEVER auto-applies.",
             _rule(),
             " Q1. What are you building? (maps to a use-case recipe)",
         ]

--- a/mcp-tools/maos-mcp-hub/lib/registry/prose_intent.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/prose_intent.py
@@ -1,0 +1,264 @@
+"""
+ProseIntent — prose need → bounded interview (≤3 Qs) → profile DRAFT
+(T5 / WAVE 5, ADR-006/007).
+
+``openspec/changes/maos-hub-console/tasks.md`` T5: *"prose need → bounded
+interview (≤3 Qs) → custom profile DRAFT (HITL). Acceptance: the
+prose→profile mapping is shown; never auto-applies."*
+
+Position in the WAVE-5 chain (compose, don't reimplement):
+
+  - **Matching is over the curated recipe catalog** (``recipes.yaml`` — the
+    Phase-2 §4 use-case stacks) + the derived T1 ``HubRegistry``; tokenizing
+    reuses the T4 ``context_rank`` tokenizer (one tokenizer, one behavior).
+  - **The output is a DRAFT, never an application.** This module has NO
+    write capability at all — ``map_prose()`` returns logged fields
+    (``applied: false`` always) and the draft YAML text. Applying goes
+    through the ONE existing gate: ``console.py select --ids … --confirm``
+    (T3 — conflict-checked + fail-closed + HITL-confirmed). One write path,
+    one set of gates.
+  - **Conflicts inside a recipe stack are surfaced, not silently resolved**:
+    recipe stacks carry OR-alternatives (e.g. ``spec-kit`` OR ``openspec``,
+    mutually exclusive) — the mapping lists them as ``open_questions`` for
+    the human, because choosing is the recipe's own documented HITL point.
+
+Determinism contract (DoD-GATE): pure-integer token-overlap scoring, sorted
+outputs, no clock/randomness — same prose + same registry ⇒ same mapping.
+
+The bounded interview: when the prose matches NOTHING (all recipe scores 0),
+the module returns the ≤3-question interview (answer domains derived LIVE
+from the registry/catalog — same questions the T3 ``prose-intent`` view
+scaffolds) instead of a fabricated mapping (anti-theater: no invented
+intent).
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Sequence
+
+import yaml
+
+# Package-relative first (hub runtime), path-injected fallback (direct CLI /
+# pytest — same plumbing as console.py / context_rank.py).
+try:  # pragma: no cover - import plumbing
+    from .console import Recipe, load_recipe_catalog
+    from .context_rank import _tokens
+    from .hub_registry import HubRegistry
+except ImportError:  # pragma: no cover
+    _HUB_ROOT = str(Path(__file__).resolve().parents[2])
+    if _HUB_ROOT not in sys.path:
+        sys.path.insert(0, _HUB_ROOT)
+    from lib.registry.console import Recipe, load_recipe_catalog  # type: ignore
+    from lib.registry.context_rank import _tokens  # type: ignore
+    from lib.registry.hub_registry import HubRegistry  # type: ignore
+
+MAX_QUESTIONS = 3
+
+
+def interview_questions(
+    registry: HubRegistry, recipes: Sequence[Recipe]
+) -> List[Dict[str, Any]]:
+    """The bounded interview (≤3 Qs) with answer domains from the live data.
+    Same three questions the T3 console view scaffolds — here as fields."""
+    questions = [
+        {
+            "q": "What are you building? (maps to a use-case recipe)",
+            "answers": [{"id": r.id, "use_case": r.use_case} for r in
+                        sorted(recipes, key=lambda r: r.id)],
+        },
+        {
+            "q": "Which capability categories do you need?",
+            "answers": sorted({rec.category for rec in registry.records()}),
+        },
+        {
+            "q": "Enforcement posture? (enforce | advisory)",
+            "answers": ["enforce", "advisory"],
+        },
+    ]
+    assert len(questions) <= MAX_QUESTIONS  # the bound IS the contract
+    return questions
+
+
+def _score_recipe(prose_tokens: frozenset, recipe: Recipe) -> Dict[str, Any]:
+    """Pure-integer overlap of prose tokens vs one recipe — reasons emitted."""
+    score = 0
+    why: List[str] = []
+    id_toks = _tokens(recipe.id)
+    case_toks = _tokens(recipe.use_case)
+    why_toks = _tokens(recipe.why)
+    for token in sorted(prose_tokens):
+        if token in id_toks:
+            score += 3
+            why.append(f"prose '{token}' matches recipe id '{recipe.id}' (+3)")
+        elif token in case_toks:
+            score += 2
+            why.append(f"prose '{token}' matches use-case '{recipe.use_case}' (+2)")
+        elif token in why_toks:
+            score += 1
+            why.append(f"prose '{token}' matches recipe rationale (+1)")
+    return {"id": recipe.id, "use_case": recipe.use_case, "score": score, "why": why}
+
+
+def map_prose(
+    prose: str,
+    registry: HubRegistry,
+    recipes: Sequence[Recipe],
+) -> Dict[str, Any]:
+    """Prose need → the SHOWN mapping + profile DRAFT. Logged fields only.
+
+    Always returns ``applied: false`` — this module cannot write. The result
+    is either:
+      - ``status: draft``      — a best-recipe mapping + draft ids + the
+        exact draft YAML + open_questions (conflicts to resolve, posture);
+      - ``status: interview``  — prose matched nothing ⇒ the bounded ≤3-Q
+        interview (never a fabricated mapping).
+    """
+    prose_tokens = frozenset(_tokens(prose or ""))
+    scored = sorted(
+        (_score_recipe(prose_tokens, r) for r in recipes),
+        key=lambda e: (-e["score"], e["id"]),
+    )
+    matched = [e for e in scored if e["score"] > 0]
+    if not matched:
+        return {
+            "status": "interview",
+            "applied": False,
+            "prose_tokens": sorted(prose_tokens),
+            "mapping": [],
+            "questions": interview_questions(registry, recipes),
+            "note": "prose matched no recipe — answer the bounded interview "
+                    "(≤3 Qs); no mapping is fabricated",
+        }
+
+    best = matched[0]
+    recipe = next(r for r in recipes if r.id == best["id"])
+
+    # Draft ids = the recipe stack, minus registry-excluded ids (fail-closed
+    # here too — an excluded tool never even enters a DRAFT).
+    draft_ids: List[str] = []
+    excluded: List[str] = []
+    for tid in recipe.stack:
+        rec = registry.get(tid)
+        if rec is not None and rec.activation == "excluded":
+            excluded.append(tid)
+        elif tid not in draft_ids:
+            draft_ids.append(tid)
+
+    # Surface intra-stack conflicts as OPEN QUESTIONS (the recipe's own HITL
+    # point) — never silently pick a side of an OR-alternative.
+    edges = registry.conflict_edges() | registry.edges_from_records()
+    draft_set = set(draft_ids)
+    open_questions: List[str] = []
+    for edge in sorted(sorted(e) for e in edges if len(e) == 2 and e <= draft_set):
+        open_questions.append(
+            f"choose ONE of the mutually-exclusive pair: {edge[0]} vs {edge[1]}"
+            f" (recipe HITL: {recipe.hitl})"
+        )
+    open_questions.append("enforcement posture: enforce | advisory")
+
+    draft_yaml = yaml.safe_dump(
+        {
+            "schema_version": "hub-profile/1.0.0",
+            "mode": "enforce",
+            "enabled": sorted(draft_ids),
+        },
+        sort_keys=False,
+        allow_unicode=True,
+    )
+    return {
+        "status": "draft",
+        "applied": False,          # ALWAYS — T5 acceptance: never auto-applies
+        "prose_tokens": sorted(prose_tokens),
+        "mapping": matched,        # the prose→recipe mapping, SHOWN
+        "recipe": recipe.id,
+        "draft_ids": sorted(draft_ids),
+        "excluded_dropped": sorted(excluded),
+        "open_questions": open_questions,
+        "draft": draft_yaml,
+        "apply_via": (
+            "console.py select --ids "
+            + ",".join(sorted(draft_ids))
+            + " --write <profile.yaml> --confirm   # the ONE gated write path (T3)"
+        ),
+    }
+
+
+def render_mapping(result: Dict[str, Any]) -> List[str]:
+    """ASCII lines for the console's prose-intent flow (mapping shown)."""
+    lines = [f" prose-intent — status: {result['status']}  (applied: false — always)"]
+    if result["status"] == "interview":
+        lines.append(" prose matched no recipe; bounded interview (<=3 Qs):")
+        for i, q in enumerate(result["questions"], start=1):
+            lines.append(f"  Q{i}. {q['q']}")
+        return lines
+    lines.append(f" matched recipe: {result['recipe']}")
+    for entry in result["mapping"]:
+        lines.append(f"  candidate: {entry['id']:<24} score: {entry['score']}")
+        for reason in entry["why"]:
+            lines.append(f"    why: {reason}")
+    lines.append(f" draft ids: {', '.join(result['draft_ids'])}")
+    if result["excluded_dropped"]:
+        lines.append(f" dropped (activation=excluded): {', '.join(result['excluded_dropped'])}")
+    for oq in result["open_questions"]:
+        lines.append(f" OPEN: {oq}")
+    lines.append(" apply via: " + result["apply_via"])
+    return lines
+
+
+# ----------------------------------------------------------------------- CLI
+
+_USAGE = """\
+MAOS Hub prose-intent (T5) — prose need -> bounded interview / profile DRAFT.
+
+usage:
+  prose_intent.py --prose "I want to refactor a legacy service" [--repo-root P] [--as-of DATE] [--json]
+
+Output is a DRAFT + the shown prose->profile mapping (logged fields;
+applied: false always). This tool CANNOT write a profile — apply the draft
+via the one gated path: console.py select --ids ... --confirm (T3).
+"""
+
+
+def _main(argv: List[str]) -> int:
+    here = Path(__file__).resolve()
+    repo_root = here.parents[4]
+    as_of = "1970-01-01"
+    prose = ""
+    as_json = False
+    args = list(argv)
+    if not args or "--help" in args or "-h" in args:
+        print(_USAGE)
+        return 0
+    while args:
+        a = args.pop(0)
+        if a == "--prose" and args:
+            prose = args.pop(0)
+        elif a == "--repo-root" and args:
+            repo_root = Path(args.pop(0)).resolve()
+        elif a == "--as-of" and args:
+            as_of = args.pop(0)
+        elif a == "--json":
+            as_json = True
+        else:
+            print(json.dumps({"verdict": "fail", "error": f"unknown argument: {a}"}))
+            return 2
+    if not (repo_root / "skills").is_dir():
+        print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
+        return 1
+    registry = HubRegistry.derive(repo_root, as_of=as_of)
+    recipes = load_recipe_catalog(
+        repo_root / "mcp-tools" / "maos-mcp-hub" / "lib" / "gateway" / "recipes.yaml"
+    )
+    result = map_prose(prose, registry, recipes)
+    if as_json:
+        print(json.dumps(result, ensure_ascii=False, indent=2))
+    else:
+        print("\n".join(render_mapping(result)))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(_main(sys.argv[1:]))

--- a/mcp-tools/maos-mcp-hub/tests/test_prose_intent.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_prose_intent.py
@@ -1,0 +1,198 @@
+"""Tests — ProseIntent (T5 / WAVE 5): prose need → interview → profile DRAFT.
+
+tasks.md T5 acceptance, as logged fields (the DoD-gate):
+  "the prose→profile mapping is shown; never auto-applies."
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from lib.registry import HubRecord, HubRegistry, Recipe
+from lib.registry.prose_intent import (
+    MAX_QUESTIONS,
+    interview_questions,
+    map_prose,
+    render_mapping,
+)
+
+_HERE = Path(__file__).resolve()
+_HUB_DIR = _HERE.parents[1]
+_REPO_ROOT = _HERE.parents[3]
+
+
+# ------------------------------------------------------------------ fixtures
+
+
+def _mk_record(rid: str, **kw) -> HubRecord:
+    base = dict(
+        id=rid, owner_repo="acme/tools", layer="L2", role="r", category="skill",
+        harness_coverage=(), requires=(), conflicts_with=(), guardrails="g",
+        impact="i", recipes=(), activation="opt-in", license_spdx="MIT",
+        provenance="p", ttl=None, last_validated="2026-07-02",
+        rollback="rb", security_status="vetted", derived_from="d",
+    )
+    base.update(kw)
+    return HubRecord(**base)
+
+
+@pytest.fixture()
+def registry() -> HubRegistry:
+    reg = HubRegistry()
+    reg._add(_mk_record("guard", activation="always-on", category="substrate"))
+    reg._add(_mk_record("spec-kit", conflicts_with=("openspec",)))
+    reg._add(_mk_record("openspec", conflicts_with=("spec-kit",)))
+    reg._add(_mk_record("cognee"))
+    reg._add(_mk_record("mallory", activation="excluded", security_status="rejected"))
+    return reg
+
+
+@pytest.fixture()
+def recipes() -> list:
+    return [
+        Recipe(id="new-idea-to-mvp", use_case="Nova ideia -> MVP",
+               stack=("guard", "spec-kit", "openspec"),
+               why="seed estrutura a ideia; deck para pitch",
+               hitl="escolha spec-kit vs openspec + aprovação do plano"),
+        Recipe(id="legacy-refactor", use_case="Refactor de legado",
+               stack=("guard", "cognee", "mallory"),
+               why="characterization tests protegem o comportamento",
+               hitl="aprovação do plano de refactor"),
+    ]
+
+
+# ------------------------------------------------------ mapping is SHOWN
+
+
+def test_prose_maps_to_recipe_with_shown_mapping(registry, recipes) -> None:
+    """T5 acceptance: the prose→profile mapping is shown (logged fields)."""
+    result = map_prose("quero refatorar um serviço legado", registry, recipes)
+    assert result["status"] == "draft"
+    assert result["recipe"] == "legacy-refactor"
+    assert result["mapping"], "mapping must be shown"
+    top = result["mapping"][0]
+    assert top["id"] == "legacy-refactor" and top["score"] > 0
+    assert any("prose 'legado'" in w or "prose 'refatorar'" in w or
+               "prose 'refactor'" in w for w in top["why"])
+
+
+def test_never_auto_applies(registry, recipes, tmp_path: Path) -> None:
+    """T5 acceptance: never auto-applies — applied:false always, no write API."""
+    import lib.registry.prose_intent as mod
+    result = map_prose("mvp idea", registry, recipes)
+    assert result["applied"] is False
+    assert "apply_via" in result and "--confirm" in result["apply_via"]
+    assert not hasattr(mod, "select") and not hasattr(mod, "write_profile")
+    interview = map_prose("zzz qqq", registry, recipes)
+    assert interview["applied"] is False
+
+
+def test_mapping_is_deterministic(registry, recipes) -> None:
+    a = json.dumps(map_prose("refactor legado", registry, recipes), sort_keys=True)
+    b = json.dumps(map_prose("refactor legado", registry, recipes), sort_keys=True)
+    assert a == b
+
+
+def test_draft_is_valid_hub_profile_yaml(registry, recipes) -> None:
+    result = map_prose("nova ideia mvp", registry, recipes)
+    doc = yaml.safe_load(result["draft"])
+    assert doc["schema_version"].startswith("hub-profile/1.")
+    assert doc["mode"] == "enforce"
+    assert sorted(doc["enabled"]) == result["draft_ids"]
+
+
+# --------------------------------------------- fail-closed + open questions
+
+
+def test_excluded_ids_never_enter_a_draft(registry, recipes) -> None:
+    """Fail-closed at DRAFT time too: mallory is in the recipe stack but
+    activation=excluded — dropped and surfaced."""
+    result = map_prose("refactor legado", registry, recipes)
+    assert "mallory" not in result["draft_ids"]
+    assert result["excluded_dropped"] == ["mallory"]
+
+
+def test_intra_stack_conflict_is_an_open_question_not_a_silent_pick(
+    registry, recipes
+) -> None:
+    """OR-alternatives (spec-kit vs openspec) are the recipe's own HITL point
+    — surfaced as an open question; BOTH stay in the draft for the human."""
+    result = map_prose("nova ideia mvp", registry, recipes)
+    assert result["recipe"] == "new-idea-to-mvp"
+    conflicts = [q for q in result["open_questions"] if "openspec vs spec-kit" in q
+                 or "spec-kit vs openspec" in q]
+    assert len(conflicts) == 1
+    assert "escolha spec-kit vs openspec" in conflicts[0]  # recipe hitl echoed
+
+
+def test_posture_question_always_open(registry, recipes) -> None:
+    result = map_prose("refactor legado", registry, recipes)
+    assert any("enforce | advisory" in q for q in result["open_questions"])
+
+
+# ------------------------------------------------------ bounded interview
+
+
+def test_unmatched_prose_returns_bounded_interview(registry, recipes) -> None:
+    """No match ⇒ the ≤3-Q interview — never a fabricated mapping."""
+    result = map_prose("xyzzy plugh", registry, recipes)
+    assert result["status"] == "interview"
+    assert result["mapping"] == []
+    assert len(result["questions"]) <= MAX_QUESTIONS
+    assert "no mapping is fabricated" in result["note"]
+
+
+def test_interview_answer_domains_come_from_live_data(registry, recipes) -> None:
+    qs = interview_questions(registry, recipes)
+    assert len(qs) <= MAX_QUESTIONS
+    assert {a["id"] for a in qs[0]["answers"]} == {"new-idea-to-mvp", "legacy-refactor"}
+    assert "substrate" in qs[1]["answers"]
+    assert qs[2]["answers"] == ["enforce", "advisory"]
+
+
+def test_empty_prose_goes_to_interview(registry, recipes) -> None:
+    assert map_prose("", registry, recipes)["status"] == "interview"
+
+
+# ---------------------------------------------------------------- rendering
+
+
+def test_render_mapping_shows_reasons_and_open_questions(registry, recipes) -> None:
+    lines = render_mapping(map_prose("nova ideia mvp", registry, recipes))
+    text = "\n".join(lines)
+    assert "applied: false" in text
+    assert "why: prose" in text
+    assert "OPEN:" in text
+    assert "apply via: console.py select" in text
+
+
+# ------------------------------------------------------------------- CLI
+
+
+def test_cli_prose_maps_and_never_writes(tmp_path: Path) -> None:
+    """CLI smoke over the LIVE repo: real recipe matched; applied:false;
+    deterministic (double-run diff)."""
+    script = _HUB_DIR / "lib" / "registry" / "prose_intent.py"
+    argv = [sys.executable, str(script), "--prose",
+            "refactor a legacy service safely", "--json",
+            "--repo-root", str(_REPO_ROOT)]
+    run1 = subprocess.run(argv, capture_output=True, text=True, check=True)
+    run2 = subprocess.run(argv, capture_output=True, text=True, check=True)
+    payload = json.loads(run1.stdout)
+    assert payload["applied"] is False
+    assert payload["status"] in ("draft", "interview")
+    assert run1.stdout == run2.stdout
+
+
+def test_cli_unknown_argument_is_an_error() -> None:
+    script = _HUB_DIR / "lib" / "registry" / "prose_intent.py"
+    out = subprocess.run([sys.executable, str(script), "--porse", "typo"],
+                         capture_output=True, text=True)
+    assert out.returncode == 2
+    assert "unknown argument" in out.stdout

--- a/skills/maos-concierge/SKILL.md
+++ b/skills/maos-concierge/SKILL.md
@@ -120,7 +120,7 @@ python3 mcp-tools/maos-mcp-hub/lib/registry/console.py select --ids a,b,c \
 # … review the emitted draft + logged fields, then the HUMAN adds:  --confirm
 ```
 
-Gates (logged fields, not prose): conflicting pair in the selection → `verdict: refused` + `conflicts: [[a,b]]`; `activation=excluded` id → refused fail-closed; no `--confirm` → `written: false, reason: confirmation_required`. The `context-aware` and `prose-intent` views are registry-rendered scaffolds whose engines land in T4 (work-compass signals) and T5 (prose→profile interview).
+Gates (logged fields, not prose): conflicting pair in the selection → `verdict: refused` + `conflicts: [[a,b]]`; `activation=excluded` id → refused fail-closed; no `--confirm` → `written: false, reason: confirmation_required`. The `context-aware` view ranks by work-compass signals via `--signals COMPASS.json` (T4 — deterministic, reasons emitted); `prose-intent` maps a prose need via `lib/registry/prose_intent.py --prose '<need>'` (T5 — DRAFT + shown mapping, never auto-applies).
 
 ### `--mode=config` (profile SSOT inspect/adjust)
 Inspect the persisted hub profile (`mcp-tools/maos-mcp-hub/profile.yaml` / `$MAOS_HUB_PROFILE`): show `mode` (enforce|advisory), the `enabled` list, and validate it against the registry (`lib.gateway.profile.validate_profile` — excluded ids are refused). Adjustments go through the same `select … --confirm` path as setup (never hand-edit advice that bypasses the conflict/HITL gates).


### PR DESCRIPTION
[PR-as-Prompt] **WAVE 5 / T5 — prose-intent engine** (ADR-006 MoE hub · ADR-007 front-door)

## Context
`openspec/changes/maos-hub-console/tasks.md` T5: *"prose need → bounded interview (≤3 Qs) → custom profile DRAFT (HITL). Acceptance: the prose→profile mapping is shown; **never auto-applies**."* Fills the second engine slot the T3 console scaffold declared. Composes: recipe catalog (T1) · T4 tokenizer (reused — one tokenizer, one behavior) · T3's `select --confirm` as the ONLY write path.

## Objectives
- `lib/registry/prose_intent.py` — `map_prose()`: deterministic token-overlap scoring vs the curated recipes (+3 id · +2 use-case · +1 rationale, reasons per token); `interview_questions()`: the bounded ≤3-Q interview with answer domains from live data; `render_mapping()`; CLI (`--prose … --json`).
- **Never auto-applies, structurally**: `applied: false` always; the module has NO write capability (a test asserts the absence of any write API); `apply_via` points at the one gated path (`console.py select … --confirm`).
- Fail-closed at DRAFT time: `activation=excluded` dropped + surfaced; intra-stack OR-alternatives become `open_questions` echoing the recipe's own HITL note — never a silent pick; unmatched prose ⇒ interview, no fabricated mapping.

## Acceptance (logged fields — DoD-gate)
- [x] **the prose→profile mapping is shown** — `mapping[]` with per-token reasons + `draft_ids` + exact draft YAML (`test_prose_maps_to_recipe_with_shown_mapping`, `test_render_mapping_shows_reasons_and_open_questions`)
- [x] **never auto-applies** — `applied: false` always + no-write-API assertion + CLI writes nothing (`test_never_auto_applies`, `test_cli_prose_maps_and_never_writes`)
- [x] bounded interview ≤3 Qs on no-match (`test_unmatched_prose_returns_bounded_interview`)
- [x] determinism double-run at engine + CLI surfaces
- [x] excluded-dropped + conflict-as-open-question fixtures
- [x] 13 new tests; 96/96 W5 suites green · validate-plugin PASS · gitleaks clean

## Risk + rollback
Additive module; console/SKILL.md changes are pointer-text only. Rollback = revert the squash commit.

## Cross-links
ADR-006 · ADR-007 · issue #204 (T5) · PRs #209/#214/#215 · `openspec/specs/maos-hub-registry/spec.md`

Signed: Claude-Dev-moe-t5 · 2026-07-02T12:52:00-03:00
