### PR TITLE
feat(maos-hub): activation taxonomy + karpathy principles internalized (WAVE5/T6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — activation taxonomy applied + karpathy principles internalized (WAVE 5 / T6, ADR-006)
+
+- **`skills/deliberate-coding/SKILL.md`** — MAOS-native articulation of the deliberation-before-
+  coding principle family (Think-Before-Coding · Simplicity-First · Surgical-Changes ·
+  Goal-Driven). **Patterns-only, zero upstream text** (the `karpathy-claude-md` intake is ADAPT
+  with conditions `patterns-only + no-redistribution` — HF2: upstream README claims MIT but ships
+  NO LICENSE file). **Credit retained** (Andrej Karpathy — inspiration; multica-ai/
+  andrej-karpathy-skills — the popularizing repo). Being a first-party skill, it auto-derives
+  into the T1 hub registry as `default-on-for-context`, MIT, license-clean — the native L0 floor.
+- **Activation taxonomy applied to the upstream records** (asserted, not prosed): the live
+  registry derives `karpathy-claude-md` → `opt-in` (license gate HF2, reason logged);
+  `request_activation` refuses upgrades past the derived tier; the mis-attributed
+  `forrestchang-andrej-karpathy-skills` (404) stays `excluded` and immutable.
+- Tests: `tests/test_activation_karpathy.py` — 7 tests (tier + logged reason, upgrade refusal,
+  excluded immutability, first-party derivation, grep-able credit, patterns-only markers,
+  content-not-runtime check).
+
+
 ### Added — prose-intent engine (WAVE 5 / T5, ADR-006 + ADR-007)
 
 - **`lib/registry/prose_intent.py`** (`mcp-tools/maos-mcp-hub`): prose need → **bounded interview

--- a/mcp-tools/maos-mcp-hub/tests/test_activation_karpathy.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_activation_karpathy.py
@@ -1,0 +1,99 @@
+"""Tests — activation taxonomy applied + karpathy principles internalized
+(T6 / WAVE 5).
+
+tasks.md T6, as logged fields (the DoD-gate): "apply the `activation`
+taxonomy; internalize the karpathy *principles* natively (credit the
+inspiration), repo as `opt-in`/`default-on-for-context`."
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lib.registry import HubRegistry
+
+_HERE = Path(__file__).resolve()
+_REPO_ROOT = _HERE.parents[3]
+AS_OF = "2026-07-02"
+
+_SKILL_MD = _REPO_ROOT / "skills" / "deliberate-coding" / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def registry() -> HubRegistry:
+    assert (_REPO_ROOT / "skills").is_dir()
+    return HubRegistry.derive(_REPO_ROOT, as_of=AS_OF)
+
+
+# ------------------------------------------------- taxonomy applied (repo)
+
+
+def test_upstream_repo_is_capped_to_opt_in_or_default_on(registry: HubRegistry) -> None:
+    """T6: 'repo as opt-in/default-on-for-context' — the derived tier of the
+    upstream record is one of the two allowed tiers, with the gate REASON
+    logged (currently the HF2 license gate caps ADAPT → opt-in)."""
+    rec = registry.get("karpathy-claude-md")
+    assert rec is not None
+    assert rec.activation in ("opt-in", "default-on-for-context")
+    assert rec.activation == "opt-in"                    # license_spdx=NONE gate
+    assert "license_spdx=NONE" in rec.activation_reason  # the reason is a logged field
+
+
+def test_upstream_repo_can_never_be_upgraded_past_derived(registry: HubRegistry) -> None:
+    """Taxonomy teeth: request_activation refuses upgrades beyond the derived
+    tier (fail-closed — YAML/API cannot lift the license gate)."""
+    decision = registry.request_activation("karpathy-claude-md", "always-on")
+    assert decision["granted"] != "always-on"
+    decision2 = registry.request_activation("karpathy-claude-md", "default-on-for-context")
+    assert decision2["granted"] != "default-on-for-context"
+
+
+def test_misattributed_variant_stays_excluded(registry: HubRegistry) -> None:
+    """The forrestchang mis-attribution (404) is excluded and immutable."""
+    rec = registry.get("forrestchang-andrej-karpathy-skills")
+    assert rec is not None and rec.activation == "excluded"
+    decision = registry.request_activation("forrestchang-andrej-karpathy-skills", "opt-in")
+    assert decision["granted"] == "excluded"
+
+
+# --------------------------------------- principles internalized natively
+
+
+def test_native_skill_derives_first_party_default_on(registry: HubRegistry) -> None:
+    """The internalized principles are a FIRST-PARTY registry record —
+    license-clean MIT, default-on-for-context (the native floor)."""
+    rec = registry.get("deliberate-coding")
+    assert rec is not None
+    assert rec.owner_repo == "ekson73/multi-agent-os"
+    assert rec.activation == "default-on-for-context"
+    assert rec.license_spdx == "MIT"
+    assert rec.security_status == "first-party"
+
+
+def test_credit_is_present_and_greppable() -> None:
+    """T6: 'credit the inspiration' — grep-able acceptance in the SKILL.md."""
+    text = _SKILL_MD.read_text(encoding="utf-8")
+    assert "Andrej Karpathy" in text
+    assert "multica-ai/andrej-karpathy-skills" in text
+    assert "karpathy-claude-md" in text  # links the registry intake record
+
+
+def test_patterns_only_no_redistribution_markers() -> None:
+    """The ADAPT conditions (patterns-only + no-redistribution) are honored
+    EXPLICITLY: the skill states it carries no upstream text, and names all
+    four principle families in MAOS's own wording."""
+    text = _SKILL_MD.read_text(encoding="utf-8")
+    assert "patterns-only" in text
+    assert "no upstream text" in text.lower()
+    for family in ("Think-Before-Coding", "Simplicity-First",
+                   "Surgical-Changes", "Goal-Driven"):
+        assert family in text, f"missing principle family: {family}"
+
+
+def test_native_skill_is_content_not_runtime() -> None:
+    """L0 substrate: content-only — the skill dir ships NO executables."""
+    skill_dir = _SKILL_MD.parent
+    non_md = [p for p in skill_dir.iterdir() if p.suffix not in (".md",)]
+    assert non_md == [], f"deliberate-coding must be content-only, found: {non_md}"

--- a/skills/deliberate-coding/SKILL.md
+++ b/skills/deliberate-coding/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: deliberate-coding
+version: "1.0.0"
+description: |
+  MAOS-native deliberation-before-coding guardrail principles (L0 substrate,
+  content-not-runtime). Use when an agent is about to write/modify code and needs the
+  house discipline for HOW to approach the change: think-before-coding (state the problem,
+  the constraint set, and at least one rejected alternative BEFORE the first edit),
+  simplicity-first (the least mechanism that fully achieves the outcome — no speculative
+  abstraction), surgical-changes (smallest reviewable diff; never opportunistic refactors
+  inside a fix), and goal-driven execution (every edit traces to the stated goal; drift =
+  stop and re-anchor). Apply at task start, before large diffs, during PDCA fix rounds,
+  and whenever a review flags over-engineering or scope creep.
+license: MIT
+provenance: |
+  MAOS-native articulation (T6 / WAVE 5, ADR-006). Principle FAMILY inspired by
+  observations popularized by Andrej Karpathy; the four-principle framing was
+  popularized by the community repo multica-ai/andrej-karpathy-skills (registry
+  intake id `karpathy-claude-md`, verdict ADAPT, conditions: patterns-only +
+  no-redistribution-until-license-clarified — HF2: upstream README claims MIT but
+  the repo ships NO LICENSE file, so its TEXT is all-rights-reserved). This
+  document therefore contains NO upstream text — patterns internalized, prose
+  original to MAOS (MIT).
+evals:
+  should_trigger:
+    - "Before I start coding this feature, what discipline should I follow?"
+    - "This fix is ballooning into a refactor — what does MAOS say?"
+    - "Review my plan for over-engineering before I implement"
+  should_not_trigger:
+    - "Run the code review itself (that is code-reviewer / persona-pipeline)"
+    - "Decide WHICH tool to route to (that is maos-concierge / agent-select)"
+---
+
+# Skill: deliberate-coding — deliberation-before-coding house principles (L0)
+
+> **Credit (inspiration, not source-text)**: the principle family below is inspired by
+> coding-with-LLM observations popularized by **Andrej Karpathy**, and by the framing that the
+> community repo **multica-ai/andrej-karpathy-skills** made ubiquitous (~180k★). Per that
+> intake's ADAPT verdict (`karpathy-claude-md`: *patterns-only, no-redistribution* — the
+> upstream ships no LICENSE file), **no upstream text appears here**: this is MAOS's own
+> articulation, internalized as a first-party, license-clean (MIT) substrate.
+
+## Why this exists (registry position)
+
+The MoE hub (ADR-006) classifies the upstream repo `opt-in` (license gate HF2 — not
+license-clean), yet the *principles* are exactly the L0 guardrail content every recipe stack
+floors on. The resolution is structural: **internalize the patterns natively** (this skill —
+first-party, `default-on-for-context`, MIT) and keep the upstream record available at its
+capped tier for whoever opts in. Content, not runtime: this skill defines *how to think about
+a change*; it executes nothing.
+
+## The four principles (MAOS articulation)
+
+### 1. Think-Before-Coding
+Before the first edit, produce — in the task record, not in your head — (a) the problem in one
+sentence, (b) the constraint set (contracts, invariants, protocols in force), and (c) at least
+one considered-and-rejected alternative with the reason. If you cannot name a rejected
+alternative, you have not yet explored the solution space; do not start typing.
+
+### 2. Simplicity-First
+Choose the least mechanism that FULLY achieves the outcome. No speculative abstraction, no
+"while I'm here" generality, no framework where a function does. Simplicity is measured at the
+reader: if the reviewer needs your conversation context to understand the design, it is not
+simple yet. (Simple ≠ simplistic: the mechanism must still fully meet the stated goal.)
+
+### 3. Surgical-Changes
+The diff is the unit of trust. Keep it the smallest reviewable change that achieves the goal:
+no opportunistic refactors inside a fix, no drive-by renames, no formatting churn. If a
+neighboring improvement is genuinely worth doing, it is worth its OWN branch/PR — file it,
+don't fold it.
+
+### 4. Goal-Driven
+Every edit must trace to the stated goal. When you notice work that doesn't (a test rewritten
+"for style", an abstraction added "for later"), STOP and re-anchor: either the goal changed —
+then restate it explicitly — or the work is drift — then drop it. Done = the goal's acceptance
+holds, not "the code looks finished".
+
+## When invoked (protocol hooks)
+
+| Moment | Application |
+|---|---|
+| Task start | Principle 1 gate: problem + constraints + rejected alternative on record |
+| Before a large diff | Principles 2+3: can the same outcome ship as a smaller/simpler change? |
+| PDCA fix rounds (pr-review) | Principle 3: fix-commits address findings only — no scope creep |
+| Review flags over-engineering | Principles 2+4: cut to the least sufficient mechanism, re-anchor to goal |
+
+## Boundaries (what this skill is NOT)
+
+- NOT a runtime/hook — content-only substrate (L0); it changes how an agent reasons, not what
+  executes. Enforcement lives in the existing protocols (Anti-Conflict, Sentinel, pr-review).
+- NOT a replacement for the upstream repo — that record stays in the registry at its derived
+  tier for opt-in users; this skill is the license-clean native floor.
+- NOT a review tool — route reviews to `code-reviewer` / `persona-pipeline`; this skill is the
+  discipline the *author* applies before and during the change.
+
+## Cross-refs
+
+`karpathy-claude-md` (registry intake — upstream record, ADAPT/patterns-only) ·
+ADR-006 (MoE hub) · `openspec/specs/maos-hub-registry/spec.md` (activation gating) ·
+`research/agentic-moe-2026/20260627-01a-substrates.md` (landscape analysis) ·
+`skills/convergence-engine` (the diff-trust discipline PDCA rides on)
+
+## Changelog
+- 2026-07-02 — v1.0.0 — Bootstrap (T6 / WAVE 5, ADR-006): native internalization of the
+  deliberation-before-coding principle family (patterns-only per the `karpathy-claude-md`
+  ADAPT verdict; zero upstream text; credit retained). First-party L0 substrate — derives
+  into the hub registry as `default-on-for-context`, MIT.


### PR DESCRIPTION
[PR-as-Prompt] **WAVE 5 / T6 — activation taxonomy + karpathy principles internalized** (ADR-006 MoE hub)

## Context
`openspec/changes/maos-hub-console/tasks.md` T6: *"apply the `activation` taxonomy; internalize the karpathy *principles* natively (credit the inspiration), repo as `opt-in`/`default-on-for-context`."* Last WAVE 5 item. The `karpathy-claude-md` intake (multica-ai/andrej-karpathy-skills, ~180k★) is verdict **ADAPT** with conditions `patterns-only + no-redistribution-until-license-clarified` — HF2: README claims MIT but the repo ships **no LICENSE file** (its text is all-rights-reserved).

## Objectives
- **`skills/deliberate-coding/SKILL.md`** — MAOS's OWN articulation of the four principle families (Think-Before-Coding · Simplicity-First · Surgical-Changes · Goal-Driven): zero upstream text, credit retained (Karpathy = inspiration; multica-ai = popularizing repo). Being first-party, it **auto-derives into the T1 registry** as `default-on-for-context`, MIT, license-clean — the native L0 floor. Content-not-runtime (executes nothing; discipline for authors).
- **Taxonomy applied, asserted**: upstream record derives `opt-in` (HF2 license gate, reason logged); `request_activation` refuses upgrades past derived; the mis-attributed `forrestchang-…` (404) stays `excluded` immutable.

## Acceptance (logged fields — DoD-gate)
- [x] repo as opt-in/default-on-for-context — `test_upstream_repo_is_capped_to_opt_in_or_default_on` (tier + logged HF2 reason)
- [x] taxonomy teeth — upgrade-past-derived refused; excluded immutable
- [x] principles internalized natively — first-party derivation asserted (`default-on-for-context`, MIT, first-party)
- [x] credit the inspiration — grep-able (`Andrej Karpathy` + `multica-ai/andrej-karpathy-skills` + intake id)
- [x] patterns-only honored — explicit no-upstream-text markers + all 4 families in MAOS wording + content-only skill dir
- [x] 7 new tests; 103/103 W5 suites green · validate-plugin PASS · gitleaks clean

## Risk + rollback
Additive skill + additive test file. Rollback = revert the squash commit (the registry re-derives without the record).

## Cross-links
ADR-006 · issue #204 (T6) · `evals/fixtures/intake_verdicts.yaml` (`karpathy-claude-md`) · `research/agentic-moe-2026/20260627-01a-substrates.md` · PRs #209/#214/#215/#216

Signed: Claude-Dev-moe-t6 · 2026-07-02T12:58:00-03:00
