### PR TITLE
docs(openspec): tasks.md WAVE 5 boxes checked (T1–T6 delivered) + PR refs

### DIFF
--- a/.claude/sessions/2026-07-05_e4656a0d_briefing.md
+++ b/.claude/sessions/2026-07-05_e4656a0d_briefing.md
@@ -1,0 +1,44 @@
+---
+name: morning-briefing-briefing-2026-07-05-maos-moe-ath
+mode: briefing
+created_utc: 2026-07-05T12:00:00Z
+originSessionId: e4656a0d-9cf9-465f-89fd-424fb20a28c6
+cwd: /Users/emilson.moraes/.superset/worktrees/multi-agent-os/maos-moe-ath
+repo: multi-agent-os
+skill_version: "1.7.0"
+lang: pt-br
+---
+
+# 🌅 Morning Briefing · multi-agent-os (maos-moe-ath)
+2026-07-05 · sáb · 🧵 sessão `e4656a0d` (quiesce ATH→MAOS Hub)
+
+> ## 🎯 Próxima Ação
+> **Duas decisões do operador destravam tudo: (1) ratificar PR #206 (MVV) · (2) GO para WAVE 6 (T7–T10).**
+> *Por quê primeiro*: WAVE 5 está 100% entregue e documentada; o backlog só avança pelo gate humano de wave (handoff). · *Esforço*: 1 review + 1 palavra ("continue") · *Deps*: nenhuma
+
+> ## 📍 Pulse
+> **Branch** `maos-moe-ath` @ `0daf3c5` (sincronizado — 0 behind após ff-pull hoje) · **Worktrees** 3 (main · sessão · peer `research-hacks-ia`) + 1 docs temporário · **Untracked** 0
+> **Done 72h** 11 PRs merged (WAVE 5 T1–T6 + 2 fix-PDCA + 2 docs + dependabot #219) · **In-flight** 1 PR (#220 docs, convergindo)
+> **Blockers** 0 🔴 · **Decisões** 2 ⏳ · **Riscos** 2 ⚠️
+
+## ⏳ Decisões aguardando · 2
+- ❓ **Ratificar PR #206 (MVV Vision touch, ADR-006)** — opções: A) merge B) editar C) rejeitar · HITL deliberado, agente não toca
+- ❓ **GO WAVE 6 (T7–T10)?** — slot-adapter · contribution-gatekeeper (exige piso CI WAVE-0 verde) · ttl-freshness · hardened-distributor · issue #204
+
+## ⚠️ Riscos / heads-up · 2
+- 📅 Snyk checks presos (quota, issue #142) — não bloqueia merges verdes, mas mantém mergeStateStatus UNSTABLE
+- 🧭 Achado de design encaminhado p/ WAVE 6: unificação dos planos de token (profile `enabled` = operation tokens vs console = tool ids) — warning `enforce_profile_gates_operations` mitigou (PR #214)
+
+## 🚧 In-flight · 1
+- **PR #220** `docs(openspec): tasks.md WAVE 5 boxes` — watcher de merge armado (auto-merge standing auth)
+
+## ✅ Done (desde 2026-07-02) · 11 PRs
+- WAVE 5 completa: T1 #209(+#211) · T2 #210(+#212) · T3 #214 · T4 #215 · T5 #216 · T6 #217 · roadmap #213/#218
+- Hoje: #219 dependabot pyyaml ≥6.0.3 merged (verde, range-widening) · doc-drift tasks.md corrigido via #220
+- 103/103 testes W5 · issue #204 = WAVE 5 COMPLETE · memória do projeto atualizada
+
+## 🌿 Detalhe de estado
+- Worktrees: checkout main (`~/Projects/multi-agent-os`) · sessão `maos-moe-ath` · peer `research-hacks-ia` (outra sessão — não tocar) · `docs-tasks-sync` (remove pós-#220)
+- ADR-006 §Implementation status = ponteiro puro pro README SSOT (sem drift) · CHANGELOG [Unreleased] com todas as entries W5
+
+> 💬 **Narrativa** — A sessão quiesce entregou as WAVES 0–5 do backlog ATH→MAOS Hub inteiras (11 PRs só na WAVE 5, todos convergidos com bots e DoD por campo logado/golden fixture). O repositório está limpo, sincronizado e documentado; o único trabalho vivo é um docs-PR trivial em convergência. Tudo agora espera as duas decisões humanas: a ratificação do MVV (#206) e o GO da WAVE 6 — a fase comunitária (front-door ADR-007), cujo gatekeeper depende do piso de CI da WAVE 0 já verde.

--- a/openspec/changes/maos-hub-console/tasks.md
+++ b/openspec/changes/maos-hub-console/tasks.md
@@ -5,23 +5,23 @@
 
 ## WAVE 5 — Registry + Console (operator control-plane)
 
-- [ ] **T1 `feature/<id>-registry-ssot`** — implement the registry SSOT per
+- [x] **T1 `feature/<id>-registry-ssot`** — implement the registry SSOT per
   `openspec/specs/maos-hub-registry/spec.md`: auto-derive records from skill/agent frontmatter +
   promote the Phase-2 N-Tree (incompatibilities + recipes) into structured data; add `activation`,
   `license`/SPDX, `provenance`, `ttl`, `rollback`, `conflicts_with`. *Acceptance: registry validates
   against the spec; `conflicts_with` graph round-trips the Phase-2 incompatibilities.*
-- [ ] **T2 `feature/<id>-profile-as-gating-input`** — persist an enablement **profile SSOT**; wire the
+- [x] **T2 `feature/<id>-profile-as-gating-input`** — persist an enablement **profile SSOT**; wire the
   MAOS Hub gating to honor it (route/expose only enabled + compatible). *Acceptance: a disabled/
   conflicting tool is not routed; the decision is logged.*
-- [ ] **T3 `feature/<id>-console-modes`** — `maos-concierge` `setup`/`config` modes: views `preset ·
+- [x] **T3 `feature/<id>-console-modes`** — `maos-concierge` `setup`/`config` modes: views `preset ·
   category · use-case · context-aware · prose-intent · safe-mode`; `--help`, `--safe-mode`. ASCII
   first-class; optional HTML artifact. *Acceptance: each view renders from the registry; selection is
   conflict-checked + HITL-confirmed before it writes the profile.*
-- [ ] **T4 `feature/<id>-context-aware-v1`** — deterministic ranking by `work-compass` project signals,
+- [x] **T4 `feature/<id>-context-aware-v1`** — deterministic ranking by `work-compass` project signals,
   **reasoning shown**. *Acceptance: same input → same ranking (byte-stable); the "why" is emitted.*
-- [ ] **T5 `feature/<id>-prose-intent`** — prose need → bounded interview (≤3 Qs) → custom profile
+- [x] **T5 `feature/<id>-prose-intent`** — prose need → bounded interview (≤3 Qs) → custom profile
   DRAFT (HITL). *Acceptance: the prose→profile mapping is shown; never auto-applies.*
-- [ ] **T6 `feature/<id>-activation-karpathy`** — apply the `activation` taxonomy; internalize the
+- [x] **T6 `feature/<id>-activation-karpathy`** — apply the `activation` taxonomy; internalize the
   karpathy *principles* natively (credit the inspiration), repo as `opt-in`/`default-on-for-context`.
 
 ## WAVE 6 — Community integration (the front-door, ADR-007)
@@ -41,5 +41,7 @@
 - [ ] **T10 `feature/<id>-hardened-distributor`** — MAOS-as-distributor hardening: signed releases +
   SBOM + provenance. *Acceptance: release carries signature + SBOM.*
 
+> **WAVE 5 delivered 2026-07-02** — T1 #209(+fix #211) · T2 #210(+fix #212) · T3 #214 · T4 #215 · T5 #216 · T6 #217. Status SSOT: chapter README §"Status do hands-on".
+>
 > Sequencing: WAVE 5 (T1→T2 first — registry then teeth) before WAVE 6. WAVE 6's gatekeeper (T8)
 > requires the deterministic floor already green (the WAVE-0 AgentShield/CI of ADR-006).


### PR DESCRIPTION
[PR-as-Documentation-Prompt] Doc-drift fix detected in morning-briefing recon 2026-07-05: `openspec/changes/maos-hub-console/tasks.md` checkboxes lagged the merged reality. Checks T1–T6 `[x]` + adds the delivery footnote with PR refs (#209/#211 · #210/#212 · #214 · #215 · #216 · #217). Status SSOT stays the chapter README (pointer, no duplication). Docs-only.

Signed: Claude-Docs-moe-sync · 2026-07-05