### PR TITLE
fix(maos-hub): gateway action-count drift 105 vs 104 — test SSOT + doc sync (closes #202)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — gateway action-count drift 105 vs 104 (issue #202)
+
+- **Test-suite action-count SSOT** (`mcp-tools/maos-mcp-hub/tests/conftest.py`):
+  `EXPECTED_GATEWAY_ACTIONS` + `EXPECTED_TOTAL_ACTIONS` (= 105) — the ONE bump point when a
+  gateway gains/loses an action. `test_gateway_discover.py` (per-gateway + cross-gateway
+  totals) and `test_hub_registration.py` (startup-log line) now consume it — closes the
+  drift class where PR #151 added `pull_request.decline` (105th action) without updating
+  three hardcoded `104` assertions (pre-existing RED on clean main, surfaced in #201).
+- Doc sync to the real count: `hub.py` self-description/docstring/section header,
+  `mcp-tools/maos-mcp-hub/README.md` (×3) and root `CLAUDE.md` gateway table
+  (jira 27 · bitbucket 56 · total 105 — was 3 bumps stale at 22/52/96).
+- Boy-scout: removed stray empty file `mcp-tools/maos-mcp-hub/=6.0.2` (unquoted
+  `pip install pyyaml>=6.0.2` shell-redirect artifact, accidentally committed in #201).
+  Full hub suite: **382 passed** (was 379 + 3 failed).
+
+
 ### Changed — MVV Vision touch ratified + WAVE 4 closed (ADR-006 §Consequences follow-up)
 
 - **`CLAUDE.md` §Organizational Identity (Vision)** — the MAOS-Hub MoE sentence proposed by

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,14 +240,14 @@ The `mcp-tools/maos-mcp-hub/` directory contains a universal MCP gateway exposin
 
 ### Meta-Tools Gateway
 
-6 Atlassian gateways collapsing 96 actions into typed meta-tools to stay within AI-provider tool limits:
+6 Atlassian gateways collapsing 105 actions into typed meta-tools to stay within AI-provider tool limits:
 
 | Tool | Actions | Scope |
 |------|---------|-------|
 | `atlassian_discover` | -- | Domain catalog |
-| `atlassian_jira` | 22 | Issues, boards, estimation, search |
+| `atlassian_jira` | 27 | Issues, boards, estimation, search |
 | `atlassian_confluence` | 12 | Pages, comments, spaces |
-| `atlassian_bitbucket` | 52 | Pipelines, PRs, branches |
+| `atlassian_bitbucket` | 56 | Pipelines, PRs, branches |
 | `atlassian_compass` | 6 | Service registry |
 | `atlassian_common` | 4 | User info, server info |
 

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -155,7 +155,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 }
 ```
 
-Restart Claude Desktop. You'll see the **6 `atlassian_*` gateway tools** (discover, jira, confluence, bitbucket, compass, common) covering 104 actions total (v2.3.0, VKS-2080).
+Restart Claude Desktop. You'll see the **6 `atlassian_*` gateway tools** (discover, jira, confluence, bitbucket, compass, common) covering 105 actions total (v2.3.0 + #151 `pull_request.decline`).
 
 ### 6. Run tests (pilot D65)
 
@@ -181,7 +181,7 @@ With 55 Bitbucket tools and Jira/Confluence/Compass on the roadmap, the flat nam
 
 ### Solution: 6 Typed Gateways
 
-The Meta-Tools Gateway collapses **104 actions** (v2.3.0) into **6 MCP tools**. Five domain gateways accept a uniform `{resource?, operation?, params?}` input; `atlassian_discover` is parameterless:
+The Meta-Tools Gateway collapses **105 actions** (v2.3.0 + #151) into **6 MCP tools**. Five domain gateways accept a uniform `{resource?, operation?, params?}` input; `atlassian_discover` is parameterless:
 
 | Gateway | Tool Name | Actions | Purpose |
 |---------|-----------|---------|---------|
@@ -318,7 +318,7 @@ hub is considered ready when these lines appear:
 ```text
 ======================================================================
 ✅ MAOS MCP Hub Ready!
-   Gateways: 6 (104 actions)
+   Gateways: 6 (105 actions)
    Total MCP tools: 6
 ======================================================================
 ```

--- a/mcp-tools/maos-mcp-hub/README.md
+++ b/mcp-tools/maos-mcp-hub/README.md
@@ -177,7 +177,7 @@ AI providers impose tool-count limits that break flat namespaces at scale:
 | Windsurf | 100       |
 | ChatGPT  | ~30       |
 
-With 55 Bitbucket tools and Jira/Confluence/Compass on the roadmap, the flat namespace (`bitbucket_get_recent_builds`, `jira_get_issue`, ...) would hit limits immediately.
+With 56 Bitbucket tools and Jira/Confluence/Compass on the roadmap, the flat namespace (`bitbucket_get_recent_builds`, `jira_get_issue`, ...) would hit limits immediately.
 
 ### Solution: 6 Typed Gateways
 
@@ -188,7 +188,7 @@ The Meta-Tools Gateway collapses **105 actions** (v2.3.0 + #151) into **6 MCP to
 | **Discover** | `atlassian_discover` | -- | Catalog of all domains and action counts |
 | **Jira** | `atlassian_jira` | 27 | Issues, boards, sprints (list/create/update), versions (create/release), estimation, comments, worklogs, links, search |
 | **Confluence** | `atlassian_confluence` | 12 | Pages, comments, spaces, search (CQL) |
-| **Bitbucket** | `atlassian_bitbucket` | 55 | Pipelines, PRs (incl. add/reply comment, update description — VKS-1853), branches, deployments, tests, caches |
+| **Bitbucket** | `atlassian_bitbucket` | 56 | Pipelines, PRs (incl. add/reply comment, update description — VKS-1853; decline — #151), branches, deployments, tests, caches |
 | **Compass** | `atlassian_compass` | 6 | Service registry, components, relationships, custom fields |
 | **Common** | `atlassian_common` | 4 | User info, accessible resources, server info |
 
@@ -262,7 +262,7 @@ gateways/                          ← Meta-tool gateway layer
 │   └── actions.py                 ← 12 actions across 4 resources
 ├── bitbucket/
 │   ├── gateway.py
-│   └── actions.py                 ← 55 actions across 9 resources (VKS-1853)
+│   └── actions.py                 ← 56 actions across 9 resources (VKS-1853 + #151)
 ├── compass/
 │   ├── gateway.py
 │   └── actions.py                 ← 6 actions across 3 resources

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -6,7 +6,8 @@ Transport: STDIO (stdin/stdout)
 
 Since v1.7 (VKS-1694 Phase 2), this hub exposes exactly 6 typed `atlassian_*`
 meta-tool gateways. v2.2 (VKS-1853) added 3 pull_request interaction ops;
-v2.3 (VKS-2080) adds 5 Jira Agile sprint/version ops → 104 actions total.
+v2.3 (VKS-2080) adds 5 Jira Agile sprint/version ops; #151 adds
+bitbucket pull_request.decline → 105 actions total.
 
 Architecture:
     hub.py
@@ -240,7 +241,9 @@ mcp = FastMCP(
     name=HUB_NAME,
     instructions=(
         f"MAOS MCP Hub v{HUB_VERSION} — Atlassian meta-tools gateway. "
-        "Exposes 6 typed `atlassian_*` gateways (104 actions total) with "
+        # NOTE: action total — keep in sync with tests/conftest.py
+        # EXPECTED_TOTAL_ACTIONS (issue #202: the single bump point).
+        "Exposes 6 typed `atlassian_*` gateways (105 actions total) with "
         "4-level progressive discovery and governance feedback. "
         "Legacy flat namespace (bitbucket_*, jira_*) was removed in v1.7."
     ),
@@ -265,7 +268,7 @@ if not discovered_servers:
 
 
 # ============================================================================
-# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 104 actions)
+# GATEWAY META-TOOL REGISTRATION (6 meta-tools, 105 actions)
 # ============================================================================
 #
 # Note (VKS-1694, v1.7):

--- a/mcp-tools/maos-mcp-hub/hub.py
+++ b/mcp-tools/maos-mcp-hub/hub.py
@@ -16,7 +16,7 @@ Architecture:
     ├── discover/   → atlassian_discover   (catalog)
     ├── jira/       → atlassian_jira       (27 actions)
     ├── confluence/ → atlassian_confluence (12 actions)
-    ├── bitbucket/  → atlassian_bitbucket  (55 actions, VKS-1853 v2.2)
+    ├── bitbucket/  → atlassian_bitbucket  (56 actions, VKS-1853 + #151)
     ├── compass/    → atlassian_compass    (6 actions)
     └── common/     → atlassian_common     (4 actions)
 

--- a/mcp-tools/maos-mcp-hub/tests/conftest.py
+++ b/mcp-tools/maos-mcp-hub/tests/conftest.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 import sys
 
+import pytest
+
 
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
@@ -22,4 +24,17 @@ EXPECTED_GATEWAY_ACTIONS = {
     "common": 4,
 }
 EXPECTED_TOTAL_ACTIONS = sum(EXPECTED_GATEWAY_ACTIONS.values())  # 105
+
+
+# Fixtures — the supported consumption surface. Tests take these as args
+# instead of `from conftest import ...` (fragile in a repo with multiple
+# conftest.py files / pytest sys.path caching — PR #222 review consensus).
+@pytest.fixture
+def expected_gateway_actions():
+    return dict(EXPECTED_GATEWAY_ACTIONS)
+
+
+@pytest.fixture
+def expected_total_actions():
+    return EXPECTED_TOTAL_ACTIONS
 

--- a/mcp-tools/maos-mcp-hub/tests/conftest.py
+++ b/mcp-tools/maos-mcp-hub/tests/conftest.py
@@ -6,3 +6,20 @@ ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
+
+# ---------------------------------------------------------------------------
+# Canonical gateway action-count SSOT for the test suite (issue #202).
+# Bump HERE — and ONLY here — when a gateway gains or loses an action.
+# Consumers: tests/test_gateway_discover.py · tests/test_hub_registration.py.
+# History: 96 → 99 (VKS-1853: +3 bitbucket PR ops) → 104 (VKS-2080: +5 Jira
+#          Agile ops) → 105 (#151: +1 bitbucket pull_request.decline).
+# ---------------------------------------------------------------------------
+EXPECTED_GATEWAY_ACTIONS = {
+    "jira": 27,
+    "confluence": 12,
+    "bitbucket": 56,
+    "compass": 6,
+    "common": 4,
+}
+EXPECTED_TOTAL_ACTIONS = sum(EXPECTED_GATEWAY_ACTIONS.values())  # 105
+

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
@@ -5,7 +5,6 @@ import os
 
 import pytest
 
-from conftest import EXPECTED_GATEWAY_ACTIONS, EXPECTED_TOTAL_ACTIONS
 from lib.gateway.types import GatewayRequest
 
 
@@ -43,7 +42,9 @@ def test_discover_returns_all_domains(monkeypatch):
     asyncio.run(run())
 
 
-def test_discover_action_counts(monkeypatch):
+def test_discover_action_counts(
+    monkeypatch, expected_gateway_actions, expected_total_actions
+):
     _setup_env(monkeypatch)
     from gateways.discover.actions import discover
 
@@ -51,11 +52,11 @@ def test_discover_action_counts(monkeypatch):
         result = await discover()
         d = result["domains"]
         # Per-gateway counts + total come from ONE SSOT (conftest, issue #202).
-        for gateway, expected in EXPECTED_GATEWAY_ACTIONS.items():
+        for gateway, expected in expected_gateway_actions.items():
             assert d[gateway]["actions"] == expected, (
                 f"{gateway}: expected {expected}, got {d[gateway]['actions']}"
             )
-        assert result["total_actions"] == EXPECTED_TOTAL_ACTIONS
+        assert result["total_actions"] == expected_total_actions
 
     asyncio.run(run())
 
@@ -132,7 +133,7 @@ def test_common_router_action_count(monkeypatch):
 # Cross-gateway: total action count (SSOT: conftest.EXPECTED_TOTAL_ACTIONS)
 # ---------------------------------------------------------------------------
 
-def test_total_action_count_across_all_gateways(monkeypatch):
+def test_total_action_count_across_all_gateways(monkeypatch, expected_total_actions):
     _setup_env(monkeypatch)
     from gateways.jira.actions import build_router as jira_router
     from gateways.confluence.actions import build_router as conf_router
@@ -147,7 +148,7 @@ def test_total_action_count_across_all_gateways(monkeypatch):
         + comp_router().action_count
         + common_router().action_count
     )
-    assert total == EXPECTED_TOTAL_ACTIONS, (
-        f"Expected {EXPECTED_TOTAL_ACTIONS} total actions "
+    assert total == expected_total_actions, (
+        f"Expected {expected_total_actions} total actions "
         f"(SSOT: tests/conftest.py EXPECTED_GATEWAY_ACTIONS), got {total}"
     )

--- a/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_gateway_discover.py
@@ -5,6 +5,7 @@ import os
 
 import pytest
 
+from conftest import EXPECTED_GATEWAY_ACTIONS, EXPECTED_TOTAL_ACTIONS
 from lib.gateway.types import GatewayRequest
 
 
@@ -49,12 +50,12 @@ def test_discover_action_counts(monkeypatch):
     async def run():
         result = await discover()
         d = result["domains"]
-        assert d["jira"]["actions"] == 27  # VKS-2080: +5 Sprint+Version CRUD
-        assert d["confluence"]["actions"] == 12
-        assert d["bitbucket"]["actions"] == 55  # VKS-1853: +3 PR ops
-        assert d["compass"]["actions"] == 6
-        assert d["common"]["actions"] == 4
-        assert result["total_actions"] == 104  # VKS-2080: 99 + 5
+        # Per-gateway counts + total come from ONE SSOT (conftest, issue #202).
+        for gateway, expected in EXPECTED_GATEWAY_ACTIONS.items():
+            assert d[gateway]["actions"] == expected, (
+                f"{gateway}: expected {expected}, got {d[gateway]['actions']}"
+            )
+        assert result["total_actions"] == EXPECTED_TOTAL_ACTIONS
 
     asyncio.run(run())
 
@@ -128,7 +129,7 @@ def test_common_router_action_count(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# Cross-gateway: total action count = 104 (VKS-2080: 99 + 5)
+# Cross-gateway: total action count (SSOT: conftest.EXPECTED_TOTAL_ACTIONS)
 # ---------------------------------------------------------------------------
 
 def test_total_action_count_across_all_gateways(monkeypatch):
@@ -146,4 +147,7 @@ def test_total_action_count_across_all_gateways(monkeypatch):
         + comp_router().action_count
         + common_router().action_count
     )
-    assert total == 104, f"Expected 104 total actions (VKS-2080: 99 + 5), got {total}"
+    assert total == EXPECTED_TOTAL_ACTIONS, (
+        f"Expected {EXPECTED_TOTAL_ACTIONS} total actions "
+        f"(SSOT: tests/conftest.py EXPECTED_GATEWAY_ACTIONS), got {total}"
+    )

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
@@ -14,6 +14,8 @@ import pathlib
 import subprocess
 import sys
 
+from conftest import EXPECTED_TOTAL_ACTIONS
+
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -63,15 +65,15 @@ def test_hub_exposes_exactly_six_mcp_tools():
 
 
 def test_hub_registers_six_atlassian_gateways():
-    """All 6 atlassian_* gateways must be registered with 104 actions total.
+    """All 6 atlassian_* gateways must be registered with the SSOT action total.
 
-    VKS-1853 (2026-04-23): +3 pull_request ops (add_comment,
-    update_description, reply_to_comment) brought total from 96 to 99.
-    VKS-2080 (2026-06-01): +5 Jira Agile ops (sprint list/create/update,
-    version create/release) bring total from 99 to 104.
+    The expected count lives in ONE place — tests/conftest.py
+    ``EXPECTED_TOTAL_ACTIONS`` (issue #202) — with the bump history
+    (VKS-1853: 96→99 · VKS-2080: 99→104 · #151: 104→105).
     """
     log = _run_hub()
-    assert "6 gateways registered (104 actions)" in log, log
+    expected = f"6 gateways registered ({EXPECTED_TOTAL_ACTIONS} actions)"
+    assert expected in log, log
 
 
 def test_hub_does_not_register_flat_bitbucket_tools():

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registration.py
@@ -14,8 +14,6 @@ import pathlib
 import subprocess
 import sys
 
-from conftest import EXPECTED_TOTAL_ACTIONS
-
 
 ROOT = pathlib.Path(__file__).resolve().parent.parent
 
@@ -64,15 +62,15 @@ def test_hub_exposes_exactly_six_mcp_tools():
     assert "Total MCP tools: 6" in log, log
 
 
-def test_hub_registers_six_atlassian_gateways():
+def test_hub_registers_six_atlassian_gateways(expected_total_actions):
     """All 6 atlassian_* gateways must be registered with the SSOT action total.
 
     The expected count lives in ONE place — tests/conftest.py
-    ``EXPECTED_TOTAL_ACTIONS`` (issue #202) — with the bump history
-    (VKS-1853: 96→99 · VKS-2080: 99→104 · #151: 104→105).
+    ``EXPECTED_TOTAL_ACTIONS`` (issue #202), consumed via fixture — with the
+    bump history (VKS-1853: 96→99 · VKS-2080: 99→104 · #151: 104→105).
     """
     log = _run_hub()
-    expected = f"6 gateways registered ({EXPECTED_TOTAL_ACTIONS} actions)"
+    expected = f"6 gateways registered ({expected_total_actions} actions)"
     assert expected in log, log
 
 


### PR DESCRIPTION
**[PR-as-Correction-Prompt]**

## Context

Issue #202: pre-existing RED on clean main — PR #151 added `pull_request.decline` (the 105th gateway action) without updating three hardcoded `104` assertions. Reproduced before fixing: `test_discover_action_counts` (bitbucket 56≠55, total 105≠104), `test_total_action_count_across_all_gateways`, `test_hub_registers_six_atlassian_gateways` (startup-log line).

## Objectives

- Make main green again.
- Kill the drift *class*, not just the instance: one canonical bump point for the expected count (issue #202's own fix guidance).

## Changes

| File | Change |
|---|---|
| `tests/conftest.py` | NEW `EXPECTED_GATEWAY_ACTIONS` (per-gateway) + `EXPECTED_TOTAL_ACTIONS` (=105) — the SSOT, with bump history (96→99→104→105) |
| `tests/test_gateway_discover.py` | Per-gateway loop + total assertions consume the SSOT (no literals) |
| `tests/test_hub_registration.py` | Startup-log assertion built from the SSOT f-string |
| `hub.py` | Self-description `(104→105 actions total)` + keep-in-sync note, docstring history, section header |
| `mcp-tools/maos-mcp-hub/README.md` | 3 stale `104` → `105` (+#151 attribution) |
| `CLAUDE.md` (root) | Gateway table de-staled: jira 27 · bitbucket 56 · total 105 (was 22/52/96 — 3 bumps behind) |
| `mcp-tools/maos-mcp-hub/=6.0.2` | **Deleted** — stray empty file (unquoted `pip install pyyaml>=6.0.2` redirect artifact, accidentally committed in #201) |
| `CHANGELOG.md` | `[Unreleased]` Fixed entry |

## Acceptance (DoD-GATE: logged fields, not prose)

- [x] Failing trio reproduced on the worktree BEFORE the fix (3 failed, 12 passed)
- [x] Full hub suite AFTER: **382 passed, 0 failed** (`uv run --with-requirements requirements.txt --with-requirements requirements-dev.txt --with pytest pytest tests/`)
- [x] `bash tests/validate-plugin.sh` → ✓ PASSED
- [x] gitleaks staged → no leaks
- [x] Grep-proof: zero remaining `104 actions` in hub source/docs (only false-positive `10407` issue-type id)

## Risk + rollback

Test + docs + one dead-file deletion; zero runtime behavior change (the startup log emitter was already dynamic). Rollback = revert squash commit.

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
