### PR TITLE
feat(skills): decompose-abstract-to-measurable (Prisma) — abstract criterion → measurable value-tree

### DIFF
--- a/skills/decompose-abstract-to-measurable/PRIOR-ART.md
+++ b/skills/decompose-abstract-to-measurable/PRIOR-ART.md
@@ -1,0 +1,74 @@
+# PRIOR-ART — decompose-abstract-to-measurable (Prisma)
+
+> Why this skill is honest engineering, not mysticism. The originating thesis
+> ("everything is energy/frequency → every abstract fully reduces to native math")
+> is, unknowingly, a **re-derivation of a 50-year-old decision-science method** —
+> whose *core is real and validated* and whose *strong form is known to be false*.
+> This file records both, so no future agent mistakes the decoration for the
+> mechanism.
+
+## 1 · The mechanism is real — and old (cited by name)
+
+| Prior art | Author(s) / origin | What the skill borrows |
+|---|---|---|
+| **MAUT** — Multi-Attribute Utility Theory | Keeney & Raiffa, 1976 | the value-tree itself: decompose a goal into weighted attributes, aggregate to a utility in [0,1] |
+| **AHP** — Analytic Hierarchy Process | Thomas Saaty, 1980 | hierarchical criteria → sub-criteria → alternatives; pairwise weight elicitation |
+| **MCDA / MCDM** — Multi-Criteria Decision Analysis | field, 1970s– | weighted-sum aggregation, sensitivity analysis, materiality |
+| **Fuzzy set membership** | Lotfi Zadeh, 1965 | leaf grades are graded membership in [0,1], not booleans |
+| **Decomposed-rubric LLM-as-judge** | G-Eval (Liu 2023) · FLASK (Ye 2023) · Prometheus (Kim 2023) | J-leaves: score a criterion against an explicit rubric + anchors, with confidence + order-swap de-biasing |
+| **Rubrics-as-rewards / checklist rewards** | 2024–2025 RLHF/eval line | anchors as the reward signal; per-criterion decomposition beats a monolithic "rate 1–10" |
+| **Swing-weighting / direct-ratio elicitation** | decision-analysis practice | making the value weights explicit + traceable (Step 4) |
+
+**The operator's "N-Tree of calculable leaves" IS a MAUT/AHP value-tree.** The
+engineering core is therefore real, standard, and validated in decision science,
+software quality models (e.g. ISO/IEC 25010 quality trees), and modern LLM
+evaluation. That is why the skill works.
+
+## 2 · The strong thesis is false — four independent limiters
+
+The claim that the abstract reduces *fully and without loss* to native math fails
+against four separate, well-established results. The skill does not defeat them —
+it **manages** them and surfaces the residue.
+
+| # | Limiter | Author / origin | Consequence encoded in the skill |
+|---|---|---|---|
+| 1 | **Is–ought gap** | David Hume, 1739 | a *value* is never entailed by *facts* alone → the weights + J-leaves are the injected value, made **explicit** (Step 4), not eliminated |
+| 2 | **Open-question argument** | G.E. Moore, 1903 | "good" is not identical to any natural property → no finite fact-set *defines* it; the tree *operationalizes* a context-bound proxy, not the concept itself |
+| 3 | **Symbol-grounding problem** | Stevan Harnad, 1990 | a symbol ("beautiful") has no context-free numeric ground → **Step 0 CONTEXT-LOCK** is mandatory; grounding is always relative to purpose + audience |
+| 4 | **Construct validity** | Cronbach & Meehl, 1955 (psychometrics) | a measure can be *reliable* yet *invalid* — repeatable but measuring the wrong thing → anchors + held-out validation (Step 7) manage, never fully close, this |
+| + | **Goodhart's law** | Charles Goodhart, 1975 | once the proxy is the target it stops measuring → the score is **evidence, not a target** (Metron guard, Step 6) |
+
+## 3 · The honest reframe (what the skill actually claims)
+
+> The abstract becomes **tractable, transparent, and calibrated**, with the
+> **irreducible residual of human judgment surfaced as a first-class output**.
+
+Concretely, an amnesic agent goes from *"I'll guess 'this looks professional →
+0.8'"* to a reproducible spec where every 0.8 is traceable to a weighted, anchored
+leaf — and where, when judgment genuinely dominates or conflicts, the tool says
+**"inconclusive → escalate"** instead of manufacturing false precision. That is a
+large, real capability gain. It is *not* proof that "good" is a number.
+
+## 4 · "Energy / vibration / frequency"
+
+Honored as **evocative inspiration**, not mechanism — which is exactly why the
+soul-name is **Prisma**: a prism performs a *real* physical frequency
+decomposition (splitting white light into measurable component wavelengths),
+grounding the operator's "frequency" intuition in optics rather than metaphysics.
+No claim in this skill depends on energy/vibration being literally true; strip the
+metaphor and the MCDA + rubric + fuzzy machinery stands on its own.
+
+## 5 · Where each piece is composed from (no re-derivation)
+
+- band boundaries (HIGH .85 / MED .65) ← `auto-self-harness.md` §1.2 autonomy_score
+- Goodhart guard / score=evidence / residual ← `agentic-observability-protocol.md` (Metron) §4/§5
+- REFINE/SELECT/**DEFER** + verifier>generator + economic-stop ← `skills/convergence-engine`
+- per-leaf measurement + evidence ← `maos:data-validator`; independent re-typing ← `maos:validation-auditor`
+- CONTEXT-LOCK + reality gate ← `anti-theater-grounding-protocol.md` Layer 2 / Layer 5
+
+## 6 · Provenance
+
+Forged 2026-07-08 from a `/deep-research` + MoA-council session on the operator's
+"everything-is-calculable" thesis. Full honest-verdict + seam doctrine persisted
+in akasha memory: `dna_abstract_to_measurable_decomposition_2026_07_08.md` and
+`reference_abstract_to_measurable_prior_art_2026_07_08.md`.

--- a/skills/decompose-abstract-to-measurable/SKILL.md
+++ b/skills/decompose-abstract-to-measurable/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: decompose-abstract-to-measurable
+description: >-
+  Use when a task, DoR, DoD, metric, KPI, or acceptance criterion is ABSTRACT
+  ("is this good / healthy / professional / beautiful / stylish / risky /
+  inconclusive?") and an agent would otherwise GUESS a number. Decomposes the
+  abstract construct into a recursive value-tree whose leaves are each directly
+  measurable (D), typeable/observable (T), or bounded-calibrated-judgment (J),
+  then a deterministic script rolls it up into score + band + confidence +
+  sensitivity + an explicit "inconclusive → escalate" verdict. Turns a guess into
+  a reproducible, auditable measurement-spec.
+triggers:
+  - "how do I measure <abstract quality>"
+  - "is this <good|healthy|professional|beautiful|stylish|clean|risky>?"
+  - "turn this DoD / KPI / acceptance criterion into a score"
+  - "is this inconclusive / can I decide this autonomously?"
+  - "score / rate / evaluate <thing> against an abstract standard"
+version: 1.0.0
+allowed-tools: Read, Write, Edit, Bash, Grep, Glob
+agnostic: [os, project, vendor]
+soul-name: Prisma
+---
+
+# decompose-abstract-to-measurable  ·  soul-name **Prisma**
+
+> A prism splits one white beam into its measurable component frequencies. This
+> skill splits one abstract construct into its measurable component leaves — so
+> an amnesic agent can **compute** "is this good?" instead of **guessing** it.
+
+## What this is for (the root bug it fixes)
+
+A human or agent hands you a task whose `[motive · purpose · DoR · DoD · metric ·
+KPI · acceptance]` is **abstract** — "make it *professional*", "is this PR
+*healthy*?", "is the release *quality-ready*?". You cannot compute an abstract
+word natively, so the failure mode is: **you fabricate a plausible number and
+ship the wrong result.** This skill replaces the guess with a transparent,
+reproducible decomposition + a deterministic roll-up that *refuses to fake
+precision* when the answer is genuinely judgment-bound.
+
+## ⚠️ Honest verdict (read before you believe the thesis)
+
+The originating thesis — *"everything is energy/frequency, so every abstract
+concept fully reduces, without loss, to native math"* — is **UNPROVEN and
+partly false**. The **strong** claim breaks against four independent, well-known
+limits, and you must not pretend otherwise:
+
+| Limit | What it means for this skill |
+|---|---|
+| **Hume is–ought** / **Moore open-question** | You cannot derive a *value* ("good") purely from *facts* ("has tests") — a value judgment is always injected. This skill makes that injection **explicit** (the weights + the J-leaves), it does not eliminate it. |
+| **Harnad symbol-grounding** | "Beautiful" has no context-free numeric ground truth; it is grounded only relative to a stated purpose + audience. → Step 0 CONTEXT-LOCK is mandatory. |
+| **Construct validity** (psychometrics) | A tree can be *reliable* (repeatable) yet *invalid* (measuring the wrong thing). Anchors + held-out validation manage this; they never fully close it. |
+| **Goodhart's law** | The moment the score becomes the target, it stops measuring. → the score is **evidence, not a target** (Metron guard). |
+
+**What the skill DOES deliver (the honest, still-powerful reframe):** the abstract
+becomes **tractable, transparent, and calibrated**, with the **irreducible
+residual of human judgment surfaced as a first-class output** (the J-leaves,
+their confidence, and the `inconclusive → escalate HITL` verdict). "Energy /
+vibration / frequency" is **evocative inspiration** (hence *Prisma*), not the
+mechanism. The mechanism is 50-year-old prior art: **MCDA / AHP / MAUT value-trees**
++ decomposed-rubric LLM-as-judge + fuzzy [0,1] membership. See `PRIOR-ART.md`.
+
+## The seam — deterministic skeleton × probabilistic muscle
+
+The one thing that must never happen: the model doing the arithmetic in its head
+and calling it a "measurement". Split the labour:
+
+| Layer | Who | Does | Nature |
+|---|---|---|---|
+| **Probabilistic muscle** | You (the LLM) | author the tree · type each leaf D/T/J · write methods + anchors · **estimate** J-leaf graded values + confidence | `f > 0` (judgment lives here — where value is created) |
+| **Deterministic skeleton** | `scripts/aggregate_spec.py` | weighted roll-up · confidence propagation · analytic sensitivity · residual + **inconclusive** detection · band | `f = 0` (repeatable, amnesia-proof, no arithmetic-in-head) |
+
+You produce a **measurement-spec** (JSON). The script consumes it and returns the
+number. The number is only as honest as the spec — which is why the steps below
+are guard-railed.
+
+## When NOT to use (skip — anti-over-engineering)
+
+- The criterion is **already concrete** (`coverage ≥ 80%`, `all checks SUCCESS`) → just measure it; no tree needed.
+- A **single** deterministic gate decides it → don't build a 4-branch tree for a one-liner.
+- The decision is **trivial / reversible / low-stakes** → a one-line judgment is fine; reserve this for criteria that will be *reused* or *auto-gated*.
+
+---
+
+## Procedure (steps 0–8)
+
+### 0 · CONTEXT-LOCK  *(hard gate — this is the cure for the root bug)*
+Bind the construct to its context **before** decomposing. Reuse
+`anti-theater-grounding-protocol` Layer 2 (2.1 context · 2.2 scope · 2.3
+priority-focus · 2.4 motivation · 2.5 targets/stakeholder). "Professional for a
+customer one-pager" ≠ "professional for an internal scratch note" — the tree and
+weights differ. **Refuse to proceed on a context-free construct** — the script
+enforces this: no `meta.context_lock` ⇒ `SpecError`. A context-free score is the
+guess this skill exists to kill.
+
+### 1 · DECOMPOSE → value-tree (a DAG)
+construct → criteria → sub-criteria → leaves. Guards (non-negotiable):
+- **depth-cap 3** (root→leaf) — over-decomposition is analysis-paralysis.
+- **materiality-prune** — drop a branch whose global flow `< 0.05`; it can't move the answer.
+- **shared sub-concept = one node with two parents** (a DAG, not a duplicated subtree).
+- **no cycles** (the script rejects them) — recursion must bottom out.
+- **deepen by sensitivity** — only split further the branches near a band boundary; leave settled branches shallow.
+
+### 2 · LEAF-TYPING D / T / J  *(the anti-"everything-is-J" gate)*
+Every leaf gets exactly one type, and **J is last resort**:
+- **D — deterministic-measurable**: a number a tool/script computes (coverage %, diff size, CVE count → mapped to [0,1]).
+- **T — typeable/observable**: a categorical fact you can classify/inventory (headings present? bots converged? migration present?).
+- **J — bounded-calibrated judgment**: only after you can state **"why there is no D or T method"**. A J-leaf is a *decomposed-rubric LLM-as-judge* call, not a vibe.
+- **Every leaf — including D and T — carries a `method` and `positive`+`negative` anchors.** The script **refuses an anchorless leaf** (`SpecError`) — an anchorless leaf is disguised guessing.
+
+### 3 · GRADE fuzzy [0,1]
+Each leaf value is a **graded membership** in [0,1] (Zadeh), not a boolean.
+"82% coverage" → `0.82` against its anchors, not a hard pass/fail. J-leaves also
+carry a **confidence** in [0,1] (how sure the judge is), separate from the value.
+De-bias the judge: **order-swap** the rubric criteria / compared items to blunt
+position, verbosity, and self-preference bias.
+
+### 4 · WEIGHTS (transparent + elicited)
+Assign sibling weights and **state the elicitation method** (swing-weighting /
+direct-ratio / AHP pairwise). Weights encode the value judgment (Hume) — making
+them explicit is the point. The script normalizes siblings to sum 1.
+
+### 5 · AGGREGATE → call the script
+Never roll up in your head. Write the spec to JSON and run:
+```bash
+python3 scripts/aggregate_spec.py --spec my-spec.json          # JSON out
+python3 scripts/aggregate_spec.py --spec my-spec.json --md      # markdown table
+```
+You get: `score` · `band` (HIGH ≥.85 / MEDIUM ≥.65 / LOW) · `aggregate_confidence`
+· `leaf_flows` (global weights, Σ=1) · `contributions` · `sensitivity`
+(analytic Δ-to-flip per leaf) · `residual` · `inconclusive`.
+
+### 6 · GUARDS (built into the script + your reading)
+- **Goodhart** — the score is **evidence, not a target** (Metron §5). Never tune the tree so a favored item "passes".
+- **construct-validity** — is the tree measuring the construct, or something adjacent? Report coverage-by-anchors.
+- **inconclusive is a first-class verdict** — the script raises `inconclusive.flag` on ANY of: `low_confidence` (agg-conf < 0.60) · `judgment_dominated` (Σ J-leaf flow ≥ 0.50) · `conflict:<branch>` (a material branch whose children's weighted-value stdev ≥ 0.25). **On inconclusive → abstain + escalate HITL** (`convergence-engine` DEFER regime). A high J-share is not a bug to hide — it is the true statement "this needs human judgment".
+- **non-compensatory veto-gate** — weighted-sum is *compensatory* by nature, so a **hard blocker** (unresolved critical CVE · secret leak · irreversible-prod · any absolute no-go) must be a **deterministic pre-gate that vetoes to LOW / no-go**, NOT a tree leaf — else a high sibling averages the blocker away (the `conflict` detector only catches it when siblings *disagree* AND the branch is material). The tree grades the *negotiable* qualities; absolute blockers gate **before** it.
+
+### 7 · VALIDATE against held-out anchors
+Calibrate the tree against **held-out exemplars you did NOT use to set weights**
+(positive / negative / **boundary** cases). A tree that only passes its own
+tuning examples is **not validated → treat as inconclusive** (Goodhart on the
+calibration set). Prefer an independent re-typing of a sample (verifier ≠
+generator — e.g. `maos:validation-auditor`). Honesty nod: the **inconclusive
+thresholds themselves** (`conflict 0.25` / `residual 0.50` / `conf 0.60`) are
+heuristic defaults that carry injected judgment — they are overridable per-spec
+and warrant the same held-out validation as the tree.
+
+### 8 · PERSIST the measurement-spec (versioned)
+Write the spec (tree + weights + methods + anchors + thresholds) to a versioned
+file so the **next amnesic agent re-runs it, does not re-derive it**. The spec IS
+the reproducible artifact; the score is just its latest evaluation.
+
+---
+
+## Composition-map (cite-only — this skill re-derives none of it)
+
+| Borrowed capability | Source (do not rebuild) |
+|---|---|
+| band boundaries (HIGH .85 / MED .65) | `~/.claude/rules/auto-self-harness.md` §1.2 autonomy_score |
+| Goodhart guard · score=evidence · residual | `~/.claude/rules/agentic-observability-protocol.md` (Metron) §4/§5 |
+| REFINE/SELECT/**DEFER** · verifier>generator · economic-stop | `skills/convergence-engine/SKILL.md` |
+| per-leaf measurement + evidence capture | `maos:data-validator` |
+| independent re-typing (verifier≠generator) | `maos:validation-auditor` |
+| CONTEXT-LOCK (Layer 2) + reality gate (Layer 5) | `~/.claude/rules/anti-theater-grounding-protocol.md` |
+| leaf grounding limit (why J can't fully vanish) | Harnad symbol-grounding (see `PRIOR-ART.md`) |
+
+## I/O contract (see `templates/measurement-spec.schema.json`)
+
+**Spec (in):** `meta.construct`, **`meta.context_lock`** (required — Step 0),
+optional `thresholds`, and `nodes[]`. Each node: `id`, optional `label`,
+`parents:[{id,weight>0}]` (root has none), `kind:"branch"|"leaf"`. Each **leaf**
+adds: `leaf_type:"D"|"T"|"J"`, `value` ∈ [0,1], `confidence` ∈ [0,1], optional
+`raw`/`method`, and **`anchors:{positive, negative}`** (required).
+
+**Result (out):** `score`, `band`, `aggregate_confidence`, `leaf_flows`,
+`contributions[]`, `sensitivity[{pivot,delta_to_flip,flips_to}]`,
+`residual{j_weight,judgment_dominated}`, `inconclusive{flag,reasons[]}` where
+reasons ∈ `low_confidence | judgment_dominated | conflict:<branch>`. Exit codes:
+`0` ok · `2` unreadable spec · `3` spec **refused** (`SpecError` — context-free,
+anchorless, cyclic, or too deep).
+
+See `examples/` for three worked specs: `pr-healthy` (conclusive HIGH),
+`doc-professional` (judgment-dominated → inconclusive), `quality-conflict`
+(conflicting material branch → inconclusive).
+
+## Anti-patterns (do NOT)
+
+1. ❌ **Score a context-free construct** — skipping Step 0. (The script refuses it; don't route around by faking a context_lock.)
+2. ❌ **Type everything J** — the disguised-guess this skill exists to kill. J requires a stated "why not D/T" + anchors.
+3. ❌ **Roll up in your head** — always call the script; arithmetic-in-head is not a measurement.
+4. ❌ **Fabricate a precise number over a real residual** — if `judgment_dominated` / `low_confidence` / `conflict` fires, report *inconclusive + escalate*, never a false-precise score (anti-theater R3/R4).
+5. ❌ **Tune the tree so a favored item passes** — Goodhart; the calibration set is held-out, and a tree that only fits its tuning examples is inconclusive.
+6. ❌ **Over-decompose** — depth-cap 3, materiality-prune, deepen only near band boundaries. A 30-leaf tree for a reversible call is over-engineering.
+7. ❌ **Believe the strong thesis** — say "tractable + calibrated + bounded residual", never "abstract fully reduced to native math".

--- a/skills/decompose-abstract-to-measurable/examples/doc-professional.json
+++ b/skills/decompose-abstract-to-measurable/examples/doc-professional.json
@@ -1,0 +1,32 @@
+{
+  "meta": {
+    "construct": "is this document professional?",
+    "version": "1.0.0",
+    "context_lock": {
+      "context": "customer-facing one-pager, en-US, pre-send",
+      "purpose": "gate whether it can go to a client without a human review",
+      "priority_focus": "credibility > completeness",
+      "stakeholder": "external client (reader) + operator (sender)",
+      "targets": "the doc body + its structure"
+    }
+  },
+  "nodes": [
+    {"id": "root", "label": "professional", "parents": [], "kind": "branch"},
+
+    {"id": "style", "label": "style", "parents": [{"id": "root", "weight": 0.6}], "kind": "branch"},
+    {"id": "l_tone", "label": "tone", "parents": [{"id": "style", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "J", "value": 0.7, "method": "rubric LLM-judge: confident-not-arrogant, no filler (order-swapped)", "confidence": 0.6,
+     "anchors": {"positive": "measured, specific, respectful → ~0.9", "negative": "salesy/hedgy/flippant → ~0.2"}},
+    {"id": "l_clarity", "label": "clarity", "parents": [{"id": "style", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "J", "value": 0.75, "method": "rubric LLM-judge: Feynman-plainness, no undefined jargon", "confidence": 0.65,
+     "anchors": {"positive": "a non-expert follows it → ~0.9", "negative": "jargon-dense, ambiguous → ~0.2"}},
+
+    {"id": "structure", "label": "structure", "parents": [{"id": "root", "weight": 0.4}], "kind": "branch"},
+    {"id": "l_headings", "label": "has-headings", "parents": [{"id": "structure", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "T", "value": 1.0, "raw": "3 sections", "method": "count headings", "confidence": 0.9,
+     "anchors": {"positive": "clear section headings → 1.0", "negative": "wall of text → 0.0"}},
+    {"id": "l_length", "label": "length-ok", "parents": [{"id": "structure", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 0.8, "raw": "1 page", "method": "word count vs target band", "confidence": 0.95,
+     "anchors": {"positive": "fits one page → ~0.9", "negative": "5+ pages for a one-pager → ~0.1"}}
+  ]
+}

--- a/skills/decompose-abstract-to-measurable/examples/pr-healthy.json
+++ b/skills/decompose-abstract-to-measurable/examples/pr-healthy.json
@@ -1,0 +1,45 @@
+{
+  "meta": {
+    "construct": "is this PR healthy?",
+    "version": "1.0.0",
+    "context_lock": {
+      "context": "vek-sales MVP, dev/hml branch, single-maintainer, auto-merge eligible",
+      "purpose": "decide whether to auto-merge without human review",
+      "priority_focus": "correctness > audit > speed",
+      "stakeholder": "operator (author) + downstream integrators",
+      "targets": "the PR diff + its CI + its bot reviews"
+    }
+  },
+  "thresholds": {"band_high": 0.85, "band_med": 0.65},
+  "nodes": [
+    {"id": "root", "label": "healthy", "parents": [], "kind": "branch"},
+
+    {"id": "tests", "label": "tests", "parents": [{"id": "root", "weight": 0.35}], "kind": "branch"},
+    {"id": "l_cov", "label": "coverage", "parents": [{"id": "tests", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 0.82, "raw": "82%", "method": "coverage report", "confidence": 0.95,
+     "anchors": {"positive": ">=80% → 1.0", "negative": "<50% → 0.0"}},
+    {"id": "l_pass", "label": "suite-passes", "parents": [{"id": "tests", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 1.0, "raw": "all green", "method": "CI statusCheckRollup", "confidence": 0.99,
+     "anchors": {"positive": "all checks SUCCESS → 1.0", "negative": "any FAILURE → 0.0"}},
+
+    {"id": "review", "label": "review", "parents": [{"id": "root", "weight": 0.30}], "kind": "branch"},
+    {"id": "l_bot", "label": "bot-convergence", "parents": [{"id": "review", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "T", "value": 0.9, "raw": "amazon-q+coderabbit converged", "method": "PR review state", "confidence": 0.9,
+     "anchors": {"positive": "all bots APPROVED/resolved → 1.0", "negative": "unresolved :stop_sign: → 0.0"}},
+    {"id": "l_clarity", "label": "code-clarity", "parents": [{"id": "review", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "J", "value": 0.7, "method": "decomposed-rubric LLM-judge (naming+cohesion+comments), order-swapped", "confidence": 0.7,
+     "anchors": {"positive": "self-documenting, matches surrounding idiom → ~0.9", "negative": "cryptic, inconsistent → ~0.2"}},
+
+    {"id": "risk", "label": "risk", "parents": [{"id": "root", "weight": 0.20}], "kind": "branch"},
+    {"id": "l_size", "label": "diff-size", "parents": [{"id": "risk", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 0.85, "raw": "62 lines", "method": "git diff --stat", "confidence": 0.9,
+     "anchors": {"positive": "<100 lines → ~0.9", "negative": ">1000 lines → ~0.1"}},
+    {"id": "l_revert", "label": "reversibility", "parents": [{"id": "risk", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "T", "value": 0.8, "raw": "no migration, no prod deploy", "method": "classify blast-radius", "confidence": 0.85,
+     "anchors": {"positive": "docs/config only, trivially revertible → 1.0", "negative": "destructive/irreversible prod → 0.0"}},
+
+    {"id": "l_changelog", "label": "changelog-present", "parents": [{"id": "root", "weight": 0.15}], "kind": "leaf",
+     "leaf_type": "T", "value": 1.0, "raw": "CHANGELOG updated", "method": "grep changelog", "confidence": 0.95,
+     "anchors": {"positive": "changelog row added → 1.0", "negative": "absent → 0.0"}}
+  ]
+}

--- a/skills/decompose-abstract-to-measurable/examples/quality-conflict.json
+++ b/skills/decompose-abstract-to-measurable/examples/quality-conflict.json
@@ -1,0 +1,28 @@
+{
+  "meta": {
+    "construct": "is this release quality-ready?",
+    "version": "1.0.0",
+    "context_lock": {
+      "context": "release candidate, staging",
+      "purpose": "go / no-go decision",
+      "priority_focus": "correctness",
+      "stakeholder": "release owner",
+      "targets": "the build + its checks"
+    }
+  },
+  "nodes": [
+    {"id": "root", "label": "quality-ready", "parents": [], "kind": "branch"},
+
+    {"id": "correctness", "label": "correctness", "parents": [{"id": "root", "weight": 0.5}], "kind": "branch"},
+    {"id": "l_functional", "label": "functional-tests", "parents": [{"id": "correctness", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 0.95, "raw": "190/200 pass", "method": "test report", "confidence": 0.9,
+     "anchors": {"positive": ">=95% pass → ~0.95", "negative": "<70% → ~0.1"}},
+    {"id": "l_security", "label": "security-scan", "parents": [{"id": "correctness", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 0.15, "raw": "1 critical CVE unresolved", "method": "SAST/dep-scan", "confidence": 0.9,
+     "anchors": {"positive": "0 high/critical → 1.0", "negative": "any unresolved critical → ~0.1"}},
+
+    {"id": "style", "label": "style", "parents": [{"id": "root", "weight": 0.5}], "kind": "leaf",
+     "leaf_type": "D", "value": 0.8, "raw": "lint clean", "method": "linter", "confidence": 0.9,
+     "anchors": {"positive": "no lint errors → ~0.9", "negative": "many errors → ~0.2"}}
+  ]
+}

--- a/skills/decompose-abstract-to-measurable/scripts/aggregate_spec.py
+++ b/skills/decompose-abstract-to-measurable/scripts/aggregate_spec.py
@@ -1,0 +1,349 @@
+#!/usr/bin/env python3
+"""aggregate_spec.py — deterministic aggregation engine for the
+`decompose-abstract-to-measurable` (soul-name *Prisma*) skill.
+
+Division of labour (the genuine deterministic × probabilistic seam):
+  • The LLM (calling agent) AUTHORS the value-tree, TYPES each leaf D/T/J, writes
+    measurement methods + anchors, and ESTIMATES judgment-leaf graded values +
+    confidence  → probabilistic muscle (f > 0).
+  • THIS script does the weighted roll-up, confidence propagation, sensitivity,
+    residual + inconclusive detection  → deterministic skeleton (f = 0),
+    amnesia-proof, repeatable, no arithmetic in the model's head.
+
+Input  : a measurement-spec JSON (see ../templates/measurement-spec.schema.json).
+Output : JSON (default) or a markdown table (--md).
+Stdlib only. Single file. No framework. Analytic sensitivity (no monte-carlo).
+
+Composes (cite-only, re-derives nothing):
+  band boundaries      ← auto-self-harness §1.2 autonomy_score (HIGH .85 / MED .65)
+  Goodhart / residual  ← agentic-observability-protocol (Metron) §5 (score = evidence, not target)
+  DEFER-on-residue      ← convergence-engine (abstain + escalate HITL)
+"""
+import argparse
+import json
+import math
+import sys
+
+DEFAULT_THRESHOLDS = {
+    "band_high": 0.85,          # ← autonomy_score §1.2 HIGH
+    "band_med": 0.65,           # ← autonomy_score §1.2 MEDIUM
+    "conf_inconclusive": 0.60,  # aggregate confidence below this → inconclusive
+    "conflict_delta": 0.25,     # weighted child-value stdev at/above this in a material branch → conflict
+    "residual_cap": 0.50,       # Σ J-leaf flow at/above this → judgment-dominated (score advisory)
+    "materiality": 0.05,        # (advisory; pruning happens in the skill, not the script)
+    "material_branch_flow": 0.20,  # a branch is "material" for conflict-detection when its flow ≥ this
+    "depth_cap": 3,             # max root→leaf path depth (over-decomposition guard)
+}
+
+
+class SpecError(ValueError):
+    """Raised when a measurement-spec is malformed, ungrounded, cyclic, or over-deep."""
+
+
+def load_spec(path):
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _thresholds(spec):
+    t = dict(DEFAULT_THRESHOLDS)
+    t.update(spec.get("thresholds", {}) or {})
+    return t
+
+
+def validate_spec(spec):
+    """Reject malformed / context-free / ungrounded / cyclic / too-deep specs.
+
+    Returns (by_id, root_id, children, thresholds). Hard refusals:
+      - no meta.context_lock         → Step-0 CONTEXT-LOCK (the root bug: scoring a context-free construct)
+      - leaf without positive+negative anchors → anchorless-leaf (disguised guessing)
+      - a cycle                       → tree must be a DAG (no infinite recursion)
+      - depth > depth_cap             → over-decomposition
+    """
+    if not isinstance(spec, dict) or "nodes" not in spec:
+        raise SpecError("spec must be an object with a 'nodes' array")
+    ctx = (spec.get("meta") or {}).get("context_lock")
+    if not isinstance(ctx, dict):
+        raise SpecError(
+            "meta.context_lock required — Step-0 CONTEXT-LOCK: refuse to score a "
+            "context-free construct (bind context+purpose+stakeholder+targets first)"
+        )
+    missing = [f for f in ("context", "purpose", "stakeholder", "targets")
+               if not (isinstance(ctx.get(f), str) and ctx[f].strip())]
+    if missing:
+        raise SpecError(
+            f"meta.context_lock incomplete — blank/absent sub-field(s) {missing}: a "
+            "context-free score is the guess this refuses (bind real context+purpose+stakeholder+targets)"
+        )
+    nodes = spec["nodes"]
+    if not nodes:
+        raise SpecError("spec.nodes is empty")
+
+    by_id = {}
+    for n in nodes:
+        nid = n.get("id")
+        if not nid:
+            raise SpecError("every node needs an 'id'")
+        if nid in by_id:
+            raise SpecError(f"duplicate node id: {nid}")
+        by_id[nid] = n
+
+    roots = [n for n in nodes if not n.get("parents")]
+    if len(roots) != 1:
+        raise SpecError(f"exactly one root (no-parent) node required; found {len(roots)}")
+    root_id = roots[0]["id"]
+
+    children = {nid: [] for nid in by_id}  # parent_id -> [(child_id, weight), ...]
+    for n in nodes:
+        for pe in n.get("parents", []):
+            pid, w = pe.get("id"), pe.get("weight")
+            if pid not in by_id:
+                raise SpecError(f"node {n['id']} references unknown parent {pid}")
+            if isinstance(w, bool) or not isinstance(w, (int, float)) or not math.isfinite(w) or w <= 0:
+                raise SpecError(f"edge {pid}->{n['id']} needs a FINITE weight > 0 (got {w!r})")
+            children[pid].append((n["id"], float(w)))
+
+    for n in nodes:
+        is_leaf = n.get("kind") == "leaf" or not children[n["id"]]
+        if is_leaf:
+            lt = n.get("leaf_type")
+            if lt not in ("D", "T", "J"):
+                raise SpecError(f"leaf {n['id']} needs leaf_type D/T/J (got {lt!r})")
+            v = n.get("value")
+            if not isinstance(v, (int, float)) or not (0.0 <= v <= 1.0):
+                raise SpecError(f"leaf {n['id']} value must be a graded [0,1] membership")
+            c = n.get("confidence")
+            if not isinstance(c, (int, float)) or not (0.0 <= c <= 1.0):
+                raise SpecError(f"leaf {n['id']} confidence must be in [0,1]")
+            a = n.get("anchors") or {}
+            pos, neg = a.get("positive"), a.get("negative")
+            if not (isinstance(pos, str) and pos.strip()) or not (isinstance(neg, str) and neg.strip()):
+                raise SpecError(
+                    f"leaf {n['id']} REFUSED: missing/blank positive+negative anchors "
+                    "(anchorless leaf = disguised guessing)"
+                )
+
+    t = _thresholds(spec)
+    WHITE, GREY, BLACK = 0, 1, 2
+    color = {nid: WHITE for nid in by_id}
+    max_depth = [0]
+
+    def dfs(nid, depth):
+        color[nid] = GREY
+        max_depth[0] = max(max_depth[0], depth)
+        for cid, _w in children[nid]:
+            if color[cid] == GREY:
+                raise SpecError(f"cycle detected via edge {nid}->{cid} (tree must be a DAG)")
+            if color[cid] == WHITE:
+                dfs(cid, depth + 1)
+        color[nid] = BLACK
+
+    try:
+        dfs(root_id, 0)
+    except RecursionError:
+        raise SpecError("spec too deep (recursion limit) — pathological chain exceeding depth_cap")
+    if max_depth[0] > t["depth_cap"]:
+        raise SpecError(f"depth {max_depth[0]} exceeds depth_cap {t['depth_cap']} (over-decomposition)")
+    unreachable = [nid for nid in by_id if color[nid] == WHITE]
+    if unreachable:
+        raise SpecError(
+            f"unreachable/orphan node(s) not connected to root: {unreachable} "
+            "(silent-drop refused — connect them to the tree or remove them)"
+        )
+    return by_id, root_id, children, t
+
+
+def normalize_weights(children):
+    """Per-parent sibling weights → sum 1. Returns {parent_id: {child_id: norm_w}}."""
+    norm = {}
+    for pid, edges in children.items():
+        total = sum(w for _c, w in edges)
+        norm[pid] = {c: (w / total) for c, w in edges} if total > 0 else {}
+    return norm
+
+
+def _topo_order(root_id, children):
+    """Parents-before-children ordering (DAG)."""
+    order, seen = [], set()
+
+    def visit(nid):
+        if nid in seen:
+            return
+        seen.add(nid)
+        for cid, _w in children[nid]:
+            visit(cid)
+        order.append(nid)
+
+    visit(root_id)
+    order.reverse()
+    return order
+
+
+def leaf_flows(root_id, children, norm):
+    """Flow conservation: root=1, splits to children by normalized weight; DAG path-sum.
+
+    Σ leaf_flows == 1. Returns (leaf_flow_map, full_flow_map).
+    """
+    order = _topo_order(root_id, children)
+    flow = {nid: 0.0 for nid in children}
+    flow[root_id] = 1.0
+    for nid in order:
+        for cid, _w in children[nid]:
+            flow[cid] += flow[nid] * norm[nid][cid]
+    leaves = [nid for nid in children if not children[nid]]
+    return {lf: flow[lf] for lf in leaves}, flow
+
+
+def node_values(root_id, children, norm, by_id):
+    """Bottom-up node value: leaf → its graded value; branch → weighted avg of children."""
+    order = _topo_order(root_id, children)
+    val = {}
+    for nid in reversed(order):  # children before parents
+        if not children[nid]:
+            val[nid] = float(by_id[nid]["value"])
+        else:
+            val[nid] = sum(norm[nid][cid] * val[cid] for cid, _w in children[nid])
+    return val
+
+
+def band_of(score, t):
+    if score >= t["band_high"]:
+        return "HIGH"
+    if score >= t["band_med"]:
+        return "MEDIUM"
+    return "LOW"
+
+
+def sensitivity(flows_leaf, by_id, score, t, top_k=3):
+    """Analytic Δ-to-flip per leaf: how far this leaf's value must move to cross the
+    nearest band boundary, and which band the score flips TO (the far side of that boundary)."""
+    out = []
+    boundaries = [t["band_med"], t["band_high"]]
+    for lid, fl in flows_leaf.items():
+        if fl <= 0:
+            continue
+        v = float(by_id[lid]["value"])
+        best = None  # (boundary, need)
+        for b in boundaries:
+            need = (b - score) / fl
+            newv = v + need
+            if -1e-9 <= newv <= 1 + 1e-9 and abs(need) > 1e-9:
+                if best is None or abs(need) < abs(best[1]):
+                    best = (b, need)
+        if best:
+            b, need = best
+            flips_to = band_of(b + math.copysign(1e-9, need), t)  # band on the destination side
+            out.append({"pivot": lid, "delta_to_flip": round(need, 4), "flips_to": flips_to})
+    out.sort(key=lambda d: abs(d["delta_to_flip"]))
+    return out[:top_k]
+
+
+def detect_inconclusive(flows_leaf, full_flow, by_id, children, norm, nvals, agg_conf, t):
+    """First-class inconclusive verdict. Fires on ANY: low aggregate confidence,
+    judgment-dominated (Σ J-flow ≥ residual_cap), or a material branch whose children conflict."""
+    reasons = []
+    if agg_conf < t["conf_inconclusive"]:
+        reasons.append("low_confidence")
+    j_weight = sum(fl for lid, fl in flows_leaf.items() if by_id[lid].get("leaf_type") == "J")
+    if j_weight >= t["residual_cap"]:
+        reasons.append("judgment_dominated")
+    for bid, edges in children.items():
+        if not edges or full_flow.get(bid, 0.0) < t["material_branch_flow"]:
+            continue
+        ws = norm[bid]
+        mean = sum(ws[cid] * nvals[cid] for cid, _w in edges)
+        var = sum(ws[cid] * (nvals[cid] - mean) ** 2 for cid, _w in edges)
+        if math.sqrt(var) >= t["conflict_delta"]:
+            reasons.append(f"conflict:{bid}")
+    return reasons, round(j_weight, 4)
+
+
+def compute(spec):
+    by_id, root_id, children, t = validate_spec(spec)
+    norm = normalize_weights(children)
+    flows_leaf, full_flow = leaf_flows(root_id, children, norm)
+    nvals = node_values(root_id, children, norm, by_id)
+    score = round(sum(flows_leaf[lid] * float(by_id[lid]["value"]) for lid in flows_leaf), 4)
+    agg_conf = round(sum(flows_leaf[lid] * float(by_id[lid]["confidence"]) for lid in flows_leaf), 4)
+    contribs = sorted(
+        [{"id": lid, "leaf_type": by_id[lid].get("leaf_type"), "flow": round(fl, 4),
+          "value": float(by_id[lid]["value"]), "contrib": round(fl * float(by_id[lid]["value"]), 4)}
+         for lid, fl in flows_leaf.items()],
+        key=lambda d: d["contrib"], reverse=True)
+    sens = sensitivity(flows_leaf, by_id, score, t)
+    reasons, j_weight = detect_inconclusive(
+        flows_leaf, full_flow, by_id, children, norm, nvals, agg_conf, t)
+    return {
+        "construct": (spec.get("meta") or {}).get("construct"),
+        "score": score,
+        "band": band_of(score, t),
+        "aggregate_confidence": agg_conf,
+        "leaf_flows": {lid: round(fl, 4) for lid, fl in flows_leaf.items()},
+        "contributions": contribs,
+        "sensitivity": sens,
+        "residual": {"j_weight": j_weight, "judgment_dominated": j_weight >= t["residual_cap"]},
+        "inconclusive": {"flag": bool(reasons), "reasons": reasons},
+    }
+
+
+def emit_md(r):
+    lines = [
+        f"### **{r['construct']}** → score `{r['score']}` · band **{r['band']}** · conf `{r['aggregate_confidence']}`",
+        "",
+        "| leaf | type | flow | value | contrib |",
+        "|---|---|---|---|---|",
+    ]
+    for c in r["contributions"]:
+        lines.append(f"| {c['id']} | {c['leaf_type']} | {c['flow']} | {c['value']} | {c['contrib']} |")
+    lines.append("")
+    lines.append(f"- residual (Σ J-flow): `{r['residual']['j_weight']}` · judgment_dominated: `{r['residual']['judgment_dominated']}`")
+    if r["inconclusive"]["flag"]:
+        lines.append(f"- ⚠️ **INCONCLUSIVE → abstain + escalate HITL** · reasons: {', '.join(r['inconclusive']['reasons'])}")
+    else:
+        lines.append("- conclusive — treat the score as **evidence, not a target** (Goodhart guard)")
+    if r["sensitivity"]:
+        s = r["sensitivity"][0]
+        lines.append(f"- most-sensitive leaf: `{s['pivot']}` (Δ`{s['delta_to_flip']}` → {s['flips_to']})")
+    return "\n".join(lines)
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Deterministic value-tree aggregator for decompose-abstract-to-measurable (Prisma).")
+    ap.add_argument("--spec", required=True, help="path to a measurement-spec JSON")
+    ap.add_argument("--out", help="write result to this path (default: stdout)")
+    ap.add_argument("--md", action="store_true", help="emit a markdown table instead of JSON")
+    ap.add_argument("--high", type=float, help="override band_high threshold")
+    ap.add_argument("--med", type=float, help="override band_med threshold")
+    ap.add_argument("--conf-threshold", type=float, help="override conf_inconclusive threshold")
+    args = ap.parse_args(argv)
+    try:
+        spec = load_spec(args.spec)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"[spec-error] cannot read {args.spec}: {e}", file=sys.stderr)
+        return 2
+    overrides = {}
+    if args.high is not None:
+        overrides["band_high"] = args.high
+    if args.med is not None:
+        overrides["band_med"] = args.med
+    if args.conf_threshold is not None:
+        overrides["conf_inconclusive"] = args.conf_threshold
+    if overrides:
+        spec.setdefault("thresholds", {}).update(overrides)
+    try:
+        result = compute(spec)
+    except SpecError as e:
+        print(f"[spec-refused] {e}", file=sys.stderr)
+        return 3
+    text = emit_md(result) if args.md else json.dumps(result, indent=2, ensure_ascii=False)
+    if args.out:
+        with open(args.out, "w", encoding="utf-8") as fh:
+            fh.write(text + "\n")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/decompose-abstract-to-measurable/templates/measurement-spec.schema.json
+++ b/skills/decompose-abstract-to-measurable/templates/measurement-spec.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://multi-agent-os/skills/decompose-abstract-to-measurable/measurement-spec.schema.json",
+  "title": "measurement-spec",
+  "description": "Input contract for aggregate_spec.py (decompose-abstract-to-measurable / Prisma). A value-tree DAG binding an abstract construct to measurable leaves. The LLM authors this; the deterministic script consumes it and never mutates it.",
+  "type": "object",
+  "required": ["meta", "nodes"],
+  "additionalProperties": true,
+  "properties": {
+    "meta": {
+      "type": "object",
+      "required": ["construct", "context_lock"],
+      "description": "context_lock is the Step-0 hard gate — a context-free construct is refused (SpecError).",
+      "properties": {
+        "construct": {"type": "string", "description": "the abstract thing being measured, e.g. 'is this PR healthy?'"},
+        "version": {"type": "string"},
+        "context_lock": {
+          "type": "object",
+          "description": "anti-theater Layer 2 binding — a construct is only measurable relative to this (Harnad grounding).",
+          "required": ["context", "purpose", "stakeholder", "targets"],
+          "properties": {
+            "context": {"type": "string"},
+            "purpose": {"type": "string"},
+            "priority_focus": {"type": "string"},
+            "stakeholder": {"type": "string"},
+            "targets": {"type": "string"}
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    },
+    "thresholds": {
+      "type": "object",
+      "description": "Optional overrides of DEFAULT_THRESHOLDS. Any omitted key keeps its default.",
+      "additionalProperties": false,
+      "properties": {
+        "band_high": {"type": "number", "default": 0.85, "description": "score >= this -> HIGH band (autonomy_score §1.2)"},
+        "band_med": {"type": "number", "default": 0.65, "description": "score >= this -> MEDIUM band"},
+        "conf_inconclusive": {"type": "number", "default": 0.60, "description": "aggregate confidence below this -> inconclusive(low_confidence)"},
+        "conflict_delta": {"type": "number", "default": 0.25, "description": "weighted child-value stdev >= this in a material branch -> inconclusive(conflict:<branch>)"},
+        "residual_cap": {"type": "number", "default": 0.50, "description": "Σ J-leaf flow >= this -> judgment_dominated + inconclusive"},
+        "materiality": {"type": "number", "default": 0.05, "description": "advisory prune threshold (applied in the skill, not the script)"},
+        "material_branch_flow": {"type": "number", "default": 0.20, "description": "a branch counts for conflict-detection when its global flow >= this"},
+        "depth_cap": {"type": "integer", "default": 3, "description": "max root->leaf path depth; deeper -> SpecError (over-decomposition)"}
+      }
+    },
+    "nodes": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The DAG. Exactly one node has no parents (the root). Shared sub-concepts have multiple parents. No cycles.",
+      "items": {
+        "type": "object",
+        "required": ["id"],
+        "additionalProperties": true,
+        "properties": {
+          "id": {"type": "string", "description": "unique node id"},
+          "label": {"type": "string"},
+          "kind": {"enum": ["branch", "leaf"], "description": "a node with no children is treated as a leaf even if kind is omitted"},
+          "parents": {
+            "type": "array",
+            "description": "incoming edges; empty ONLY for the single root",
+            "items": {
+              "type": "object",
+              "required": ["id", "weight"],
+              "properties": {
+                "id": {"type": "string", "description": "parent node id"},
+                "weight": {"type": "number", "exclusiveMinimum": 0, "description": "relative weight under that parent; siblings are normalized to sum 1"}
+              },
+              "additionalProperties": false
+            }
+          },
+          "leaf_type": {"enum": ["D", "T", "J"], "description": "LEAF only. D=deterministic-measurable, T=typeable/observable, J=bounded-calibrated-judgment (last resort; requires a stated 'why not D/T')"},
+          "value": {"type": "number", "minimum": 0, "maximum": 1, "description": "LEAF only. graded [0,1] membership (Zadeh), never a raw boolean"},
+          "confidence": {"type": "number", "minimum": 0, "maximum": 1, "description": "LEAF only. how sure the measurement/judge is (propagated to aggregate_confidence)"},
+          "raw": {"type": "string", "description": "LEAF: the raw observation, e.g. '82%', '190/200 pass', '1 critical CVE'"},
+          "method": {"type": "string", "description": "LEAF: how the value was obtained (tool, count, rubric)"},
+          "anchors": {
+            "type": "object",
+            "description": "LEAF: REQUIRED. positive+negative reference points that ground the [0,1] scale. An anchorless leaf is refused (disguised guessing).",
+            "required": ["positive", "negative"],
+            "properties": {
+              "positive": {"type": "string"},
+              "negative": {"type": "string"},
+              "boundary": {"type": "string", "description": "optional held-out boundary exemplar for validation (Step 7)"}
+            },
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  },
+  "$comment": "OUTPUT (aggregate_spec.py): {construct, score, band(HIGH|MEDIUM|LOW), aggregate_confidence, leaf_flows{id:flow Σ=1}, contributions[{id,leaf_type,flow,value,contrib}], sensitivity[{pivot,delta_to_flip,flips_to}], residual{j_weight,judgment_dominated}, inconclusive{flag,reasons[]}}. reasons ∈ low_confidence|judgment_dominated|conflict:<branch>. Exit: 0 ok, 2 unreadable, 3 SpecError(refused)."
+}

--- a/skills/decompose-abstract-to-measurable/tests/test_aggregate.py
+++ b/skills/decompose-abstract-to-measurable/tests/test_aggregate.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Behavioral tests for aggregate_spec.py. Stdlib only. Run: python tests/test_aggregate.py
+Exit 0 = all pass; nonzero = failure. No pytest dependency."""
+import json
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+sys.path.insert(0, os.path.join(SKILL, "scripts"))
+import aggregate_spec as A  # noqa: E402
+
+EX = os.path.join(SKILL, "examples")
+
+
+def _load(name):
+    with open(os.path.join(EX, name), "r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+CTX = {"context": "t", "purpose": "t", "stakeholder": "t", "targets": "t"}
+CASES = []
+
+
+def case(fn):
+    CASES.append(fn)
+    return fn
+
+
+@case
+def test_pr_healthy_high_conclusive():
+    r = A.compute(_load("pr-healthy.json"))
+    assert r["band"] == "HIGH", r["band"]                       # (i) all-D-ish high → HIGH
+    assert r["score"] >= 0.85, r["score"]
+    assert r["aggregate_confidence"] >= 0.85, r["aggregate_confidence"]
+    assert r["inconclusive"]["flag"] is False, r["inconclusive"]
+    assert r["residual"]["judgment_dominated"] is False
+    assert abs(sum(r["leaf_flows"].values()) - 1.0) < 1e-6      # flow conservation Σ=1
+
+
+@case
+def test_doc_professional_judgment_dominated():
+    r = A.compute(_load("doc-professional.json"))
+    assert r["residual"]["judgment_dominated"] is True, r["residual"]   # (ii) Σ J-flow ≥ 0.5
+    assert r["inconclusive"]["flag"] is True
+    assert "judgment_dominated" in r["inconclusive"]["reasons"], r["inconclusive"]
+
+
+@case
+def test_quality_conflict_flag():
+    r = A.compute(_load("quality-conflict.json"))
+    assert r["inconclusive"]["flag"] is True                          # (iii) conflicting material branch
+    assert any(x.startswith("conflict:") for x in r["inconclusive"]["reasons"]), r["inconclusive"]
+    assert r["band"] == "MEDIUM", r["band"]
+
+
+@case
+def test_cycle_rejected():                                            # (iv) cycle → refuse
+    spec = {"meta": {"construct": "c", "context_lock": CTX}, "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "a", "parents": [{"id": "root", "weight": 1}, {"id": "b", "weight": 1}], "kind": "branch"},
+        {"id": "b", "parents": [{"id": "a", "weight": 1}], "kind": "branch"},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "cycle" in str(e).lower(), e
+        return
+    raise AssertionError("cycle spec was NOT rejected")
+
+
+@case
+def test_anchorless_leaf_rejected():                                  # (v) anchorless leaf → refuse
+    spec = {"meta": {"construct": "c", "context_lock": CTX}, "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "l1", "parents": [{"id": "root", "weight": 1}], "kind": "leaf",
+         "leaf_type": "D", "value": 0.8, "confidence": 0.9},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "anchor" in str(e).lower(), e
+        return
+    raise AssertionError("anchorless leaf was NOT rejected")
+
+
+@case
+def test_context_free_rejected():                                     # (vi) Step-0 gate → refuse
+    spec = {"meta": {"construct": "c"}, "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "l1", "parents": [{"id": "root", "weight": 1}], "kind": "leaf",
+         "leaf_type": "D", "value": 0.8, "confidence": 0.9,
+         "anchors": {"positive": "p", "negative": "n"}},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "context_lock" in str(e).lower(), e
+        return
+    raise AssertionError("context-free spec was NOT rejected")
+
+
+@case
+def test_nonfinite_weight_rejected():                                 # (vii) NaN/inf weight → refuse, not NaN-score
+    spec = {"meta": {"construct": "c", "context_lock": CTX}, "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "l1", "parents": [{"id": "root", "weight": float("inf")}], "kind": "leaf",
+         "leaf_type": "D", "value": 0.8, "confidence": 0.9,
+         "anchors": {"positive": "p", "negative": "n"}},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "finite" in str(e).lower(), e
+        return
+    raise AssertionError("non-finite weight was NOT rejected (would ship a NaN score)")
+
+
+@case
+def test_orphan_node_rejected():                                      # (viii) unreachable/orphan → refuse silent-drop
+    spec = {"meta": {"construct": "c", "context_lock": CTX}, "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "l1", "parents": [{"id": "root", "weight": 1}], "kind": "leaf",
+         "leaf_type": "D", "value": 0.8, "confidence": 0.9,
+         "anchors": {"positive": "p", "negative": "n"}},
+        {"id": "a", "parents": [{"id": "b", "weight": 1}], "kind": "branch"},   # a,b: unreachable cycle
+        {"id": "b", "parents": [{"id": "a", "weight": 1}], "kind": "branch"},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "unreachable" in str(e).lower() or "orphan" in str(e).lower(), e
+        return
+    raise AssertionError("unreachable/orphan node was silently dropped, NOT rejected")
+
+
+@case
+def test_blank_context_subfield_rejected():                           # (ix) junk Step-0 gate → refuse
+    spec = {"meta": {"construct": "c", "context_lock": {"context": " ", "purpose": "p",
+                                                        "stakeholder": "s", "targets": "t"}},
+            "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "l1", "parents": [{"id": "root", "weight": 1}], "kind": "leaf",
+         "leaf_type": "D", "value": 0.8, "confidence": 0.9,
+         "anchors": {"positive": "p", "negative": "n"}},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "context_lock" in str(e).lower(), e
+        return
+    raise AssertionError("blank context_lock sub-field was NOT rejected")
+
+
+@case
+def test_blank_anchor_rejected():                                     # (x) whitespace-junk anchor → refuse
+    spec = {"meta": {"construct": "c", "context_lock": CTX}, "nodes": [
+        {"id": "root", "parents": [], "kind": "branch"},
+        {"id": "l1", "parents": [{"id": "root", "weight": 1}], "kind": "leaf",
+         "leaf_type": "D", "value": 0.8, "confidence": 0.9,
+         "anchors": {"positive": " ", "negative": "   "}},
+    ]}
+    try:
+        A.compute(spec)
+    except A.SpecError as e:
+        assert "anchor" in str(e).lower(), e
+        return
+    raise AssertionError("blank whitespace anchors were NOT rejected")
+
+
+def run():
+    failures = 0
+    for fn in CASES:
+        try:
+            fn()
+            print(f"PASS  {fn.__name__}")
+        except Exception as e:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL  {fn.__name__}: {e}")
+    print(f"\n{len(CASES) - failures}/{len(CASES)} passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(run())


### PR DESCRIPTION
## `[PR-as-Announcement-Prompt]` — new skill: `decompose-abstract-to-measurable` (soul-name *Prisma*)

### Context
Agents routinely receive a task whose `[motive · DoR · DoD · metric · KPI · acceptance]` is **abstract** ("make it *professional*", "is this PR *healthy*?"). They can't compute an abstract word natively → they **fabricate a plausible number and ship the wrong result**. This skill replaces the guess with a reproducible, auditable decomposition.

### What it does
Decomposes an abstract construct into a **value-tree DAG** whose leaves are typed **D** (deterministic-measurable) / **T** (typeable-observable) / **J** (bounded-calibrated-judgment), then a **deterministic stdlib script** (`aggregate_spec.py`) rolls it up into `score · band (HIGH ≥.85 / MED ≥.65 / LOW) · aggregate_confidence · analytic sensitivity · residual` and a **first-class `inconclusive → escalate HITL` verdict**.

**The seam:** the LLM authors the tree + estimates J-leaves (`f>0`, where judgment lives); the script does the arithmetic (`f=0`, amnesia-proof — never roll up in the model's head).

### ⚠️ Honest verdict (stated in every artifact — this is not mysticism)
The originating thesis ("everything abstract fully reduces, without loss, to native math") is **UNPROVEN + partly false** — it breaks on **Hume is–ought · Moore open-question · Harnad symbol-grounding · construct-validity · Goodhart**. The mechanism is 50-year prior art: **MCDA / AHP / MAUT value-trees + decomposed-rubric LLM-as-judge + fuzzy [0,1]**. "Energy/frequency" is evocative inspiration only — hence the soul-name *Prisma* (a prism does a *real* frequency split). Honest reframe delivered: the abstract becomes **tractable · transparent · calibrated, with the irreducible judgment residual surfaced first-class**. See `PRIOR-ART.md`.

### Composition (cite-only — rebuilds nothing)
bands ← `auto-self-harness §1.2` · Goodhart/residual ← `agentic-observability-protocol` (Metron) §5 · DEFER ← `convergence-engine` · measurement/audit ← `data-validator`/`validation-auditor` · context/reality ← `anti-theater-grounding-protocol` L2/L5.

### Objectives / acceptance
- [x] Deterministic engine + 3 worked examples + JSON schema + `PRIOR-ART.md`
- [x] **10/10 tests** pass, incl. adversarial refusals (non-finite weight, orphan node, cyclic, anchorless, context-free, over-deep all refused at `exit 3`)
- [x] Ratified by a **2-member independent council** (governance + adversarial-technical, verifier ≠ generator); the adversary's blocking finding (non-finite weight → NaN score) + 4 hardening notes all fixed + re-verified
- [x] No secrets (gitleaks clean, 53KB scanned)

### Files
`skills/decompose-abstract-to-measurable/` → `SKILL.md` (0–8 procedure) · `scripts/aggregate_spec.py` (stdlib-only engine) · `templates/measurement-spec.schema.json` · `examples/{pr-healthy,doc-professional,quality-conflict}.json` · `tests/test_aggregate.py` · `PRIOR-ART.md`.

### Cross-links
Sibling fold in `akasha-claude`: `anti-theater-grounding-protocol.md` v1.1.1 (Layer-5 R6 → this skill as the operational *how* of grounding an abstract criterion). Knowledge persisted in akasha memory `dna_abstract_to_measurable_decomposition` + `reference_abstract_to_measurable_prior_art`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
