### PR TITLE
feat(tips): MAOS-Tips — session-start discoverability nudges (ADR-008)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_comment": "MAOS plugin manifest. Edit version on release; see CHANGELOG.md. Namespacing + vendor-reserved details below.",
   "name": "maos",
-  "version": "1.18.0",
+  "version": "1.19.0",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — MAOS-Tips: session-start discoverability nudges (ADR-008)
+
+- **`plugin-scripts/session-tip.sh`** (5th SessionStart hook): surfaces ONE curated tip about a maos
+  agentic-tool per new session so the ~116 tools (63 skills + 25 cmds + 28 agents) become discoverable
+  — *what it does · when to use it · how to invoke it*. Fires only on `.source ∈ {startup, clear}`
+  (skips `resume`/`compact`), one per session (`session_id` idempotency) + a no-repeat seen-ledger at
+  `~/.claude/maos/tips-state.json` (atomic-mv + symlink-guard; never committed). Advisory, always exits 0,
+  degrades to a silent no-op if `tips/` or `jq` is absent. **Recon**: the native "Message from <org>:"
+  banner is `companyAnnouncements` (org-server-side, not plugin-writable) — the hook channel is the
+  community-portable substitute.
+- **Silenceable + tunable**: `MAOS_TIPS=off` · `MAOS_NO_TIPS=1` · `~/.claude/.maos-no-tips` silence it;
+  `MAOS_TIPS_EVERY=Nd` throttles to ≤1/N-days; `MAOS_TIPS_LANG=pt-br` reserved (v1 catalog is en-US).
+- **`tips/catalog.json`** — 16 seed tips + `families{}` routing (all → `maos-concierge`). **Hybrid source**:
+  hand-curated copy + CI-validated integrity.
+- **`tips/validate-tips.sh`** — anti-orphan / anti-rot CI gate: fails the build if any `tool_path` is
+  orphaned, a `family`/`route` doesn't resolve, or a tip's family drifts from the tool's declared
+  `metadata.family` (family-sync). Wired into `tests/validate-plugin.sh`.
+- **`commands/tip.md`** (`/maos:tip`) — on-demand tip (`--family <f>`), plus `--emit-announcements [N]`:
+  prints paste-ready startup-announcement strings so an operator can replicate the native banner in their
+  own `settings.json` / org console. **The plugin never writes settings** (HUMAN_DOMAIN).
+- **`tips/inference.md`** (selection logic) · **`tests/governance/test-session-tip.sh`** (behavior fixtures:
+  opt-out · skip resume/compact · no-repeat · idempotency · announce · degrade) · **`docs/adrs/ADR-008-*.md`**.
+- DRY: a tip is a 1-line PUSH nudge + route to the concierge; depth stays in the concierge (not restated).
+
 ### Fixed — `voice` skill renamed to `voice-director` (host `/voice` slash-command collision)
 
 - **`skills/voice/` → `skills/voice-director/`** (`name: voice` → `name: voice-director`). Skills

--- a/commands/tip.md
+++ b/commands/tip.md
@@ -1,0 +1,46 @@
+---
+name: tip
+description: Show a MAOS discoverability tip on demand (which agentic-tool to use, when) — or generate paste-ready startup announcements.
+---
+
+# /maos:tip Command
+
+Surface a **MAOS Tip** — a one-line nudge about a maos agentic-tool (what it does, when to use it,
+how to invoke it) so you get the most out of the ~116 tools in this plugin. This is the on-demand
+twin of the session-start tip that fires once per new session.
+
+## Usage
+
+```
+/maos:tip                              # one random tip now (non-mutating — never burns the session rotation)
+/maos:tip --family <family>            # a tip scoped to a family (worktree-lifecycle, orchestration-convergence, …)
+/maos:tip --emit-announcements [N]     # print N (default 10) paste-ready startup-announcement strings
+```
+
+## What to do
+
+Run the tips hook in the requested mode and show its output verbatim:
+
+```bash
+bash "${CLAUDE_PLUGIN_ROOT}/plugin-scripts/session-tip.sh" --print ${ARGUMENTS:-}
+```
+
+- Default → one random tip (`💡 MAOS Tip · <tool>: <when-to-use>. Try: /maos:<tool> · more: /maos:maos-concierge`).
+- `--family <f>` → filter to that family; if none match, say so.
+- `--emit-announcements [N]` → run the hook with `--emit-announcements` instead of `--print`; print the JSON array
+  and the paste instructions verbatim. **Do NOT write `settings.json` / `companyAnnouncements` yourself** — that
+  channel is server-side / org-managed (HUMAN_DOMAIN); the operator pastes the array.
+
+If the operator's current work matches the surfaced tool, offer to route them to it (or to `/maos:maos-concierge`
+for a guided pick). Depth lives in the concierge — a tip only points the way (DRY).
+
+## Silencing
+
+Session-start tips are opt-out via `MAOS_TIPS=off`, `MAOS_NO_TIPS=1`, or `~/.claude/.maos-no-tips`;
+`MAOS_TIPS_EVERY=Nd` throttles them to at most one per N days. `/maos:tip` itself is always on-demand.
+
+## Related
+
+- `skills/maos-concierge/SKILL.md` — deep onboarding + intent→tool routing (where tips route to).
+- `plugin-scripts/session-tip.sh` — the hook that powers this command.
+- `tips/inference.md` — selection logic. `docs/adrs/ADR-008-*.md` — design decision + rationale.

--- a/docs/adrs/ADR-008-maos-tips-session-discoverability.md
+++ b/docs/adrs/ADR-008-maos-tips-session-discoverability.md
@@ -1,0 +1,92 @@
+# ADR-008: MAOS-Tips — Session-Start Discoverability Nudges
+
+- **Status**: Accepted
+- **Date**: 2026-07-10
+- **Deciders**: Operator + orchestrator (council: recon 3/3 + debate/converge 3-lens + Anima naming)
+- **Scope**: multi-agent-os (Layer-1 community, MIT, en-US)
+
+## Context
+
+MAOS ships ~116 agentic-tools (63 skills + 25 commands + 28 agents). Discovery is poor: unless a user
+already knows a tool's name they won't find it, and the value of the plugin stays locked. The operator
+saw the Claude Code **native `companyAnnouncements`** feature render a "Message from vek-im: VSAF…"
+orange-bar banner at session start (delivered server-side by the org's Anthropic Console enterprise
+policy) and asked for a MAOS-owned equivalent that teaches *which tool to use, when*.
+
+**Recon finding**: `companyAnnouncements` is org-server-side (same channel as `organizationInstructions`),
+absent from any local settings, and **not writable by a plugin** — server-side, org-only, and Layer-impure
+for a community artifact. So a plugin cannot reuse that channel; the portable substitute is the
+**SessionStart hook** channel (stderr human line + stdout `additionalContext`).
+
+## Decision
+
+Ship **MAOS-Tips**: a SessionStart hook that surfaces **one curated tip** about a maos tool per new
+session, plus an on-demand command and a print-only announcements generator.
+
+1. **Target = multi-agent-os only.** vek-ai-toolkit is out (empty `hooks.json`; Layer Purity — no
+   corporate content here). A Vek overlay is a separate roadmap item.
+2. **Placement = session-start (v1).** End-of-action is v2 — a context-mismatched tip mid-work is a
+   credibility-killer; startup is low-risk.
+3. **Frequency = 1 per session** (operator directive) — fires only on `.source ∈ {startup, clear}`
+   (skip `resume`/`compact`), with `session_id` idempotency + a no-repeat seen-ledger. `MAOS_TIPS_EVERY=Nd`
+   throttles further. Silenceable via `MAOS_TIPS=off` / `MAOS_NO_TIPS=1` / `~/.claude/.maos-no-tips`.
+4. **Source = hybrid (curated + CI-validated).** The catalog is hand-curated (the when-to-use clause is
+   UX craft) but its *integrity* is a CI gate: `tips/validate-tips.sh` fails the build if any `tool_path`
+   is orphaned or a tip's family drifts from the tool's declared `metadata.family`. This kills catalog rot
+   (the concierge's AWARENESS-REGISTRY drifted to "~31 skills" for 63 real — the failure mode we refuse).
+5. **DRY route, not duplicate.** A tip is a 1-line PUSH nudge + a route to `maos-concierge`; depth (PULL)
+   stays in the concierge. Not a skill (avoids the SKILL.md ceremony); no hardcoded version.
+6. **Announcements generator = opt-in, print-only.** `--emit-announcements [N]` prints paste-ready strings
+   so an operator can replicate the native banner in their *own* `settings.json` or org console. The plugin
+   **never writes settings** (HUMAN_DOMAIN).
+7. **Language.** en-US in the community artifact; `MAOS_TIPS_LANG=pt-br` reserved as an operator-side opt-in.
+
+### Artifacts
+
+| Artifact | Role |
+|----------|------|
+| `plugin-scripts/session-tip.sh` | SessionStart hook (5th entry) + `--print` / `--emit-announcements` / `--family` modes |
+| `tips/catalog.json` | curated corpus (16 seed tips) + `families{family→{route,blurb}}` |
+| `tips/inference.md` | selection logic (trigger gate · rotation+no-repeat · render · fallback) |
+| `tips/validate-tips.sh` | anti-orphan CI gate (tool_path exists · family-sync · route resolves · smoke-run) |
+| `commands/tip.md` | `/maos:tip` on-demand |
+| `tests/governance/test-session-tip.sh` | behavior fixtures (opt-out · skip · no-repeat · idempotency · announce) |
+
+Seen-ledger lives user-scope at `~/.claude/maos/tips-state.json` (JSON; atomic-mv + symlink-guard,
+cloned from `auto-name-session.sh`), **never committed**.
+
+## Alternatives rejected
+
+- **Write `companyAnnouncements` from the plugin** — impossible/inappropriate (server-side, org-only,
+  HUMAN_DOMAIN, Layer-impure). → print-only generator instead.
+- **Hand-written catalog with no validation** — rots (proven by the concierge registry drift). → CI gate.
+- **End-of-action placement in v1** — context-mismatch risk. → deferred to v2.
+- **Make it a skill** — adds SKILL.md ceremony for a hook-driven nudge. → command + hook, no skill.
+- **1 per day (recommended default)** — operator chose 1 per session; honored (`MAOS_TIPS_EVERY` available
+  for those who want less).
+- **Auto-derive tips from SKILL.md frontmatter** — the *when-to-use* phrasing is craft, not derivable
+  cleanly today. → v2 (curated now; validated for integrity).
+
+## Consequences
+
+- **Positive**: discoverability nudge with near-zero risk (advisory, silenceable, degrades to no-op);
+  catalog rot is now a build failure, not a slow drift; the announcements generator gives operators the
+  native banner without the plugin touching settings.
+- **Negative / cost**: the curated catalog needs occasional hand-editing as tools evolve (mitigated —
+  `validate-tips.sh` makes a stale entry fail CI, so drift is caught, not shipped).
+- **Security**: catalog = static strings + boolean/count signals only; never file contents/ticket
+  bodies/PII; announcements are print-only.
+
+## TTL / revisit
+
+Revisit when: (a) tool count materially grows and hand-curation strains → build the v2 frontmatter
+auto-derivation; (b) end-of-action demand emerges → v2 placement; (c) a Vek overlay is scoped →
+separate corporate artifact honoring Layer Purity.
+
+## References
+
+- `tips/inference.md` · `tips/catalog.json` · `plugin-scripts/session-tip.sh` · `commands/tip.md`
+- Native feature: Claude Code `companyAnnouncements` (org-server-side; not plugin-writable)
+- Pattern precedents: `plugin-scripts/governance/single-conductor-scan.sh` (SessionStart emit),
+  `plugin-scripts/governance/auto-name-session.sh` (atomic state), `statusmap/inference.md` (data+inference)
+- Sibling: `skills/maos-concierge/SKILL.md` (deep onboarding — where tips route to)

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -19,6 +19,10 @@
           {
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/plugin-scripts/governance/single-conductor-scan.sh"
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/plugin-scripts/session-tip.sh"
           }
         ]
       }

--- a/plugin-scripts/session-tip.sh
+++ b/plugin-scripts/session-tip.sh
@@ -64,10 +64,14 @@ read_state() {
 write_state() {  # $1 = json
   [ -n "${HOME:-}" ] || return 0
   mkdir -p "$STATE_DIR" 2>/dev/null || return 0
-  [ -L "$STATE" ] && return 0   # refuse to follow a symlink
+  [ -L "$STATE" ] && return 0   # courtesy: don't clobber an intentional symlink (NOT the security boundary — see below)
   local tmp; tmp="$(mktemp "${STATE_DIR}/.tips-state.XXXXXX" 2>/dev/null)" || return 0
+  # Security (CWE-367 N/A): the write goes to a fresh mktemp file (never a symlink), then `mv` —
+  # which is rename(2): atomic and does NOT follow symlinks. A symlink swapped into $STATE after
+  # the check above is REPLACED by our regular file (the write is never traversed through it), so
+  # there is no TOCTOU write-through. (`mv -n` is intentionally NOT used — it would refuse to
+  # overwrite and freeze the state, breaking the no-repeat rotation, which must update each session.)
   if printf '%s\n' "$1" > "$tmp" 2>/dev/null; then
-    [ -L "$STATE" ] && { rm -f "$tmp"; return 0; }
     mv "$tmp" "$STATE" 2>/dev/null || rm -f "$tmp"
   else
     rm -f "$tmp"

--- a/plugin-scripts/session-tip.sh
+++ b/plugin-scripts/session-tip.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# /**
+#  * MAOS-Tips — session-start discoverability nudge (RULE: MAOS-Tips v1)
+#  * @context ~116 MAOS agentic-tools (63 skills + 25 cmds + 28 agents) are hard to
+#  *   discover. This hook surfaces ONE curated tip about a maos tool at session start
+#  *   (startup/clear only) so the operator/community learns what exists + when to use it.
+#  * @reason Discoverability. Native companyAnnouncements is org-server-side (not plugin-
+#  *   writable); the hook channel is the community-portable substitute. Depth is the
+#  *   concierge's job — a tip is a 1-line PUSH nudge + route (DRY).
+#  * @impact Additive, advisory, never blocks (always exit 0). Degrades to no-op if tips/
+#  *   or jq is absent. Silenceable (MAOS_TIPS=off / MAOS_NO_TIPS=1 / ~/.claude/.maos-no-tips).
+#  * @security Catalog = static strings + boolean/count signals ONLY. Never reads file
+#  *   contents, ticket bodies, or PII. --emit-announcements is print-only (operator pastes;
+#  *   the plugin NEVER writes settings.json/companyAnnouncements — HUMAN_DOMAIN).
+#  * @modes (default) SessionStart hook · --print · --emit-announcements [N] · --family <f>
+#  */
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_ROOT="${CLAUDE_PLUGIN_ROOT:-$(dirname "$SCRIPT_DIR")}"
+CATALOG="${PLUGIN_ROOT}/tips/catalog.json"
+
+# Reuse governance lib helpers when present (json_escape, log_audit, EXIT_SUCCESS);
+# session-tip is a session-lifecycle hook (top-level), not governance, so it sources
+# the shared lib from governance/lib rather than living under governance/.
+LIB="${SCRIPT_DIR}/governance/lib/common.sh"
+# shellcheck source=/dev/null
+[ -f "$LIB" ] && source "$LIB" 2>/dev/null || true
+EXIT_OK="${EXIT_SUCCESS:-0}"
+
+# --- fallbacks if the lib is unavailable (never hard-depend) -------------------
+if ! declare -f json_escape >/dev/null 2>&1; then
+  json_escape() { local s="$1"; s="${s//\\/\\\\}"; s="${s//\"/\\\"}"; s="${s//$'\n'/\\n}"; s="${s//$'\r'/}"; s="${s//$'\t'/\\t}"; printf '%s' "$s"; }
+fi
+if ! declare -f log_audit >/dev/null 2>&1; then
+  log_audit() { :; }
+fi
+
+STATE_DIR="${HOME:-/tmp}/.claude/maos"
+STATE="${STATE_DIR}/tips-state.json"
+DEFAULT_STATE='{"last_session_id":"","seen":[],"last_shown_ts":0}'
+
+# --- opt-out (any of three) ---------------------------------------------------
+_tips_off() {
+  [ "${MAOS_TIPS:-}" = "off" ] && return 0
+  [ "${MAOS_NO_TIPS:-0}" = "1" ] && return 0
+  [ -n "${HOME:-}" ] && [ -f "${HOME}/.claude/.maos-no-tips" ] && return 0
+  return 1
+}
+
+# --- ready = jq + a valid catalog present (else silent no-op) ------------------
+_ready() {
+  command -v jq >/dev/null 2>&1 || return 1
+  [ -f "$CATALOG" ] || return 1
+  jq empty "$CATALOG" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# --- state (JSON; symlink-guarded atomic write, mirrors auto-name-session.sh) --
+read_state() {
+  if [ -L "$STATE" ]; then printf '%s' "$DEFAULT_STATE"; return; fi
+  if [ -f "$STATE" ] && jq empty "$STATE" >/dev/null 2>&1; then cat "$STATE"; else printf '%s' "$DEFAULT_STATE"; fi
+}
+write_state() {  # $1 = json
+  [ -n "${HOME:-}" ] || return 0
+  mkdir -p "$STATE_DIR" 2>/dev/null || return 0
+  [ -L "$STATE" ] && return 0   # refuse to follow a symlink
+  local tmp; tmp="$(mktemp "${STATE_DIR}/.tips-state.XXXXXX" 2>/dev/null)" || return 0
+  if printf '%s\n' "$1" > "$tmp" 2>/dev/null; then
+    [ -L "$STATE" ] && { rm -f "$tmp"; return 0; }
+    mv "$tmp" "$STATE" 2>/dev/null || rm -f "$tmp"
+  else
+    rm -f "$tmp"
+  fi
+}
+
+# --- render helpers (route = the family's concierge) --------------------------
+render_human() {  # $1 = id
+  jq -r --arg id "$1" '
+    .families as $fam
+    | (.tips[] | select(.id==$id)) as $t
+    | ($fam[$t.family].route // $fam._default.route) as $r
+    | "💡 MAOS Tip · \($t.tool): \($t.text) Try: \($t.invocation)  ·  more: /maos:\($r)"
+  ' "$CATALOG"
+}
+render_agent() {  # $1 = id
+  jq -r --arg id "$1" '
+    .families as $fam
+    | (.tips[] | select(.id==$id)) as $t
+    | ($fam[$t.family].route // $fam._default.route) as $r
+    | "MAOS-Tip surfaced: \($t.tool) (\($t.family)) — \($t.text) If the current work matches, route to \($t.invocation) or /maos:\($r)."
+  ' "$CATALOG"
+}
+
+# --- arg parse (mode select happens BEFORE any stdin read) --------------------
+MODE="hook"; FAMILY=""; N=10
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --print)                MODE="print" ;;
+    --emit-announcements)   MODE="announce"
+                            case "${2:-}" in ''|*[!0-9]*) ;; *) N="$2"; shift ;; esac ;;
+    --emit-announcements=*) MODE="announce"; v="${1#*=}"; case "$v" in ''|*[!0-9]*) ;; *) N="$v" ;; esac ;;
+    --family)               FAMILY="${2:-}"; shift ;;
+    --family=*)             FAMILY="${1#*=}" ;;
+    *) ;;
+  esac
+  shift
+done
+
+_tips_off && exit "$EXIT_OK"
+_ready    || exit "$EXIT_OK"
+
+# --- MODE: emit-announcements (print-only; operator pastes into settings) ------
+if [ "$MODE" = "announce" ]; then
+  jq --argjson n "$N" '[ .tips[] | "💡 MAOS Tip · \(.tool): \(.text) (try \(.invocation))" ] | .[0:$n]' "$CATALOG"
+  cat >&2 <<'EOF'
+
+# ^ Paste the JSON array above to replicate the native "Message from <org>:" startup
+#   banner. The plugin NEVER writes these for you (settings = HUMAN_DOMAIN). You apply:
+#   • Solo / this machine  → ~/.claude/settings.json  →  "companyAnnouncements": [ ...array... ]
+#   • Org-wide (real "Message from <org>:" bar) → your Anthropic Console managed-settings policy.
+EOF
+  exit "$EXIT_OK"
+fi
+
+# --- MODE: print (on-demand /maos:tip — random, family-filterable, non-mutating)
+if [ "$MODE" = "print" ]; then
+  ID="$(jq -r --arg fam "$FAMILY" '[.tips[] | select(($fam=="") or (.family==$fam)) | .id] | .[]' "$CATALOG" \
+        | awk 'BEGIN{srand()} {a[NR]=$0} END{if(NR>0) print a[int(rand()*NR)+1]}')"
+  if [ -z "$ID" ]; then echo "No MAOS tips found${FAMILY:+ for family '$FAMILY'}." >&2; exit "$EXIT_OK"; fi
+  render_human "$ID"
+  exit "$EXIT_OK"
+fi
+
+# --- MODE: hook (default) -----------------------------------------------------
+INPUT="$(cat 2>/dev/null || printf '{}')"
+SRC="$(printf '%s' "$INPUT" | jq -r '.source // "startup"' 2>/dev/null || printf 'startup')"
+SID="$(printf '%s' "$INPUT" | jq -r '.session_id // ""'   2>/dev/null || printf '')"
+
+# Only fire on a genuinely new/cleared session — skip resume & compact (context
+# is already warm; a tip there is noise). CI never gets a tip.
+case "$SRC" in startup|clear) ;; *) exit "$EXIT_OK" ;; esac
+[ "${CI:-}" = "true" ] && exit "$EXIT_OK"
+
+ST="$(read_state)"
+LAST_SID="$(printf '%s' "$ST" | jq -r '.last_session_id // ""' 2>/dev/null || printf '')"
+# Idempotency: if SessionStart double-fires for the same session_id, tip only once.
+[ -n "$SID" ] && [ "$SID" = "$LAST_SID" ] && exit "$EXIT_OK"
+
+# Optional throttle: MAOS_TIPS_EVERY=Nd → at most one tip per N days.
+EVERY="${MAOS_TIPS_EVERY:-}"
+if printf '%s' "$EVERY" | grep -qE '^[0-9]+d$'; then
+  DAYS="${EVERY%d}"
+  LAST_TS="$(printf '%s' "$ST" | jq -r '.last_shown_ts // 0' 2>/dev/null || printf '0')"
+  NOW="$(date +%s)"; MIN=$(( DAYS * 86400 ))
+  if [ "$LAST_TS" -gt 0 ] 2>/dev/null && [ $(( NOW - LAST_TS )) -lt "$MIN" ]; then exit "$EXIT_OK"; fi
+fi
+
+# Select: rotation with no-repeat. eligible = all ids − seen; empty ⇒ recycle.
+SEEN="$(printf '%s' "$ST" | jq -c '.seen // []' 2>/dev/null || printf '[]')"
+ELIG="$(jq -r --argjson seen "$SEEN" '[.tips[].id] - $seen | .[]' "$CATALOG" 2>/dev/null || printf '')"
+if [ -z "$ELIG" ]; then
+  ID="$(jq -r '.tips[0].id' "$CATALOG")"
+  NEW_SEEN="$(jq -cn --arg id "$ID" '[$id]')"
+else
+  ID="$(printf '%s' "$ELIG" | head -1)"
+  NEW_SEEN="$(printf '%s' "$ST" | jq -c --arg id "$ID" '(.seen // []) + [$id]')"
+fi
+[ -n "$ID" ] || exit "$EXIT_OK"
+
+HUMAN="$(render_human "$ID")"
+AGENT="$(render_agent "$ID")"
+
+printf '\n%s\n' "$HUMAN" >&2
+printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$(json_escape "$AGENT")"
+log_audit "maos_tip_surfaced" "$(printf '{"tip":"%s","session":"%s"}' "$(json_escape "$ID")" "$(json_escape "$SID")")" 2>/dev/null || true
+
+NEW_STATE="$(jq -cn --arg sid "$SID" --argjson seen "$NEW_SEEN" --argjson ts "$(date +%s)" \
+  '{last_session_id:$sid, seen:$seen, last_shown_ts:$ts}')"
+write_state "$NEW_STATE"
+
+exit "$EXIT_OK"

--- a/tests/governance/test-session-tip.sh
+++ b/tests/governance/test-session-tip.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Test: test-session-tip.sh
+# Purpose: MAOS-Tips session-start hook (plugin-scripts/session-tip.sh). DoD-gate is a
+#   BEHAVIOR over GOLDEN FIXTURES (a fixture catalog + a fixture HOME for the seen-ledger),
+#   never a prose THEN: opt-out silences · resume/compact skipped · startup fires exactly
+#   one valid tip · no-repeat across sessions · same-session idempotency · --print on-demand ·
+#   --emit-announcements array · absent catalog degrades to silent no-op.
+# ═══════════════════════════════════════════════════════════════════════════════
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+HOOK="${PROJECT_ROOT}/plugin-scripts/session-tip.sh"
+
+TESTS_RUN=0; TESTS_PASSED=0; TESTS_FAILED=0
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+
+TMP=""
+setup() {
+  TMP="$(mktemp -d)"
+  mkdir -p "$TMP/plug/tips" "$TMP/plug/skills/maos-concierge" "$TMP/home/.claude" "$TMP/empty/tips"
+  # a valid concierge skill so family.route resolves (not used by the hook, but realistic)
+  printf 'name: maos-concierge\n' > "$TMP/plug/skills/maos-concierge/SKILL.md"
+  cat > "$TMP/plug/tips/catalog.json" <<'JSON'
+{ "version":"1.0.0",
+  "families":{ "f1":{"route":"maos-concierge","blurb":"x"}, "_default":{"route":"maos-concierge","blurb":"d"} },
+  "tips":[
+    {"id":"t1","tool":"alpha","invocation":"/maos:alpha","tool_type":"skill","tool_path":"skills/alpha/SKILL.md","family":"f1","text":"do alpha."},
+    {"id":"t2","tool":"bravo","invocation":"/maos:bravo","tool_type":"skill","tool_path":"skills/bravo/SKILL.md","family":"f1","text":"do bravo."}
+  ] }
+JSON
+}
+teardown() { [ -n "$TMP" ] && [ -d "$TMP" ] && rm -rf "$TMP"; }
+
+assert_eq() {
+  local expected="$1" actual="$2" name="${3:-assert}"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [ "$expected" = "$actual" ]; then echo -e "  ${GREEN}✓${NC} $name"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else echo -e "  ${RED}✗${NC} $name (expected='$expected' actual='$actual')"; TESTS_FAILED=$((TESTS_FAILED + 1)); fi
+}
+assert_contains() {
+  local hay="$1" needle="$2" name="${3:-assert-contains}"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if printf '%s' "$hay" | grep -q -- "$needle"; then echo -e "  ${GREEN}✓${NC} $name"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else echo -e "  ${RED}✗${NC} $name (missing '$needle' in: $hay)"; TESTS_FAILED=$((TESTS_FAILED + 1)); fi
+}
+assert_ne() {
+  local a="$1" b="$2" name="${3:-assert-ne}"
+  TESTS_RUN=$((TESTS_RUN + 1))
+  if [ "$a" != "$b" ]; then echo -e "  ${GREEN}✓${NC} $name"; TESTS_PASSED=$((TESTS_PASSED + 1))
+  else echo -e "  ${RED}✗${NC} $name (both='$a')"; TESTS_FAILED=$((TESTS_FAILED + 1)); fi
+}
+
+# run the hook in hook-mode with a given source+session_id; echoes STDERR (the human line)
+run_hook() {  # $1=source $2=sid ; extra env via caller
+  printf '{"source":"%s","session_id":"%s"}' "$1" "$2" \
+    | CLAUDE_PLUGIN_ROOT="$TMP/plug" HOME="$TMP/home" bash "$HOOK" 2>&1 >/dev/null
+}
+run_hook_stdout() {  # stdout only (the additionalContext JSON)
+  printf '{"source":"%s","session_id":"%s"}' "$1" "$2" \
+    | CLAUDE_PLUGIN_ROOT="$TMP/plug" HOME="$TMP/home" bash "$HOOK" 2>/dev/null
+}
+tool_of() { printf '%s' "$1" | sed -n 's/.*💡 MAOS Tip · \([a-z]*\):.*/\1/p'; }
+
+echo "== test-session-tip =="
+setup
+trap teardown EXIT
+
+# A: opt-out MAOS_TIPS=off → silence + exit 0
+OUT="$(printf '{"source":"startup","session_id":"sA"}' | MAOS_TIPS=off CLAUDE_PLUGIN_ROOT="$TMP/plug" HOME="$TMP/home" bash "$HOOK" 2>&1)"; RC=$?
+assert_eq "0" "$RC"  "opt-out MAOS_TIPS=off exits 0"
+assert_eq ""  "$OUT" "opt-out emits nothing"
+
+# A2: opt-out ~/.claude/.maos-no-tips sentinel file
+: > "$TMP/home/.claude/.maos-no-tips"
+OUT="$(printf '{"source":"startup","session_id":"sA2"}' | CLAUDE_PLUGIN_ROOT="$TMP/plug" HOME="$TMP/home" bash "$HOOK" 2>&1)"
+assert_eq "" "$OUT" "sentinel file .maos-no-tips silences"
+rm -f "$TMP/home/.claude/.maos-no-tips"
+
+# B: source=resume → skip (no tip); source=compact → skip
+assert_eq "" "$(run_hook resume  sB)" "source=resume is skipped"
+assert_eq "" "$(run_hook compact sB2)" "source=compact is skipped"
+
+# C: source=startup → exactly one valid tip on stderr + additionalContext on stdout
+E1="$(run_hook startup s1)"
+assert_contains "$E1" "💡 MAOS Tip"        "startup surfaces a tip line"
+assert_contains "$E1" "more: /maos:maos-concierge" "tip carries the concierge route"
+O1="$(run_hook_stdout startup s1b)"
+assert_contains "$O1" '"hookEventName":"SessionStart"' "stdout emits SessionStart additionalContext"
+
+# D: no-repeat across DIFFERENT sessions — second tip differs from first (2-tip corpus)
+T_A="$(tool_of "$(run_hook startup d1)")"
+T_B="$(tool_of "$(run_hook startup d2)")"
+assert_ne "$T_A" "$T_B" "consecutive sessions get different tips (no-repeat)"
+
+# E: idempotency — same session_id twice → second run silent
+E_first="$(run_hook startup eS)"
+E_again="$(run_hook startup eS)"
+assert_contains "$E_first" "💡 MAOS Tip" "same-session first run tips"
+assert_eq "" "$E_again"                  "same-session second run is silent (idempotent)"
+
+# F: --emit-announcements N → JSON array of length N on stdout
+ANN="$(CLAUDE_PLUGIN_ROOT="$TMP/plug" HOME="$TMP/home" bash "$HOOK" --emit-announcements 2 2>/dev/null)"
+LEN="$(printf '%s' "$ANN" | jq 'length' 2>/dev/null || echo -1)"
+assert_eq "2" "$LEN" "--emit-announcements 2 prints a 2-element array"
+assert_contains "$ANN" "MAOS Tip" "announcement strings carry the tip glyph"
+
+# G: --print on-demand → a tip on stdout, ledger untouched (non-mutating)
+P="$(CLAUDE_PLUGIN_ROOT="$TMP/plug" HOME="$TMP/home" bash "$HOOK" --print 2>/dev/null)"
+assert_contains "$P" "💡 MAOS Tip" "--print renders a tip to stdout"
+
+# H: absent catalog → silent no-op, exit 0 (degrade, never fail)
+OUT="$(printf '{"source":"startup","session_id":"sH"}' | CLAUDE_PLUGIN_ROOT="$TMP/empty" HOME="$TMP/home" bash "$HOOK" 2>&1)"; RC=$?
+assert_eq "0" "$RC" "absent catalog exits 0"
+assert_eq "" "$OUT" "absent catalog emits nothing"
+
+# I: HOME unset → still renders (state degrades, never aborts under set -u)
+I_OUT="$(printf '{"source":"startup","session_id":"sI"}' | env -u HOME CLAUDE_PLUGIN_ROOT="$TMP/plug" bash "$HOOK" 2>&1 >/dev/null)"; I_RC=$?
+assert_eq "0" "$I_RC" "hook exits 0 with HOME unset"
+assert_contains "$I_OUT" "💡 MAOS Tip" "hook still tips with HOME unset"
+
+echo ""
+echo "  Run: $TESTS_RUN  Passed: $TESTS_PASSED  Failed: $TESTS_FAILED"
+[ "$TESTS_FAILED" -eq 0 ]

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -312,6 +312,27 @@ else
 fi
 echo ""
 
+# MAOS-Tips corpus (ADR-008) — integrity + anti-orphan gate
+echo "Validating MAOS-Tips..."
+
+TIPS_VALIDATOR="$PLUGIN_ROOT/tips/validate-tips.sh"
+TIPS_HOOK="$PLUGIN_ROOT/plugin-scripts/session-tip.sh"
+if [ -f "$TIPS_VALIDATOR" ]; then
+    if [ -x "$TIPS_HOOK" ]; then
+        pass "plugin-scripts/session-tip.sh is executable"
+    else
+        fail "plugin-scripts/session-tip.sh is not executable"
+    fi
+    if bash "$TIPS_VALIDATOR" "$PLUGIN_ROOT" >/dev/null 2>&1; then
+        pass "tips/validate-tips.sh passes (zero orphan tips)"
+    else
+        fail "tips/validate-tips.sh FAILED (run 'bash tips/validate-tips.sh' for details)"
+    fi
+else
+    warn "tips/validate-tips.sh missing (MAOS-Tips not installed)"
+fi
+echo ""
+
 # Summary
 echo "========================================"
 echo "  Validation Summary"

--- a/tips/catalog.json
+++ b/tips/catalog.json
@@ -1,0 +1,34 @@
+{
+  "_comment": "MAOS-Tips corpus v1 — one helpful, discoverability-oriented tip per session about the maos agentic-tools. CURATED copy (the when-to-use clause is UX craft) + CI-VALIDATED integrity (every tool_path must resolve to a real skill/command/agent; family must match the tool's metadata.family when it declares one) via tips/validate-tips.sh. en-US (Layer-Purity: community artifact stays en-US; MAOS_TIPS_LANG=pt-br is an operator-side opt-in, not baked here). Tips are a 1-line PUSH nudge + route; depth is the concierge's job (DRY — never restate concierge content).",
+  "version": "1.0.0",
+  "families": {
+    "worktree-lifecycle":       { "route": "maos-concierge", "blurb": "session/worktree lifecycle" },
+    "agentic-tool-lifecycle":   { "route": "maos-concierge", "blurb": "forge/adopt/name tools" },
+    "orchestration-convergence":{ "route": "maos-concierge", "blurb": "orchestration & convergence" },
+    "content-lifecycle":        { "route": "maos-concierge", "blurb": "recast/narrate/proofread" },
+    "spec-lifecycle":           { "route": "maos-concierge", "blurb": "code ↔ spec" },
+    "concierge":                { "route": "maos-concierge", "blurb": "onboarding & routing" },
+    "navigation":               { "route": "maos-concierge", "blurb": "work aggregation & nav" },
+    "session":                  { "route": "maos-concierge", "blurb": "session state & recap" },
+    "governance":               { "route": "maos-concierge", "blurb": "governance & review" },
+    "_default":                 { "route": "maos-concierge", "blurb": "MAOS tools" }
+  },
+  "tips": [
+    { "id": "tip-preflight",           "tool": "preflight",           "invocation": "/maos:preflight",           "tool_type": "skill", "tool_path": "skills/preflight/SKILL.md",           "family": "worktree-lifecycle",        "text": "Before you touch code, heal your branch & spin an isolated worktree." },
+    { "id": "tip-postflight",          "tool": "postflight",          "invocation": "/maos:postflight",          "tool_type": "skill", "tool_path": "skills/postflight/SKILL.md",          "family": "worktree-lifecycle",        "text": "Before you /compact, close the session clean & seed the next one's handoff." },
+    { "id": "tip-work-compass",        "tool": "work-compass",        "invocation": "/maos:work-compass",        "tool_type": "skill", "tool_path": "skills/work-compass/SKILL.md",        "family": "navigation",                "text": "Lost across repos? See every scattered Jira/PR/session/branch in one N-Tree." },
+    { "id": "tip-quiesce",             "tool": "quiesce",             "invocation": "/maos:quiesce",             "tool_type": "skill", "tool_path": "skills/quiesce/SKILL.md",             "family": "orchestration-convergence", "text": "Leave the session with nothing pending — every PR green & answered." },
+    { "id": "tip-gap-loop",            "tool": "gap-loop",            "invocation": "/maos:gap-loop",            "tool_type": "skill", "tool_path": "skills/gap-loop/SKILL.md",            "family": "orchestration-convergence", "text": "Drive a register of gaps to convergence, self-scored, until all dispositioned." },
+    { "id": "tip-convergence-engine",  "tool": "convergence-engine",  "invocation": "/maos:convergence-engine",  "tool_type": "skill", "tool_path": "skills/convergence-engine/SKILL.md",  "family": "orchestration-convergence", "text": "Drive a result to high quality (verifier > generator, ~3 rounds) before asking a human." },
+    { "id": "tip-agentic-tool-forge",  "tool": "agentic-tool-forge",  "invocation": "/maos:agentic-tool-forge",  "tool_type": "skill", "tool_path": "skills/agentic-tool-forge/SKILL.md",  "family": "agentic-tool-lifecycle",    "text": "Turn a repeated instruction into a reusable skill/command/agent." },
+    { "id": "tip-agentic-tool-intake", "tool": "agentic-tool-intake", "invocation": "/maos:agentic-tool-intake", "tool_type": "skill", "tool_path": "skills/agentic-tool-intake/SKILL.md", "family": "agentic-tool-lifecycle",    "text": "Found an external tool/MCP? Decide install vs build vs adapt before adopting." },
+    { "id": "tip-anima",               "tool": "anima",               "invocation": "/maos:anima",               "tool_type": "skill", "tool_path": "skills/anima/SKILL.md",               "family": "agentic-tool-lifecycle",    "text": "Need a name for anything? Get one research-grounded, sovereign name." },
+    { "id": "tip-content-recast",      "tool": "content-recast",      "invocation": "/maos:content-recast",      "tool_type": "skill", "tool_path": "skills/content-recast/SKILL.md",      "family": "content-lifecycle",         "text": "Re-target your technical work for a CEO/PO/junior — faithfully, in any format." },
+    { "id": "tip-opera-debrief",       "tool": "opera-debrief",       "invocation": "/maos:opera-debrief",       "tool_type": "skill", "tool_path": "skills/opera-debrief/SKILL.md",       "family": "content-lifecycle",         "text": "Get your session recap as a narrative 'opera' — story arc + insights." },
+    { "id": "tip-proofread",           "tool": "proofread",           "invocation": "/maos:proofread",           "tool_type": "skill", "tool_path": "skills/proofread/SKILL.md",           "family": "content-lifecycle",         "text": "Before shipping a doc/PR/commit, catch typos & grammar (pt-BR + en-US)." },
+    { "id": "tip-reveng",              "tool": "reveng",              "invocation": "/maos:reveng",              "tool_type": "skill", "tool_path": "skills/reveng/SKILL.md",              "family": "spec-lifecycle",            "text": "Reverse-engineer source code into an OpenSpec behavioral contract." },
+    { "id": "tip-morning-briefing",    "tool": "morning-briefing",    "invocation": "/maos:morning-briefing",    "tool_type": "skill", "tool_path": "skills/morning-briefing/SKILL.md",    "family": "session",                   "text": "Cold-start a state recap across repos/PRs/tasks — no prior save needed." },
+    { "id": "tip-bot-finding-arbiter", "tool": "bot-finding-arbiter", "invocation": "/maos:bot-finding-arbiter", "tool_type": "skill", "tool_path": "skills/bot-finding-arbiter/SKILL.md", "family": "governance",                "text": "CI blocked on a CodeRabbit/Qodo finding? Adjudicate it — fix, accept, or justify-reject." },
+    { "id": "tip-maos-concierge",      "tool": "maos-concierge",      "invocation": "/maos:maos-concierge",      "tool_type": "skill", "tool_path": "skills/maos-concierge/SKILL.md",      "family": "concierge",                 "text": "New to MAOS? Onboard, or ask which tool fits your intent." }
+  ]
+}

--- a/tips/inference.md
+++ b/tips/inference.md
@@ -1,0 +1,79 @@
+# MAOS-Tips — Selection Inference
+
+> How `plugin-scripts/session-tip.sh` decides **whether** to surface a tip, **which** tip,
+> and **how** it renders. Mirrors `statusmap/inference.md` (data-file + inference doc pattern).
+> Design SSOT: `docs/adrs/ADR-008-maos-tips-session-discoverability.md`.
+
+## When to surface (trigger gate — ALL must hold)
+
+| # | Gate | Rule |
+|---|------|------|
+| 1 | **Not opted out** | none of `MAOS_TIPS=off` · `MAOS_NO_TIPS=1` · `~/.claude/.maos-no-tips` |
+| 2 | **Ready** | `jq` present AND `tips/catalog.json` exists AND is valid JSON (else silent no-op) |
+| 3 | **Fresh session** | SessionStart `.source ∈ {startup, clear}` — **skip `resume` and `compact`** (context already warm ⇒ a tip there is noise) |
+| 4 | **Not CI** | `CI != true` |
+| 5 | **Not already tipped this session** | `.session_id != state.last_session_id` (idempotency for double-fire) |
+| 6 | **Throttle (optional)** | if `MAOS_TIPS_EVERY=Nd`, at least `N` days since `state.last_shown_ts` |
+
+Fail any gate → `exit 0`, emit nothing. The hook **never** blocks or errors the session.
+
+## Which tip (selection = rotation + no-repeat)
+
+```
+eligible = [ every tip id ] − state.seen          # set difference (jq: [..] - $seen)
+if eligible is empty:  recycle → pick tips[0], reset seen = [picked]      # corpus exhausted
+else:                  pick first eligible (stable id order) → seen += [picked]
+```
+
+- **Frequency = 1 per session** (operator directive) — gate 5 guarantees at most one per `session_id`;
+  gate 3 restricts to startup/clear. `MAOS_TIPS_EVERY=Nd` reduces further to ≤1 per N days.
+- **No-repeat**: the seen-ledger cycles the whole corpus before repeating → variety without randomness.
+- **On-demand (`--print`)** ignores gates 3–6 and the ledger (random pick, non-mutating) so `/maos:tip`
+  never "burns" the session's rotation.
+
+## Context variables
+
+| Var | Source | Use |
+|-----|--------|-----|
+| `.source` | SessionStart stdin JSON | gate 3 (startup/clear vs resume/compact) |
+| `.session_id` | SessionStart stdin JSON | gate 5 idempotency + written to state |
+| `MAOS_TIPS` / `MAOS_NO_TIPS` / `~/.claude/.maos-no-tips` | env / file | gate 1 opt-out |
+| `MAOS_TIPS_EVERY` | env (`Nd`) | gate 6 daily throttle |
+| `MAOS_TIPS_LANG` | env (`pt-br`) | reserved: operator-side language opt-in (v1 catalog is en-US) |
+| `CI` | env | gate 4 |
+| `CLAUDE_PLUGIN_ROOT` | env | locate `tips/catalog.json` |
+| `HOME` | env | seen-ledger state at `~/.claude/maos/tips-state.json` |
+
+## Output format (1 line + leading blank line)
+
+```
+💡 MAOS Tip · <tool>: <when-to-use>. Try: /maos:<tool>  ·  more: /maos:<family-route>
+```
+
+- **stderr** = the human line above (glyph 💡, distinct from 🧭 status-map / 🛡️ conductor-scan).
+- **stdout** = `{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"<router-hint>"}}`
+  so the agent can proactively route the operator's *actual* work to the surfaced tool.
+- `<family-route>` resolves via `families[tip.family].route` (all → `maos-concierge`; DRY — the tip
+  routes to depth, it does not restate the concierge).
+
+## Print-only announcements discipline
+
+`--emit-announcements [N]` prints up to N tip strings as a JSON array (companyAnnouncements shape) +
+paste instructions to stderr. **The plugin never writes `settings.json` / `companyAnnouncements`** —
+that channel is server-side / org-managed (HUMAN_DOMAIN); the operator applies the paste. This is the
+community-portable echo of the native "Message from <org>:" banner, not a replacement for it.
+
+## Fallback strategy (degrade, never fail)
+
+| Missing | Behavior |
+|---------|----------|
+| `tips/` or `catalog.json` | silent no-op (exit 0) — the plugin works without tips |
+| `jq` | silent no-op |
+| `HOME` unset | tips still render; state degrades to `/tmp` (no persistence) |
+| `governance/lib/common.sh` | inline `json_escape` fallback + `log_audit` no-op |
+| corpus exhausted | recycle (reset seen) — never runs dry |
+
+## v2 / roadmap (YAGNI now)
+
+`weight`/weighted-random · context-gates (min_tools, repo-signal) · `tags` · end-of-action placement ·
+auto-derivation of tips from SKILL.md frontmatter · surfacing analytics · `MAOS_TIPS_LANG=pt-br` catalog.

--- a/tips/validate-tips.sh
+++ b/tips/validate-tips.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# /**
+#  * validate-tips.sh — anti-orphan / anti-theater integrity gate for the MAOS-Tips corpus.
+#  * @context A hand-curated tip catalog ROTS (AWARENESS-REGISTRY drift proved it: "~31 skills"
+#  *   for 63 real). This makes "zero orphan tips" a CI gate: every tool a tip points at must
+#  *   actually exist, and a tip's family must match the tool's own declared metadata.family.
+#  * @checks (1) jq + valid JSON  (2) unique ids  (3) each tool_path resolves (+ skill name: check)
+#  *   (4) tip.family ∈ families  (5) family.route → skills/<route>/SKILL.md exists
+#  *   (6) family-sync: a skill that DECLARES metadata.family must match its tip's family
+#  *   (7) smoke-run: the hook renders one tip.
+#  * @exit 0 = all pass · 1 = any failure. Invoked standalone + from tests/validate-plugin.sh.
+#  */
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="${1:-$(dirname "$SCRIPT_DIR")}"     # arg1 override (validate-plugin.sh passes PLUGIN_ROOT); default = repo root
+CATALOG="${ROOT}/tips/catalog.json"
+HOOK="${ROOT}/plugin-scripts/session-tip.sh"
+
+ERRORS=0
+pass() { echo "  ✓ $1"; }
+fail() { echo "  ✗ $1"; ERRORS=$((ERRORS + 1)); }
+
+echo "Validating MAOS-Tips corpus..."
+
+# (1) jq + valid JSON
+if ! command -v jq >/dev/null 2>&1; then echo "  (skip: jq absent)"; exit 0; fi
+if [ ! -f "$CATALOG" ]; then fail "tips/catalog.json missing"; echo "  Errors: $ERRORS"; exit 1; fi
+if jq empty "$CATALOG" >/dev/null 2>&1; then pass "catalog.json is valid JSON"; else fail "catalog.json is invalid JSON"; echo "  Errors: $ERRORS"; exit 1; fi
+
+# (2) unique ids
+TOTAL="$(jq '.tips | length' "$CATALOG")"
+UNIQ="$(jq '[.tips[].id] | unique | length' "$CATALOG")"
+if [ "$TOTAL" = "$UNIQ" ]; then pass "$TOTAL tips, all ids unique"; else fail "duplicate tip id(s): $TOTAL tips but $UNIQ unique"; fi
+
+# frontmatter family extractor (scan ONLY the YAML block, not body prose)
+skill_family() {  # $1 = SKILL.md path → echoes metadata.family or empty
+  awk 'NR==1&&/^---[[:space:]]*$/{f=1;next} f&&/^---[[:space:]]*$/{exit} f' "$1" 2>/dev/null \
+    | grep -m1 -E '^[[:space:]]*family:[[:space:]]*' \
+    | sed -E 's/^[[:space:]]*family:[[:space:]]*//; s/[[:space:]]*$//; s/^["'"'"']//; s/["'"'"']$//'
+}
+
+# (3)+(6) per-tip: tool_path exists, skill name: present, family-sync
+while IFS=$'\t' read -r id tool ttype tpath fam; do
+  [ -n "$id" ] || continue
+  ABS="${ROOT}/${tpath}"
+  if [ -f "$ABS" ]; then
+    pass "tip '$id' → $tpath exists"
+    if [ "$ttype" = "skill" ]; then
+      if grep -qE "^name:[[:space:]]*${tool}[[:space:]]*$" "$ABS"; then
+        pass "tip '$id' skill frontmatter name: $tool"
+      else
+        fail "tip '$id' → $tpath missing 'name: $tool' frontmatter"
+      fi
+      DECL="$(skill_family "$ABS" || true)"   # empty (no declared family) is expected, not an error
+      if [ -n "$DECL" ]; then
+        if [ "$DECL" = "$fam" ]; then
+          pass "tip '$id' family-sync ($fam == declared)"
+        else
+          fail "tip '$id' family MISMATCH: catalog='$fam' but $tpath declares metadata.family='$DECL'"
+        fi
+      fi   # no declared family ⇒ authored family, sync-check skipped (by design)
+    fi
+  else
+    fail "tip '$id' → $tpath does NOT exist (orphan)"
+  fi
+done < <(jq -r '.tips[] | [.id, .tool, .tool_type, .tool_path, .family] | @tsv' "$CATALOG")
+
+# (4) every tip.family is defined in families{}
+while IFS= read -r fam; do
+  [ -n "$fam" ] || continue
+  if jq -e --arg f "$fam" '.families[$f]' "$CATALOG" >/dev/null 2>&1; then
+    pass "family '$fam' defined"
+  else
+    fail "family '$fam' used by a tip but not defined in families{}"
+  fi
+done < <(jq -r '[.tips[].family] | unique | .[]' "$CATALOG")
+
+# (5) every family.route resolves to a real concierge skill
+while IFS=$'\t' read -r fam route; do
+  [ -n "$route" ] || continue
+  if [ -f "${ROOT}/skills/${route}/SKILL.md" ]; then
+    pass "family '$fam' route → skills/$route/SKILL.md exists"
+  else
+    fail "family '$fam' route '$route' → skills/$route/SKILL.md missing"
+  fi
+done < <(jq -r '.families | to_entries[] | [.key, .value.route] | @tsv' "$CATALOG")
+
+# (7) smoke: the hook renders one tip
+if [ -x "$HOOK" ]; then
+  if OUT="$(CLAUDE_PLUGIN_ROOT="$ROOT" bash "$HOOK" --print 2>/dev/null)" && printf '%s' "$OUT" | grep -q "MAOS Tip"; then
+    pass "hook --print renders a tip"
+  else
+    fail "hook --print produced no tip"
+  fi
+else
+  fail "plugin-scripts/session-tip.sh missing or not executable"
+fi
+
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+  echo "  MAOS-Tips: ✓ PASSED ($TOTAL tips, zero orphans)"
+  exit 0
+else
+  echo "  MAOS-Tips: ✗ FAILED ($ERRORS error(s))"
+  exit 1
+fi


### PR DESCRIPTION
## Context

MAOS ships ~116 agentic-tools (63 skills + 25 commands + 28 agents), but they're hard to discover: unless you already know a tool's name, you won't find it, and the plugin's value stays locked. This adds **MAOS-Tips** — a session-start nudge that surfaces **one curated tip** about a maos tool per new session (*what it does · when to use it · how to invoke it*).

**Recon**: the native "Message from &lt;org&gt;:" startup banner is Claude Code's `companyAnnouncements` — delivered org-server-side via the Anthropic Console enterprise policy, absent from any local settings, and **not writable by a plugin**. So the SessionStart **hook channel** (stderr human line + stdout `additionalContext`) is the community-portable substitute.

## What's in it

| Artifact | Role |
|---|---|
| `plugin-scripts/session-tip.sh` | 5th SessionStart hook + `--print` / `--emit-announcements [N]` / `--family` modes |
| `tips/catalog.json` | 16 seed tips + `families{}` routing (all → `maos-concierge`) |
| `tips/validate-tips.sh` | anti-orphan CI gate (tool_path exists · family-sync · route resolves · smoke-run) |
| `commands/tip.md` | `/maos:tip` on-demand + print-only announcements generator |
| `tips/inference.md` | selection logic | `tests/governance/test-session-tip.sh` | 18 behavior fixtures | `docs/adrs/ADR-008` | decision record |

Edits: `hooks.json` (+5th entry) · `plugin.json` 1.18.0→1.19.0 · `CHANGELOG` `[Unreleased]` · `validate-plugin.sh` (+tips gate).

## Behavior

- Fires only on `.source ∈ {startup, clear}` (skips `resume`/`compact` — a tip in warm context is noise).
- **1 per session** (`session_id` idempotency) + **no-repeat** seen-ledger (`~/.claude/maos/tips-state.json`, atomic-mv + symlink-guard, never committed).
- **Silenceable**: `MAOS_TIPS=off` · `MAOS_NO_TIPS=1` · `~/.claude/.maos-no-tips`; **tunable**: `MAOS_TIPS_EVERY=Nd`. Advisory, always `exit 0`, degrades to a silent no-op if `tips/` or `jq` is absent.
- DRY: a tip is a 1-line PUSH nudge + route to `maos-concierge`; depth (PULL) stays in the concierge, not restated.

## Design decisions (ADR-008)

- **Hybrid source** (curated copy + CI-validated integrity): the *when-to-use* phrasing is craft, but `validate-tips.sh` fails the build if any `tool_path` is orphaned or a tip's family drifts from the tool's declared `metadata.family` — killing the catalog-rot class (the concierge registry drifted to "~31 skills" for 63 real; we refuse to repeat that).
- **Announcements generator is print-only**: `--emit-announcements` prints paste-ready strings so an operator can replicate the native banner in their *own* `settings.json` / org console. The plugin **never writes settings** (HUMAN_DOMAIN).

## Security

Catalog = static strings + boolean/count signals only — never file contents, ticket bodies, or PII. Community artifact stays en-US (`MAOS_TIPS_LANG=pt-br` reserved as an operator-side opt-in).

## Test plan (dogfooded, all green)

- [x] `bash tips/validate-tips.sh` → 63 checks, zero orphans, family-sync for the 8 declared-family skills
- [x] `bash tests/governance/test-session-tip.sh` → 18/18 (opt-out · skip resume/compact · no-repeat · idempotency · announce · print · absent-catalog degrade · HOME-unset)
- [x] `bash tests/validate-plugin.sh` → 0 errors (1 pre-existing unrelated warning)
- [x] `bash tests/governance/run-all.sh` → all 9 suites pass

## Risk + rollback

Additive; every path degrades to a no-op if `tips/` is absent. Rollback = revert this commit (removes the 5th hook entry + `tips/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2orT1ThkEzijzRwdBKQvT
