### PR TITLE
feat(work-compass): scan 5 blind-spot surfaces + work-surface taxonomy SSOT (v1.1.0)

### DIFF
--- a/bin/tests/test_work_compass.py
+++ b/bin/tests/test_work_compass.py
@@ -10,9 +10,13 @@ Run: python3 bin/tests/test_work_compass.py
 from __future__ import annotations
 
 import importlib.util
+import os
 import sys
+import tempfile
+import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 
 # import the sibling module under test
 _HERE = Path(__file__).resolve().parent
@@ -175,14 +179,179 @@ def test_scope_validation(capsys=None):
           all(i["domain"] == "branch" for i in sideways))
 
 
+# ── 6. extended blind-spot scanners (v1.1.0) ──────────────────────────────────
+def test_collect_plans():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        (base / "old-plan.md").write_text("# Old Plan\n\n- [ ] step one\n- [x] done\n",
+                                          encoding="utf-8")
+        (base / "new-plan.md").write_text("# Fresh Plan\n\n- [ ] a\n", encoding="utf-8")
+        old = time.time() - 30 * 86400
+        os.utime(base / "old-plan.md", (old, old))
+        items, diag = wc.collect_plans(plans_dir=td)
+        by = {i["id"]: i for i in items}
+        check("plans: both collected", len(items) == 2)
+        check("plans: domain graph-node", all(i["domain"] == "graph-node" for i in items))
+        check("plans: title parsed", by["plan:old-plan.md"]["title"] == "Old Plan")
+        check("plans: open next-steps counted",
+              by["plan:old-plan.md"]["refs"]["open_next_steps"] == 1)
+        wc.detect(items, stale_days=7)
+        by = {i["id"]: i for i in items}
+        check("plans: stale + open steps → plan-orphan",
+              "plan-orphan" in by["plan:old-plan.md"]["flags"])
+        check("plans: fresh → no flag", not by["plan:new-plan.md"]["flags"])
+    # absent dir degrades, never raises
+    _, d = wc.collect_plans(plans_dir="/nonexistent-plans-xyz")
+    check("plans: absent dir → diag not raise", isinstance(d, str))
+
+
+def test_collect_bg_jobs():
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        j1 = base / "job-running"; j1.mkdir()
+        (j1 / "state.json").write_text('{"status": "running"}', encoding="utf-8")
+        (j1 / "timeline.jsonl").write_text('{"t": 1}\n', encoding="utf-8")
+        old = time.time() - 30 * 86400
+        os.utime(j1 / "timeline.jsonl", (old, old))
+        j2 = base / "job-done"; j2.mkdir()
+        (j2 / "state.json").write_text('{"status": "completed"}', encoding="utf-8")
+        items, diag = wc.collect_bg_jobs(jobs_dir=td)
+        by = {i["id"]: i for i in items}
+        check("jobs: both collected", len(items) == 2)
+        check("jobs: domain process", all(i["domain"] == "process" for i in items))
+        check("jobs: status parsed", by["job:job-running"]["refs"]["job_status"] == "running")
+        wc.detect(items, stale_days=7)
+        by = {i["id"]: i for i in items}
+        check("jobs: running + stale → job-orphan",
+              "job-orphan" in by["job:job-running"]["flags"])
+        check("jobs: fresh completed → no stale flag",
+              not any(f.startswith("job-") for f in by["job:job-done"]["flags"]))
+
+
+def test_collect_stashes():
+    orig_run, orig_have = wc.run, wc.have
+    wc.have = lambda c: True
+    wc.run = lambda argv, timeout=30: (
+        0,
+        "stash@{0}|%s|WIP on feat/x\nstash@{1}|%s|WIP on main\n" % (_old(30), _new()),
+        "",
+    )
+    try:
+        items, diag = wc.collect_stashes("/x")
+        check("stashes: two collected", len(items) == 2)
+        check("stashes: domain graph-node", all(i["domain"] == "graph-node" for i in items))
+        wc.detect(items, stale_days=7)
+        by = {i["id"]: i for i in items}
+        check("stashes: old → stash-forgotten", "stash-forgotten" in by["stash:stash@{0}"]["flags"])
+        check("stashes: fresh → not forgotten",
+              "stash-forgotten" not in by["stash:stash@{1}"]["flags"])
+    finally:
+        wc.run, wc.have = orig_run, orig_have
+
+
+def test_tree_state_and_wip():
+    orig_run = wc.run
+
+    def fake_dirty(argv, timeout=30):
+        if "symbolic-ref" in argv:
+            return (0, "", "")                                  # attached HEAD
+        if "status" in argv:
+            return (0, " M tracked.py\n?? untracked.txt\n", "")  # tracked change → DIRTY
+        return (1, "", "")
+
+    def fake_clean(argv, timeout=30):
+        if "symbolic-ref" in argv:
+            return (0, "", "")
+        if "status" in argv:
+            return (0, "?? only-untracked.txt\n", "")            # untracked-only → CLEAN
+        return (1, "", "")
+
+    try:
+        wc.run = fake_dirty
+        check("tree_state: tracked change → DIRTY", wc._tree_state("/x") == "DIRTY")
+        wc.run = fake_clean
+        check("tree_state: untracked-only → CLEAN", wc._tree_state("/x") == "CLEAN")
+    finally:
+        wc.run = orig_run
+    # H7 in detect()
+    wt = wc.item("worktree:/w", "worktree", "w",
+                 refs={"branch": "feat/x", "path": "/w", "wip_state": "DIRTY"})
+    wt_clean = wc.item("worktree:/c", "worktree", "c",
+                       refs={"branch": "feat/y", "path": "/c", "wip_state": "CLEAN"})
+    wc.detect([wt, wt_clean], stale_days=7)
+    check("H7 worktree-dirty-wip flagged", "worktree-dirty-wip" in wt["flags"])
+    check("H7 no false positive on CLEAN", "worktree-dirty-wip" not in wt_clean["flags"])
+
+
+def test_collect_codex():
+    with tempfile.TemporaryDirectory() as td:
+        idx = Path(td) / "session_index.jsonl"
+        idx.write_text(
+            '{"id": "abc", "thread_name": "refactor auth", "updated_at": "%s"}\n'
+            '{"id": "def", "thread_name": "old thing", "updated_at": "%s"}\n'
+            '\n'
+            'not-json-line\n' % (_new(), _old(30)),
+            encoding="utf-8")
+        items, diag = wc.collect_codex_sessions(index_path=str(idx))
+        by = {i["id"]: i for i in items}
+        check("codex: valid rows only (2)", len(items) == 2)
+        check("codex: domain session", all(i["domain"] == "session" for i in items))
+        check("codex: id namespaced", "codex-session:abc" in by)
+        check("codex: vendor tagged", by["codex-session:abc"]["refs"]["vendor"] == "codex")
+        wc.detect(items, stale_days=7)
+        by = {i["id"]: i for i in items}
+        check("codex: old session → H4 stale", any(">7d" in f for f in by["codex-session:def"]["flags"]))
+        check("codex: fresh → no false orphan",
+              "session-orphan" not in by["codex-session:abc"]["flags"])
+    _, d = wc.collect_codex_sessions(index_path="/nonexistent-codex-xyz.jsonl")
+    check("codex: absent index → diag not raise", isinstance(d, str))
+
+
+# ── 7. guardrails: openclaw exclusion + registry + new-domain determinism ──────
+def test_openclaw_exclusion():
+    inside = str(wc.HOME / "openclaw" / "agents" / "eko" / "SOUL.md")
+    plans = str(wc.HOME / ".claude" / "plans" / "x.md")
+    check("openclaw: path inside sovereign tree excluded", wc._is_openclaw(inside) is True)
+    check("openclaw: root itself excluded", wc._is_openclaw(str(wc.HOME / "openclaw")) is True)
+    check("openclaw: normal plans path not excluded", wc._is_openclaw(plans) is False)
+
+
+def test_registry_flags():
+    for n in ("stashes", "plans", "jobs", "codex"):
+        check(f"registry: {n} in COLLECTORS", n in wc.COLLECTORS)
+    ns = SimpleNamespace(inventory=None, repo_dir="/nonexistent-xyz", repo=None,
+                         **{f"no_{n}": True for n in wc.COLLECTORS})
+    items, unavailable = wc.aggregate(ns)
+    check("registry: all-disabled → zero items", items == [])
+    check("registry: all-disabled → zero diags", unavailable == [])
+
+
+def test_new_domains_populated():
+    items = [
+        wc.item("plan:a.md", "graph-node", "a", last_ts=_new(), refs={"open_next_steps": 0}),
+        wc.item("stash:stash@{0}", "graph-node", "wip", last_ts=_new(), refs={}),
+        wc.item("job:x", "process", "job x", last_ts=_new(), refs={"job_status": "running"}),
+        wc.item("codex-session:z", "session", "z", last_ts=_new(), refs={"vendor": "codex"}),
+    ]
+    g1 = wc.build_graph([dict(i) for i in items], "current", None, [])
+    g2 = wc.build_graph([dict(i) for i in items], "current", None, [])
+    check("new domains: deterministic",
+          [i["id"] for i in g1["items"]] == [i["id"] for i in g2["items"]])
+    check("new domains: graph-node populated", len(g1["by_domain"]["graph-node"]) == 2)
+    check("new domains: process populated", len(g1["by_domain"]["process"]) == 1)
+
+
 def main() -> int:
-    print("test_work_compass — work-compass Phase-1")
+    print("test_work_compass — work-compass v1.1.0")
     print("=" * 60)
     for fn in [
         test_item_normalization, test_build_graph_deterministic,
         test_detector, test_detector_no_false_positive_on_fresh_linked,
         test_renderer_determinism, test_router, test_read_only_safety,
         test_scope_validation,
+        test_collect_plans, test_collect_bg_jobs, test_collect_stashes,
+        test_tree_state_and_wip, test_collect_codex,
+        test_openclaw_exclusion, test_registry_flags, test_new_domains_populated,
     ]:
         print(f"\n[{fn.__name__}]")
         fn()

--- a/bin/work-compass-aggregate.py
+++ b/bin/work-compass-aggregate.py
@@ -49,6 +49,15 @@ HOME = Path.home()
 DEFAULT_STALE_DAYS = 7
 INVENTORY_SCRIPT = HOME / ".claude" / "scripts" / "inventory-sessions.py"
 
+# ⛔ openclaw is a detect-only sovereign domain — NEVER enumerate/read under it
+# (openclaw-detect-only-sovereign-mandatory). Every store-glob excludes this subtree.
+OPENCLAW_ROOT = os.path.realpath(str(HOME / "openclaw"))
+
+# Default local stores for the extended scanners (overridable for tests).
+PLANS_DIR = HOME / ".claude" / "plans"
+JOBS_DIR = HOME / ".claude" / "jobs"
+CODEX_INDEX = HOME / ".codex" / "session_index.jsonl"
+
 # The 7 CPT domains (cowork-process-topology-protocol §1). One bucket per domain.
 DOMAINS = ["ticket", "worktree", "branch", "session", "thread", "process", "graph-node"]
 
@@ -99,6 +108,38 @@ def days_since(ts: str | None, ref: datetime | None = None) -> float | None:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return ((ref or now_utc()) - dt).total_seconds() / 86400.0
+
+
+def _is_openclaw(path) -> bool:
+    """True if `path` is the openclaw sovereign tree or inside it (detect-only guard)."""
+    try:
+        rp = os.path.realpath(str(path))
+    except OSError:
+        rp = str(path)
+    return rp == OPENCLAW_ROOT or rp.startswith(OPENCLAW_ROOT + os.sep)
+
+
+def _mtime_iso(p: Path) -> str:
+    """File/dir mtime as ISO-8601 UTC, or '' on error. Metadata only (no content)."""
+    try:
+        return datetime.fromtimestamp(p.stat().st_mtime, timezone.utc).isoformat()
+    except OSError:
+        return ""
+
+
+def _tree_state(path: str) -> str:
+    """Replicate gbd_tree_state (read-only): DIRTY | CLEAN | DETACHED.
+
+    DIRTY = uncommitted TRACKED changes (porcelain line not starting with '??');
+    untracked-only stays CLEAN — the exact WIP-loss class. Never raises.
+    """
+    rc, _, _ = run(["git", "-C", path, "symbolic-ref", "--quiet", "HEAD"])
+    if rc != 0:
+        return "DETACHED"
+    rc, out, _ = run(["git", "-C", path, "status", "--porcelain"])
+    if rc == 0 and any(ln and not ln.startswith("??") for ln in out.splitlines()):
+        return "DIRTY"
+    return "CLEAN"
 
 
 # ── work-item model ──────────────────────────────────────────────────────────────
@@ -198,6 +239,10 @@ def collect_worktrees_and_branches(repo_dir: str) -> tuple[list[dict], str | Non
                 source="git branch -vv",
                 refs={"name": name},
             ))
+    # enrich each worktree with its working-tree state (blind-spot: WIP-dirty inside)
+    for it in items:
+        if it["domain"] == "worktree" and it["refs"].get("path"):
+            it["refs"]["wip_state"] = _tree_state(it["refs"]["path"])
     return items, None
 
 
@@ -293,7 +338,141 @@ def collect_jira() -> tuple[list[dict], str | None]:
     return items, None
 
 
-# ── detector (≤6 transparent heuristics; surfaces CANDIDATES, never auto-actions) ──
+# ── extended local scanners (blind-spots — compose native git + fs; metadata-only) ──
+def collect_stashes(repo_dir: str) -> tuple[list[dict], str | None]:
+    """git stash list (native git). Forgotten WIP hidden in the stash stack.
+
+    Domain graph-node. Metadata only (reflog selector · date · subject). Never raises.
+    """
+    if not have("git"):
+        return [], "stashes: git not available"
+    # %gd=selector(stash@{0}) · %cI=strict-ISO committer date · %gs=reflog subject
+    rc, out, _ = run(["git", "-C", repo_dir, "stash", "list", "--format=%gd|%cI|%gs"])
+    if rc != 0:
+        return [], None  # not a repo / no stashes → silent (absence is not an error)
+    items: list[dict] = []
+    for ln in out.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        parts = ln.split("|", 2)
+        ref = parts[0]
+        ts = parts[1] if len(parts) > 1 else ""
+        subj = parts[2] if len(parts) > 2 else ""
+        items.append(item(
+            f"stash:{ref}", "graph-node", subj or ref,
+            last_ts=ts, source="git stash list",
+            refs={"stash_ref": ref},
+        ))
+    return items, None
+
+
+def _plan_meta(p: Path) -> tuple[str, int]:
+    """First heading (≤60c) + count of unchecked '- [ ]' next-steps. Metadata only."""
+    title, open_steps = "", 0
+    try:
+        text = p.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return "", 0
+    for ln in text.splitlines():
+        s = ln.strip()
+        if not title and s.startswith("# "):
+            title = s[2:].strip()[:60]
+        if s.startswith("- [ ]") or s.startswith("* [ ]"):
+            open_steps += 1
+    return title, open_steps
+
+
+def collect_plans(plans_dir: str | Path | None = None) -> tuple[list[dict], str | None]:
+    """Walk ~/.claude/plans/*.md (mtime + open next-steps). Abandoned plans rot here.
+
+    Domain graph-node. Emits path/title/mtime/open-step-count only — never file body.
+    """
+    base = Path(plans_dir) if plans_dir else PLANS_DIR
+    if not base.is_dir():
+        return [], "plans: ~/.claude/plans not present"
+    items: list[dict] = []
+    for p in sorted(base.glob("*.md")):
+        if _is_openclaw(p):  # ⛔ never enumerate the sovereign tree
+            continue
+        title, open_steps = _plan_meta(p)
+        items.append(item(
+            f"plan:{p.name}", "graph-node", title or p.stem,
+            last_ts=_mtime_iso(p), source="~/.claude/plans",
+            refs={"path": str(p), "open_next_steps": open_steps},
+        ))
+    return items, None
+
+
+def collect_bg_jobs(jobs_dir: str | Path | None = None) -> tuple[list[dict], str | None]:
+    """Scan ~/.claude/jobs/<id>/ (state.json status + timeline.jsonl mtime).
+
+    Domain process. Orphaned/stale background jobs hide here. Metadata only.
+    """
+    base = Path(jobs_dir) if jobs_dir else JOBS_DIR
+    if not base.is_dir():
+        return [], "jobs: ~/.claude/jobs not present"
+    items: list[dict] = []
+    for d in sorted(base.iterdir()):
+        if not d.is_dir() or _is_openclaw(d):
+            continue
+        status = "unknown"
+        state_f = d / "state.json"
+        if state_f.is_file():
+            try:
+                status = str(json.loads(state_f.read_text(encoding="utf-8",
+                                                           errors="replace")).get("status", "unknown"))
+            except (OSError, json.JSONDecodeError):
+                pass
+        tl = d / "timeline.jsonl"
+        last_ts = _mtime_iso(tl if tl.is_file() else d)
+        wc_status = "ok" if status in ("completed", "done", "succeeded") else "warn"
+        items.append(item(
+            f"job:{d.name}", "process", f"bg-job {d.name} ({status})",
+            status=wc_status, last_ts=last_ts, source="~/.claude/jobs",
+            refs={"path": str(d), "job_status": status},
+        ))
+    return items, None
+
+
+def collect_codex_sessions(index_path: str | Path | None = None) -> tuple[list[dict], str | None]:
+    """Cross-vendor: read Codex's structured ~/.codex/session_index.jsonl.
+
+    Domain session. Codex sessions are invisible to the Claude-only session producer.
+    Cursor/Copilot/Gemini/Aider adapters are documented stubs (YAGNI) — not built.
+    """
+    idx = Path(index_path) if index_path else CODEX_INDEX
+    if not idx.is_file():
+        return [], "codex: ~/.codex/session_index.jsonl not present"
+    if _is_openclaw(idx):
+        return [], None
+    try:
+        text = idx.read_text(encoding="utf-8", errors="replace")
+    except OSError as e:
+        return [], f"codex: {type(e).__name__}"
+    items: list[dict] = []
+    for ln in text.splitlines():
+        ln = ln.strip()
+        if not ln:
+            continue
+        try:
+            row = json.loads(ln)
+        except json.JSONDecodeError:
+            continue
+        sid = str(row.get("id") or row.get("session_id") or "")
+        if not sid:
+            continue
+        title = row.get("thread_name") or row.get("name") or "(codex session)"
+        items.append(item(
+            f"codex-session:{sid}", "session", str(title)[:60],
+            last_ts=row.get("updated_at") or row.get("updatedAt") or "",
+            source="~/.codex/session_index.jsonl",
+            refs={"vendor": "codex"},
+        ))
+    return items, None
+
+
+# ── detector (≤10 transparent heuristics; surfaces CANDIDATES, never auto-actions) ──
 def detect(items: list[dict], stale_days: int) -> None:
     by_id = {it["id"]: it for it in items}
     branches = {it["refs"].get("name", "") for it in items if it["domain"] == "branch"}
@@ -345,6 +524,26 @@ def detect(items: list[dict], stale_days: int) -> None:
             b = refs.get("branch", "")
             if b and b not in branches and b not in worktree_branches:
                 it["flags"].append("session-orphan")
+        # H7 worktree-dirty-wip (uncommitted TRACKED changes hiding inside a worktree)
+        if d == "worktree" and refs.get("wip_state") == "DIRTY":
+            it["flags"].append("worktree-dirty-wip")
+        # H8 stash-forgotten (a stash older than the staleness threshold)
+        if it["id"].startswith("stash:"):
+            ds = days_since(it.get("last_ts"))
+            if ds is not None and ds > stale_days:
+                it["flags"].append("stash-forgotten")
+        # H9 plan-orphan (stale + open next-steps) / plan-stale (stale, no open steps)
+        if it["id"].startswith("plan:"):
+            ds = days_since(it.get("last_ts"))
+            if ds is not None and ds > stale_days:
+                it["flags"].append("plan-orphan" if refs.get("open_next_steps", 0) > 0
+                                   else "plan-stale")
+        # H10 job-orphan (claims running but untouched >Nd) / job-stale (old idle job)
+        if it["id"].startswith("job:"):
+            ds = days_since(it.get("last_ts"))
+            if ds is not None and ds > stale_days:
+                running = refs.get("job_status", "") in ("running", "active", "in_progress")
+                it["flags"].append("job-orphan" if running else "job-stale")
         if it["flags"] and it["status"] in ("ok", "unknown"):
             it["status"] = "orphan" if any("orphan" in f or "-no-" in f for f in it["flags"]) else it["status"]
     return None
@@ -368,6 +567,12 @@ ROUTES = {
     "_stale":         ("morning-briefing", "/morning-briefing --mode=recap  # review stale {id}", "stale — recap before deciding"),
     "_session":       ("auto-orchestrator", "/auto-orchestrator  # resume {id}", "resume session work"),
     "_pr":            ("quiesce", "/maos:quiesce  # converge open PR {id}", "drive PR to green"),
+    "worktree-dirty-wip": ("postflight", "/maos:postflight  # commit or stash WIP in {id}", "uncommitted WIP inside worktree — commit/stash before it is lost"),
+    "stash-forgotten":    ("git", "git stash show -p {id}  # review then pop/drop", "forgotten stash — review + pop or drop"),
+    "plan-orphan":        ("auto-pilot", "/maos:auto-pilot \"resume plan {id}\"", "abandoned plan with open next-steps — resume or archive"),
+    "plan-stale":         ("postflight", "/maos:postflight  # archive stale plan {id}", "stale plan, no open steps — archive"),
+    "job-orphan":         ("postflight", "/maos:postflight  # inspect orphaned bg-job {id}", "bg-job claims running but stale — inspect/kill"),
+    "job-stale":          ("postflight", "/maos:postflight  # clean stale bg-job {id}", "stale bg-job — clean up"),
 }
 
 
@@ -521,27 +726,29 @@ def build_graph(items: list[dict], scope: str, node_id: str | None,
 
 
 # ── main ─────────────────────────────────────────────────────────────────────────
+# collector registry — add a surface = ONE entry here (drives --no-<name> flags too).
+COLLECTORS = ["sessions", "git", "github", "jira", "stashes", "plans", "jobs", "codex"]
+
+
 def aggregate(args) -> tuple[list[dict], list[str]]:
+    """Fan-out every enabled collector in fixed (deterministic) order."""
+    registry = {
+        "sessions": lambda: collect_sessions(args.inventory),
+        "git":      lambda: collect_worktrees_and_branches(args.repo_dir),
+        "github":   lambda: collect_github(args.repo),
+        "jira":     lambda: collect_jira(),
+        "stashes":  lambda: collect_stashes(args.repo_dir),
+        "plans":    lambda: collect_plans(),
+        "jobs":     lambda: collect_bg_jobs(),
+        "codex":    lambda: collect_codex_sessions(),
+    }
     items: list[dict] = []
     unavailable: list[str] = []
-    if not args.no_sessions:
-        s, diag = collect_sessions(args.inventory)
-        items += s
-        if diag:
-            unavailable.append(diag)
-    if not args.no_git:
-        g, diag = collect_worktrees_and_branches(args.repo_dir)
-        items += g
-        if diag:
-            unavailable.append(diag)
-    if not args.no_github:
-        gh, diag = collect_github(args.repo)
-        items += gh
-        if diag:
-            unavailable.append(diag)
-    if not args.no_jira:
-        j, diag = collect_jira()
-        items += j
+    for name in COLLECTORS:
+        if getattr(args, f"no_{name}", False):
+            continue
+        got, diag = registry[name]()
+        items += got
         if diag:
             unavailable.append(diag)
     return items, unavailable
@@ -559,10 +766,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--repo", default=None, help="GitHub owner/name (else inferred)")
     ap.add_argument("--repo-dir", default=os.getcwd(), help="git repo dir for worktrees/branches")
     ap.add_argument("--inventory", default=None, help="reserved: pre-generated inventory path")
-    ap.add_argument("--no-jira", action="store_true")
-    ap.add_argument("--no-github", action="store_true")
-    ap.add_argument("--no-sessions", action="store_true")
-    ap.add_argument("--no-git", action="store_true")
+    for _name in COLLECTORS:  # registry-driven skip flags (--no-<collector>)
+        ap.add_argument(f"--no-{_name}", action="store_true", help=f"skip the {_name} collector")
     ap.add_argument("--detect-only", action="store_true",
                     help="print only the flagged candidates")
     ap.add_argument("--route", default=None, help="node id to route (prints suggested command)")

--- a/openspec/specs/work-compass/spec.md
+++ b/openspec/specs/work-compass/spec.md
@@ -5,10 +5,11 @@
 
 ## Purpose
 
-Aggregate the operator's cross-domain work items (Jira/GitHub issues, Claude sessions, git
-worktrees/branches, open PRs) into ONE deterministic, navigable N-Tree across the 7 CPT
-domains; detect stale/orphan/pending items via transparent heuristics; and route a node to
-a SUGGESTED command for an existing tool — read-only, review-before-submit.
+Aggregate the operator's cross-domain work items (Jira/GitHub issues, Claude + cross-vendor
+Codex sessions, git worktrees/branches/stashes/uncommitted-WIP, open PRs, ~/.claude plans +
+background jobs) into ONE deterministic, navigable N-Tree across the 7 CPT domains; detect
+stale/orphan/pending items via transparent heuristics; and route a node to a SUGGESTED
+command for an existing tool — read-only, review-before-submit.
 
 ## Requirements
 
@@ -24,7 +25,17 @@ gh CLI, acli, native git) and SHALL NOT reimplement their logic.
 #### Scenario: id namespacing
 - WHEN items from multiple providers are normalized
 - THEN every id is provider-namespaced (`jira:KEY`, `gh:owner/repo#n`, `session:<id>`,
-  `worktree:<path>`, `branch:<name>`, `pr:<repo>#n`) so cross-provider collisions cannot occur.
+  `worktree:<path>`, `branch:<name>`, `pr:<repo>#n`, and v1.1 `codex-session:<id>`,
+  `job:<id>`, `plan:<file>`, `stash:<ref>`) so cross-provider collisions cannot occur.
+
+### Requirement: Registry-driven collector extension
+Collectors SHALL be registered in a single `COLLECTORS` list; adding a surface SHALL require
+one registry entry (which auto-generates its `--no-<name>` skip flag) plus one
+`collect_<provider>()` function — no other change.
+
+#### Scenario: every collector disabled
+- WHEN all `--no-<name>` flags are set
+- THEN aggregation returns zero items and zero diagnostics, without error.
 
 ### Requirement: Deterministic rendering
 The renderer SHALL produce identical output for identical input (CPT §9.5 consumer contract).
@@ -34,13 +45,31 @@ The renderer SHALL produce identical output for identical input (CPT §9.5 consu
 - THEN the ASCII and mermaid outputs are byte-identical.
 
 ### Requirement: Transparent stale/orphan/pending detection
-The system SHALL flag candidates via ≤6 transparent heuristics (branch-no-PR, PR-no-ticket,
-ticket-no-session, >Nd-no-update, worktree-no-branch, session-orphan) and SHALL surface them
-as CANDIDATES, never auto-actioning.
+The system SHALL flag candidates via ≤10 transparent heuristics (branch-no-PR, PR-no-ticket,
+ticket-no-session, >Nd-no-update, worktree-no-branch, session-orphan, and v1.1
+worktree-dirty-wip, stash-forgotten, plan-orphan/plan-stale, job-orphan/job-stale) and SHALL
+surface them as CANDIDATES, never auto-actioning.
 
 #### Scenario: a linked, fresh item
 - WHEN a branch has an open PR, a PR cites a ticket, and a session references the branch+ticket
 - THEN none of branch-no-PR / PR-no-ticket / session-orphan are raised (no false positives).
+
+#### Scenario: a fresh plan / job / stash / clean worktree
+- WHEN a plan/job/stash was updated within the staleness window, or a worktree is CLEAN
+- THEN none of plan-*/job-*/stash-forgotten/worktree-dirty-wip are raised (no false positives).
+
+### Requirement: Extended local scanners — metadata-only, sovereign-safe
+The v1.1 local scanners (plans, background jobs, git stashes, worktree WIP) and the Codex
+cross-vendor scanner SHALL emit metadata only (path · title · status · mtime · counts) and
+SHALL NEVER emit file contents. Any store-glob SHALL exclude the `~/openclaw/` sovereign tree.
+
+#### Scenario: openclaw exclusion
+- WHEN a scanned path resolves inside `~/openclaw/`
+- THEN it is skipped (never read or enumerated).
+
+#### Scenario: absent store
+- WHEN a store dir (`~/.claude/plans`, `~/.claude/jobs`, `~/.codex/session_index.jsonl`) is absent
+- THEN a diagnostic is appended and aggregation continues (never raises).
 
 ### Requirement: Read-only delegation routing
 The router SHALL return a SUGGESTED command with `execute: false` and SHALL NEVER execute a
@@ -60,10 +89,14 @@ The system SHALL NOT emit secrets/PII (it composes a sanitizing producer for ses
 
 ## Validation
 
-34 stdlib tests (`bin/tests/test_work_compass.py`) + a dogfood run on real data
-(4364 items, 5/7 domains, 0 secret-like hits).
+73 stdlib tests (`bin/tests/test_work_compass.py`) + a dogfood run on real data
+(5288 items full-run / 176 local-only, 6/7 domains, deterministic, read-only verified,
+0 secret-like hits). The ~37-surface landscape + coverage is catalogued in
+`skills/work-compass/references/work-surface-taxonomy.md`.
 
 ## Deferred (out of scope this capability)
 
-Static HTML view · drag-drop/admin panel · Linear/GitLab/ClickUp adapters · ML-suggested
-rules. Adapter-stub interface documented in SKILL.md; build-on-demand only (YAGNI).
+Cross-vendor beyond Codex (Cursor/Copilot/Gemini/Aider) · `--depth/--breadth/--height`
+traversal modifiers · Linear/GitLab/ClickUp + Confluence/Drive + Slack/email + CI-pipelines/
+deployments (+ 26 blind-spots in the taxonomy) · static HTML view · ML-suggested rules.
+Registry-driven adapter-stub interface documented in SKILL.md; build-on-demand only (YAGNI).

--- a/skills/work-compass/SKILL.md
+++ b/skills/work-compass/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: work-compass
 description: |
-  Aggregate the operator's scattered work — Jira/GitHub issues, Claude sessions, git
-  worktrees/branches, and open PRs — into ONE navigable N-Tree across the 7 CPT domains,
+  Aggregate the operator's scattered work — Jira/GitHub issues, Claude + cross-vendor
+  (Codex) sessions, git worktrees/branches/stashes/uncommitted-WIP, open PRs, and
+  ~/.claude plans + background jobs — into ONE navigable N-Tree across the 7 CPT domains,
   detect stale/orphan/pending items via transparent heuristics, and route node actions to
   existing tools (preflight/postflight/auto-pilot/recap/quiesce/auto-orchestrator) with
   operator review-before-submit. The visual elevation of the Cowork Process Topology
@@ -11,7 +12,7 @@ description: |
   de trabalho", "o que está parado/órfão". Read-only by default; every write/pause/stop/
   delete is operator-gated (prints a command, never executes). Capability-detected
   (git/gh/acli optional), stdlib-only, cross-vendor (AAIF).
-prompt_version: "1.0.0"
+prompt_version: "1.1.0"
 type: skill
 spec: AAIF / agentskills.io
 applicable_hosts: [Claude Code, Cursor, GitHub Copilot, Aider, any AAIF-compliant agent]
@@ -116,9 +117,13 @@ bin/work-compass-aggregate.py --format=mermaid
 ## The 7 CPT domains (grouping)
 
 `ticket · worktree · branch · session · thread · process · graph-node` — items namespaced
-`jira:KEY · gh:owner/repo#n · session:<id> · worktree:<path> · branch:<name> · pr:<repo>#n`.
+`jira:KEY · gh:owner/repo#n · session:<id> · worktree:<path> · branch:<name> · pr:<repo>#n`
+and (v1.1) `codex-session:<id> · job:<id> · plan:<file> · stash:<ref>`. As of v1.1 **6/7
+domains are populated** (`graph-node` filled by plans+stashes, `process` enriched by jobs;
+`thread` remains deferred). The full landscape of ~37 work-surfaces + coverage is catalogued
+in `references/work-surface-taxonomy.md` (the SSOT roadmap).
 
-## Detector heuristics (≤6, transparent — CANDIDATES, never auto-actioned)
+## Detector heuristics (≤10, transparent — CANDIDATES, never auto-actioned)
 
 1. **branch-no-PR** — feature branch with no open PR.
 2. **PR-no-ticket** — PR whose title/refs cite no tracker ticket.
@@ -126,6 +131,10 @@ bin/work-compass-aggregate.py --format=mermaid
 4. **>Nd-no-update** — any item not updated in N days (default 7 → status `stale`).
 5. **worktree-no-branch** — worktree on a detached/unknown branch.
 6. **session-orphan** — session whose branch no longer exists.
+7. **worktree-dirty-wip** *(v1.1)* — uncommitted TRACKED changes hiding inside a worktree (loss-risk).
+8. **stash-forgotten** *(v1.1)* — a git stash older than the staleness threshold.
+9. **plan-orphan / plan-stale** *(v1.1)* — a `~/.claude/plans` file past staleness (orphan = still has open next-steps).
+10. **job-orphan / job-stale** *(v1.1)* — a background job past staleness (orphan = claims running but untouched).
 
 Thresholds are configurable; false-positives are surfaced, not enforced.
 
@@ -152,17 +161,22 @@ CPT §9.5 consumer-contract: verb-membership validation (invalid → diagnostic 
 `current`), determinism (same input+verb → same output), graceful degrade, cross-vendor
 (stdlib). Registered as a consumer alongside morning-briefing / auto-orchestrator.
 
-## Deferred (Phase-2/3 — gated on ≥2 dogfood cycles)
+## Deferred (build-on-demand — the 26 blind-spots in `references/work-surface-taxonomy.md`)
 
-Static HTML view (reuse maos-concierge `dashboard.html` zero-dep pattern) · drag-drop +
-admin panel · Linear/GitLab/ClickUp/Trello/Asana/Monday adapters (stub interface only,
-capability-detected, build-on-demand) · ML-suggested rules/automations.
+Cross-vendor sessions beyond Codex (Cursor/Copilot/Gemini/Aider — schema-spelunking, stub) ·
+`--depth/--breadth/--height` traversal modifiers (a separate CPT §9.5 gap) · Linear/GitLab/
+ClickUp/Trello/Asana/Monday tracker adapters · Confluence/Drive · commits/tags/notes ·
+subagents/OS-processes/tmux/scheduled/loops/threads · memory/session-reports/rules/TODOs/seeds ·
+Slack/email/Discord · CI pipelines + deployments · static HTML view · ML-suggested rules.
+Each is a tracked row in the taxonomy — build only on real need (YAGNI / Gordian).
 
-## Adapter-stub interface (documented, NOT built)
+## Adapter-stub interface (v1.1 — registry-driven)
 
-A new provider plugs in by adding a `collect_<provider>() -> (list[item], diag|None)`
-function that capability-detects its CLI/MCP and normalizes into `item(id, domain, title,
-...)` with a namespaced id. No other change required. Build only on real need (YAGNI).
+A new surface plugs in by (1) adding a `collect_<provider>() -> (list[item], diag|None)`
+function that capability-detects its store/CLI/MCP and normalizes into `item(id, domain,
+title, ...)` with a namespaced id, and (2) adding one entry to the `COLLECTORS` registry
+in `bin/work-compass-aggregate.py` — which auto-generates its `--no-<name>` skip flag. No
+other change required. Build only on real need (YAGNI).
 
 ## Sunset (DUED — qualitative, not counter-based)
 
@@ -172,8 +186,11 @@ composes expose a joint API making aggregation redundant (E6) · operator retrac
 
 ## Refs
 
+- `references/work-surface-taxonomy.md` (v1.1 — SSOT catalog of the ~37 work-surfaces + coverage roadmap)
 - `~/.claude/scripts/inventory-sessions.py` (sessions/branches producer — composed)
+- `plugin-scripts/governance/lib/git-branch-detect.sh` `gbd_tree_state()` (WIP porcelain logic replicated in `_tree_state`)
 - `~/.claude/rules/cowork-process-topology-protocol.md` §9/§9.5 (Compass API + consumer-contract)
+- `~/.claude/rules/openclaw-detect-only-sovereign-mandatory.md` (⛔ store-globs exclude `~/openclaw/` — `_is_openclaw` guard)
 - `statusmap/README.md` (ASCII house-style reused)
 - `skills/{preflight,postflight,morning-briefing}/SKILL.md` (siblings)
 - `~/.claude/rules/{reuse-and-elevate-protocol,over-engineering-circuit-breaker,eko-system-default-mode-laws}.md`
@@ -182,4 +199,5 @@ composes expose a joint API making aggregation redundant (E6) · operator retrac
 
 | Version | Date | Change |
 |---|---|---|
+| 1.1.0 | 2026-07-10 | Blind-spot extension (Strata — extend, don't reinvent). **Collector registry** refactor (`COLLECTORS` — add-surface = 1 entry, auto-generates `--no-<name>`). **5 new surfaces**: WIP-dirty-inside-worktree (H7, reuses `gbd_tree_state` porcelain), git stashes (`collect_stashes`, H8), plans (`collect_plans`, H9), background jobs (`collect_bg_jobs`, H10), cross-vendor **Codex** sessions (`collect_codex_sessions`). Coverage **~6→~11 surfaces, 5/7→6/7 CPT domains** (`graph-node` filled by plans+stashes, `process` enriched by jobs). New `references/work-surface-taxonomy.md` SSOT (37 surfaces / 6 categories / coverage roadmap). ⛔ `~/openclaw/` detect-only guard (`_is_openclaw`); metadata-only (no file-body leak); read-only preserved. **73 stdlib tests** (was 34); dogfooded live (5288 items full-run, 176 local-only, 6/7 domains, deterministic). Cursor/Copilot/Gemini/Aider + `--depth/breadth/height` + 26 other surfaces deferred (tracked in the taxonomy). |
 | 1.0.0 | 2026-06-13 | Phase-1 bootstrap — aggregator + ASCII/mermaid N-Tree renderer + 6-heuristic detector + read-only delegation-router. Composes inventory-sessions.py + gh + acli + git; reimplements none. 34 stdlib tests; dogfooded on real data (4364 items, 5/7 domains). CPT §9.5 consumer registered. HTML/adapters/ML deferred. |

--- a/skills/work-compass/references/work-surface-taxonomy.md
+++ b/skills/work-compass/references/work-surface-taxonomy.md
@@ -1,0 +1,119 @@
+---
+name: work-surface-taxonomy
+description: SSOT catalog of the ~37 non-theater work-surface types (identifiers that carry knowledge/instruction/task/decision) across 6 categories, each tagged EXEC/STALE + current work-compass coverage — the blind-spot roadmap
+version: 1.0.0
+---
+
+# Work-Surface Taxonomy (SSOT)
+
+> **Version**: 1.0.0 (2026-07-10)
+> **Scope**: AAIF cross-vendor. The single source of truth for *what kinds of surface can hold running or stale work*.
+> **Consumer**: `skills/work-compass` — the aggregator scans a subset of these surfaces and detects stale/orphan/pending items; this catalog defines the full landscape + which surfaces are covered vs. blind-spots. Feeds the CPT §9.5 Compass-consumer contract.
+> **Parent SSOT**: `~/.claude/rules/cowork-process-topology-protocol.md` §9/§9.5 (the topology + Compass API this taxonomy is downstream of). External, user-scope — reference only.
+> **Cross-link slug**: `work-surface-taxonomy`
+
+## Purpose
+
+A "work-surface" is any identifier that **carries knowledge / instruction / task / decision** and **feeds into work** — work already done, being done, or to be done. Each surface has two orthogonal state potentials:
+
+- 🔄 **EXEC** — it can be *actively executing right now* (a running process/session/pipeline).
+- 💤 **STALE** — it can *silently rot* (abandoned, orphaned, forgotten, past its freshness).
+
+> Repo master principle (from work-compass): *"O que não é visto não é lembrado"* — what is not surfaced is not remembered, by humans **and** amnesic agents. This catalog exists so a fresh agent never re-derives the landscape, and so every blind-spot is a tracked, closeable gap rather than an invisible one.
+
+The catalog is **reconstructed faithfully from the operator's OODA enumeration** (the operator's list is the source of truth) and **grounded against the on-disk stores confirmed by live recon** (79 plans · 81 background jobs · Codex `session_index.jsonl` · git worktrees/stashes). It is **non-theater**: every row is a surface that genuinely holds work-carrying content, not a decorative category.
+
+**Coverage legend** (work-compass, as of v1.1.0):
+- ✅ **covered** — scanned by a `collect_*` collector since v1.0.
+- 🆕 **added-v1.1** — new collector this upgrade.
+- ⬜ **blind-spot** — real surface, not yet scanned (deferred; YAGNI/Gordian — build on demand).
+
+## Layer purity
+
+This taxonomy is **provider-neutral**: it names *kinds of surface*, never a specific vendor/org/tracker as the surface itself. Vendors appear only as *examples* of a kind (e.g. "Jira / Linear" exemplify the *external-tracker* kind). A `work-compass` collector may target one concrete provider (capability-detected), but the taxonomy row is the neutral kind.
+
+## Category 1 — Trackers (external work-tracking systems)
+
+| # | Surface | Carries | 🔄/💤 | work-compass |
+|---|---|---|---|---|
+| 1 | Issue tracker — Jira workitem | task · acceptance · decision | 🔄💤 | ✅ covered (`collect_jira`, acli) |
+| 2 | Issue tracker — Linear issue | task · acceptance | 🔄💤 | ⬜ blind-spot (adapter stub) |
+| 3 | Issue tracker — GitHub Issue | task · discussion | 🔄💤 | ✅ covered (`collect_github`) |
+| 4 | Issue tracker — Bitbucket issue | task | 🔄💤 | ⬜ blind-spot |
+| 5 | Knowledge page — Confluence page | decision · spec | 💤 | ⬜ blind-spot |
+| 6 | Doc surface — Google Drive doc | decision · spec | 💤 | ⬜ blind-spot |
+| 7 | Board card — Trello / Asana / Monday | task | 🔄💤 | ⬜ blind-spot |
+
+## Category 2 — Git / VCS artifacts
+
+| # | Surface | Carries | 🔄/💤 | work-compass |
+|---|---|---|---|---|
+| 8 | Branch | in-flight change-set | 🔄💤 | ✅ covered (`git branch -vv`) |
+| 9 | Worktree | isolated workspace | 🔄💤 | ✅ covered (`git worktree list`) |
+| 10 | Pull Request | change + review + decision | 🔄💤 | ✅ covered (`gh pr list`) |
+| 11 | Commit (local, unpushed) | done work not yet shared | 💤 | ⬜ blind-spot |
+| 12 | **Uncommitted WIP inside a worktree** | in-progress edits (loss-risk) | 🔄💤 | 🆕 added-v1.1 (`_tree_state` porcelain → H7) |
+| 13 | **Git stash** | forgotten shelved WIP | 💤 | 🆕 added-v1.1 (`collect_stashes` → H8) |
+| 14 | Tag / release | published milestone | 💤 | ⬜ blind-spot |
+| 15 | Git note | out-of-band annotation | 💤 | ⬜ blind-spot |
+
+## Category 3 — Agentic session / process (running or resumable)
+
+| # | Surface | Carries | 🔄/💤 | work-compass |
+|---|---|---|---|---|
+| 16 | Claude Code session | goal · transcript · decisions | 🔄💤 | ✅ covered (`inventory-sessions.py`) |
+| 17 | **Cross-vendor session** (Codex/Cursor/Copilot/Gemini/Aider) | goal · transcript | 🔄💤 | 🆕 added-v1.1 (**Codex** via `session_index.jsonl`; others ⬜ stub) |
+| 18 | Subagent (spawned Task/Agent) | delegated task + result | 🔄 | ⬜ blind-spot |
+| 19 | **Background job** (`~/.claude/jobs/`) | detached long-running task | 🔄💤 | 🆕 added-v1.1 (`collect_bg_jobs` → H10) |
+| 20 | OS process (long-running) | live execution | 🔄 | ⬜ blind-spot |
+| 21 | tmux / screen session | live shell context | 🔄💤 | ⬜ blind-spot |
+| 22 | Scheduled task (cron / ScheduleWakeup) | deferred future work | 🔄💤 | ⬜ blind-spot |
+| 23 | Loop (Ralph / goal / quiesce loop) | iterated driver | 🔄 | ⬜ blind-spot |
+| 24 | Thread (cross-session slug) | continuity across sessions | 🔄💤 | ⬜ blind-spot (CPT `thread` domain — deferred) |
+| 25 | CPT topology node (process graph) | orchestration position | 🔄💤 | ⬜ blind-spot (CPT `graph-node` topology events) |
+
+## Category 4 — Agentic persistence (durable knowledge/instruction on disk)
+
+| # | Surface | Carries | 🔄/💤 | work-compass |
+|---|---|---|---|---|
+| 26 | **Plan** (`~/.claude/plans/*.md`) | roadmap · next-steps · decisions | 💤 | 🆕 added-v1.1 (`collect_plans` → H9) |
+| 27 | Memory file (`projects/*/memory` + MEMORY.md) | durable lesson/fact | 💤 | ⬜ blind-spot |
+| 28 | Session report (`.claude/sessions/`) | handoff record | 💤 | ⬜ blind-spot |
+| 29 | Rule (auto-loaded governance) | binding instruction | 💤 | ⬜ blind-spot (see `corpus-firing-audit`) |
+| 30 | TODO / TaskList item | pending step | 🔄💤 | ⬜ blind-spot |
+| 31 | Continuation seed / handoff file | resume instruction | 💤 | ⬜ blind-spot |
+| 32 | CPT session journal (JSONL events) | FIFO event log | 🔄💤 | ⬜ blind-spot |
+
+## Category 5 — Omnichannel (inbound work carrying instruction/decision)
+
+| # | Surface | Carries | 🔄/💤 | work-compass |
+|---|---|---|---|---|
+| 33 | Chat message/thread — Slack | request · decision | 🔄💤 | ⬜ blind-spot |
+| 34 | Email — Gmail / Outlook | request · decision | 💤 | ⬜ blind-spot |
+| 35 | Chat — Discord / other | request | 🔄💤 | ⬜ blind-spot |
+
+## Category 6 — CI/CD
+
+| # | Surface | Carries | 🔄/💤 | work-compass |
+|---|---|---|---|---|
+| 36 | Pipeline / workflow run (GH Actions / Bitbucket Pipelines) | build+test verdict | 🔄💤 | ⬜ blind-spot |
+| 37 | Deployment + canary monitor | live release state | 🔄💤 | ⬜ blind-spot |
+
+## Coverage summary (v1.1.0)
+
+- **Covered (✅ + 🆕): 11 / 37** surfaces — Jira · GitHub Issues · PRs · branches · worktrees · Claude sessions (v1.0) + WIP-dirty · stashes · Codex sessions · background jobs · plans (v1.1).
+- **CPT domains live: 6 / 7** — `ticket · branch · session · process · graph-node · worktree` populated; `thread` deferred.
+- **Blind-spots: 26 / 37** — tracked here as a roadmap; each is buildable on real demand via the `collect_<provider>()` adapter-stub interface (SKILL.md §"Adapter-stub interface"). Build-on-demand (YAGNI / Gordian) — the catalog makes the gap *visible*, not mandatory to fill.
+
+## Refs
+
+- `skills/work-compass/SKILL.md` (consumer — the aggregator + detector)
+- `~/.claude/rules/cowork-process-topology-protocol.md` §9/§9.5 (parent topology SSOT + Compass API)
+- `skills/preflight/references/session-type-taxonomy.md` (sibling taxonomy — session *types*, this one = work *surfaces*)
+- Cross-link slug: `work-surface-taxonomy`
+
+## Changelog
+
+| Version | Date | Change |
+|---|---|---|
+| 1.0.0 | 2026-07-10 | Bootstrap — 37 non-theater work-surface types across 6 categories (trackers · git/VCS · agentic session/process · agentic persistence · omnichannel · CI/CD), each tagged 🔄EXEC/💤STALE + work-compass coverage (✅ v1.0 · 🆕 v1.1 · ⬜ blind-spot). Reconstructed from the operator's OODA enumeration; grounded against confirmed on-disk stores. Coverage: 11/37 surfaces, 6/7 CPT domains. Provider-neutral (layer-pure). Consumer: work-compass; parent: CPT §9.5. |


### PR DESCRIPTION
**[PR-as-Enhancement-Prompt]**

## Context

An OODA enumeration found **~37 non-theater work-surface types** (identifiers that carry knowledge / instruction / task / decision) across 6 categories. `work-compass` v1.0.0 aggregated only **~6 of 37** — the other ~31 were blind-spots where stale/running work hides undetected. Live recon confirmed the top-5 on disk: **79 plans**, **~81 background jobs**, **uncommitted WIP inside worktrees** (a real data-loss class), **git stashes**, and **cross-vendor sessions** (invisible because v1.0 read only Claude transcripts).

## Objectives

1. Persist the 37-type catalog as a discoverable SSOT so a fresh amnesic agent never re-derives it.
2. Extend work-compass (**Strata: extend, don't reinvent**) to scan the 4 cheap high-value LOCAL blind-spots + Codex cross-vendor — lifting live coverage **~6 → ~11 surfaces** and filling the dead `graph-node` CPT domain (**5/7 → 6/7**).

## Summary

- **Engine** (`bin/work-compass-aggregate.py`): `COLLECTORS` registry refactor (add-surface = 1 entry, auto-generates `--no-<name>`); new `collect_stashes` (H8), `collect_plans` (H9), `collect_bg_jobs` (H10), `collect_codex_sessions`; worktree WIP-dirty via `_tree_state` (H7, replicates `gbd_tree_state` porcelain); `_is_openclaw` guard excluding the `~/openclaw` sovereign tree; metadata-only, read-only preserved.
- **SSOT**: new `skills/work-compass/references/work-surface-taxonomy.md` (37 surfaces / 6 categories / coverage roadmap).
- **Docs**: `SKILL.md` + `openspec/specs/work-compass/spec.md` → v1.1.0.

## Test plan

- [x] `python3 bin/tests/test_work_compass.py` → **73 passed, 0 failed** (was 34): new collectors, H7-H10, no-false-positive, openclaw-exclusion, registry, determinism.
- [x] `bash tests/validate-plugin.sh` → PASSED (0 errors).
- [x] Live dogfood: 5288 items full-run (**6/7 domains**), 176 local-only (72 plans · 81 jobs · 8 Codex · 2 WIP-dirty worktrees), deterministic across 2 runs.
- [x] Read-only proof: `git status` after runs shows only source edits — tool wrote nothing; the banned-string test still passes.

## Risk + rollback

Low-Risk (additive · read-only tool + docs + tests · community repo, Class B GitHub Flow). Rollback = `git revert <merge-sha>` — no schema/state change, no behavioral change to existing collectors.

## Out of scope (deferred — tracked in the taxonomy)

Cross-vendor beyond Codex (Cursor/Copilot/Gemini/Aider) · `--depth/--breadth/--height` traversal modifiers (separate CPT §9.5 gap) · the 26 other blind-spot surfaces · HTML view · ML. Build-on-demand (YAGNI / Gordian).

## Cross-links

- Approved plan: `~/.claude/plans/ooda-pesquise-identifique-wise-moore.md`
- Parent SSOT: `cowork-process-topology-protocol` §9/§9.5 (CPT Compass consumer contract — unchanged; consumer registry refresh is an optional akasha-claude follow-up)
- Sibling taxonomy: `skills/preflight/references/session-type-taxonomy.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
