### PR TITLE
feat(registry): WAVE 6 T9 — ttl-freshness enforcement (upstream auto-flag + console freshness view)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — WAVE 6 T9: TTL & freshness enforcement (registry + console)
+
+- **`lib/registry/hub_registry.py`**: the spec's "Freshness + rollback" requirement is now fully
+  enforced — (1) **every record carries `ttl` + `last_validated`** (first-party records get the
+  `OWN_TTL_DAYS = 90` re-validation deadline, the ttl-policy skill's Protocol/Standard cadence;
+  presence enforced by the `all_required_fields_present` invariant); (2) new **`upstream_status`**
+  field (`active | abandoned | compromised`) derived from intake-fixture flags
+  (`rug-pull-confirmed`/`live-threat-npm-keys` → compromised; `stale`/`404-not-resolving`/
+  `abandoned` … → abandoned) — the scenario's date-independent branch, firing today on the live
+  GSD/awesome-design-tools rows (the GSD/MemPalace lesson); (3) **`eject_candidates()`** now
+  returns `{id, reason}` records covering BOTH branches and is always surfaced in
+  `report().invariants` (candidates are HITL-surfaced, never auto-ejected).
+- **`lib/registry/console.py`**: new 7th view **`freshness`** (+ CLI `--today YYYY-MM-DD`) — the
+  HITL surface listing eject-candidates with reasons plus every record's ttl/last_validated/
+  upstream_status (deterministic: `today` is an explicit parameter, never the wall clock).
+- Tests: +6 (both scenario branches on the live fixture · every-record-carries-ttl · synthetic
+  stale golden fixture · freshness view + CLI smoke) — hub suite 388 passed.
+
 ### Changed — ADR-007 amended: publish-by-default doctrine (per-tile thaw)
 
 - **`docs/adrs/ADR-007-curated-community-integration-platform.md`**: status `Exploratory/DRAFT (FROZEN)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added — WAVE 6 T9: TTL & freshness enforcement (registry + console)
 
-- **`lib/registry/hub_registry.py`**: the spec's "Freshness + rollback" requirement is now fully
+- **`mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py`**: the spec's "Freshness + rollback" requirement is now fully
   enforced — (1) **every record carries `ttl` + `last_validated`** (first-party records get the
   `OWN_TTL_DAYS = 90` re-validation deadline, the ttl-policy skill's Protocol/Standard cadence;
   presence enforced by the `all_required_fields_present` invariant); (2) new **`upstream_status`**
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   GSD/awesome-design-tools rows (the GSD/MemPalace lesson); (3) **`eject_candidates()`** now
   returns `{id, reason}` records covering BOTH branches and is always surfaced in
   `report().invariants` (candidates are HITL-surfaced, never auto-ejected).
-- **`lib/registry/console.py`**: new 7th view **`freshness`** (+ CLI `--today YYYY-MM-DD`) — the
+- **`mcp-tools/maos-mcp-hub/lib/registry/console.py`**: new 7th view **`freshness`** (+ CLI `--today YYYY-MM-DD`) — the
   HITL surface listing eject-candidates with reasons plus every record's ttl/last_validated/
   upstream_status (deterministic: `today` is an explicit parameter, never the wall clock).
 - Tests: +6 (both scenario branches on the live fixture · every-record-carries-ttl · synthetic

--- a/mcp-tools/maos-mcp-hub/lib/registry/console.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/console.py
@@ -85,7 +85,10 @@ except ImportError:  # pragma: no cover
     from lib.registry.context_rank import rank as rank_by_signals  # type: ignore
     from lib.gateway.profile import PROFILE_MODES, HubProfile, validate_profile  # type: ignore
 
-VIEWS = ("preset", "category", "use-case", "context-aware", "prose-intent", "safe-mode")
+VIEWS = (
+    "preset", "category", "use-case", "context-aware", "prose-intent",
+    "safe-mode", "freshness",
+)
 
 _OWN_REPO = "ekson73/multi-agent-os"
 _WIDTH = 78
@@ -168,10 +171,14 @@ class HubConsole:
         registry: HubRegistry,
         recipes: Sequence[Recipe],
         signals: Sequence[str] = (),
+        today: Optional[str] = None,
     ) -> None:
         self.registry = registry
         self.recipes = sorted(recipes, key=lambda r: r.id)
         self.signals: Tuple[str, ...] = tuple(sorted(set(signals)))
+        # T9 freshness view: an EXPLICIT date, never the wall clock — the
+        # determinism contract (byte-stable for the same inputs) holds.
+        self.today = today
 
     # ------------------------------------------------------------------ views
 
@@ -185,6 +192,7 @@ class HubConsole:
             "context-aware": self._view_context_aware,
             "prose-intent": self._view_prose_intent,
             "safe-mode": self._view_safe_mode,
+            "freshness": self._view_freshness,
         }[view]()
         head = [
             _rule("="),
@@ -291,6 +299,41 @@ class HubConsole:
         ]
         lines.extend(_record_header())
         lines.extend(_record_line(rec) for rec in safe)
+        return lines
+
+    def _view_freshness(self) -> List[str]:
+        """T9: the HITL surface of the registry freshness invariant — the
+        eject-candidates (ttl-expired / upstream-abandoned / -compromised)
+        plus every record's freshness fields. Ejection is a HITL decision:
+        re-validate (re-derive / new intake verdict) or eject via the
+        record's rollback recipe — the console never auto-ejects."""
+        candidates = self.registry.eject_candidates(self.today)
+        scope = (
+            f"today: {self.today}"
+            if self.today
+            else "no --today: ttl-expiry not evaluated; upstream flags only"
+        )
+        lines = [
+            f" freshness — eject-candidates: {len(candidates)}  ({scope})",
+            _rule(),
+        ]
+        for cand in candidates:
+            lines.append(f"   ! {cand['id']:<28} {cand['reason']}")
+        if candidates:
+            lines.append(
+                "   -> HITL: re-validate (re-derive / new intake verdict) or eject"
+            )
+            lines.append("      via the record's rollback recipe. Never auto-ejected.")
+        lines.append(_rule())
+        lines.append(
+            f"  {'id':<28} {'ttl':<12} {'last_validated':<15} upstream_status"
+        )
+        lines.append("  " + _rule()[:76])
+        for rec in self.registry.records():
+            lines.append(
+                f"  {rec.id:<28} {rec.ttl or '-':<12} "
+                f"{rec.last_validated or '-':<15} {rec.upstream_status}"
+            )
         return lines
 
     # -------------------------------------------------------------- selection
@@ -436,13 +479,14 @@ _USAGE = """\
 MAOS Hub console (T3) — render registry views / write the enablement profile.
 
 usage:
-  console.py view <name> [--repo-root P] [--as-of DATE] [--html OUT.html]
+  console.py view <name> [--repo-root P] [--as-of DATE] [--today DATE] [--html OUT.html]
                   [--signals COMPASS.json]   # work-compass --json snapshot (T4 ranking)
   console.py select --ids a,b,c [--mode enforce|advisory] [--write PROFILE.yaml] [--confirm]
   console.py --safe-mode            # shortcut for: view safe-mode
   console.py --help
 
-views: preset | category | use-case | context-aware | prose-intent | safe-mode
+views: preset | category | use-case | context-aware | prose-intent | safe-mode | freshness
+       (freshness: --today YYYY-MM-DD evaluates ttl-expiry; upstream flags always shown)
 
 Selection is conflict-checked against BOTH edge sources (curated
 conflicts.yaml UNION per-record conflicts_with), fail-closed
@@ -454,19 +498,23 @@ registry TOOL ids emit `warning: enforce_profile_gates_operations`.
 
 
 def _build_console(
-    repo_root: Path, as_of: str, signals: Sequence[str] = ()
+    repo_root: Path,
+    as_of: str,
+    signals: Sequence[str] = (),
+    today: Optional[str] = None,
 ) -> HubConsole:
     registry = HubRegistry.derive(repo_root, as_of=as_of)
     recipes = load_recipe_catalog(
         repo_root / "mcp-tools" / "maos-mcp-hub" / "lib" / "gateway" / "recipes.yaml"
     )
-    return HubConsole(registry, recipes, signals=signals)
+    return HubConsole(registry, recipes, signals=signals, today=today)
 
 
 def _main(argv: List[str]) -> int:
     here = Path(__file__).resolve()
     repo_root = here.parents[4]  # lib/registry/x.py -> lib -> maos-mcp-hub -> mcp-tools -> ROOT
     as_of = "1970-01-01"
+    today: Optional[str] = None
     args = list(argv)
     if not args or "--help" in args or "-h" in args:
         print(_USAGE)
@@ -490,6 +538,8 @@ def _main(argv: List[str]) -> int:
             repo_root = Path(args.pop(0)).resolve()
         elif a == "--as-of" and args:
             as_of = args.pop(0)
+        elif a == "--today" and args:
+            today = args.pop(0)
         elif a == "--html" and args:
             html_out = Path(args.pop(0))
         elif a == "--signals" and args:
@@ -518,7 +568,7 @@ def _main(argv: List[str]) -> int:
     if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson, T1)
         print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
         return 1
-    console = _build_console(repo_root, as_of, signals=signals)
+    console = _build_console(repo_root, as_of, signals=signals, today=today)
 
     if cmd == "view":
         if view_name not in VIEWS:

--- a/mcp-tools/maos-mcp-hub/lib/registry/console.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/console.py
@@ -67,7 +67,13 @@ import yaml
 # `python3 lib/registry/console.py …` has no parent package — inject the hub
 # dir so `lib.*` absolute imports resolve).
 try:  # pragma: no cover - import plumbing
-    from .hub_registry import ACTIVATION_TIERS, HubRecord, HubRegistry, _flatten_stack
+    from .hub_registry import (
+        ACTIVATION_TIERS,
+        HubRecord,
+        HubRegistry,
+        _flatten_stack,
+        _valid_iso_date,
+    )
     from .context_rank import load_signals_file, render_ranking
     from .context_rank import rank as rank_by_signals
     from ..gateway.profile import PROFILE_MODES, HubProfile, validate_profile
@@ -80,6 +86,7 @@ except ImportError:  # pragma: no cover
         HubRecord,
         HubRegistry,
         _flatten_stack,
+        _valid_iso_date,
     )
     from lib.registry.context_rank import load_signals_file, render_ranking  # type: ignore
     from lib.registry.context_rank import rank as rank_by_signals  # type: ignore
@@ -567,6 +574,13 @@ def _main(argv: List[str]) -> int:
 
     if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson, T1)
         print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
+        return 1
+    try:  # validate date inputs at the boundary (Qodo #1/#2, T9 fix-PDCA)
+        as_of = _valid_iso_date(as_of, "--as-of")
+        if today is not None:
+            today = _valid_iso_date(today, "--today")
+    except ValueError as exc:
+        print(json.dumps({"verdict": "fail", "error": str(exc)}))
         return 1
     console = _build_console(repo_root, as_of, signals=signals, today=today)
 

--- a/mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py
@@ -28,7 +28,9 @@ Spec scenarios implemented as CHECKABLE fields (the DoD-gate — no prose):
   - "two conductors selected"      → the ``conflicts_with`` graph round-trips
     ``conflicts.yaml`` exactly (``report().invariants.conflicts_roundtrip``).
   - "upstream goes stale/abandoned" → ``eject_candidates(today)`` flags records
-    whose ``ttl`` deadline has passed (the GSD/MemPalace lesson).
+    whose ``ttl`` re-validation deadline has passed OR whose upstream is
+    flagged abandoned/compromised (the GSD/MemPalace lesson) — surfaced for
+    HITL, never auto-ejected (T9 / WAVE 6).
 
 Deterministic activation derivation (documented, fail-closed):
 
@@ -51,6 +53,7 @@ import json
 import re
 import sys
 from dataclasses import dataclass, field
+from datetime import date, timedelta
 from pathlib import Path
 from typing import Any, Dict, FrozenSet, Iterable, List, Optional, Set, Tuple
 
@@ -77,6 +80,24 @@ CONFLICT_ALIASES = {
     "bmad-as-co-runtime": "bmad-method",
 }
 
+#: First-party re-validation cadence (days). Own tools are re-derived from
+#: the live checkout every build (derivation IS validation), so the ttl
+#: guards the SNAPSHOT: a registry not re-derived within the cadence goes
+#: eject-candidate. 90 days = the ttl-policy skill's "Protocol/Standard"
+#: tier (skills/ttl-policy/SKILL.md).
+OWN_TTL_DAYS = 90
+
+#: Upstream-health flags (intake-fixture vocabulary) → ``upstream_status``.
+#: Exact-match, checkable — the spec's "flagged abandoned/compromised"
+#: branch (T9). Live examples: gsd-build-get-shit-done carries
+#: rug-pull-confirmed; awesome-design-tools carries stale.
+_COMPROMISED_FLAGS = frozenset(
+    {"compromised", "malware", "rug-pull-confirmed", "live-threat-npm-keys"}
+)
+_ABANDONED_FLAGS = frozenset(
+    {"abandoned", "stale", "archived", "deprecated", "404-not-resolving"}
+)
+
 _OWN_REPO = "ekson73/multi-agent-os"
 _OWN_LICENSE = "MIT"
 _FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.S)
@@ -100,12 +121,16 @@ class HubRecord:
     activation: str
     license_spdx: str
     provenance: str
-    ttl: Optional[str]            # deadline date (ISO) after which re-validation is due
+    # ``ttl`` stores the precomputed re-validation DEADLINE (ISO date =
+    # last_validated + cadence) — the deadline realization of the spec's
+    # ``now - last_validated > ttl`` (ttl-as-period) scenario.
+    ttl: Optional[str]
     last_validated: Optional[str]
     rollback: str
     security_status: str
     derived_from: str             # provenance of the DERIVATION itself (checkable)
     activation_reason: str = ""   # why the tier was capped/granted (logged field)
+    upstream_status: str = "active"  # active | abandoned | compromised (T9 freshness branch 2)
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -129,6 +154,7 @@ class HubRecord:
             "security_status": self.security_status,
             "derived_from": self.derived_from,
             "activation_reason": self.activation_reason,
+            "upstream_status": self.upstream_status,
         }
 
 
@@ -156,6 +182,12 @@ def _flatten_stack(stack: Iterable[Any]) -> List[str]:
         else:
             out.append(str(item))
     return out
+
+
+def _ttl_deadline(last_validated: str, days: int) -> str:
+    """Deadline realization of the spec's ``now - last_validated > ttl``:
+    the stored ``ttl`` IS the precomputed re-validation deadline."""
+    return (date.fromisoformat(last_validated) + timedelta(days=days)).isoformat()
 
 
 class HubRegistry:
@@ -242,7 +274,7 @@ class HubRegistry:
                     activation="default-on-for-context",
                     license_spdx=_OWN_LICENSE,
                     provenance=f"repo:{_OWN_REPO}@{rel}",
-                    ttl=None,
+                    ttl=_ttl_deadline(as_of, OWN_TTL_DAYS),
                     last_validated=as_of,
                     rollback="git revert the introducing commit; plugin re-install",
                     security_status="first-party",
@@ -281,7 +313,7 @@ class HubRegistry:
                     activation="opt-in",
                     license_spdx=_OWN_LICENSE,
                     provenance=f"repo:{_OWN_REPO}@{rel}",
-                    ttl=None,
+                    ttl=_ttl_deadline(as_of, OWN_TTL_DAYS),
                     last_validated=as_of,
                     rollback="git revert the introducing commit; plugin re-install",
                     security_status="first-party",
@@ -309,6 +341,13 @@ class HubRegistry:
             edges = tuple(sorted(conflicts.get(tid, ())))
             activation, reason = self._third_party_activation(tid, verdict, license_spdx, edges)
             flags = [str(f) for f in entry.get("flags", [])]
+            flag_set = set(flags)
+            if flag_set & _COMPROMISED_FLAGS:
+                upstream = "compromised"
+            elif flag_set & _ABANDONED_FLAGS:
+                upstream = "abandoned"
+            else:
+                upstream = "active"
             if entry.get("blocked") or verdict == "EXCLUDED":
                 security = "supply-chain-veto"
             elif "license-none" in flags:
@@ -338,6 +377,7 @@ class HubRegistry:
                     security_status=security,
                     derived_from=rel,
                     activation_reason=reason,
+                    upstream_status=upstream,
                 )
             )
 
@@ -442,12 +482,29 @@ class HubRegistry:
         )
         return decision
 
-    def eject_candidates(self, today: str) -> List[str]:
-        """Freshness invariant: ttl deadline passed → eject-candidate (HITL)."""
-        out = []
+    def eject_candidates(self, today: Optional[str] = None) -> List[Dict[str, str]]:
+        """Freshness invariant (spec Requirement: Freshness + rollback, T9).
+
+        A record is an eject-candidate WHEN its ``ttl`` re-validation
+        deadline has passed (``today > ttl`` — the deadline realization of
+        ``now - last_validated > ttl``) OR its upstream is flagged
+        abandoned/compromised (date-independent — evaluated even without
+        ``today``). Candidates are SURFACED for HITL, never auto-ejected:
+        ejection is destructive, so the human decides — re-validate (a new
+        derivation / intake verdict) or eject via the record's ``rollback``.
+        """
+        out: List[Dict[str, str]] = []
         for rec in self.records():
-            if rec.ttl and today > rec.ttl:
-                out.append(rec.id)
+            if rec.upstream_status in ("abandoned", "compromised"):
+                out.append({"id": rec.id, "reason": f"upstream-{rec.upstream_status}"})
+            elif today and rec.ttl and today > rec.ttl:
+                out.append({
+                    "id": rec.id,
+                    "reason": (
+                        f"ttl-expired (ttl={rec.ttl}, "
+                        f"last_validated={rec.last_validated})"
+                    ),
+                })
         return out
 
     # ------------------------------------------------------------ outputs ---
@@ -472,6 +529,9 @@ class HubRegistry:
             bool(r.id) and bool(r.provenance) and bool(r.derived_from)
             and bool(r.activation) and bool(r.license_spdx) and bool(r.rollback)
             and bool(r.security_status) and bool(r.category)
+            # T9: "Every record SHALL carry a ttl + last_validated" (spec
+            # Requirement: Freshness + rollback) — presence enforced here.
+            and bool(r.ttl) and bool(r.last_validated)
             for r in recs
         )
         vocab_ok = all(r.activation in ACTIVATION_TIERS for r in recs)
@@ -491,8 +551,9 @@ class HubRegistry:
             "third_party_always_on": third_party_always_on,
             "id_collisions": list(self._collisions),
         }
-        if today:
-            invariants["eject_candidates"] = self.eject_candidates(today)
+        # Always present (T9): the upstream-abandoned/compromised branch is
+        # date-independent; the ttl branch additionally needs ``today``.
+        invariants["eject_candidates"] = self.eject_candidates(today)
         ok = (
             required_ok and vocab_ok and roundtrip
             and not third_party_always_on and not cross_category_collisions

--- a/mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py
+++ b/mcp-tools/maos-mcp-hub/lib/registry/hub_registry.py
@@ -190,6 +190,19 @@ def _ttl_deadline(last_validated: str, days: int) -> str:
     return (date.fromisoformat(last_validated) + timedelta(days=days)).isoformat()
 
 
+def _valid_iso_date(value: str, field: str) -> str:
+    """Parse-validate a date CLI input; returns the CANONICAL zero-padded
+    ISO form (so downstream date handling is unambiguous). Raises
+    ``ValueError`` with the offending field name on malformed input —
+    CLI layers convert that into their JSON fail contract (Qodo #1/#2)."""
+    try:
+        return date.fromisoformat(value).isoformat()
+    except ValueError as exc:
+        raise ValueError(
+            f"{field} must be an ISO date (YYYY-MM-DD), got: {value!r}"
+        ) from exc
+
+
 class HubRegistry:
     """Plugin-level registry derived from the repo's own sources of truth."""
 
@@ -494,10 +507,24 @@ class HubRegistry:
         derivation / intake verdict) or eject via the record's ``rollback``.
         """
         out: List[Dict[str, str]] = []
+        # Dates compared as date OBJECTS, never raw strings (Copilot/Qodo #2:
+        # non-zero-padded inputs would silently mis-order). ``today`` raises
+        # ValueError on malformed input — the CLI layers validate first.
+        today_d = date.fromisoformat(today) if today else None
         for rec in self.records():
             if rec.upstream_status in ("abandoned", "compromised"):
                 out.append({"id": rec.id, "reason": f"upstream-{rec.upstream_status}"})
-            elif today and rec.ttl and today > rec.ttl:
+                continue
+            if today_d is None or not rec.ttl:
+                continue
+            try:
+                ttl_d = date.fromisoformat(rec.ttl)
+            except ValueError:
+                # Fail-closed: an unparseable deadline cannot prove freshness
+                # — surface it for HITL instead of silently skipping.
+                out.append({"id": rec.id, "reason": f"ttl-unparseable (ttl={rec.ttl})"})
+                continue
+            if today_d > ttl_d:
                 out.append({
                     "id": rec.id,
                     "reason": (
@@ -618,6 +645,13 @@ def _main(argv: List[str]) -> int:
             today = args.pop(0)
     if not (repo_root / "skills").is_dir():  # empirical root check (Qodo lesson)
         print(json.dumps({"verdict": "fail", "error": f"not a repo root: {repo_root}"}))
+        return 1
+    try:  # validate date inputs at the boundary (Qodo #1: no raw tracebacks)
+        as_of = _valid_iso_date(as_of, "--as-of")
+        if today is not None:
+            today = _valid_iso_date(today, "--today")
+    except ValueError as exc:
+        print(json.dumps({"verdict": "fail", "error": str(exc)}))
         return 1
     reg = HubRegistry.derive(repo_root, as_of=as_of)
     report = reg.report(today=today)

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
@@ -292,6 +292,21 @@ def test_cli_freshness_view_accepts_today(tmp_path: Path) -> None:
     assert "upstream-compromised" in out.stdout    # the live GSD row fires
 
 
+def test_cli_rejects_malformed_today_with_json_fail(tmp_path: Path) -> None:
+    """T9 fix-PDCA (Qodo #1/#2): malformed --today on the console CLI yields
+    the JSON fail contract (never a raw traceback / silent mis-order)."""
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    out = subprocess.run(
+        [sys.executable, str(script), "view", "freshness",
+         "--repo-root", str(_REPO_ROOT), "--today", "2026-7-1"],
+        capture_output=True, text=True,
+    )
+    assert out.returncode == 1
+    payload = json.loads(out.stdout.splitlines()[-1])
+    assert payload["verdict"] == "fail"
+    assert "ISO date" in payload["error"]
+
+
 def test_cli_help_flag(tmp_path: Path) -> None:
     script = _HUB_DIR / "lib" / "registry" / "console.py"
     out = subprocess.run([sys.executable, str(script), "--help"],

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_console.py
@@ -30,7 +30,7 @@ def _mk_record(rid: str, **kw) -> HubRecord:
         id=rid, owner_repo="acme/tools", layer="L2", role="r", category="skill",
         harness_coverage=(), requires=(), conflicts_with=(), guardrails="g",
         impact="i", recipes=(), activation="opt-in", license_spdx="MIT",
-        provenance="p", ttl=None, last_validated="2026-07-02",
+        provenance="p", ttl="2026-12-31", last_validated="2026-07-02",
         rollback="rb", security_status="vetted", derived_from="d",
     )
     base.update(kw)
@@ -148,6 +148,37 @@ def test_golden_safe_mode_fixture(console: HubConsole) -> None:
     ]
 
 
+def test_freshness_view_surfaces_eject_candidates(recipes: list) -> None:
+    """T9 acceptance: the freshness view is the HITL surface — candidates
+    rendered with reasons; ejection is never automatic."""
+    reg = HubRegistry()
+    reg._add(_mk_record("fresh-one", ttl="2027-01-01"))
+    reg._add(_mk_record("stale-one", ttl="2026-01-01"))
+    reg._add(_mk_record("pwned-one", upstream_status="compromised",
+                        category="third-party"))
+    console = HubConsole(reg, recipes, today="2026-07-10")
+    out = console.render("freshness")
+    assert "eject-candidates: 2" in out
+    assert "! stale-one" in out and "ttl-expired" in out
+    assert "! pwned-one" in out and "upstream-compromised" in out
+    assert "fresh-one" in out                      # the full table still lists it
+    assert "Never auto-ejected" in out             # the HITL posture, stated
+    assert console.render("freshness") == console.render("freshness")  # byte-stable
+
+
+def test_freshness_view_without_today_is_upstream_only(recipes: list) -> None:
+    """Without --today the ttl branch is NOT evaluated (and says so);
+    the date-independent upstream branch still fires."""
+    reg = HubRegistry()
+    reg._add(_mk_record("stale-one", ttl="2026-01-01"))
+    reg._add(_mk_record("ghost-one", upstream_status="abandoned"))
+    console = HubConsole(reg, recipes)             # no today
+    out = console.render("freshness")
+    assert "eject-candidates: 1" in out
+    assert "! ghost-one" in out and "upstream-abandoned" in out
+    assert "ttl-expiry not evaluated" in out
+
+
 def test_html_artifact_wraps_ascii(console: HubConsole) -> None:
     html = console.render_html("category")
     assert html.startswith("<!DOCTYPE html>")
@@ -244,6 +275,21 @@ def test_cli_view_renders_and_select_gates(tmp_path: Path) -> None:
     assert payload["written"] is False
     assert payload["reason"] == "confirmation_required"
     assert not (tmp_path / "p.yaml").exists()
+
+
+def test_cli_freshness_view_accepts_today(tmp_path: Path) -> None:
+    """CLI smoke over the LIVE repo (T9): --today flows to the freshness
+    view; the live intake fixture's compromised upstream (GSD) surfaces."""
+    script = _HUB_DIR / "lib" / "registry" / "console.py"
+    out = subprocess.run(
+        [sys.executable, str(script), "view", "freshness",
+         "--repo-root", str(_REPO_ROOT), "--as-of", "2026-07-02",
+         "--today", "2026-07-10"],
+        capture_output=True, text=True, check=True,
+    )
+    assert "view: freshness" in out.stdout
+    assert "today: 2026-07-10" in out.stdout
+    assert "upstream-compromised" in out.stdout    # the live GSD row fires
 
 
 def test_cli_help_flag(tmp_path: Path) -> None:

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registry.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registry.py
@@ -156,15 +156,88 @@ def test_license_classified_never_assumed(registry: HubRegistry) -> None:
 
 # --- Requirement: Freshness + rollback ---------------------------------------
 
+# Live-fixture upstream-health rows (T9, scenario branch 2): the intake flags
+# rug-pull-confirmed / stale / 404-not-resolving map to upstream_status.
+_UPSTREAM_FLAGGED = {
+    "gsd-build-get-shit-done": "upstream-compromised",
+    "awesome-design-tools": "upstream-abandoned",
+    "forrestchang-andrej-karpathy-skills": "upstream-abandoned",
+}
+
+
 def test_scenario_upstream_goes_stale(registry: HubRegistry) -> None:
-    """Scenario: now - last_validated > ttl -> eject-candidate."""
-    fresh = registry.eject_candidates("2026-08-01")   # before revisit 2026-09-27
-    stale = registry.eject_candidates("2026-12-01")   # after revisit
-    third = [r.id for r in registry.records() if r.category == "third-party"]
-    assert fresh == []
-    assert set(stale) == set(third)                   # every fixture record shares the TTL
+    """Scenario branch 1: now - last_validated > ttl -> eject-candidate
+    (``ttl`` stored as the precomputed re-validation deadline)."""
+    fresh = registry.eject_candidates("2026-08-01")   # before every deadline
+    stale = registry.eject_candidates("2026-12-01")   # after 2026-09-27 (3p) + as_of+90d (own)
+    # Before any deadline: only the date-independent upstream-flagged rows.
+    assert {c["id"]: c["reason"] for c in fresh} == _UPSTREAM_FLAGGED
+    # After every deadline: EVERY record is stale — own records included (the
+    # snapshot itself went past its OWN_TTL_DAYS re-validation cadence).
+    all_ids = {r.id for r in registry.records()}
+    assert {c["id"] for c in stale} == all_ids
+    ttl_reasons = [c["reason"] for c in stale if c["id"] not in _UPSTREAM_FLAGGED]
+    assert ttl_reasons and all(r.startswith("ttl-expired") for r in ttl_reasons)
     report = registry.report(today="2026-12-01")
-    assert set(report["invariants"]["eject_candidates"]) == set(third)
+    assert {c["id"] for c in report["invariants"]["eject_candidates"]} == all_ids
+
+
+def test_scenario_upstream_flagged_abandoned_or_compromised(registry: HubRegistry) -> None:
+    """Scenario branch 2 (T9): upstream flagged abandoned/compromised ->
+    eject-candidate, date-INDEPENDENT (no ``today`` needed) — the
+    GSD/MemPalace lesson firing on the live fixture."""
+    candidates = {c["id"]: c["reason"] for c in registry.eject_candidates()}
+    assert candidates == _UPSTREAM_FLAGGED
+    for rid, reason in _UPSTREAM_FLAGGED.items():
+        assert registry.get(rid).upstream_status == reason.split("-", 1)[1]
+    # report() surfaces them even WITHOUT today (always-present invariant)
+    report = registry.report()
+    surfaced = {c["id"] for c in report["invariants"]["eject_candidates"]}
+    assert surfaced == set(_UPSTREAM_FLAGGED)
+
+
+def test_every_record_carries_ttl_and_last_validated(registry: HubRegistry) -> None:
+    """Spec (T9): 'Every record SHALL carry a ttl + last_validated' —
+    first-party records get the OWN_TTL_DAYS deadline (as_of + 90d), and
+    presence is enforced by the all_required_fields_present invariant."""
+    for rec in registry.records():
+        assert rec.ttl, rec.id
+        assert rec.last_validated, rec.id
+    own = next(r for r in registry.records() if r.category == "skill")
+    assert own.ttl == "2026-09-30"          # AS_OF 2026-07-02 + 90 days
+    assert registry.report()["invariants"]["all_required_fields_present"] is True
+
+
+def test_stale_golden_fixture_synthetic_repo(tmp_path: Path) -> None:
+    """tasks.md T9 acceptance: 'a stale fixture is flagged + the registry
+    marks it for ejection' — golden synthetic intake fixture."""
+    (tmp_path / "skills").mkdir()
+    (tmp_path / "agents").mkdir()
+    fx = tmp_path / "mcp-tools" / "maos-mcp-hub" / "evals" / "fixtures"
+    fx.mkdir(parents=True)
+    (fx / "intake_verdicts.yaml").write_text(
+        "decided: '2026-01-01'\n"
+        "revisit: '2026-03-01'\n"
+        "entries:\n"
+        "  - {id: healthy, repo: a/h, layer: L2, role: r, license: MIT,\n"
+        "     verdict: INSTALL, flags: [], conditions: [], rationale: ok}\n"
+        "  - {id: ghosted, repo: a/g, layer: L2, role: r, license: MIT,\n"
+        "     verdict: INSTALL, flags: [abandoned], conditions: [], rationale: gone}\n"
+        "  - {id: pwned, repo: a/p, layer: L2, role: r, license: MIT,\n"
+        "     verdict: EXCLUDED, blocked: true, flags: [compromised],\n"
+        "     conditions: [], rationale: rug-pull}\n",
+        encoding="utf-8",
+    )
+    reg = HubRegistry.derive(tmp_path, as_of="2026-01-01")
+    # date-independent: the flagged upstreams are marked immediately
+    assert {c["id"]: c["reason"] for c in reg.eject_candidates()} == {
+        "ghosted": "upstream-abandoned",
+        "pwned": "upstream-compromised",
+    }
+    # past the revisit deadline: the healthy record goes ttl-stale too
+    stale = {c["id"]: c["reason"] for c in reg.eject_candidates("2026-06-01")}
+    assert stale["healthy"].startswith("ttl-expired")
+    assert set(stale) == {"healthy", "ghosted", "pwned"}
 
 
 def test_every_record_has_rollback(registry: HubRegistry) -> None:
@@ -220,7 +293,7 @@ def _mk_record(rid: str, category: str, **kw) -> HubRecord:
         id=rid, owner_repo="x/y", layer="L2", role="r", category=category,
         harness_coverage=(), requires=(), conflicts_with=(), guardrails="",
         impact="", recipes=(), activation="opt-in", license_spdx="MIT",
-        provenance="p", ttl=None, last_validated="2026-07-02",
+        provenance="p", ttl="2026-12-31", last_validated="2026-07-02",
         rollback="rb", security_status="vetted", derived_from="d",
     )
     base.update(kw)

--- a/mcp-tools/maos-mcp-hub/tests/test_hub_registry.py
+++ b/mcp-tools/maos-mcp-hub/tests/test_hub_registry.py
@@ -286,6 +286,33 @@ def test_cli_contract() -> None:
     assert payload["verdict"] == "pass"
 
 
+def test_cli_rejects_malformed_dates_with_json_fail() -> None:
+    """T9 fix-PDCA (Qodo #1): a malformed --as-of/--today yields the JSON
+    fail contract (never a raw traceback)."""
+    for extra in (["--as-of", "2026-7-1"],
+                  ["--as-of", AS_OF, "--today", "garbage"]):
+        proc = subprocess.run(
+            [sys.executable, "-m", "lib.registry.hub_registry",
+             "--repo-root", str(_REPO_ROOT), *extra],
+            cwd=_HUB_DIR, capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 1, extra
+        payload = json.loads(proc.stdout)
+        assert payload["verdict"] == "fail"
+        assert "ISO date" in payload["error"]
+
+
+def test_unparseable_record_ttl_is_flagged_fail_closed() -> None:
+    """T9 fix-PDCA (Qodo/Copilot #2): a record whose ttl cannot parse is
+    SURFACED as an eject-candidate (fail-closed), never silently skipped —
+    and dates are compared as date objects, not raw strings."""
+    reg = HubRegistry()
+    reg._add(_mk_record("weird", "skill", ttl="soon"))
+    assert reg.eject_candidates("2026-01-01") == [
+        {"id": "weird", "reason": "ttl-unparseable (ttl=soon)"}
+    ]
+
+
 # --- PR #209 bot-finding regressions (fix/T1-registry-bot-findings) ----------
 
 def _mk_record(rid: str, category: str, **kw) -> HubRecord:

--- a/openspec/changes/maos-hub-console/tasks.md
+++ b/openspec/changes/maos-hub-console/tasks.md
@@ -42,9 +42,14 @@
   changelog (adopt/adapt/reject + justification) + credit/license (`co-author-standard` +
   `THIRD_PARTY_NOTICES`) + the fallback commit. *Acceptance: a planted-malicious fixture is
   blocked by the floor; the agent never auto-accepts; all artifacts generated.*
-- [ ] **T9 `feature/<id>-ttl-freshness`** — every integration carries a TTL + re-validation cadence;
+- [x] **T9 `feature/<id>-ttl-freshness`** — every integration carries a TTL + re-validation cadence;
   stale/abandoned/compromised upstream auto-flag + eject. *Acceptance: a stale fixture is flagged + the
-  registry marks it for ejection.*
+  registry marks it for ejection.* **Delivered 2026-07-10** — every record carries `ttl`
+  (first-party = `as_of + 90d`, the ttl-policy Protocol/Standard cadence) + `last_validated`
+  (presence enforced by `all_required_fields_present`); `upstream_status` derived from intake
+  flags (`rug-pull-confirmed`/`stale`/`404-not-resolving` …) fires the date-independent
+  abandoned/compromised branch; `eject_candidates()` returns `{id, reason}` surfaced in
+  `report()` + the new console `freshness` view (HITL — never auto-ejected).
 - [ ] **T10 `feature/<id>-hardened-distributor`** — MAOS-as-distributor hardening: signed releases +
   SBOM + provenance. *Acceptance: release carries signature + SBOM.*
 

--- a/openspec/specs/maos-hub-registry/spec.md
+++ b/openspec/specs/maos-hub-registry/spec.md
@@ -16,7 +16,9 @@ it, and the integrator can grow it.
 Each record SHALL carry: `id` · `owner/repo` · `layer (L0–L9)` · `role (substrate|knowledge|pipeline|
 amplifier)` · `category` · `harness_coverage[]` · `requires[]` · `conflicts_with[]` · `guardrails` ·
 `impact` · `recipes[]` (use-cases) · **`activation`** ∈ {always-on, default-on-for-context, opt-in,
-excluded} · `license_spdx` · `provenance` (source + pin + SBOM ref) · `ttl` (+ last_validated) ·
+excluded} · `license_spdx` · `provenance` (source + pin + SBOM ref) · `ttl` (+ last_validated; `ttl`
+is stored as the precomputed re-validation DEADLINE, ISO date = last_validated + cadence — the
+deadline realization of the "now - last_validated > ttl" scenario) ·
 `rollback` (revert/uninstall recipe) · `security_status`.
 
 ## Requirements

--- a/research/agentic-moe-2026/README.md
+++ b/research/agentic-moe-2026/README.md
@@ -55,7 +55,8 @@ CTS scorer, memória mem0, OTel, model-router, registry, eval) — cada item em 
 | 5 | T4 context-aware ranking v1 (work-compass signals · byte-stable · why emitido) | ADR-007 | 🟢 merged (2026-07-02) | [#215](https://github.com/ekson73/multi-agent-os/pull/215) |
 | 5 | T5 prose-intent engine (entrevista ≤3 Qs · mapping mostrado · DRAFT nunca auto-aplica) | ADR-007 | 🟢 merged (2026-07-02) | [#216](https://github.com/ekson73/multi-agent-os/pull/216) |
 | 5 | T6 activation-karpathy (`skills/deliberate-coding` first-party · upstream capped opt-in HF2) | ADR-006 | 🟢 merged (2026-07-02) | [#217](https://github.com/ekson73/multi-agent-os/pull/217) |
-| 6 | T9 ttl-freshness → T8 gatekeeper-core → T7 slot-adapter (on-first-vendored-use) — ordem por utilidade interna | ADR-007 (Amendment 2026-07-10) | 🟡 destravada per-tile (gate: consumidor interno nomeado + 7 guardrails + HITL por tile; piso CI WAVE-0 ✅ verde 2026-07-10; demand-gate #183 retirado — post vira divulgação opcional) | — |
+| 6 | T9 ttl-freshness (ttl em TODO record `as_of+90d` first-party · `upstream_status` abandoned/compromised auto-flag das flags do intake · `eject_candidates` `{id, reason}` · console view `freshness` + `--today` — HITL, nunca auto-eject) | ADR-007 (Amendment 2026-07-10) | 🟢 merged (2026-07-10) | [#238](https://github.com/ekson73/multi-agent-os/pull/238) |
+| 6 | T8 gatekeeper-core → T7 slot-adapter (on-first-vendored-use) — ordem por utilidade interna | ADR-007 (Amendment 2026-07-10) | 🟡 destravada per-tile (gate: consumidor interno nomeado + 7 guardrails + HITL por tile; piso CI WAVE-0 ✅ verde 2026-07-10; demand-gate #183 retirado — post vira divulgação opcional) | — |
 | 6 | T10 hardened-distributor | ADR-007 | ⏸ DEFERRED (LOW-MED utilidade interna; slice mínimo = SBOM no release CI quando existir canal de release) | — |
 
 Tracking do restante: [issue #204](https://github.com/ekson73/multi-agent-os/issues/204) (Waves 4–6); contratos em


### PR DESCRIPTION
**[PR-as-Prompt]** — WAVE 6 · T9 ttl-freshness (first tile under the ADR-007 Amendment per-tile gate)

## Context

The registry spec (`openspec/specs/maos-hub-registry/spec.md`, Requirement **Freshness + rollback**) demands: every record SHALL carry `ttl` + `last_validated` + `rollback`; WHEN `now - last_validated > ttl` OR the upstream is flagged abandoned/compromised THEN the record is marked `eject-candidate` and surfaced to HITL (the GSD/MemPalace lesson). T1 shipped only half of this: `ttl` existed as a field (null on first-party records) and `eject_candidates(today)` covered only the ttl branch. **The spec'd-but-unenforced field was exactly the theater T9 exists to close.**

Per-tile entry criteria (ADR-007 Amendment 2026-07-10, `febd352`): **named internal consumer today** = the T1 registry + T3 console + the live intake fixture (which already carries the branch-2 signals: `rug-pull-confirmed` on GSD, `stale` on awesome-design-tools, `404-not-resolving` on the excluded fork) · 7 guardrails · HITL per tile (this PR).

## Objectives

1. **Every record carries `ttl` + `last_validated`** — first-party records get `as_of + OWN_TTL_DAYS (90)` (the ttl-policy skill's Protocol/Standard cadence: an un-re-derived registry snapshot IS stale); presence is enforced by the `all_required_fields_present` invariant (fail-closed: a fixture without `revisit` now fails the report verdict).
2. **Scenario branch 2** — new `upstream_status` field (`active | abandoned | compromised`) derived from intake-fixture flags via exact-match sets; date-independent (evaluated even without `--today`).
3. **Marked + surfaced to HITL** — `eject_candidates()` returns `{id, reason}` for both branches; always present in `report().invariants`; new console **`freshness` view** (7th) + CLI `--today` renders candidates with reasons + per-record freshness fields. Candidates are **never auto-ejected** — ejection is destructive, the human decides (re-validate via re-derivation/new intake verdict, or eject via the record's `rollback` recipe).
4. **Determinism preserved** — `today` is an explicit parameter, never the wall clock (byte-stable views, golden-fixture tested).

## Acceptance (DoD-gate — logged fields / golden fixtures, no prose)

- [x] tasks.md T9: *"a stale fixture is flagged + the registry marks it for ejection"* → `test_stale_golden_fixture_synthetic_repo` (synthetic intake fixture: healthy/ghosted/pwned).
- [x] Scenario branch 1 (`ttl` deadline) → `test_scenario_upstream_goes_stale` (live fixture; own records go stale past `as_of+90d` too).
- [x] Scenario branch 2 (abandoned/compromised) → `test_scenario_upstream_flagged_abandoned_or_compromised` — fires on the LIVE fixture rows (GSD = `upstream-compromised`).
- [x] "Every record SHALL carry a ttl" → `test_every_record_carries_ttl_and_last_validated`.
- [x] HITL surface → `test_freshness_view_surfaces_eject_candidates` + `test_freshness_view_without_today_is_upstream_only` + `test_cli_freshness_view_accepts_today` (live GSD row rendered).
- [x] Hub suite **388 passed** (382 baseline + 6 new) · `validate-plugin.sh` PASSED · gitleaks clean.

## Risk + rollback

Additive schema (spec field-set is a floor; `upstream_status` defaults `active`). One deliberate API evolution: `eject_candidates` now returns `List[{id, reason}]` (was `List[str]`) — consumers verified in-repo only (report + tests, both updated). `report()` verdict is UNAFFECTED by eject-candidates (surface, not build-fail). Rollback: `git revert` the squash commit.

## Cross-links

Ticket: #204 (WAVE 6 T9) · ADR-006 / ADR-007 (+Amendment 2026-07-10 `febd352`) · spec `openspec/specs/maos-hub-registry/spec.md` · consumers: `lib/registry/console.py` (T3) · `skills/ttl-policy/SKILL.md` (cadence SSOT) · session `48c8f27b`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018BZ1gsfkfJVjdcBJbcquMg
