### PR TITLE
feat(postflight): signoff verb + P3.6 continuation-broadcast marker (ADR-010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rug-pull fixture row with safe-successor surfacing) and never-auto-accepts (structural
   vocabulary assert + HITL invariant over a candidate spread) + conductor isolation (live overlay
   + synthetic tmp-repo) + determinism + CLI contract.
+### Added — `signoff` verb + postflight P3.6 BROADCAST: discoverable continuation marker (ADR-010)
+
+- **`commands/signoff.md` + `skills/signoff/SKILL.md`** (`/maos:signoff`, v0.1.0) — the operator's
+  end-of-session **sign-off / encerramento** verb. A thin **OODA-framed** composition
+  (Observe=recon + the complete 10-item hunt · Orient=root-cause + anti-theater + Eisenhower ·
+  Decide=Taxis disposition · Act=drive-to-green + sweep + ticket-sync + seed + **broadcast** +
+  spawn + full git) that reimplements NOTHING — it composes `quiesce` (`--converge`) +
+  `postflight full --broadcast --spawn`, with **BROADCAST default-ON** (the point of a sign-off is
+  to close cleanly *and* leave a discoverable trail). Anima-named (`signoff`; rejected runner-up
+  `disembark`).
+- **`skills/postflight/SKILL.md` v0.7.0 → v0.8.0** — adds **P3.6 BROADCAST** (opt-in `--broadcast`;
+  OFF by default on `postflight`, default-ON in `signoff`) and completes **P2 DEBRIEF's 10-item
+  close-out HUNT** (fails · errors · warnings · risks+mitigations · gaps · pendings ·
+  decisions-not-taken · unasked-Qs · unanswered-Qs; each atom dispositioned fix-now / ticket / seed
+  / drop — no silent drop).
+- **`bin/continuation-broadcast.sh` (v0.2.0) + `bin/tests/continuation-broadcast.test.sh`** — the
+  deterministic P3.6 executor: injects a **bounded, structured, byte-idempotent back-pointer MARKER**
+  (to the P2.5 continuation ticket + P3 seed) into work artifacts — the exit **commit trailer**
+  (`Continue-Here: <key> · seed:<path>`) + the open **PR body** (idempotent upsert via `gh`) under
+  `--scope conservative` (default), plus caller-named **docs/changelogs** under `--scope all`
+  (**ADRs refused**). Guardrails: `--dry-run` default · `MAOS_BROADCAST=0` kill-switch · idempotent
+  upsert (never accumulate) · metadata-only (sanitized) · NOOP when nothing pending · audit-trail.
+  - **v0.2.0 MoE-council security hardening** (adversarial verify pass, verifier>generator): the
+    upsert is **fail-closed** on any malformed/duplicated/out-of-order sentinel state (whole-line
+    matched) so a hand-edited/merge-mangled PR body or doc can **never** be mass-deleted-to-EOF or
+    duplicated; the **seed referent is verified to exist** before emitting (no "promise with no
+    backing" — an unfound `--seed` is dropped, noop if nothing else backs it); the block is
+    **byte-idempotent** (no timestamp → re-apply is a true no-op) and **self-declares stale**;
+    ADR/decision-record refusal is **case-insensitive** + covers MADR `decisions/` + **refuses
+    symlink targets**; payloads carrying a sentinel/comment/newline are refused; `shift 2` arg-guards
+    (no bash-3.2 infinite-loop on a trailing value-flag); `mktemp` fail-closed (no predictable
+    `/tmp`). **20-assertion safety suite** (idempotency · byte-idempotence · dry-run-default ·
+    fail-closed-on-malformed · ADR/MADR/symlink-refusal · payload-injection · unbacked-seed-drop ·
+    kill-switch · sanitize).
+- **`docs/adrs/ADR-010-continuation-broadcast.md`** — reconciles the marker with `exit-hygiene.md`'s
+  anti-breadcrumb rule: a **structured back-pointer ≠ a free-form "fix next session" TODO** — it is
+  exit-hygiene's own *"registered with traceability"* (Axiom 4 + Delegation gate) surfaced at the
+  point of future contact (structured · idempotent · bounded · pointer-only · noop-when-clean).
+- **SSOTs**: `skills/postflight/references/continuation-broadcast-protocol.md` (marker shape/sinks/
+  guardrails) + `skills/postflight/references/close-out-hunt-checklist.md` (the 10-item hunt +
+  disposition rubric). **`continuation-seed-contract.md` v1.1.0 → v1.2.0** — 1 new OPTIONAL field
+  `risks` (`{risk, mitigation, severity?}`), the seed home for the hunt's forward-looking half.
+- **`tests/validate-plugin.sh`** — new validation block (broadcast script exists+executable+
+  dry-run-default+kill-switch · test-suite green · signoff skill/command frontmatter · SSOT docs).
+- DRY: BROADCAST **points at** the P3 seed + P2.5 ticket — it reinvents neither; `signoff` composes
+  `postflight`/`quiesce` — it reimplements neither.
 
 ### Added — WAVE 6 T9: TTL & freshness enforcement (registry + console)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rug-pull fixture row with safe-successor surfacing) and never-auto-accepts (structural
   vocabulary assert + HITL invariant over a candidate spread) + conductor isolation (live overlay
   + synthetic tmp-repo) + determinism + CLI contract.
+
 ### Added — `signoff` verb + postflight P3.6 BROADCAST: discoverable continuation marker (ADR-010)
 
 - **`commands/signoff.md` + `skills/signoff/SKILL.md`** (`/maos:signoff`, v0.1.0) — the operator's

--- a/bin/continuation-broadcast.sh
+++ b/bin/continuation-broadcast.sh
@@ -1,0 +1,310 @@
+#!/usr/bin/env bash
+# /**
+#  * multi-agent-os · bin/continuation-broadcast.sh   (postflight P3.6 — BROADCAST)
+#  * @context End-of-session continuation: postflight P3 emits a continuation SEED and P2.5 files
+#  *          a continuation TICKET. This script BROADCASTS a bounded, structured, idempotent
+#  *          back-pointer MARKER — an *additional discovery sink* of that ONE canonical seed/ticket
+#  *          — into selected work artifacts (the exit commit's trailer, the open PR body, and,
+#  *          only under --scope all, caller-named docs/changelogs) so a fresh amnesic agent that
+#  *          lands on the artifact DISCOVERS there is pending work + where to resume it.
+#  * @reason  The seed/ticket are the SSOT, but a fresh agent opening a commit/PR/doc doesn't know
+#  *          to look for them. The marker makes the tracked continuation *discoverable at the point
+#  *          of future contact* — it is exit-hygiene's "registered with traceability" (Axiom 4 +
+#  *          Delegation gate) surfaced where it will be found. It is NOT a free-form "fix next
+#  *          session" TODO: it is structured, back-pointer-only (duplicates no content), and
+#  *          idempotent (upsert, never append-duplicate). Reconciliation: docs/adrs/ADR-010.
+#  * @impact  Reads/writes ONLY: stdout (the commit-trailer text), the named PR body (via gh,
+#  *          idempotent upsert), and caller-named --file targets (--scope all only; ADRs REFUSED
+#  *          — a decision record is not a transient worklist). --dry-run is the DEFAULT (writes
+#  *          nothing); mutation requires --apply. Guardrails: kill-switch · dry-run-default ·
+#  *          idempotent-upsert · ADR-refusal · payload-sanitization (metadata-only) · audit-trail.
+#  * @note    DRY: consumes postflight's P3 seed path + P2.5 ticket key — it does NOT generate them
+#  *          (never re-implements the seed/ticket). It only points AT them.
+#  * @version 0.2.0
+#  * @hardening v0.2.0 — MoE-council security pass: upsert is fail-closed on malformed/duplicated
+#  *          sentinels (never mass-deletes to EOF); sentinel/newline-injected payloads refused;
+#  *          symlink + case-insensitive + MADR `decisions/` ADR-refusal; `shift 2` arg-guards;
+#  *          mktemp fail-closed (no predictable /tmp); the seed referent is VERIFIED (no unbacked
+#  *          marker); the block is byte-idempotent (no churning timestamp) + self-cleans when stale.
+#  * Portability: AAIF cross-vendor — POSIX Bash 3.2; jq NOT required; no associative arrays.
+#  * Exit codes ([C06]): 0 success/graceful-noop · 1 usage/validation · 2 setup/write-fail.
+#  */
+set -uo pipefail   # NOT -e: a fallible sink must reach its skip-with-note path, never abort the run.
+
+SENTINEL_START='<!-- MAOS-CONTINUE:START -->'
+SENTINEL_END='<!-- MAOS-CONTINUE:END -->'
+TRAILER_TOKEN='Continue-Here'
+
+# ── self-contained json-escape (match spawn-continuation / precompact convention) ──
+json_escape() {
+  local s="$1"; s=${s//\\/\\\\}; s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}; s=${s//$'\r'/\\r}; s=${s//$'\t'/\\t}; printf '%s' "$s"
+}
+
+usage() {
+  cat <<EOF
+continuation-broadcast — inject a structured, idempotent continuation back-pointer MARKER into
+work artifacts (postflight P3.6 BROADCAST). Points at the ONE canonical continuation ticket/seed;
+never free-form. --dry-run is the DEFAULT (mutation requires --apply). Reconciliation: docs/adrs/ADR-010.
+
+Usage:
+  $(basename "$0") (--ticket <KEY> | --seed <path>) [options]
+
+Pointer (at least one required — nothing to point at otherwise):
+  --ticket <KEY>     the P2.5 continuation ticket key (e.g. VKS-123) or 'none'
+  --seed <path>      the P3 continuation seed file (repo-relative preferred; abs is relativized)
+
+Sinks:
+  --scope <s>        conservative (default) = commit-trailer + PR-body only (exit-hygiene-safe)
+                     all                    = ALSO the caller-named --file targets (ADRs refused)
+  --pr <N>           PR number → idempotent-upsert the marker block into the PR body (needs gh)
+  --file <path>      a file sink (repeatable; honored ONLY under --scope all; ADR paths refused)
+  --session <id>     source session id for the marker payload (default: \$CLAUDE_CODE_SESSION_ID)
+
+Mode:
+  --dry-run          print what WOULD be written; touch nothing            (DEFAULT)
+  --apply            actually write the enabled sinks
+  --help
+
+Guardrails:
+  MAOS_BROADCAST=0   hard kill-switch — never broadcast (deterministic opt-out).
+
+The commit-trailer is always printed to stdout (append it to the exit commit message):
+  $TRAILER_TOKEN: <KEY> · seed:<relpath>
+EOF
+  exit "${1:-0}"
+}
+
+# ── parse args ────────────────────────────────────────────────────────────────
+TICKET="" SEED="" SCOPE="conservative" PR="" SESSION="" APPLY=0
+FILES=""   # newline-separated (Bash 3.2: no arrays needed for append+iterate)
+# A value-expecting flag as the LAST arg must NOT `shift 2` past $#=1 (bash 3.2 errors,
+# $# stays, the case re-reads the same flag → infinite loop). Guard the value's presence.
+_need2() { [ "$1" -ge 2 ] || { printf 'continuation-broadcast: %s requires a value\n' "$2" >&2; usage 1; }; }
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --ticket)   _need2 "$#" --ticket;  TICKET="$2"; shift 2 ;;
+    --seed)     _need2 "$#" --seed;    SEED="$2"; shift 2 ;;
+    --scope)    _need2 "$#" --scope;   SCOPE="$2"; shift 2 ;;
+    --pr)       _need2 "$#" --pr;      PR="$2"; shift 2 ;;
+    --file)     _need2 "$#" --file;    FILES="${FILES}${2}"$'\n'; shift 2 ;;
+    --session)  _need2 "$#" --session; SESSION="$2"; shift 2 ;;
+    --apply)    APPLY=1; shift ;;
+    --dry-run)  APPLY=0; shift ;;
+    --help|-h)  usage 0 ;;
+    *) printf 'continuation-broadcast: unknown arg: %s\n' "$1" >&2; usage 1 ;;
+  esac
+done
+
+# ── G1 kill-switch ──────────────────────────────────────────────────────────
+if [ "${MAOS_BROADCAST:-1}" = "0" ]; then
+  printf '{"status":"noop","reason":"MAOS_BROADCAST=0 (kill-switch)","action":"none"}\n'; exit 0
+fi
+
+# ── validate scope + defaults ─────────────────────────────────────────────────
+case "$SCOPE" in conservative|all) ;; *) printf 'continuation-broadcast: --scope must be conservative|all\n' >&2; usage 1 ;; esac
+SESSION="${SESSION:-${CLAUDE_CODE_SESSION_ID:-${CLAUDE_SESSION_ID:-unknown}}}"
+[ -n "$TICKET" ] || TICKET="none"
+
+# ── relativize the seed path (marker is metadata-only: no abs/home leak) ─────
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SEED_REL="$SEED"
+case "$SEED" in
+  "$REPO_ROOT"/*) SEED_REL="${SEED#"$REPO_ROOT"/}" ;;
+  "$HOME"/*)      SEED_REL="~/${SEED#"$HOME"/}" ;;
+esac
+
+# ── verify the seed REFERENT exists (ADR-010: point at a REGISTERED continuation, not a promise) ──
+# Only a seed file that actually exists may back the marker; an unfound --seed is dropped as backing.
+# (The ticket is caller-registered by postflight P2.5 — asserted, per ADR-010.)
+SEED_VERIFIED=0
+if [ -n "$SEED" ]; then
+  if [ -f "$SEED" ] || { [ -n "$REPO_ROOT" ] && [ -f "$REPO_ROOT/$SEED_REL" ]; }; then
+    SEED_VERIFIED=1
+  else
+    printf 'continuation-broadcast: --seed %s not found — dropping it as backing (not a verified referent)\n' "$SEED" >&2
+    SEED_REL=""   # never point at an unbacked seed
+  fi
+fi
+
+# ── must have something REAL to point at (a verified seed OR a named ticket) ──
+if { [ -z "$TICKET" ] || [ "$TICKET" = "none" ]; } && [ "$SEED_VERIFIED" != 1 ]; then
+  printf '{"status":"noop","reason":"nothing verifiably to point at (no --ticket and no existing --seed) — broadcast skipped","action":"none"}\n'; exit 0
+fi
+
+# ── G-inject: the payload is metadata-only — it may NOT carry a sentinel/comment/newline ─────
+# (else a crafted ticket/seed/session could restructure the marker block or forge a JSON/log line).
+for _v in "$TICKET" "$SEED_REL" "$SESSION"; do
+  case "$_v" in
+    *MAOS-CONTINUE*|*'<!--'*|*'-->'*)
+      printf '{"status":"error","reason":"marker payload may not contain sentinel/comment markers"}\n' >&2; exit 1 ;;
+  esac
+  case "$_v" in
+    *$'\n'*|*$'\r'*|*$'\t'*)
+      printf '{"status":"error","reason":"marker payload may not contain newlines/tabs (metadata is single-line)"}\n' >&2; exit 1 ;;
+  esac
+done
+
+# ── G-sanitize: refuse anything that smells like a live secret (defense-in-depth) ──
+if printf '%s %s %s' "$TICKET" "$SEED_REL" "$SESSION" \
+   | grep -Eiq '(-----BEGIN [A-Z ]*PRIVATE KEY|aws_secret_access_key|gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,}|xox[baprs]-[A-Za-z0-9-]{10,}|AKIA[0-9A-Z]{12,}|sk-[A-Za-z0-9]{20,}|AIza[0-9A-Za-z_-]{20,}|glpat-[A-Za-z0-9_-]{16,}|password["'\'' :=]+[^ "'\'']{6,})'; then
+  printf '{"status":"error","reason":"marker payload appears to contain a secret — refusing (metadata-only)"}\n' >&2; exit 1
+fi
+
+NOW_UTC="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo unknown)"   # audit-log only (NOT in the block)
+
+# ── build the ONE marker block (single source → identical across every sink) ──
+# Line 1/4: sentinels (idempotent-upsert delimiters). Line 2: machine JSON payload. Line 3: human mirror.
+# The block is BYTE-IDEMPOTENT: it carries no timestamp, so a re-apply on unchanged inputs is a true
+# no-op (identical bytes) — never a timestamp-only churn write.
+SEED_HINT=""; [ -n "$SEED_REL" ] && SEED_HINT=" (seed: \`${SEED_REL}\`)"
+TICKET_HINT="$TICKET"; [ "$TICKET" = "none" ] && TICKET_HINT="the continuation seed"
+BLOCK_FILE="$(mktemp 2>/dev/null)" || { printf '{"status":"error","reason":"mktemp failed — refusing (no predictable-path fallback)"}\n' >&2; exit 2; }
+trap 'rm -f "$BLOCK_FILE" 2>/dev/null' EXIT
+{
+  printf '%s\n' "$SENTINEL_START"
+  printf '<!-- MAOS-CONTINUE {"ticket":"%s","seed":"%s","session":"%s"} -->\n' \
+    "$(json_escape "$TICKET")" "$(json_escape "$SEED_REL")" "$(json_escape "$SESSION")"
+  printf '> 🔁 **Continuation pending** — resume at **%s**%s. A fresh amnesic agent: run `/maos:preflight`, then continue from the ticket/seed. _(structured back-pointer to the tracked continuation, not a TODO — see `docs/adrs/ADR-010-continuation-broadcast.md`. If **%s** is already resolved/closed this marker is STALE — delete this block.)_\n' \
+    "$TICKET_HINT" "$SEED_HINT" "$TICKET_HINT"
+  printf '%s\n' "$SENTINEL_END"
+} > "$BLOCK_FILE"
+
+# the commit-trailer form (single line; git-trailer parseable — token before the first ": ")
+TRAILER="${TRAILER_TOKEN}: ${TICKET} · seed:${SEED_REL:-none}"
+
+# ── idempotent-upsert helper — replace exactly one well-formed sentinel region, else append ──
+# Reads the block from $BLOCK_FILE (multi-line-safe). Atomic (tmp → mv).
+# FAIL-CLOSED (returns 2, writes NOTHING) on any malformed/ambiguous sentinel state so a stray or
+# tool-mangled marker in a PR body / doc can NEVER cause a mass-delete-to-EOF or a duplicated block:
+#   • no sentinels           → append one fresh block (return 0)
+#   • exactly ONE START, ONE END, START-line before END-line → replace that region in place (return 0)
+#   • anything else (dangling START/END, duplicate sentinels, END-before-START, substring-only
+#     mentions on a partial line) → REFUSE (return 2)
+# Sentinels are matched as WHOLE LINES (grep -xF / awk $0==) so a mention inside prose or a code
+# fence never counts unless it is its own exact line.
+upsert_block() {
+  local file="$1" tmp ns ne ls le
+  tmp="${file}.mcont.tmp.$$"
+  ns="$(grep -cxF "$SENTINEL_START" "$file" 2>/dev/null)"; ns="${ns:-0}"
+  ne="$(grep -cxF "$SENTINEL_END"   "$file" 2>/dev/null)"; ne="${ne:-0}"
+  if [ "$ns" -eq 0 ] && [ "$ne" -eq 0 ]; then
+    { printf '\n'; cat "$BLOCK_FILE"; } >> "$file" 2>/dev/null && return 0
+    return 1
+  fi
+  # any sentinel present → require exactly one balanced, correctly-ordered pair, else fail closed.
+  [ "$ns" -eq 1 ] && [ "$ne" -eq 1 ] || return 2
+  ls="$(grep -nxF "$SENTINEL_START" "$file" 2>/dev/null | head -1 | cut -d: -f1)"
+  le="$(grep -nxF "$SENTINEL_END"   "$file" 2>/dev/null | head -1 | cut -d: -f1)"
+  { [ -n "$ls" ] && [ -n "$le" ] && [ "$ls" -lt "$le" ]; } || return 2
+  awk -v bf="$BLOCK_FILE" -v s="$SENTINEL_START" -v e="$SENTINEL_END" '
+    BEGIN { blk=""; while ((getline line < bf) > 0) blk = blk line "\n" }
+    $0 == s          { printf "%s", blk; skip=1; next }   # emit replacement at START
+    skip==1 && $0==e { skip=0; next }                     # consume through END
+    skip!=1          { print }                            # keep everything outside the region
+  ' "$file" > "$tmp" 2>/dev/null && mv "$tmp" "$file" && return 0
+  rm -f "$tmp" 2>/dev/null; return 1
+}
+
+# ── audit-trail (append one line per applied sink; best-effort) ───────────────
+JOBS_DIR="${CLAUDE_JOBS_DIR:-${HOME:-/tmp}/.claude/jobs}"
+AUDIT_LOG="${JOBS_DIR}/continuation-broadcasts.log"
+audit() { # sink, target, action
+  [ "$APPLY" = 1 ] || return 0
+  mkdir -p "$JOBS_DIR" 2>/dev/null || true
+  printf '%s\tsink=%s\ttarget=%s\taction=%s\tticket=%s\tsession=%s\n' \
+    "$NOW_UTC" "$1" "$2" "$3" "$TICKET" "$SESSION" >> "$AUDIT_LOG" 2>/dev/null || true
+}
+
+# ── collect per-sink results (JSON array assembled at the end) ────────────────
+SINKS_JSON=""
+add_sink() { # sink, target, action, reason
+  local frag; frag=$(printf '{"sink":"%s","target":"%s","action":"%s","reason":"%s"}' \
+    "$(json_escape "$1")" "$(json_escape "$2")" "$(json_escape "$3")" "$(json_escape "$4")")
+  if [ -z "$SINKS_JSON" ]; then SINKS_JSON="$frag"; else SINKS_JSON="${SINKS_JSON},${frag}"; fi
+}
+
+# ── SINK 1: commit-trailer (always — it is just text the caller appends) ─────
+# Printed to stderr as guidance; emitted in the JSON so the caller can consume it.
+printf '↳ commit-trailer (append to the exit commit message):\n    %s\n' "$TRAILER" >&2
+add_sink "commit-trailer" "exit-commit-message" "emitted" "append the trailer line to the closing commit"
+
+# ── SINK 2: PR body (idempotent upsert via gh) ───────────────────────────────
+if [ -n "$PR" ]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    add_sink "pr-body" "PR#${PR}" "skipped" "gh not found (capability-detect)"
+  elif [ "$APPLY" != 1 ]; then
+    printf '↳ [dry-run] would upsert the marker block into PR #%s body\n' "$PR" >&2
+    add_sink "pr-body" "PR#${PR}" "would-write" "dry-run (pass --apply to write)"
+  else
+    BODY_TMP="$(mktemp 2>/dev/null)" || { printf '{"status":"error","reason":"mktemp failed"}\n' >&2; exit 2; }
+    if gh pr view "$PR" --json body -q .body > "$BODY_TMP" 2>/dev/null; then
+      upsert_block "$BODY_TMP"; urc=$?
+      if [ "$urc" -eq 0 ]; then
+        if gh pr edit "$PR" --body-file "$BODY_TMP" >/dev/null 2>&1; then
+          add_sink "pr-body" "PR#${PR}" "written" "idempotent upsert"; audit "pr-body" "PR#${PR}" "written"
+        else
+          add_sink "pr-body" "PR#${PR}" "skipped" "gh pr edit failed (permissions/network)"
+        fi
+      elif [ "$urc" -eq 2 ]; then
+        add_sink "pr-body" "PR#${PR}" "refused" "existing marker malformed (dangling/duplicate sentinel) — body left untouched (fail-closed)"
+      else
+        add_sink "pr-body" "PR#${PR}" "skipped" "upsert write failed"
+      fi
+    else
+      add_sink "pr-body" "PR#${PR}" "skipped" "gh pr view failed (no such PR / no access)"
+    fi
+    rm -f "$BODY_TMP" 2>/dev/null || true
+  fi
+fi
+
+# ── SINK 3: files (ONLY under --scope all; caller-named; ADRs refused) ───────
+if [ -n "$FILES" ]; then
+  if [ "$SCOPE" != "all" ]; then
+    add_sink "file" "(deferred)" "skipped" "--file honored only under --scope all (conservative default)"
+  else
+    # Here-string (NOT a pipe) keeps the loop in THIS shell so add_sink mutations to SINKS_JSON
+    # persist (a `printf | while` subshell would silently drop the file-sink results).
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      # Reject symlinks: the refusal below matches the NAME, but append/`mv` FOLLOW the link — a
+      # symlinked path could otherwise smuggle a write into an ADR or an arbitrary file (F3).
+      if [ -L "$f" ]; then
+        add_sink "file" "$f" "refused" "symlink — refusing (could redirect the write outside the named target)"; continue
+      fi
+      # ADR / MADR decision-record refusal — case-INSENSITIVE, covers adrs//adr//decisions/ dirs and
+      # numbered MADR basenames (0001-*.md) as well as ADR-*.md / adr-*.md anywhere (F2/F9).
+      flc="$(printf '%s' "$f" | tr '[:upper:]' '[:lower:]')"; bn="${flc##*/}"
+      case "$flc" in
+        */adrs/*|*/adr/*|*/decisions/*|adr-*.md|*/adr-*.md)
+          add_sink "file" "$f" "refused" "ADR/decision record — immutable, not a transient worklist (ADR-010)"; continue ;;
+      esac
+      case "$bn" in
+        [0-9][0-9][0-9][0-9]-*.md)
+          add_sink "file" "$f" "refused" "MADR numbered decision record — immutable, not a transient worklist (ADR-010)"; continue ;;
+      esac
+      if [ ! -f "$f" ]; then
+        add_sink "file" "$f" "skipped" "no such file (or not a regular file)"; continue
+      fi
+      if [ "$APPLY" != 1 ]; then
+        printf '↳ [dry-run] would upsert the marker block into %s\n' "$f" >&2
+        add_sink "file" "$f" "would-write" "dry-run (pass --apply to write)"; continue
+      fi
+      upsert_block "$f"; urc=$?
+      if [ "$urc" -eq 0 ]; then
+        add_sink "file" "$f" "written" "idempotent upsert"; audit "file" "$f" "written"
+      elif [ "$urc" -eq 2 ]; then
+        add_sink "file" "$f" "refused" "existing marker malformed (dangling/duplicate sentinel) — left untouched (fail-closed)"
+      else
+        add_sink "file" "$f" "skipped" "write failed"
+      fi
+    done <<< "$FILES"
+  fi
+fi
+
+# ── emit JSON summary ─────────────────────────────────────────────────────────
+MODE="$([ "$APPLY" = 1 ] && echo apply || echo dry-run)"
+printf '{"status":"ok","mode":"%s","scope":"%s","ticket":"%s","seed":"%s","session":"%s","trailer":"%s","sinks":[%s]}\n' \
+  "$MODE" "$SCOPE" "$(json_escape "$TICKET")" "$(json_escape "$SEED_REL")" "$(json_escape "$SESSION")" \
+  "$(json_escape "$TRAILER")" "$SINKS_JSON"
+exit 0

--- a/bin/tests/continuation-broadcast.test.sh
+++ b/bin/tests/continuation-broadcast.test.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# ═══════════════════════════════════════════════════════════════════════════════
+# Tests: bin/continuation-broadcast.sh — the postflight P3.6 BROADCAST marker (v0.2.0)
+# Scope: the SAFETY CONTRACT of the structured continuation back-pointer marker —
+#   - dry-run is the DEFAULT (no --apply ⇒ zero file mutation)
+#   - commit-trailer always emitted + well-formed (git-trailer parseable)
+#   - conservative scope IGNORES --file (only --scope all honors file sinks)
+#   - --scope all writes the marker; a 2nd --apply is IDEMPOTENT (upsert, not append-duplicate)
+#   - the block is BYTE-idempotent (no churning timestamp) — re-apply is a true no-op
+#   - ADR/MADR decision records are REFUSED (case-insensitive; not a transient worklist)
+#   - symlink --file targets are REFUSED (can't smuggle a write through the link)
+#   - malformed/duplicated in-file sentinels ⇒ FAIL-CLOSED (never mass-delete / duplicate)
+#   - a sentinel/newline-injected payload ⇒ refused (can't restructure the block)
+#   - an unfound --seed is DROPPED as backing (marker points only at REGISTERED referents)
+#   - a value-flag as the LAST arg ⇒ usage error, not an infinite loop (bash 3.2)
+#   - MAOS_BROADCAST=0 kill-switch ⇒ noop · nothing to point at ⇒ noop
+#   - secret-shaped payload ⇒ refused (metadata-only guarantee)
+# Bash 3.2-safe. Isolated jobs registry (audit log never touches ~/.claude).
+# Run: bash bin/tests/continuation-broadcast.test.sh
+# ═══════════════════════════════════════════════════════════════════════════════
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+BC="$SCRIPT_DIR/../continuation-broadcast.sh"
+
+PASS=0 FAIL=0
+ok()  { PASS=$((PASS+1)); printf '  ✅ %s\n' "$1"; }
+bad() { FAIL=$((FAIL+1)); printf '  ❌ %s\n     got: %s\n' "$1" "${2:-<empty>}"; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+printf '{}' > "$TMP/seed.json"   # a REAL seed referent (verified backing; dogfoods governance-F2)
+# Run from $TMP (not a git repo ⇒ REPO_ROOT falls back to pwd) so a relative --seed resolves here,
+# and isolate the audit log so the test never writes ~/.claude/jobs.
+run() { ( cd "$TMP" && CLAUDE_JOBS_DIR="$TMP/jobs" bash "$BC" "$@" 2>/dev/null ); }
+
+echo "── continuation-broadcast SAFETY tests"
+
+# 1. commit-trailer always emitted + well-formed (token · seed:<verified relpath>)
+OUT="$(run --ticket VKS-123 --seed seed.json)"
+case "$OUT" in
+  *'"trailer":"Continue-Here: VKS-123 · seed:seed.json"'*) ok "commit-trailer well-formed (Continue-Here: <key> · seed:<verified path>)" ;;
+  *) bad "commit-trailer shape" "$OUT" ;;
+esac
+
+# 2. dry-run is the DEFAULT: a --scope all --file target is NOT mutated without --apply
+F="$TMP/doc.md"; printf '# Doc\n\nbody\n' > "$F"
+BEFORE="$(cat "$F")"
+run --ticket VKS-123 --seed seed.json --scope all --file "$F" >/dev/null
+if [ "$(cat "$F")" = "$BEFORE" ]; then ok "dry-run default: --file target untouched (no --apply)"; else bad "dry-run mutated the file" "$(cat "$F")"; fi
+
+# 3. conservative scope IGNORES --file (deferred, not written)
+OUT="$(run --ticket VKS-123 --seed seed.json --file "$F")"   # no --scope all
+case "$OUT" in
+  *'"action":"skipped","reason":"--file honored only under --scope all'*) ok "conservative scope defers --file" ;;
+  *) bad "conservative should defer --file" "$OUT" ;;
+esac
+
+# 4. --scope all --apply WRITES the marker block (one START + one END sentinel)
+run --apply --ticket VKS-123 --seed seed.json --scope all --file "$F" >/dev/null
+S1=$(grep -cF '<!-- MAOS-CONTINUE:START -->' "$F" 2>/dev/null | tr -d ' ')
+E1=$(grep -cF '<!-- MAOS-CONTINUE:END -->' "$F" 2>/dev/null | tr -d ' ')
+if [ "$S1" = "1" ] && [ "$E1" = "1" ]; then ok "--apply writes exactly one marker block"; else bad "marker block count after 1st apply" "START=$S1 END=$E1"; fi
+
+# 5. IDEMPOTENCY (the crux): a 2nd --apply upserts — still exactly ONE block, not two
+run --apply --ticket VKS-456 --seed seed.json --scope all --file "$F" >/dev/null
+S2=$(grep -cF '<!-- MAOS-CONTINUE:START -->' "$F" 2>/dev/null | tr -d ' ')
+E2=$(grep -cF '<!-- MAOS-CONTINUE:END -->' "$F" 2>/dev/null | tr -d ' ')
+if [ "$S2" = "1" ] && [ "$E2" = "1" ]; then ok "2nd --apply is idempotent (upsert — still ONE block)"; else bad "idempotency broken (block accumulated)" "START=$S2 END=$E2"; fi
+# ...and the block was UPDATED to the new ticket (VKS-456), original preserved around it
+if grep -qF 'VKS-456' "$F" && grep -qF '# Doc' "$F" && grep -qF 'body' "$F"; then ok "upsert refreshed payload (VKS-456) + preserved surrounding content"; else bad "upsert content" "$(cat "$F")"; fi
+
+# 6. ADR files are REFUSED (never injected)
+ADR="$TMP/docs/adrs/ADR-777-x.md"; mkdir -p "$(dirname "$ADR")"; printf '# ADR-777\n' > "$ADR"
+OUT="$(run --apply --ticket VKS-1 --seed seed.json --scope all --file "$ADR")"
+if grep -qF '"action":"refused"' <<< "$OUT" && [ "$(cat "$ADR")" = "# ADR-777" ]; then ok "ADR refused + left untouched"; else bad "ADR should be refused+untouched" "$OUT / $(cat "$ADR")"; fi
+
+# 7. kill-switch
+OUT="$(MAOS_BROADCAST=0 run --ticket VKS-1 --seed seed.json)"
+case "$OUT" in *'"status":"noop"'*'kill-switch'*) ok "MAOS_BROADCAST=0 kill-switch ⇒ noop" ;; *) bad "kill-switch" "$OUT" ;; esac
+
+# 8. nothing to point at ⇒ noop
+OUT="$(run --session x)"
+case "$OUT" in *'"status":"noop"'*'nothing verifiably to point at'*) ok "no ticket + no seed ⇒ noop" ;; *) bad "no-op guard" "$OUT" ;; esac
+
+# 9. secret-shaped payload ⇒ refused (exit 1, metadata-only guarantee)
+if run --ticket 'ghp_0123456789012345678901234' --seed seed.json >/dev/null 2>&1; then
+  bad "secret-shaped ticket should be refused" "exit 0"
+else
+  ok "secret-shaped payload refused (exit != 0)"
+fi
+
+# 10. read-only guarantee: a dry-run (in a FRESH jobs registry) writes NO audit log (apply-only side-effect)
+FRESH="$TMP/jobs-fresh"
+( cd "$TMP" && CLAUDE_JOBS_DIR="$FRESH" bash "$BC" --ticket VKS-123 --seed seed.json --scope all --file "$F" >/dev/null 2>&1 )
+if [ ! -e "$FRESH/continuation-broadcasts.log" ]; then ok "dry-run wrote no audit log (apply-only side-effect)"; else bad "dry-run wrote the audit log" "$(cat "$FRESH/continuation-broadcasts.log")"; fi
+
+# ── v0.2.0 hardening regressions (MoE-council security pass) ──────────────────
+
+# 11. BYTE-idempotent: re-apply identical inputs ⇒ file bytes UNCHANGED (no timestamp churn)
+G="$TMP/idem.md"; printf '# I\n\ntext\n' > "$G"
+run --apply --ticket VKS-9 --seed seed.json --scope all --file "$G" >/dev/null
+C1="$(cksum < "$G")"
+run --apply --ticket VKS-9 --seed seed.json --scope all --file "$G" >/dev/null
+C2="$(cksum < "$G")"
+if [ "$C1" = "$C2" ]; then ok "byte-idempotent re-apply (no churning timestamp)"; else bad "re-apply changed bytes" "$C1 vs $C2"; fi
+
+# 12. FAIL-CLOSED on a dangling START (no END) ⇒ file UNTOUCHED, refused (never mass-delete to EOF)
+D="$TMP/dangling.md"; printf '# D\n<!-- MAOS-CONTINUE:START -->\nkeep me\nand me\n' > "$D"
+BEF="$(cat "$D")"
+OUT="$(run --apply --ticket VKS-9 --seed seed.json --scope all --file "$D")"
+if grep -qF '"action":"refused"' <<< "$OUT" && [ "$(cat "$D")" = "$BEF" ]; then ok "dangling START ⇒ fail-closed (file untouched, no mass-delete)"; else bad "dangling START not fail-closed" "$OUT / $(cat "$D")"; fi
+
+# 13. FAIL-CLOSED on duplicate START sentinels ⇒ untouched, refused (never duplicate-block)
+DUP="$TMP/dup.md"
+printf '<!-- MAOS-CONTINUE:START -->\na\n<!-- MAOS-CONTINUE:END -->\n<!-- MAOS-CONTINUE:START -->\nb\n<!-- MAOS-CONTINUE:END -->\n' > "$DUP"
+BEF="$(cat "$DUP")"
+OUT="$(run --apply --ticket VKS-9 --seed seed.json --scope all --file "$DUP")"
+if grep -qF '"action":"refused"' <<< "$OUT" && [ "$(cat "$DUP")" = "$BEF" ]; then ok "duplicate sentinels ⇒ fail-closed (untouched)"; else bad "duplicate sentinels not fail-closed" "$OUT"; fi
+
+# 14. payload carrying a sentinel/comment marker ⇒ refused (can't restructure the block)
+if run --ticket 'VKS-1 --> <!-- MAOS-CONTINUE:END -->' --seed seed.json >/dev/null 2>&1; then
+  bad "sentinel-injected ticket should be refused" "exit 0"
+else ok "sentinel-injected payload refused"; fi
+
+# 15. a value-flag as the LAST arg ⇒ usage error (exit 1), NOT an infinite loop (bash 3.2)
+TMO=""; command -v gtimeout >/dev/null 2>&1 && TMO="gtimeout 5"; [ -z "$TMO" ] && command -v timeout >/dev/null 2>&1 && TMO="timeout 5"
+if $TMO bash "$BC" --ticket >/dev/null 2>&1; then bad "trailing --ticket should error" "exit 0"; else ok "trailing value-flag ⇒ usage error (no hang)"; fi
+
+# 16. lowercase adr- and MADR numbered decision records are ALSO refused (case-insensitive)
+LADR="$TMP/docs/adrs/adr-888-y.md"; mkdir -p "$(dirname "$LADR")"; printf '# adr\n' > "$LADR"
+MADR="$TMP/docs/decisions/0007-z.md"; mkdir -p "$(dirname "$MADR")"; printf '# madr\n' > "$MADR"
+O1="$(run --apply --ticket VKS-1 --seed seed.json --scope all --file "$LADR")"
+O2="$(run --apply --ticket VKS-1 --seed seed.json --scope all --file "$MADR")"
+if grep -qF '"action":"refused"' <<< "$O1" && [ "$(cat "$LADR")" = "# adr" ] \
+   && grep -qF '"action":"refused"' <<< "$O2" && [ "$(cat "$MADR")" = "# madr" ]; then
+  ok "lowercase adr- + MADR decisions/ refused (case-insensitive)"
+else bad "lowercase/MADR ADR not refused" "$O1 | $O2"; fi
+
+# 17. a symlink --file target is refused (can't smuggle a write through the link)
+REAL="$TMP/real.md"; printf 'orig\n' > "$REAL"
+LN="$TMP/link.md"; ln -s "$REAL" "$LN"
+OUT="$(run --apply --ticket VKS-1 --seed seed.json --scope all --file "$LN")"
+if grep -qF '"action":"refused"' <<< "$OUT" && [ "$(cat "$REAL")" = "orig" ]; then ok "symlink target refused (real file untouched)"; else bad "symlink not refused" "$OUT / $(cat "$REAL")"; fi
+
+# 18. an unfound --seed is DROPPED as backing (marker points only at REGISTERED referents)
+OUT="$(run --ticket none --seed does/not/exist.json)"   # ticket 'none' + missing seed ⇒ nothing verifiable
+case "$OUT" in *'"status":"noop"'*'nothing verifiably'*) ok "unbacked seed + no ticket ⇒ noop (no unbacked marker)" ;; *) bad "unbacked seed should noop" "$OUT" ;; esac
+OUT2="$(run --ticket VKS-5 --seed does/not/exist.json)"  # ...but a NAMED ticket still backs it (seed→none)
+case "$OUT2" in *'"trailer":"Continue-Here: VKS-5 · seed:none"'*) ok "named ticket backs marker; unfound seed dropped to none" ;; *) bad "ticket-backed marker with dropped seed" "$OUT2" ;; esac
+
+echo "── $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/commands/postflight.md
+++ b/commands/postflight.md
@@ -15,7 +15,7 @@ entry point over the [`postflight` skill](../skills/postflight/SKILL.md).
 ## Usage
 
 ```
-/postflight [action] [--spawn | --no-spawn] [--no-kickoff] [--dry-run]
+/postflight [action] [--spawn | --no-spawn] [--no-kickoff] [--broadcast[=conservative|all]] [--dry-run]
 ```
 
 > Surfaces at runtime as `/maos:postflight` (Sandwich Namespacing per `.claude-plugin/plugin.json`).
@@ -30,8 +30,11 @@ entry point over the [`postflight` skill](../skills/postflight/SKILL.md).
 | `tickets` | P2.5 only — reconcile the backlog with the session: bounded gap→ticket triage (≤3 + 1 batch) + an idempotent continuation ticket + enrich the anchored ticket, delegated to a capability-detected ticketing primitive (DEFER if absent). Requires P2 (DoR). SSOT: `skills/postflight/references/ticket-sync-protocol.md`. |
 | `seed` | P3 only — emit the ai-agnostic continuation seed (agent-register envelope + human mirror) + clipboard. Requires P1+P2+P2.5 (DoR). |
 | `spawn` | P3.5 only — launch a fresh, named `claude` continuation session pre-seeded with the P3 seed (`bin/spawn-continuation.sh`). Requires a seed (DoR). |
+| `broadcast` | P3.6 only — inject the **structured continuation back-pointer marker** (commit trailer + PR body under `conservative`; ALSO caller-named docs under `--broadcast=all`, ADRs refused) pointing at the P2.5 continuation ticket + P3 seed, so a fresh amnesic agent discovers the pending work at the point of contact. Requires a seed and/or continuation ticket (DoR). Idempotent · `--dry-run` default · metadata-only. SSOT: `skills/postflight/references/continuation-broadcast-protocol.md`; reconciliation: `docs/adrs/ADR-010-continuation-broadcast.md`. |
 
 > **P3.5 SPAWN** (tool 5.1) runs by default after `seed` on a `full` run (**spawn ON**); pass `--no-spawn` to opt out, `--no-kickoff` to spawn WITHOUT the initial kickoff prompt (the new session starts idle at the REPL instead of immediately resuming the seed — kickoff is ON by default and starts consuming tokens right away), `--dry-run` to preview the launch without spawning. It is high-blast (a real session burns tokens) → guarded by a kill-switch, once-per-source-session idempotency, an anti-recursion depth-cap, capability-detected graceful-noop, and seed sanitization. See the skill for the full guardrail list.
+
+> **P3.6 BROADCAST** is **OFF by default** on `/postflight` — opt in with `--broadcast` (`=conservative` [default] = commit-trailer + PR-body; `=all` ALSO stamps caller-named docs/changelogs, ADRs refused). It injects a **structured back-pointer marker** to the tracked continuation (seed + P2.5 ticket) so a fresh agent discovers the pending work — it is a structured back-pointer, **never a free-form TODO** (reconciled with exit-hygiene by ADR-010): idempotent (upsert, never accumulate), metadata-only (sanitized), `--dry-run` by default, and a **NOOP when nothing is pending**. Kill-switch: `MAOS_BROADCAST=0`. It is **default-ON only in `/maos:signoff`** (the sign-off / encerramento verb).
 
 ## Behavior (safe-or-DEFER)
 
@@ -76,6 +79,7 @@ Next agent: /maos:preflight, then start at the first non-blocked next-action.
 | `POSTFLIGHT_SNAPSHOT_PRS=1` | The PreCompact hook also fetches open-PR state via `gh` (network; default off = fast/offline-safe). |
 | `POSTFLIGHT_SEED_DIR=<path>` | Override where the PreCompact hook writes the seed snapshot (default: inside the repo's git dir — git-ignored, so it never dirties the working tree). |
 | `POSTFLIGHT_SPAWN=0` | **P3.5 kill-switch** — never spawn a continuation session (deterministic opt-out; overrides `--spawn`). |
+| `MAOS_BROADCAST=0` | **P3.6 kill-switch** — never broadcast the continuation back-pointer marker (deterministic opt-out; overrides `--broadcast`). |
 | `POSTFLIGHT_KICKOFF=0` | Spawn WITHOUT the initial kickoff prompt (same as `--no-kickoff`) — the session is seeded but starts idle at the REPL. Default: kickoff ON (the spawned session immediately reads its seed and resumes work). |
 | `POSTFLIGHT_SCORECARD_MODEL=<1..8\|name>` | Pin the P2 scorecard layout model (highest precedence in ANY mode; e.g. `cockpit`, `telemetry`, `4`, `briefing`). Default: dynamic context-based selection via `bin/scorecard-select-model.sh` (round-robin preserved as `--mode round-robin` fallback). |
 | `POSTFLIGHT_SCORECARD_STATE=<path>` | Override the round-robin pointer file (default: `~/.claude/jobs/.postflight-scorecard-model`). |
@@ -87,4 +91,6 @@ Next agent: /maos:preflight, then start at the first non-blocked next-action.
 - Skill: [`skills/postflight/SKILL.md`](../skills/postflight/SKILL.md) (the orchestrator).
 - Hook: `plugin-scripts/governance/postflight-precompact.sh` (PreCompact — deterministic seed snapshot; never blocks; never spawns).
 - Composes: `protocols/exit-hygiene.md`, `skills/postflight/references/ticket-sync-protocol.md` (P2.5 SSOT) + a capability-detected ticketing skill (ref: `ticket-as-prompt`), `skills/{sync-to-git,quiesce,morning-briefing,session-fission}`, `commands/worktree.md`, `bin/dogfood-mark`, `bin/spawn-continuation.sh` (P3.5 spawn primitive), `bin/locus.sh` (P2 locus) + `bin/scorecard.py` + `bin/scorecard-select-model.sh` (P2 scorecard dynamic selector) + `bin/scorecard-next-model.sh` (round-robin fallback).
+- Broadcast (P3.6): `bin/continuation-broadcast.sh` + `skills/postflight/references/{continuation-broadcast-protocol.md,close-out-hunt-checklist.md}` + `docs/adrs/ADR-010-continuation-broadcast.md`.
+- Wrapped by: `/maos:signoff` (`commands/signoff.md` + `skills/signoff/SKILL.md`) — the sign-off / encerramento verb that runs this with `--broadcast --spawn` default-ON under an OODA framing.
 - Counterpart: `/preflight` (start-of-session) — together the loop: `preflight → work → postflight → (spawn) → preflight …`.

--- a/commands/signoff.md
+++ b/commands/signoff.md
@@ -1,6 +1,6 @@
 ---
 name: signoff
-description: Sign off / encerrar a session — close it out cleanly AND leave the pending work discoverable for the next mind (OODA-framed close-out that composes quiesce + postflight with the continuation BROADCAST default-ON)
+description: Sign off / encerrar a sessão — close it out cleanly AND leave the pending work discoverable for the next mind (OODA-framed close-out that composes quiesce + postflight with the continuation BROADCAST default-ON)
 ---
 
 # /signoff Command
@@ -27,7 +27,7 @@ the pending work findable. Thin entry point over the [`signoff` skill](../skills
 | **Observe** | environment recon + the **complete 10-item close-out hunt** (fails · errors · warnings · risks+mitigations · gaps · pendings · decisions-not-taken · unasked-Qs · unanswered-Qs) | Skopos recon · `postflight` P2 DEBRIEF + `close-out-hunt-checklist.md` |
 | **Orient** | root-cause (not symptom) + anti-theater filter + Eisenhower rank | `root-cause-first` · `anti-theater` · `postflight` P2 |
 | **Decide** | Taxis disposition per atom — fix-now / ticket / seed / drop (no silent drop); is a pendency left? | `postflight` P2.5 · Taxis |
-| **Act** | drive-to-green → sweep → ticket-sync → seed → **broadcast the marker** → spawn → full git | `quiesce` + `postflight full --broadcast --spawn` |
+| **Act** | drive-to-green → sweep → ticket-sync → seed → spawn → **broadcast the marker** → full git | `quiesce` + `postflight full --broadcast --spawn` |
 
 ## Flags
 

--- a/commands/signoff.md
+++ b/commands/signoff.md
@@ -1,0 +1,81 @@
+---
+name: signoff
+description: Sign off / encerrar a session — close it out cleanly AND leave the pending work discoverable for the next mind (OODA-framed close-out that composes quiesce + postflight with the continuation BROADCAST default-ON)
+---
+
+# /signoff Command
+
+**Sign off** the session (encerramento): run the full end-of-session close-out **and** broadcast a
+discoverable continuation trail for whoever comes next. A thin OODA-framed wrapper that composes
+`quiesce` (drive-to-green, optional) + the [`postflight` skill](../skills/postflight/SKILL.md)
+with **BROADCAST default-ON** — because the point of signing off is to close cleanly *and* leave
+the pending work findable. Thin entry point over the [`signoff` skill](../skills/signoff/SKILL.md).
+
+> Surfaces at runtime as `/maos:signoff` (Sandwich Namespacing per `.claude-plugin/plugin.json`).
+> Naming: Anima-named (`signoff`; rejected runner-up `disembark`). Operator may override (`[C-naming]`).
+
+## Usage
+
+```
+/signoff [--converge] [--broadcast=<conservative|all> | --no-broadcast] [--spawn | --no-spawn] [--dry-run]
+```
+
+## What it does (OODA — recon → hunt → disposition → act)
+
+| Stage | Action | Delegates to |
+|-------|--------|--------------|
+| **Observe** | environment recon + the **complete 10-item close-out hunt** (fails · errors · warnings · risks+mitigations · gaps · pendings · decisions-not-taken · unasked-Qs · unanswered-Qs) | Skopos recon · `postflight` P2 DEBRIEF + `close-out-hunt-checklist.md` |
+| **Orient** | root-cause (not symptom) + anti-theater filter + Eisenhower rank | `root-cause-first` · `anti-theater` · `postflight` P2 |
+| **Decide** | Taxis disposition per atom — fix-now / ticket / seed / drop (no silent drop); is a pendency left? | `postflight` P2.5 · Taxis |
+| **Act** | drive-to-green → sweep → ticket-sync → seed → **broadcast the marker** → spawn → full git | `quiesce` + `postflight full --broadcast --spawn` |
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--converge` | First drive the open PR toward green via `quiesce`, then close out. |
+| `--broadcast=<scope>` | Marker reach: `conservative` (default) = commit-trailer + PR-body; `all` = ALSO caller-named docs/changelogs (ADRs refused). |
+| `--no-broadcast` | Sign off WITHOUT leaving a marker (rare; broadcast is a NOOP anyway when nothing is pending). |
+| `--spawn` / `--no-spawn` | Launch (default) / skip the pre-seeded continuation session. |
+| `--dry-run` | Preview the whole close-out (sweep plan, seed, marker, spawn command) — writes/launches nothing. |
+
+> **BROADCAST is default-ON here** (that is the whole point of a sign-off) — unlike bare
+> `/postflight` where it is opt-in. It is a **structured back-pointer, never a free-form TODO**
+> (reconciled with exit-hygiene by `docs/adrs/ADR-010-continuation-broadcast.md`): idempotent,
+> metadata-only, ADRs refused, and a NOOP when nothing is pending. Kill-switch: `MAOS_BROADCAST=0`.
+
+## Behavior (safe-or-DEFER — all inherited)
+
+- **Never clobbers**: dirty tree / conflict / held `.git/index.lock` / untracked-you-did-not-create → **DEFER**.
+- **Handoff + marker are gated**: emitted only after the sweep + debrief, so they never misreport the state.
+- **Governance-aware**: reads `CLAUDE/AGENTS/CONTRIBUTING/README/protocols/memories` and adapts; full git under `pr-review-protocol` + `auto-merge-standing-authorization` (HITL only for genuine residue).
+
+## Examples
+
+```
+/signoff                       # close out + broadcast (conservative) + spawn — run before /compact
+/signoff --converge            # drive PR green first, then close out + broadcast + spawn
+/signoff --broadcast=all       # ALSO stamp caller-named docs/changelogs (ADRs still refused)
+/signoff --no-spawn            # close out + broadcast, but don't open a new session
+/signoff --dry-run             # preview the entire close-out (nothing written/launched)
+```
+
+## Output
+
+```
+✍️  signoff (OODA)
+─────────────────────────────────────────────────
+OBSERVE  debrief + 10-item hunt → 1 gap · 1 risk · 0 fails
+ORIENT   root-caused · anti-theater PASS · Eisenhower Q2/Q2
+DECIDE   gap → continuation ticket · risk → seed.risks[] · nothing else pending
+ACT      swept (pushed feat/x · PR #42 green) · seed + spawn · 🔁 BROADCAST → PR #42 body + commit trailer
+─────────────────────────────────────────────────
+✅ Signed off. Continuation VKS-456 discoverable in PR #42 + the exit commit. Next: /maos:preflight.
+```
+
+## Integration
+
+- Skill: [`skills/signoff/SKILL.md`](../skills/signoff/SKILL.md) (the OODA composition contract).
+- Composes: [`skills/postflight/SKILL.md`](../skills/postflight/SKILL.md) (P1–P3.6, `--broadcast` default-ON) + `skills/quiesce/SKILL.md` (`--converge`).
+- Broadcast: `bin/continuation-broadcast.sh` + `skills/postflight/references/continuation-broadcast-protocol.md` + `docs/adrs/ADR-010-continuation-broadcast.md`.
+- Counterpart: `/preflight` (start-of-session) — the loop: `preflight → work → signoff → (spawn) → preflight …`.

--- a/docs/adrs/ADR-010-continuation-broadcast.md
+++ b/docs/adrs/ADR-010-continuation-broadcast.md
@@ -1,0 +1,120 @@
+# ADR-010 — Continuation-Broadcast: a structured back-pointer marker (not a breadcrumb TODO)
+
+- **Status:** Accepted (built in this change — `bin/continuation-broadcast.sh` + postflight P3.6 + the `signoff` verb)
+- **Date:** 2026-07-10
+- **Deciders:** operator (Emilson) + Claude (Opus 4.8)
+- **Origin:** operator `/enhance /deep-research Ultrathink` 2026-07-10 — "gerar handoff-prompt de continuidade … injetar o prompt de continuidade **onde for cabível** (tickets, docs, ADRs, changelogs, PRs, commits) para quando algum new-fresh-born-amnesic-agentic se deparar com o problema saber que tem pendências a serem continuadas."
+- **Naming:** system-slug `continuation-broadcast` (COMP/machine register — descriptive-canonical, no soul-name per Anima §3.4). The operator-facing sign-off verb is Anima-named **`signoff`** (surfaces `/maos:signoff`; rejected runner-up `disembark` — best flight-family resonance but less self-describing to an amnesic agent than the literal operator gesture "sign-off/encerramento"). Operator may override (`[C-naming]`).
+
+## Context
+
+The operator's close-out ask has a **discovery** requirement that the existing machinery did not
+satisfy. `postflight` already, at session end:
+
+- **P2.5 TICKET-SYNC** files a bounded **continuation ticket** (the backlog anchor), and
+- **P3 HANDOFF** emits an ai-agnostic **continuation seed** (the resume packet),
+
+so the pending work is **tracked** (`ticket-sync-protocol.md` + `continuation-seed-contract.md`).
+But a fresh amnesic agent — or a *different* mind days later — who later opens **a commit, a PR,
+or a doc** has **no reason to know the seed/ticket exist**. The continuation is tracked, yet
+**not discoverable from where the next agent actually arrives**. Per the locus master principle,
+*"what is not seen is not remembered."*
+
+The obvious fix — "leave a note where they'll find it" — collides head-on with
+`protocols/exit-hygiene.md`, whose anti-patterns explicitly forbid *"Fix next session"* notes and
+*"accepting incremental disorder — it's just one more TODO"* (entropy is exponential; one TODO
+becomes five becomes tech-debt). And `postflight` anti-pattern #2 restates it. So a naive
+free-form breadcrumb is **prohibited by our own governance**. This ADR resolves the tension.
+
+| Prior-art (what exists) | Why it does NOT close the discovery gap |
+|---|---|
+| `continuation-seed-contract` (P3 seed) | the **payload**, but lands only in the seed file + clipboard + spawned session — not in the artifacts a next agent lands on |
+| `ticket-sync-protocol` (P2.5 continuation ticket) | the backlog **anchor**, but a next agent reading a commit/PR/doc isn't looking at the backlog |
+| `exit-hygiene` Delegation gate | *requires* "registered with traceability" — but doesn't say **where** the trace should be discoverable |
+| free-form "TODO next session" | **forbidden** by exit-hygiene (unbounded, unstructured, accumulates) |
+
+## Decision
+
+Add **P3.6 BROADCAST**: inject a **bounded, structured, idempotent back-pointer MARKER** — a
+*discovery pointer* to the ONE canonical continuation seed/ticket — into selected work artifacts.
+Executor: `bin/continuation-broadcast.sh` (deterministic, `--dry-run` default). Full shape/sinks/
+guardrails: `skills/postflight/references/continuation-broadcast-protocol.md`.
+
+**The reconciliation claim (the crux):** a structured back-pointer marker is **NOT** the breadcrumb
+TODO exit-hygiene forbids — it is exit-hygiene's *own* **"registered with traceability"** (Axiom 4
+proactive-resolution + the Delegation gate) **surfaced at the point of future contact**. It differs
+from a forbidden TODO on every axis exit-hygiene cares about:
+
+| exit-hygiene's objection to TODOs | how the marker answers it |
+|---|---|
+| unstructured prose | **structured** — sentinel-delimited (`MAOS-CONTINUE:START/END`, matched as whole lines) + a machine-readable JSON payload |
+| a promise with no backing | a **back-pointer** to a **verified** referent — the executor confirms the seed file **exists** before emitting (an unfound `--seed` is dropped); the ticket is caller-registered by P2.5. The marker never points at a phantom. |
+| accumulates ("one more TODO") | **byte-idempotent** — a re-run *upserts* (replaces the one sentinel region) and the block carries **no timestamp**, so a re-apply on unchanged inputs is a true no-op (identical bytes); a marker never accumulates nor churns |
+| unbounded, anywhere | **bounded** — one block per artifact; **ADR/decision records refused** (case-insensitive, incl. MADR `decisions/`); symlinks refused; only caller-named files under `--scope all` |
+| duplicates the work description | **pointer only** — names the seed/ticket; duplicates no content (DRY) |
+| left even on finished work | **nothing-verifiable-to-point-at ⇒ noop**; and the block's human line **self-declares stale** ("if `<KEY>` is resolved/closed, delete this block") so a reader can retire it on sight |
+
+**Scope gate** (honoring *"onde for cabível"* without weaponizing it):
+
+- **`conservative` (default)** = **commit-trailer + PR-body** — the two places a continuation
+  naturally belongs, both of which already carry session state (exit-hygiene-safe).
+- **`all` (opt-in)** = the above **plus caller-named `--file` targets** (docs, CHANGELOG
+  `[Unreleased]`) — broader amnesia-coverage on demand. **The caller (agent), not the script,
+  decides which files are *cabível*** — the script only *enforces* safety (idempotent · ADR-refused
+  · sanitized · dry-run-default). Judgment stays with the agent; safety with the deterministic layer.
+
+**ADR / decision records are refused.** A decision record is immutable and is not a transient
+worklist — a continuation marker does not belong in it (the anti-theater-honest reading of *cabível*:
+an ADR is not an *appropriate* place). The executor refuses, **case-insensitively**, any path under
+`adrs/`, `adr/`, or `decisions/`, any `ADR-*.md`/`adr-*.md` basename, and any MADR numbered basename
+(`0001-*.md`). It also **refuses symlink targets** (a symlinked name could otherwise redirect the
+write past the refusal). This is best-effort-by-path, not a semantic guarantee — see the residual
+below.
+
+**Corruption-safe by construction.** The in-file upsert is **fail-closed**: it acts only on a
+*well-formed* single sentinel region (exactly one correctly-ordered `START…END` pair, whole-line
+matched). Any malformed state — a dangling `START`, a duplicated or out-of-order sentinel (e.g. a
+hand-edited or merge-mangled PR body) — makes the executor **refuse and leave the artifact
+untouched** rather than risk a mass-delete-to-EOF or a duplicated block. Regression-locked by the
+test suite.
+
+**Opt-in, backward-compatible.** BROADCAST is **off by default on `postflight`** (existing behavior
+unchanged) — enabled via `--broadcast[=conservative|all]`. It is **default-ON only in the new
+`signoff` verb**, whose whole purpose is the operator's "close out + leave breadcrumbs" gesture.
+
+## Consequences
+
+**Positive**
+- The tracked continuation becomes **discoverable** where the next agent lands (commit/PR/optionally docs) — the operator's core ask, without violating exit-hygiene.
+- Deterministic + byte-idempotent + dry-run-default + kill-switch (`MAOS_BROADCAST=0`) + **fail-closed on malformed input** → safe to compose into the autonomous close-out; verified by `bin/tests/continuation-broadcast.test.sh` (20 assertions incl. idempotency, the malformed-sentinel fail-closed, payload-injection, symlink, and unbacked-seed regressions).
+- DRY: reuses the P3 seed + P2.5 ticket (points at them; reinvents neither).
+
+**Negative / mitigations**
+- A marker is one more thing in a commit/PR. *Mitigation:* one bounded block, byte-idempotent (no accumulation, no churn), and only when a **verified** pendency exists (noop otherwise).
+- **Stale-marker in a durable `--scope all` doc is the sharpest residual.** commit-trailer and PR-body staleness is self-limiting (immutable history / PRs close), but a marker left in a *durable doc* after the continuation resolves would read as a live pendency. *Mitigations shipped:* the block's human line **self-declares stale + instructs its own removal** once `<KEY>` is closed, and `--scope all` is **opt-in / experimental** for durable docs (the safe default is `conservative` = commit-trailer + PR-body). *Deferred (tracked, not built here):* a `--retract` that removes markers when the continuation closes — the mechanical complement to the self-declaration.
+- **`--scope all` semantic-appropriateness rests on agent discretion; only decision-records are mechanically excluded.** The deterministic layer prevents *accumulation / immutable-doc mutation / secrets / malformed-corruption* — it does **not** judge *wrong-file*. *Mitigation:* `conservative` is the defensible default; `all` is the deliberate opt-in whose file choice is the agent's (audited) judgment, bounded by ADR-refusal + caller-named-only + dry-run-default.
+
+## Rejected alternatives
+
+- **(a) Free-form "TODO: continue X next session" breadcrumb** — the naive fix; **forbidden** by
+  exit-hygiene (unbounded, unstructured, accumulating). Rejected outright.
+- **(b) Ticket/seed only (status quo — no marker)** — leaves the continuation tracked but
+  **undiscoverable** from the artifacts a next agent lands on (the exact gap). Rejected: it is the
+  problem.
+- **(c) Broadcast into every artifact by default, including ADRs** — maximal discovery but
+  weaponizes *"cabível"* into entropy + mutates immutable decision records. Rejected: `conservative`
+  default + ADR-refusal is the safe middle.
+- **(d) A new standalone marker file (`CONTINUATION.md`)** — a single well-known file. Rejected:
+  it re-introduces a discovery problem (the next agent must know to open it) and duplicates the
+  seed; the marker-at-point-of-contact + the existing seed/ticket already cover it (Gordian: no new
+  artifact where existing sinks + a pointer suffice).
+
+## Related
+
+- `skills/postflight/references/continuation-broadcast-protocol.md` — the marker SSOT (shape/sinks/guardrails).
+- `bin/continuation-broadcast.sh` + `bin/tests/continuation-broadcast.test.sh` — executor + tests.
+- `skills/postflight/SKILL.md` **P3.6 BROADCAST** — the phase that invokes it (opt-in).
+- `commands/signoff.md` + `skills/signoff/SKILL.md` — the sign-off verb (broadcast default-ON).
+- `protocols/exit-hygiene.md` — the anti-breadcrumb rule reconciled here.
+- `skills/postflight/references/{continuation-seed-contract.md,ticket-sync-protocol.md}` — the SSOT the marker points at.
+- `skills/postflight/references/close-out-hunt-checklist.md` — the P2 hunt that determines whether a pendency (hence a broadcast) exists.

--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -189,7 +189,7 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
    ⇒ DEFER(ticket) (record in `tickets_created`), then continue. Record the continuation key
    for P3.5.
 3. P3 HANDOFF: synthesize the continuation seed (below) from P1+P2+P2.5 → print + clipboard.
-   Populate (per contract v1.1.0): `refs.ticket` = **the P2.5 continuation ticket key** (so the
+   Populate (per contract v1.2.0): `refs.ticket` = **the P2.5 continuation ticket key** (so the
    spawned session's preflight R0 hook — which anchors off `refs.ticket` — wakes anchored on
    the *right* node; falls back to the current anchor only when no continuation ticket) ·
    `session_type` (`<mode>/<work>`) · `dna` (the 3 principles + ≤5 `session_learnings` +

--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -11,10 +11,14 @@ description: |
   ticketing primitive; (P3 HANDOFF) emit an ai-agnostic continuation seed (carrying the DNA
   Geracional) a fresh amnesic agent can resume from; (P3.5 SPAWN, optional, default-ON) launch
   a fresh, pre-seeded `claude` continuation session so the work continues across the
-  compact/clear boundary. The end-of-session counterpart to the `preflight` skill. Reads
+  compact/clear boundary; (P3.6 BROADCAST, opt-in) inject a bounded, structured, idempotent
+  continuation **back-pointer marker** (to the P2.5 ticket + P3 seed) into work artifacts
+  (commit trailer · PR body · caller-named docs) so a fresh amnesic agent that lands on the
+  artifact discovers the pending work — a structured back-pointer, never a free-form TODO
+  (reconciled with exit-hygiene by ADR-010). The end-of-session counterpart to the `preflight` skill. Reads
   whatever governance is present at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/
   memories) and adapts.
-version: 0.7.0
+version: 0.8.0
 triggers:
   - postflight
   - run postflight
@@ -30,7 +34,7 @@ triggers:
   - sync the backlog
   - file the loose ends as tickets
 metadata:
-  version: "0.7.0"
+  version: "0.8.0"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -78,11 +82,16 @@ turns that volatile state into durable, hand-off-able artifacts **before** the l
 ## Core Rule
 
 ```
-SWEEP (P1) → DEBRIEF (P2) → TICKET-SYNC (P2.5) → HANDOFF (P3) → [SPAWN (P3.5, optional, default-ON)]
+SWEEP (P1) → DEBRIEF (P2) → TICKET-SYNC (P2.5) → HANDOFF (P3) → [SPAWN (P3.5, optional, default-ON)] → [BROADCAST (P3.6, opt-in)]
 Each step is SAFE-or-DEFER. Never clobber. Never block. HANDOFF requires SWEEP+DEBRIEF (DoR).
+DEBRIEF hunts the COMPLETE 10-item taxonomy (references/close-out-hunt-checklist.md): fails · errors ·
+warnings · risks · mitigations · gaps · pendings · decisions-not-taken · unasked-Qs · unanswered-Qs.
 TICKET-SYNC needs the P2 atoms + runs BEFORE the seed (so the continuation ticket lands in it);
 it is bounded (<=3 tickets + 1 batch) + capability-detected + DEFER-not-block when no tracker.
 SPAWN requires the P3 seed (DoR) + passes the spawn guardrails; opt out with --no-spawn.
+BROADCAST is OPT-IN (--broadcast[=conservative|all]); it needs the P3 seed + the P2.5 continuation
+ticket, points a structured back-pointer marker AT them (never free-form; ADR-010), is idempotent,
+--dry-run by default, and NOOP when there is no pendency to point at. Default-ON only in `signoff`.
 The environment MUST be left better, safer, and more traceable than it was found.
 ```
 
@@ -91,10 +100,11 @@ The environment MUST be left better, safer, and more traceable than it was found
 | # | Responsibility | How (safe-or-DEFER) | Composes |
 |---|---|---|---|
 | **P1** | **SWEEP** — operationalize the exit-hygiene checklist: no loose ends, no banana peels | for each axis {git · docs · ADRs · changelogs · memories · rules · tickets/backlogs · worktrees/branches · stale metrics}: *survey* gaps/opportunities → classify by Eisenhower → **act** (persist/fix/version/commit/push/close) **or register** a tracked follow-up. Read-before-discard is mandatory. | `protocols/exit-hygiene.md`, `skills/sync-to-git`, `skills/quiesce`, `commands/worktree.md`, `bin/reap-sessions.sh`, `bin/dogfood-mark` |
-| **P2** | **DEBRIEF** — calculate the session map | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive), gaps, pendings, undecided decisions, unasked/unanswered questions, next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know locus** — D2 status line + D3 ntree + D4 conv — via `bin/locus.sh` (the compact projection of this debrief; grammar SSOT `references/locus-spec.md`), **and the end-of-action scorecard** — `bin/scorecard.py --model N` where `N` is chosen by `bin/scorecard-select-model.sh` (dynamic context-based decision table; round-robin preserved as `--mode round-robin` fallback; see "The End-of-Action Scorecard" below). | `skills/morning-briefing`, `bin/locus.sh`, `bin/scorecard.py`, `bin/scorecard-select-model.sh` |
+| **P2** | **DEBRIEF** — calculate the session map + run the complete close-out hunt | compose `morning-briefing` (its 7-section state: done · in-flight · blockers · decisions · next-action) then **synthesize on top** the objectives N-Tree (primary/secondary/auxiliary × sequential/parallel/recursive) + the **COMPLETE 10-item close-out HUNT** (`references/close-out-hunt-checklist.md` — fails · errors · warnings · risks+mitigations · gaps · pendings · decisions-not-taken · unasked-Qs · unanswered-Qs; each atom dispositioned fix-now / ticket / seed-field / drop-with-note — no silent drop), next-actions ranked by Eisenhower (non-blocked first). Then **render the glance-and-know locus** — D2 status line + D3 ntree + D4 conv — via `bin/locus.sh` (the compact projection of this debrief; grammar SSOT `references/locus-spec.md`), **and the end-of-action scorecard** — `bin/scorecard.py --model N` where `N` is chosen by `bin/scorecard-select-model.sh` (dynamic context-based decision table; round-robin preserved as `--mode round-robin` fallback; see "The End-of-Action Scorecard" below). | `skills/morning-briefing`, `bin/locus.sh`, `bin/scorecard.py`, `bin/scorecard-select-model.sh` |
 | **P2.5** | **TICKET-SYNC** — reconcile the backlog with the session | *(a)* triage each P2 atom (gaps · pendings · undecided · unasked-Qs · out-of-scope) → anti-theater filter → dedup → Eisenhower Q1-Q4 → file under the **cap (≤3 tickets + 1 batch housekeeping ticket)**; *(b)* create/reuse the **idempotent continuation ticket** (search-before-create; body mirrors the seed; provider-relative linkage); *(c)* enrich the anchored ticket. **All ops delegated** to a capability-detected ticketing primitive (no custom state — the tracker is the state). Bounded-autonomous; HITL only for HUMAN_DOMAIN / unknown-provider. **No tracker ⇒ DEFER(ticket), never block.** | `skills/postflight/references/ticket-sync-protocol.md` (SSOT) + a capability-detected ticketing skill (ref: `ticket-as-prompt`) |
-| **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` field `<status>·<anchor>·<slug>[·#seq]`, the `session_type`, the `dna` block, the `continuation_ticket` from P2.5, and `tickets_created`); print to screen + best-effort clipboard. DoR = P1+P2+P2.5 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) + `references/continuation-seed-contract.md` v1.1.0 |
+| **P3** | **HANDOFF** — emit the continuation seed | a minimal-sufficient, ai-agnostic seed (structured agent-register envelope + human mirror) a fresh amnesic agent can resume from (the seed carries the D1 `locus` field `<status>·<anchor>·<slug>[·#seq]`, the `session_type`, the `dna` block, the `continuation_ticket` from P2.5, and `tickets_created`); print to screen + best-effort clipboard. DoR = P1+P2+P2.5 done. | this skill (the elevation over `morning-briefing` recap) + `skills/session-fission` (seed shape) + `references/continuation-seed-contract.md` v1.2.0 |
 | **P3.5** | **SPAWN** *(optional, default-ON)* — launch the next session, pre-seeded | hand the P3 seed to `bin/spawn-continuation.sh`, which launches a fresh **named** detached `claude` session (tmux/cmux) — the name IS the D1 locus (`<status> · <anchor> · <slug> · #<short>`, e.g. `🟡 · VKS-123 · payment-retry · #a1b2c3d4`; pass the ticket via `--ticket` so it anchors, keep the `--slug` to the 2-4-word work essence — locus dedupes anchor-repeated tokens; emoji-first experiment, `POSTFLIGHT_NAME_STYLE=legacy` restores the ascii `<ticket>-<slug>-#<short>`) — with the seed injected as durable system context — so the work *continues itself* across the compact/clear boundary instead of waiting on a manual paste — the spawn also submits a positional **kickoff prompt** (pointing at the persisted seed file) so the new session STARTS WORKING instead of idling at the REPL (opt out: `--no-kickoff` / `POSTFLIGHT_KICKOFF=0`). DoR = P3 seed. Opt out: `--no-spawn`. | `bin/spawn-continuation.sh` (consumes the P3 seed; reuses `session-fission`'s reseed idea) |
+| **P3.6** | **BROADCAST** *(opt-in)* — make the tracked continuation discoverable at the point of future contact | ONLY when a pendency remains: inject a **bounded, structured, idempotent back-pointer marker** (to the P2.5 continuation ticket + P3 seed) into work artifacts via `bin/continuation-broadcast.sh` — `--scope conservative` (default) = the exit **commit trailer** (`Continue-Here: <key> · seed:<path>`) + the open **PR body** (idempotent upsert via `gh`); `--scope all` ALSO stamps **caller-named `--file` docs/changelogs** (ADRs REFUSED). The marker is a **structured back-pointer, not a free-form TODO** (reconciled with exit-hygiene by ADR-010): sentinel-delimited + machine-readable + idempotent (upsert, never accumulate) + metadata-only (sanitized) + `--dry-run` default + kill-switch (`MAOS_BROADCAST=0`). DoR = P3 seed and/or the P2.5 ticket. **NOOP when nothing pending.** OFF by default on `postflight` (`--broadcast` to enable); default-ON in `signoff`. | `bin/continuation-broadcast.sh` + `references/continuation-broadcast-protocol.md` (SSOT) + `docs/adrs/ADR-010-continuation-broadcast.md` (consumes the P3 seed + P2.5 ticket — reinvents neither) |
 
 **SWEEP never clobbers**: a dirty tree, a divergence-with-conflict, a held `.git/index.lock`,
 or an untracked file you did not create → **DEFER** (report/register, do not act). Deleting or
@@ -149,9 +159,14 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
      job (not here) — P1 owns ticket **close**, P2.5 owns ticket **create/enrich**.
    - Classify every surfaced item by Eisenhower; act on Q1/Q2, register Q3, note/drop Q4.
 2. P2 DEBRIEF: invoke `morning-briefing` for the 7-section state, then synthesize ON TOP the
-   objectives N-Tree + Eisenhower next-actions (non-blocked first) + gaps/pendings/undecided/
-   unasked-Qs. (The community `morning-briefing` provides state + next-action; postflight adds
-   the N-Tree + Eisenhower ranking.) **Distil ≤5 session learnings** and append them to the
+   objectives N-Tree + Eisenhower next-actions (non-blocked first) + the **COMPLETE 10-item
+   close-out HUNT** (SSOT `references/close-out-hunt-checklist.md`): survey fails · errors ·
+   warnings · risks+mitigations · gaps · pendings · decisions-not-taken · unasked-Qs ·
+   unanswered-Qs — each atom past the anti-theater filter, dispositioned exactly one of
+   fix-now / ticket (P2.5) / seed-field (P3) / drop-with-note (Taxis no-silent-drop). Risks land
+   in the seed's `risks[]` (contract v1.2.0); the hunt result also decides whether P3.6 broadcasts.
+   (The community `morning-briefing` provides state + next-action; postflight adds the N-Tree +
+   Eisenhower ranking + the complete hunt.) **Distil ≤5 session learnings** and append them to the
    DNA learnings log (governance-discovered path; they become the seed's `dna.session_learnings`).
    This is the session map — then render it as the
    glance-and-know locus (D2+D3+D4) via `bin/locus.sh`, AND render the end-of-action
@@ -189,8 +204,19 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
    work (payment-retry · judge-round-a3). Never embed the ticket id / repo name / status —
    pass the ticket via --ticket (it becomes the anchor); locus drops anchor-duplicated
    tokens anyway (spec: references/locus-spec.md "slug quality + normalization").
+3.6 P3.6 BROADCAST (OPT-IN — `--broadcast[=conservative|all]`; skip when off / no pendency /
+   kill-switch — SSOT: references/continuation-broadcast-protocol.md + ADR-010):
+   ONLY if the P2 hunt found a genuine pendency (gap/pending/undecided/risk the next agent must
+   pick up) AND a P3 seed and/or a P2.5 continuation ticket exists → make it *discoverable at the
+   point of future contact*. Run `bin/continuation-broadcast.sh --ticket <CONT-KEY> --seed
+   <seedfile> --scope <conservative|all> [--pr <N>] [--file <path> ...] --apply` (default `--dry-run`):
+   it prints the `Continue-Here: <key> · seed:<path>` **commit trailer** (append it to the closing
+   commit), idempotently upserts the marker block into the **PR body** (`--pr`, needs `gh`), and —
+   under `--scope all` — into **caller-named docs** (`--file`; ADRs refused). Structured back-pointer,
+   never a free-form TODO; idempotent; metadata-only (sanitized); NOOP when nothing pending. OFF by
+   default on postflight; default-ON in `signoff`.
 4. Emit a concise exit summary (swept items, tickets closed/created/continuation, deferred
-   items, seed location, spawned session).
+   items, seed location, spawned session, broadcast markers).
 ```
 
 ## The Continuation Seed (the P3 deliverable)
@@ -201,14 +227,15 @@ amnesia premise: a gifted agent with no cross-session recall). Two registers, sa
 - **Agent register** (default — economical, machine-parseable; emit as a JSON-RPC-style
   envelope, `--lang` selectable).
 
-  **SSOT (contract v1.1.0)**: the full seed shape lives in
+  **SSOT (contract v1.2.0)**: the full seed shape lives in
   [`templates/continuation-seed.template.json`](templates/continuation-seed.template.json)
   and its field-by-field contract in
   [`references/continuation-seed-contract.md`](references/continuation-seed-contract.md)
   (REQUIRED resume-spine: `who_you_are` · `bootstrap_order` · `inherited_state` · `mission`
   · `guardrails` · `dod` · `dag` · `refs` · `resume_instructions`; plus the optional debrief
   fields and the v1.1.0 additions `session_type` · `dna` (object) · `continuation_ticket` ·
-  `tickets_created`). Populate the template — do NOT re-derive the shape inline. Short excerpt:
+  `tickets_created` + the v1.2.0 addition `risks` (the hunt's forward-looking half)). Populate
+  the template — do NOT re-derive the shape inline. Short excerpt:
 
 ```json
 {"jsonrpc":"2.0","method":"session.continuation","params":{
@@ -223,9 +250,10 @@ amnesia premise: a gifted agent with no cross-session recall). Two registers, sa
   "dna":{"principles":["...","...","..."],"canonical_ref":"...","session_learnings":["..."],"learnings_ref":"<path|none>"},
   "continuation_ticket":{"key":"<key|none>","url":"...","parent":"...","link":"relates-to|child-of"},
   "tickets_created":[{"key":"<key>","eisenhower":"Q1|Q2|Q3|Q4","link":"..."},{"deferred":true,"eisenhower":"Q1|Q2|Q3|Q4","link":"none","reason":"..."}],
+  "risks":[{"risk":"<forward-looking hazard for the next agent>","mitigation":"<how to mitigate>","severity":"low|med|high"}],
   "next_actions":[{"task":"...","eisenhower":"Q1|Q2|Q3|Q4","blocked_by":null}],
   "resume_instructions":"Run /maos:preflight first; then follow bootstrap_order; then the first non-blocked next_action. INTERNALIZE params.dna + transcribe the 3 principles to every sub-agent you spawn."
-},"data":{"layer":"community","contract":"skills/postflight/references/continuation-seed-contract.md","contract_version":"1.1.0"}}
+},"data":{"layer":"community","contract":"skills/postflight/references/continuation-seed-contract.md","contract_version":"1.2.0"}}
 ```
 
 - **Human mirror**: the same, rendered as a short scannable briefing for the operator.
@@ -272,7 +300,8 @@ Gallery of the 8 models: `skills/postflight/scorecards/gallery.md`.
 
 | Condition | Path |
 |---|---|
-| operator-invoked / on-demand | `/maos:postflight` (full) or a sub-phase `sweep` / `debrief` / `seed` / `spawn` |
+| operator-invoked / on-demand | `/maos:postflight` (full) or a sub-phase `sweep` / `debrief` / `seed` / `spawn` / `broadcast` |
+| broadcast the continuation marker (opt-in) | `/maos:postflight --broadcast[=conservative\|all]` (OFF by default here; **default-ON** in `/maos:signoff`); kill-switch `MAOS_BROADCAST=0` |
 | auto-invoked before context loss / `compact` / `clear` / **context>N%** | a **live agent** runs the full skill (incl. P3.5 SPAWN); the deterministic **PreCompact hook** is a snapshot-only safety-net that **never spawns** (a shell hook must not launch a token-burning agentic session — anti-pattern #5/#9) |
 | mid-action checkpoint | `/maos:postflight debrief` (recap without the full sweep) |
 | spawn opt-out / preview | `/maos:postflight --no-spawn` · `--dry-run` · env `POSTFLIGHT_SPAWN=0` |
@@ -318,6 +347,10 @@ postflight P1: branch=main tree=DIRTY → SWEEP DEFERRED (uncommitted tracked ch
 12. ❌ **Ticket-for-theater** — filing a ticket for a non-actionable/vanity/already-done atom. A ticket must change someone's next action (it must pass the anti-theater filter).
 13. ❌ Call a **tracker API from the deterministic PreCompact hook** — P2.5 ticket I/O belongs to the live skill; the hook is a zero-network snapshot and must never hit a tracker.
 14. ❌ Create a **duplicate continuation ticket** — always `auto` (search-before-create); the 2nd run reuses + enriches the existing one, never re-creates.
+15. ❌ **Partial hunt** — surveying only the 5 easy P2 atoms and leaving fails/errors/warnings/risks/mitigations implicit; run the COMPLETE 10-item hunt (`references/close-out-hunt-checklist.md`), disposition every atom (no silent drop).
+16. ❌ **Free-form BROADCAST** — injecting a "TODO next session" marker instead of the structured back-pointer block (defeats the exit-hygiene reconciliation, ADR-010; the executor only emits the structured, idempotent form).
+17. ❌ **BROADCAST into an ADR** or mid-content of a doc — ADRs are refused; the executor upserts the sentinel region only, into caller-named files under `--scope all`.
+18. ❌ **BROADCAST with no pendency** — a marker on a fully-closed session is noise (NOOP when nothing pending); and never a **non-idempotent** placement (the sentinel upsert prevents accumulation — entropy is exponential).
 
 ## Related Multi-Agent OS Artifacts
 
@@ -330,6 +363,9 @@ postflight P1: branch=main tree=DIRTY → SWEEP DEFERRED (uncommitted tracked ch
 - `skills/sync-to-git/SKILL.md` · `skills/quiesce/SKILL.md` — git close-out + PR convergence P1 composes.
 - `skills/session-fission/SKILL.md` — orthogonal: it *splits* a tangled session into N seeds; P3 emits *one* resume seed for continuity, and P3.5 reuses its reseed-a-fresh-session idea for continuity-spawn.
 - `bin/spawn-continuation.sh` — the **P3.5 SPAWN** primitive: launches the named, pre-seeded `claude` continuation session (tmux/cmux) with the 7 guardrails; consumes the P3 seed.
+- `bin/continuation-broadcast.sh` + `skills/postflight/references/continuation-broadcast-protocol.md` (SSOT) + `docs/adrs/ADR-010-continuation-broadcast.md` — the **P3.6 BROADCAST** executor + spec + reconciliation: a bounded, structured, idempotent back-pointer marker (commit trailer · PR body · caller-named docs) that makes the tracked continuation discoverable at the point of future contact (opt-in; structured back-pointer, never a free-form TODO). `bin/tests/continuation-broadcast.test.sh` is its safety-contract suite.
+- `skills/postflight/references/close-out-hunt-checklist.md` — the **P2 DEBRIEF** complete 10-item HUNT SSOT (fails · errors · warnings · risks+mitigations · gaps · pendings · decisions-not-taken · unasked-Qs · unanswered-Qs) + the fix-now/ticket/seed/drop disposition rubric.
+- `commands/signoff.md` + `skills/signoff/SKILL.md` — the operator-facing **sign-off / encerramento** verb (`/maos:signoff`) that composes `[quiesce →] postflight full --broadcast --spawn` under an OODA framing; the one place BROADCAST is default-ON.
 - `commands/worktree.md` (surfaces `reap`) · `bin/reap-sessions.sh` (the safe executor P1 SWEEP delegates stale/orphan worktree+branch pruning to — dry-run default, never-clobber) · `bin/dogfood-mark` — worktree cleanup + dogfood-cycle ledger.
 - `commands/postflight.md` → `/maos:postflight` (ergonomic entry point; surfaces `--spawn`/`--no-spawn`/`--dry-run`).
 - `plugin-scripts/governance/postflight-precompact.sh` — PreCompact hook (deterministic seed snapshot; never blocks; **never spawns**).

--- a/skills/postflight/references/close-out-hunt-checklist.md
+++ b/skills/postflight/references/close-out-hunt-checklist.md
@@ -1,0 +1,95 @@
+---
+name: close-out-hunt-checklist
+description: The complete 10-item end-of-session HUNT taxonomy (fails · errors · warnings · risks · mitigations · gaps · pendings · decisions-not-taken · unasked-Qs · unanswered-Qs) + a disposition rubric (fix-now / ticket / seed-field / drop) — the SSOT postflight P2 DEBRIEF surveys
+version: 1.0.0
+---
+
+# Close-Out Hunt Checklist (SSOT) — postflight P2 DEBRIEF
+
+> **Version**: 1.0.0 (2026-07-10)
+> **Scope**: AAIF cross-vendor. The single source of truth for **what postflight P2 DEBRIEF
+> hunts for** at the session boundary — the complete 10-category survey — and **where each
+> found atom is dispositioned** (fix-now · ticket · seed-field · drop-with-note).
+> **Position**: consumed by `skills/postflight/SKILL.md` **P2 DEBRIEF**; its outputs feed
+> **P2.5 TICKET-SYNC** (the ticketable atoms), **P3 HANDOFF** (the seed fields), and — when
+> `--broadcast` is on — **P3.6 BROADCAST** (the discovery markers).
+> **Cross-link slug**: `close-out-hunt-checklist`
+
+## Purpose
+
+An amnesic agent that debriefs an incomplete list leaves the rest **invisible** — and *"what
+is not seen is not remembered"* (the locus master principle). The operator's close-out ask is
+explicit: at exit, **hunt for `[fails · errors · warnings · risks · mitigations · gaps ·
+pendings · decisions-not-taken · important-unasked-questions · unanswered-questions]`** so the
+handoff is honest and complete. This checklist makes that survey **first-class + total** — no
+category is implicit — and binds every found atom to a **disposition**, so nothing is either
+silently dropped (Taxis no-silent-drop) or theatrically filed (anti-theater).
+
+Historically postflight P2 surfaced **5 of the 10** first-class (`gaps · pendings · undecided
+· unasked-Qs · unanswered-Qs`); the diagnostic + forward-looking half (`fails · errors ·
+warnings · risks · mitigations`) was implicit. This SSOT completes the taxonomy.
+
+## The 10-category hunt (survey → disposition)
+
+For each category: **survey** the session's real state (verified, not asserted — Mente Tomé),
+then **dispose** per the rubric. Every atom passes the **anti-theater filter first**
+(real ∧ actionable ∧ changes-someone's-next-move? — else drop-with-one-line-note, never file).
+
+| # | Category | Survey question (what to look for) | Default disposition | Lands in |
+|---|---|---|---|---|
+| 1 | **fails** | Did anything the session ran **fail**? (CI/build/test red, a job that exited non-zero, an unmet acceptance criterion) | **fix-now** if in-scope + cheap (exit-hygiene "fix NOW"); else **ticket** (P2.5, Eisenhower) + record | seed `inherited_state.verified_facts` / `gaps`; P2.5 ticket |
+| 2 | **errors** | Any **error** encountered (runtime exception, tool error, a command that errored and was worked-around)? | **fix-now** the root (root-cause-first) if in-scope; else **ticket** + record the workaround | seed `gaps`; P2.5 ticket |
+| 3 | **warnings** | Any **warning** raised (deprecation, lint, a non-fatal advisory, a "works but…") that a next agent should know? | **note** if it changes the next agent's behavior; else **drop-with-note** | seed `gaps` (or dropped-note) |
+| 4 | **risks** | What could **go wrong for the next agent / downstream** (fragile assumption, untested path, irreversible-adjacent step, a "for now" shortcut)? | **carry forward** (always — a risk unseen is a risk realized); Q1/Q2 risk also → **ticket** | seed `risks[]` (`{risk, mitigation, severity}`); P2.5 ticket if high |
+| 5 | **mitigations** | For each risk, **how is it mitigated / how should the next agent mitigate it**? | **pair with its risk** (a risk without a mitigation is half-surveyed) | seed `risks[].mitigation` |
+| 6 | **gaps** | What is **missing** from "done" (a deliverable not produced, coverage not added, a spec not met)? | **ticket** per P2.5 Eisenhower; carry forward | seed `gaps[]`; P2.5 ticket |
+| 7 | **pendings** | What is **started-but-not-finished** / awaiting an external event (a PR mid-PDCA, a running job, a review pending)? | **continuation** (anchors the next session) + carry forward | seed `pendings[]`; P2.5 **continuation ticket** |
+| 8 | **decisions-not-taken** | What **open decision / undecided fork** did the session leave (an A/B/C not chosen, a design left ambiguous)? | **carry forward**; if it BLOCKS the next step → surface to operator (AskUserQuestion) or ticket | seed `undecided[]` |
+| 9 | **unasked-questions** | What **important question should have been asked** but wasn't (a should-have-clarified, a blind-spot)? | **carry forward** (the next agent asks it) | seed `unasked_questions[]` |
+| 10 | **unanswered-questions** | What operator/HITL question is **still pending an answer** (asked, not yet answered)? | **carry forward** + surface in the exit briefing | seed `unasked_questions[]` (or its own note); exit briefing |
+
+## Disposition rubric (the four exits — one per atom, never "silent nothing")
+
+Per Taxis (`loose-end-triage-queue` — no silent drop) + exit-hygiene (Axiom 4 proactive-resolution
++ the Delegation gate "registered with traceability"), every surveyed atom exits via **exactly
+one** of:
+
+1. **fix-now** — resolve it this session (exit-hygiene "fix NOW, there is no later"). Preferred
+   for in-scope, cheap, reversible fails/errors (P1 SWEEP).
+2. **ticket** — file a bounded, Eisenhower-triaged ticket via **P2.5 TICKET-SYNC** (≤3 + 1 batch
+   cap). The tracker becomes the durable memory (mechanize-don't-memorize).
+3. **seed-field** — carry it into the **P3 HANDOFF** continuation seed (the field named in the
+   table's "Lands in" column) so the next amnesic agent inherits it. Risks/gaps/pendings/
+   undecided/questions are seed-carried **by default** (they change the next agent's behavior).
+4. **drop-with-note** — decide NOT to carry it, logging a one-line audit note (what + why). An
+   honest, logged non-carry — the ONLY legitimate "nothing" (never omission).
+
+**No fifth exit.** An atom that is neither fixed, ticketed, seeded, nor explicitly-dropped is a
+**silently-dropped loose end** — the exact anti-pattern this checklist (and Taxis) forbids.
+
+## Anti-patterns (do NOT)
+
+1. ❌ **Partial hunt** — surveying only the 5 easy categories and leaving fails/errors/warnings/
+   risks/mitigations implicit (the incompleteness this SSOT exists to fix).
+2. ❌ **Hunt-theater** — filing a ticket / seeding an atom that is vanity/already-done/non-actionable
+   (fails the anti-theater filter). An atom must change someone's next move.
+3. ❌ **Silent drop** — letting a surveyed atom exit via none of the four dispositions (Taxis).
+4. ❌ **Risk without mitigation** — carrying a `risk` with no paired mitigation (half-surveyed;
+   the next agent inherits the fear without the remedy).
+5. ❌ **Assert-not-verify** — reporting a fail/error from memory instead of the real session
+   state (a stale/guessed status is worse than none — Mente Tomé + anti-theater R3).
+
+## Related artifacts
+
+- `skills/postflight/SKILL.md` — **P2 DEBRIEF** runs this hunt; **P2.5** tickets the ticketable
+  atoms; **P3** seeds the carried atoms; **P3.6** (opt-in) broadcasts the discovery marker.
+- `skills/postflight/references/continuation-seed-contract.md` — the seed fields the carried
+  atoms land in (`gaps` · `pendings` · `undecided` · `unasked_questions` · **`risks`** (added
+  in contract v1.2.0 for categories 4+5) · `inherited_state`).
+- `skills/postflight/references/ticket-sync-protocol.md` — **P2.5** files the ticketable atoms
+  (bounded ≤3 + 1 batch).
+- `protocols/exit-hygiene.md` — the fix-now vs register-with-traceability gate this rubric applies.
+
+## License
+
+MIT (matches the multi-agent-os repo `LICENSE`).

--- a/skills/postflight/references/continuation-broadcast-protocol.md
+++ b/skills/postflight/references/continuation-broadcast-protocol.md
@@ -1,0 +1,146 @@
+---
+name: continuation-broadcast-protocol
+description: SSOT for postflight P3.6 BROADCAST — the bounded, structured, idempotent continuation back-pointer MARKER injected into work artifacts (commit trailer · PR body · caller-named docs) as additional discovery sinks of the ONE canonical continuation seed/ticket. Structured back-pointer, never a free-form TODO (reconciled with exit-hygiene by ADR-010).
+version: 1.0.0
+---
+
+# Continuation-Broadcast Protocol (SSOT) — postflight P3.6
+
+> **Version**: 1.0.0 (2026-07-10)
+> **Scope**: AAIF cross-vendor. The single source of truth for **P3.6 BROADCAST**, the postflight
+> phase that makes the tracked continuation (the P2.5 ticket + the P3 seed) **discoverable at the
+> point of future contact** — by stamping a bounded, structured, idempotent **back-pointer marker**
+> into selected work artifacts.
+> **Position**: runs **after P3 HANDOFF** (it needs the seed + the P2.5 continuation ticket key as
+> input) and is **opt-in** (`--broadcast`) on `postflight`; it is **default-ON** only in the
+> `signoff` verb. Emitting nothing when there is no pending continuation is correct behavior.
+> **Executor**: `bin/continuation-broadcast.sh` (deterministic; `--dry-run` default).
+> **Reconciliation with exit-hygiene**: `docs/adrs/ADR-010-continuation-broadcast.md`.
+> **Cross-link slug**: `continuation-broadcast-protocol`
+
+## Purpose
+
+The continuation **seed** (P3) and **ticket** (P2.5) are the SSOT of "there is pending work, here
+is how to resume it." But a fresh amnesic agent (or a different mind) who later lands on **a
+commit, a PR, or a doc** has no reason to know the seed/ticket exist. The pending work is
+**tracked but not discoverable** from where the next agent actually arrives.
+
+BROADCAST closes that gap: it injects a **discovery marker** — a structured back-pointer to the
+canonical seed/ticket — into the artifacts a next agent will encounter, so *"what is not seen is
+not remembered"* (the locus master principle) does not swallow the continuation.
+
+## The marker is a back-pointer, NOT a breadcrumb TODO (the decisive distinction)
+
+`protocols/exit-hygiene.md` forbids free-form "fix next session" TODOs and "one more TODO"
+incremental disorder. The marker is the **opposite** on every axis — it is structured (not prose),
+a verified back-pointer (not a promise, not a content-duplicate), byte-idempotent (never
+accumulates), bounded (one block per artifact; decision-records refused), and a noop when there is
+no verifiable pendency. It is exit-hygiene's own *"registered with traceability"* (Axiom 4 + the
+Delegation gate) surfaced where the next agent will find it. **The full reconciliation table lives
+in `docs/adrs/ADR-010-continuation-broadcast.md` (the decision record) — it is not duplicated here.**
+
+## The marker shape (single source → identical across sinks)
+
+Built once by the executor from `--ticket` + `--seed` (+ `--session`), so every sink carries the
+same payload.
+
+**Block form** (PR body, caller-named docs) — sentinel-delimited for idempotent upsert:
+
+```markdown
+<!-- MAOS-CONTINUE:START -->
+<!-- MAOS-CONTINUE {"ticket":"<KEY>","seed":"<repo-rel-path>","session":"<id>"} -->
+> 🔁 **Continuation pending** — resume at **<KEY>** (seed: `<repo-rel-path>`). A fresh amnesic agent: run `/maos:preflight`, then continue from the ticket/seed. _(structured back-pointer, not a TODO — see ADR-010. If **<KEY>** is already resolved/closed this marker is STALE — delete this block.)_
+<!-- MAOS-CONTINUE:END -->
+```
+
+- **Line 1/4** — `MAOS-CONTINUE:START` / `:END` sentinels, matched as **whole lines**: the
+  idempotency anchors (upsert replaces the region between them; if absent, the block is appended
+  once). The payload carries **no timestamp** → the block is byte-idempotent (re-apply = no-op).
+- **Line 2** — the machine-readable JSON payload (greppable + parseable): `ticket`, `seed`
+  (repo-relative), `session`.
+- **Line 3** — the human mirror (one line; the operator/next-agent reads it at a glance) — including
+  the **self-declared stale** instruction so a reader can retire a resolved marker on sight.
+
+**Trailer form** (the exit commit) — a git-trailer-parseable single line the executor prints for
+the caller to append to the closing commit message:
+
+```
+Continue-Here: <KEY> · seed:<repo-rel-path>
+```
+
+`git log --format='%(trailers:key=Continue-Here)'` / `git interpret-trailers` surface it.
+
+## The three sinks (by `--scope`)
+
+| Sink | `--scope` | How | Safety |
+|---|---|---|---|
+| **commit-trailer** | conservative (default) + all | executor prints `Continue-Here: …`; the caller appends it to the **exit commit** message | text-only; no file mutation; git-native |
+| **pr-body** | conservative (default) + all | `--pr <N>` → `gh pr view` → **idempotent upsert** of the block → `gh pr edit --body-file` | capability-detected (no `gh` ⇒ skip-with-note); byte-idempotent; **fail-closed** on a malformed existing marker (body left untouched); never clobbers |
+| **file** | **all only** | caller-named `--file <path>` (repeatable) → **idempotent upsert** of the block | opt-in; **ADR/decision records + symlinks REFUSED** (case-insensitive); unknown file ⇒ skip; fail-closed on malformed marker; never globs/discovers (caller decides *cabível*) |
+
+**`conservative` (the default)** = commit-trailer + PR-body — the exit-hygiene-safe set (the two
+places a continuation naturally belongs and that already carry session state). **`all`** = the
+above **plus** the caller-named `--file` targets (docs, CHANGELOG `[Unreleased]`, …) for broader
+amnesia-coverage — honoring the operator's *"onde for cabível"* while the caller (not the script)
+decides which files are appropriate.
+
+## Guardrails (deterministic; the executor enforces)
+
+1. **`--dry-run` is the DEFAULT** — mutation requires `--apply`. A preview writes nothing.
+2. **Kill-switch** — `MAOS_BROADCAST=0` ⇒ noop (deterministic opt-out).
+3. **Byte-idempotent upsert, fail-closed** — a 2nd run replaces the one sentinel region (never
+   accumulates) and the block has no timestamp (a re-apply on unchanged inputs is a true no-op). The
+   upsert acts **only** on a well-formed single `START…END` pair (whole-line matched, correctly
+   ordered); any malformed state (dangling/duplicate/out-of-order sentinel) makes it **refuse and
+   leave the artifact untouched** — it can never mass-delete-to-EOF or duplicate a block.
+4. **ADR / decision-record refusal** — refused **case-insensitively**: any `adrs/` · `adr/` ·
+   `decisions/` path, any `ADR-*.md`/`adr-*.md` basename, any MADR `0001-*.md` basename. **Symlink
+   targets are also refused** (a symlinked name could redirect the write past the refusal). A
+   decision record is immutable, not a transient worklist.
+5. **Caller-named only** — the executor never globs/discovers files; the agent decides which
+   artifacts are *cabível* (judgment stays with the agent, safety with the script).
+6. **Sanitization + injection-refusal** — the payload is **metadata-only** (ticket key · repo-relative
+   seed path · session id): a secret-shaped payload is refused, and a payload carrying a sentinel/
+   comment marker or a newline is refused (it could otherwise restructure the block). Absolute/`$HOME`
+   seed paths are relativized (no machine-path leak).
+7. **Verified referent, else noop** — the marker points only at a **verified** referent: an unfound
+   `--seed` is dropped, and with no named ticket + no existing seed the run is a noop (BROADCAST
+   never emits an unbacked marker; no pendency ⇒ nothing broadcast).
+8. **Audit-trail** — one line per **applied** sink to `~/.claude/jobs/continuation-broadcasts.log`
+   (dry-runs write nothing).
+
+## When to broadcast (and when NOT)
+
+- **Broadcast** when P2.5 produced a continuation ticket AND/OR P3 produced a seed AND a genuine
+  pendency remains (the hunt found a gap/pending/undecided/risk the next agent must pick up).
+- **Do NOT broadcast** a clean, fully-closed session (nothing pending) — there is nothing to point
+  at, and a marker on finished work is noise (the nothing-to-point-at noop enforces this).
+
+## Anti-patterns (do NOT)
+
+1. ❌ **Free-form marker** — writing prose "TODO next session" instead of the structured back-pointer
+   block (defeats the whole exit-hygiene reconciliation; the executor only emits the structured form).
+2. ❌ **Blind file injection** — stamping a marker into an ADR or mid-content of a doc (ADRs are
+   refused; the executor only upserts the sentinel region or appends one bounded block).
+3. ❌ **Duplicating the seed/ticket content** into the marker — the marker is a *pointer*; the seed
+   is the payload (no content duplication — DRY).
+4. ❌ **Broadcasting with no pendency** — a marker on a fully-closed session is noise.
+5. ❌ **Non-idempotent placement** — appending a new block each run (the sentinel upsert exists
+   precisely to prevent accumulation — entropy is exponential).
+6. ❌ **Marker payload with a secret / file body** — metadata-only (sanitization refuses it).
+
+## Related artifacts
+
+- `bin/continuation-broadcast.sh` — the deterministic executor (this protocol's implementation).
+- `bin/tests/continuation-broadcast.test.sh` — the safety-contract test suite (idempotency,
+  dry-run-default, ADR-refusal, kill-switch, sanitization).
+- `skills/postflight/SKILL.md` — **P3.6 BROADCAST** invokes this protocol (opt-in `--broadcast`).
+- `skills/postflight/references/continuation-seed-contract.md` — the seed the marker points at.
+- `skills/postflight/references/ticket-sync-protocol.md` — the P2.5 continuation ticket the marker points at.
+- `protocols/exit-hygiene.md` — the anti-breadcrumb rule this marker is reconciled with.
+- `docs/adrs/ADR-010-continuation-broadcast.md` — the reconciliation decision record.
+- `commands/signoff.md` / `skills/signoff/SKILL.md` — the sign-off verb that turns `--broadcast` ON by default.
+
+## License
+
+MIT (matches the multi-agent-os repo `LICENSE`).

--- a/skills/postflight/references/continuation-seed-contract.md
+++ b/skills/postflight/references/continuation-seed-contract.md
@@ -1,12 +1,12 @@
 ---
 name: continuation-seed-contract
 description: Field-by-field SSOT contract for the session.continuation continuation-seed envelope (worktree-lifecycle family)
-version: 1.1.0
+version: 1.2.0
 ---
 
 # Continuation-Seed Contract (SSOT)
 
-> **Version**: 1.1.0 (2026-06-13)
+> **Version**: 1.2.0 (2026-07-10)
 > **Scope**: AAIF cross-vendor. The single source of truth for the shape, semantics, and
 > hygiene rules of the `session.continuation` seed emitted/consumed across the
 > `worktree-lifecycle` family.
@@ -63,6 +63,7 @@ JSON-RPC 2.0 **notification** shape (fire-and-forget — the producer does not a
 | `objectives` | OPTIONAL | `{primary[], secondary[], auxiliary[]}` N-Tree from P2 DEBRIEF. |
 | `done` / `in_flight` | OPTIONAL | What is finished vs. mid-flight at seed-time. |
 | `gaps` / `pendings` / `undecided` / `unasked_questions` | OPTIONAL | The debrief's loose-end taxonomy. |
+| `risks` | OPTIONAL | The P2 DEBRIEF **risk survey** (the hunt's forward-looking half — `close-out-hunt-checklist.md` categories 4 **risks** + 5 **mitigations**): an array of `{risk, mitigation, severity?}`. Each element is a hazard for the next agent/downstream **paired with its mitigation** (a risk without a mitigation is half-surveyed). Carried so the resuming agent inherits the hazard AND the remedy — not just the fear. `severity` ∈ `low\|med\|high` (optional). |
 | `next_actions` | OPTIONAL | `[{task, eisenhower: Q1..Q4, blocked_by}]` — resume entry-points, non-blocked first. |
 | `governance_refs` | OPTIONAL | Governance docs the resuming agent should honor. |
 | `session_type` | OPTIONAL | The session's classification `<mode>/<work>` (e.g. `continuation/feat`), from preflight R0 / the P2 DEBRIEF. Two orthogonal axes — see `skills/preflight/references/session-type-taxonomy.md`. Lets the resuming agent (and the continuation ticket) know the *kind* of work it is continuing. |
@@ -128,5 +129,6 @@ MUST still tolerate unknown fields within the same MAJOR.
 
 | Version | Date | Change |
 |---|---|---|
+| 1.2.0 | 2026-07-10 | MINOR — 1 new OPTIONAL field `risks` (array of `{risk, mitigation, severity?}`), the seed home for the P2 DEBRIEF risk survey (the hunt's forward-looking half — `close-out-hunt-checklist.md` categories 4 "risks" + 5 "mitigations"). No REQUIRED change, no envelope break; consumers ignore it Postel-style. Producer: `skills/postflight/SKILL.md` P2/P3 (v0.8.0). |
 | 1.1.0 | 2026-06-13 | MINOR — 4 new OPTIONAL fields + 1 new consumer (no REQUIRED change, no envelope break). Adds `session_type` (the `<mode>/<work>` classification from preflight R0 / P2 DEBRIEF), upgrades `dna` to accept a **string OR object** (`{principles[3], canonical_ref, session_learnings[≤5], learnings_ref}`) so the **DNA Geracional** travels into spawned sessions (back-compat string preserved), and adds `continuation_ticket` + `tickets_created` (the P2.5 TICKET-SYNC outputs). Registers `skills/preflight/SKILL.md` **R0 ANCHOR** as a Consumer of `refs.ticket` + `session_type` — closing the `postflight → spawn → preflight` loop. Producer: `skills/postflight/SKILL.md` P2.5/P3 (v0.7.0). |
 | 1.0.0 | 2026-06-11 | Bootstrap — extracts the seed shape (previously inline-only in SKILL.md P3 + a synthesized fallback in `spawn-continuation.sh`) into a reusable template + this contract. Adds the REQUIRED resume-spine fields (`who_you_are`, `bootstrap_order`, `inherited_state`, `mission`, `guardrails`, `dod`, `dag`, `refs`) on top of the existing P3 envelope fields (kept, now OPTIONAL except `resume_instructions`; `goal` is OPTIONAL legacy-compat — skeleton producers omit it). |

--- a/skills/signoff/SKILL.md
+++ b/skills/signoff/SKILL.md
@@ -53,7 +53,7 @@ whatever mind arrives next (a fresh amnesic agent, another agent, or the operato
 It **composes, it does not reimplement** (Strata / Gordian — no new machinery). Everything is delegated:
 
 ```
-signoff [--converge] [--broadcast=<conservative|all> | --no-broadcast] [--no-spawn] [--dry-run]
+signoff [--converge] [--broadcast=<conservative|all> | --no-broadcast] [--spawn | --no-spawn] [--dry-run]
   ├─ (optional, --converge) → `quiesce`   # drive the open PR toward green first
   └─ `postflight` full --broadcast[=<scope>] [--spawn|--no-spawn] [--dry-run]
         P1 SWEEP → P2 DEBRIEF (+ the complete 10-item hunt) → P2.5 TICKET-SYNC

--- a/skills/signoff/SKILL.md
+++ b/skills/signoff/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: signoff
+description: |
+  The operator's END-OF-SESSION SIGN-OFF (encerramento) verb — invoked when you are DONE and
+  want the session closed out AND its pending work left discoverable for whoever comes next.
+  A thin OODA-framed composition (it reimplements NOTHING): Observe (recon + the complete
+  10-item close-out hunt) → Orient (root-cause + anti-theater + Eisenhower) → Decide (Taxis
+  disposition per atom) → Act (drive-to-green, sweep, ticket-sync, seed, BROADCAST the
+  continuation back-pointer marker, spawn, full git close-out). Composes `quiesce` (drive PR
+  green, optional) + `postflight full --broadcast --spawn` (the heavy close-out) — BROADCAST is
+  default-ON here (that is the whole point of a sign-off: leave a discoverable trail). Use at the
+  end of a session/thread, especially before `/compact` or `/clear`, or when handing off.
+version: 0.1.0
+triggers:
+  - signoff
+  - sign off
+  - sign off this session
+  - encerrar
+  - encerrar a sessão
+  - close out and leave breadcrumbs
+  - wrap up and broadcast the continuation
+  - end of thread sign-off
+  - i'm done here, close it out
+metadata:
+  version: "0.1.0"
+  scope: AAIF cross-vendor
+  family: worktree-lifecycle
+  lifecycle-stage: operate
+  cross_link_slug: signoff
+  dogfood_status: in-progress
+  id: MAOS-SKILL-signoff
+  type: skill
+  status: active
+  owner: maos-community
+  wraps: postflight
+  naming: "Anima-named (COMP register, descriptive-canonical) — `signoff`; rejected runner-up `disembark`. Operator may override ([C-naming])."
+  dogfooding_validation:
+    cycles_completed: 0
+    cycles_required: 2
+    promotion_eligible: false
+allowed-tools: Read, Glob, Grep, Bash, Task
+---
+
+# Signoff Skill — the sign-off / encerramento verb
+
+## Purpose
+
+`signoff` is the operator's **"I'm done — close this out properly and leave a trail"** gesture.
+Where `postflight` is the close-out *machinery*, `signoff` is the operator-facing verb that runs it
+with the continuation **BROADCAST default-ON** — so the pending work is left **discoverable** for
+whatever mind arrives next (a fresh amnesic agent, another agent, or the operator days later).
+
+It **composes, it does not reimplement** (Strata / Gordian — no new machinery). Everything is delegated:
+
+```
+signoff [--converge] [--broadcast=<conservative|all>] [--no-spawn] [--dry-run]
+  ├─ (optional, --converge) → `quiesce`   # drive the open PR toward green first
+  └─ `postflight` full --broadcast[=<scope>] [--spawn|--no-spawn] [--dry-run]
+        P1 SWEEP → P2 DEBRIEF (+ the complete 10-item hunt) → P2.5 TICKET-SYNC
+        → P3 HANDOFF (seed) → P3.5 SPAWN (default-ON) → P3.6 BROADCAST (default-ON HERE)
+```
+
+## What differs from bare `postflight` (its entire net behavior)
+
+| Aspect | `postflight` | `signoff` |
+|---|---|---|
+| BROADCAST | opt-in (`--broadcast`) | **default-ON** (`conservative`) — the point of a sign-off |
+| framing | phases | explicit **OODA** (Observe = recon + 10-item hunt · Orient = root-cause + anti-theater · Decide = Taxis · Act = execute + broadcast + git) — table in `commands/signoff.md` |
+| `--converge` | — | optionally drive the PR green via `quiesce` first |
+
+Everything else — the sweep, debrief, hunt, ticket-sync, seed, spawn, and every guardrail — is
+`postflight`'s (and `quiesce`'s). `signoff` owns only the broadcast-default-ON policy + the OODA
+framing; it holds no machinery of its own.
+
+## When to Use
+
+At the **end of a session/thread**, especially before `/compact` or `/clear`, or when handing off —
+whenever you want the close-out **and** a discoverable continuation trail (the default).
+
+## Guardrails (all inherited — `signoff` adds none of its own)
+
+Safe-or-DEFER close-out (P1: dirty tree / conflict / held `index.lock` / untracked-you-didn't-create
+→ DEFER), structured-back-pointer-not-TODO broadcast (P3.6 / ADR-010: byte-idempotent · fail-closed ·
+metadata-only · decision-records refused · `MAOS_BROADCAST=0` kill-switch · NOOP when nothing
+pending), high-blast spawn (P3.5: `POSTFLIGHT_SPAWN=0` · depth-cap · `--no-spawn`), and full git
+under `pr-review-protocol` + `auto-merge-standing-authorization` (HITL only for genuine
+HUMAN_DOMAIN residue). Full flag/example reference: `commands/signoff.md`.
+
+## Anti-patterns (do NOT)
+
+1. ❌ **Reimplement** sweep/debrief/seed/broadcast inside `signoff` — it COMPOSES `quiesce` + `postflight`.
+2. ❌ **Sign off over an un-swept state**, OR **force a spawn/broadcast the operator opted out of** —
+   the P3 DoR gates the seed/marker (so they never misreport reality); honor `--no-spawn` /
+   `--no-broadcast` / the kill-switches.
+
+## Related Multi-Agent OS Artifacts
+
+- `skills/postflight/SKILL.md` — the close-out machinery `signoff` wraps (P1–P3.6).
+- `skills/postflight/references/{continuation-broadcast-protocol.md,close-out-hunt-checklist.md}`
+  + `bin/continuation-broadcast.sh` + `docs/adrs/ADR-010-continuation-broadcast.md` — the P3.6 marker.
+- `skills/quiesce/SKILL.md` — the drive-to-green `signoff --converge` composes.
+- `commands/signoff.md` — the `/maos:signoff` entry point (full flags + examples + the OODA table).
+- `skills/preflight/SKILL.md` — start-of-session counterpart; loop `preflight → work → signoff → (spawn) → preflight …`.
+
+## License
+
+MIT (matches the multi-agent-os repo `LICENSE`).

--- a/skills/signoff/SKILL.md
+++ b/skills/signoff/SKILL.md
@@ -53,7 +53,7 @@ whatever mind arrives next (a fresh amnesic agent, another agent, or the operato
 It **composes, it does not reimplement** (Strata / Gordian — no new machinery). Everything is delegated:
 
 ```
-signoff [--converge] [--broadcast=<conservative|all>] [--no-spawn] [--dry-run]
+signoff [--converge] [--broadcast=<conservative|all> | --no-broadcast] [--no-spawn] [--dry-run]
   ├─ (optional, --converge) → `quiesce`   # drive the open PR toward green first
   └─ `postflight` full --broadcast[=<scope>] [--spawn|--no-spawn] [--dry-run]
         P1 SWEEP → P2 DEBRIEF (+ the complete 10-item hunt) → P2.5 TICKET-SYNC

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -312,6 +312,67 @@ else
 fi
 echo ""
 
+# signoff + continuation-broadcast (postflight P3.6 — ADR-010)
+echo "Validating signoff + continuation-broadcast..."
+
+BC_SCRIPT="$PLUGIN_ROOT/bin/continuation-broadcast.sh"
+if [ -x "$BC_SCRIPT" ]; then
+    pass "bin/continuation-broadcast.sh exists and is executable"
+    if bash "$BC_SCRIPT" --help >/dev/null 2>&1; then
+        pass "continuation-broadcast.sh --help exits 0"
+    else
+        fail "continuation-broadcast.sh --help should exit 0"
+    fi
+    # dry-run is the DEFAULT: a --scope all --file target is NOT mutated without --apply
+    BC_TMP="$(mktemp)"; BC_JOBS="$(mktemp -d)"; printf 'x\n' > "$BC_TMP"
+    CLAUDE_JOBS_DIR="$BC_JOBS" bash "$BC_SCRIPT" --ticket VKS-1 --seed s.json --scope all --file "$BC_TMP" >/dev/null 2>&1
+    if [ "$(cat "$BC_TMP")" = "x" ]; then
+        pass "continuation-broadcast dry-run default (no --apply ⇒ no mutation)"
+    else
+        fail "continuation-broadcast dry-run mutated a file without --apply"
+    fi
+    rm -f "$BC_TMP"; rm -rf "$BC_JOBS"
+    # kill-switch ⇒ noop
+    if MAOS_BROADCAST=0 bash "$BC_SCRIPT" --ticket VKS-1 2>/dev/null | grep -q '"status":"noop"'; then
+        pass "continuation-broadcast MAOS_BROADCAST=0 kill-switch ⇒ noop"
+    else
+        fail "continuation-broadcast kill-switch should noop"
+    fi
+else
+    fail "bin/continuation-broadcast.sh missing or not executable"
+fi
+
+BC_TESTS="$PLUGIN_ROOT/bin/tests/continuation-broadcast.test.sh"
+if [ -f "$BC_TESTS" ]; then
+    if bash "$BC_TESTS" >/dev/null 2>&1; then
+        pass "bin/tests/continuation-broadcast.test.sh passes"
+    else
+        fail "bin/tests/continuation-broadcast.test.sh FAILED (run 'bash bin/tests/continuation-broadcast.test.sh')"
+    fi
+else
+    fail "bin/tests/continuation-broadcast.test.sh missing"
+fi
+
+# signoff skill + command frontmatter
+if [ -f "$PLUGIN_ROOT/skills/signoff/SKILL.md" ] && grep -q "^name: signoff$" "$PLUGIN_ROOT/skills/signoff/SKILL.md"; then
+    pass "skills/signoff/SKILL.md has correct frontmatter"
+else
+    fail "skills/signoff/SKILL.md missing or frontmatter wrong"
+fi
+if [ -f "$PLUGIN_ROOT/commands/signoff.md" ] && grep -q "^name: signoff$" "$PLUGIN_ROOT/commands/signoff.md"; then
+    pass "commands/signoff.md has correct frontmatter"
+else
+    fail "commands/signoff.md missing or frontmatter wrong"
+fi
+
+# supporting SSOT docs
+for d in skills/postflight/references/continuation-broadcast-protocol.md \
+         skills/postflight/references/close-out-hunt-checklist.md \
+         docs/adrs/ADR-010-continuation-broadcast.md; do
+    if [ -f "$PLUGIN_ROOT/$d" ]; then pass "$d exists"; else fail "$d missing"; fi
+done
+echo ""
+
 # MAOS-Tips corpus (ADR-008) — integrity + anti-orphan gate
 echo "Validating MAOS-Tips..."
 


### PR DESCRIPTION
## [PR-as-Enhancement] Sign-off verb + postflight P3.6 continuation-broadcast marker

### Context
`maos:postflight` already tracks a session's continuation (P2.5 **ticket** + P3 **seed**), but a
fresh amnesic agent who later lands on a **commit / PR / doc** has no reason to know they exist —
the continuation is *tracked but not discoverable from where the next agent arrives*. The obvious
fix (leave a note) collides head-on with `protocols/exit-hygiene.md`, which forbids free-form
"fix next session" / "one more TODO" breadcrumbs.

### What this adds
- **`/maos:signoff`** — the operator's end-of-session **sign-off / encerramento** verb. A thin
  **OODA-framed** composition that reimplements nothing: `quiesce` (`--converge`) + `postflight full
  --broadcast --spawn`, with **BROADCAST default-ON**. Anima-named (`signoff`; rejected `disembark`).
- **postflight P3.6 BROADCAST** (opt-in `--broadcast` on `postflight`; default-ON in `signoff`) —
  injects a **bounded, structured, byte-idempotent back-pointer MARKER** to the P2.5 ticket + P3 seed
  into the exit **commit trailer** + open **PR body** (`--scope conservative`, default), plus
  caller-named **docs** (`--scope all`; ADR/decision-records refused).
- **Completes P2 DEBRIEF's 10-item close-out hunt** (adds fails · errors · warnings ·
  risks+mitigations as first-class alongside gaps · pendings · decisions-not-taken · unasked-Qs ·
  unanswered-Qs; each atom dispositioned fix-now / ticket / seed / drop — no silent drop).
- **`ADR-010`** reconciles the marker with exit-hygiene: a **structured back-pointer ≠ a free-form
  TODO** — it is exit-hygiene's own *"registered with traceability"* (Axiom 4 + Delegation gate)
  surfaced at the point of future contact (structured · verified · byte-idempotent · bounded ·
  pointer-only · noop-when-clean).

### MoE-council adversarial verify pass (verifier > generator)
A 3-lens council (security · governance · anti-over-engineering) reviewed the *built* artifacts and
found real defects the green tests missed — all fixed and regression-locked (executor v0.1.0 → v0.2.0):
- **fail-closed upsert** — a hand-edited/merge-mangled PR body (dangling/duplicate/out-of-order
  sentinel, whole-line matched) can **never** be mass-deleted-to-EOF or duplicated → refused, untouched.
- **verified seed referent** — an unfound `--seed` is dropped; no "promise with no backing".
- **byte-idempotent** block (no timestamp → re-apply is a true no-op) + **self-declares stale**.
- case-insensitive ADR/MADR `decisions/` refusal + **symlink rejection**; sentinel/newline payload
  refusal; `shift 2` arg-guards (no bash-3.2 hang); `mktemp` fail-closed.
- **governance/anti-dup**: docs made honest (stale-lifecycle + `--scope all` residual disclosed);
  `signoff/SKILL.md` trimmed 145 → 107 (removed the near-verbatim twin of `commands/signoff.md`).

### Test plan
- `bin/tests/continuation-broadcast.test.sh` — **20/20** (idempotency · byte-idempotence ·
  dry-run-default · fail-closed-on-malformed · ADR/MADR/symlink-refusal · payload-injection ·
  unbacked-seed-drop · kill-switch · sanitize).
- `bash tests/validate-plugin.sh` — **PASSED** (0 errors; 1 pre-existing unrelated warning).
- Dogfood: a dangling-`START` PR-body-like file → **refused, untouched** (no mass-delete).

### Risk + rollback
Additive + opt-in (BROADCAST OFF by default on `postflight`; existing behavior unchanged). Executor
is `--dry-run` by default + `MAOS_BROADCAST=0` kill-switch. Fully revertible (`git revert <sha>`).

### Out of scope (tracked, not dropped)
- `--retract` (mechanical stale-marker removal) — deferred; the self-declared-stale line is the
  interim mitigation.
- `morning-briefing --mode=recap` defect (referenced by postflight P2 / opera-debrief / work-compass
  but not implemented) — to be filed as a separate ticket.

### Refs
`docs/adrs/ADR-010-continuation-broadcast.md` · `skills/postflight/references/{continuation-broadcast-protocol.md,close-out-hunt-checklist.md}` · `protocols/exit-hygiene.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSqxp5hofyLXBTp8R7vb1x
