### PR TITLE
docs(prisma): E3 cross-model pilot = same-vendor correlation, not a pass (v1.2.1)

### DIFF
--- a/skills/decompose-abstract-to-measurable/E3-PILOT.md
+++ b/skills/decompose-abstract-to-measurable/E3-PILOT.md
@@ -1,9 +1,11 @@
 # E3 Pilot — inter-rater reliability of the D/T/J typing (2026-07-09)
 
-> **Honest one-line verdict:** the pilot shows the D/T/J typing rubric is **internally
-> reproducible** (κ = 0.96, almost-perfect) — a *necessary* signal — but it does **NOT** close
-> E3, because the raters were correlated (same model, same prompt). **capability ≠ validation
-> (SAGE v10.7); Tier-Professional stays BLOCKED.** E3 remains **OPEN**.
+> **Honest one-line verdict:** two lean pilots show the D/T/J typing is **internally reproducible**
+> (same-model κ = 0.96; within-Anthropic **cross-model** κ = 1.0) — a *necessary* signal — but
+> **neither closes E3**: both used **correlated raters** (same model, or same-vendor models that agree
+> even on items *designed* to split them — so the cross-model κ = 1.0 is *evidence of* that correlation,
+> not a pass). Genuine E3 needs **cross-VENDOR / human** raters. **capability ≠ validation (SAGE v10.7);
+> Tier-Professional stays BLOCKED.** E3 remains **OPEN**.
 
 ## What E3 is (and what this pilot did)
 
@@ -63,9 +65,34 @@ Also: reliability ≠ validity. Even perfect agreement would not prove the typin
 3. **Non-author constructs** — ideally constructs the skill author did not pick (removes fixture-bias),
    which also overlaps with **E2**.
 
+## Cross-model pilot addendum (2026-07-09) — within-vendor is NOT enough (empirical)
+
+Operationalized next-step 1's *cross-model* slice with the raters actually reachable in-session: **3
+genuinely-different Claude models** as independent naive raters — **Opus 4.8 · Sonnet 5 · Fable 5** (all
+≥1M per `agentic-delegation-context-floor`), same fixture, same neutral prompt, independent parallel runs
+(distinct token-usage 468k/475k/469k + latency 9s/22s/28s → not a cached echo). Raw:
+`tests/e3_crossmodel_labels.json`.
+
+| Metric | Value |
+|---|---|
+| **Fleiss' κ** (3 models × 24 items) | **1.0** → *almost-perfect* |
+| Pairwise Cohen κ | opus×sonnet = opus×fable = sonnet×fable = **1.0** |
+| Disagreement items | **0 / 24** (incl. every planted-ambiguous leaf) |
+
+**This is NOT a pass — it is evidence of the ceiling.** The fixture deliberately plants leaves *designed
+to split independent raters*; the 3 models agreed byte-identically on **every one** (reading-grade→D,
+survey→D, tone/blast-radius/elegance→J, and even `c6.l2` follows-REST→**T** — the exact leaf the same-model
+pilot had *split* on, rA=J/rB=T/rC=T). Perfect agreement *on items built to disagree* is the empirical
+fingerprint of **shared-vendor correlation** (`convergence-engine §4.7.5`): same-lineage models resolve
+ambiguity identically because they share trained priors. **Conclusion:** *cross-model* is insufficient
+when the models share a vendor — the diversity E3 requires is specifically **cross-VENDOR (GPT / Gemini)
+or human**, now *demonstrated*, not merely argued. E3 remains **OPEN**; reliability ≠ validity;
+capability ≠ validation.
+
 ## Assets shipped by this pilot (permanent, regardless of the ceiling)
 
 - `scripts/e3_kappa.py` — reusable, tested κ harness (any future E3 run uses it).
 - `tests/test_e3_kappa.py` — 9 deterministic self-tests (hand-verified κ values).
 - `tests/e3_fixture.json` — the neutral construct×leaf fixture.
-- `tests/e3_pilot_labels.json` — this pilot's raw data (reproducible).
+- `tests/e3_pilot_labels.json` — the same-model pilot's raw data (reproducible).
+- `tests/e3_crossmodel_labels.json` — the within-Anthropic cross-model pilot's raw data (Opus 4.8 · Sonnet 5 · Fable 5).

--- a/skills/decompose-abstract-to-measurable/SKILL.md
+++ b/skills/decompose-abstract-to-measurable/SKILL.md
@@ -15,7 +15,7 @@ triggers:
   - "turn this DoD / KPI / acceptance criterion into a score"
   - "is this inconclusive / can I decide this autonomously?"
   - "score / rate / evaluate <thing> against an abstract standard"
-version: 1.2.0
+version: 1.2.1
 allowed-tools: Read, Write, Edit, Bash, Grep, Glob
 agnostic: [os, project, vendor]
 soul-name: Prisma
@@ -64,10 +64,12 @@ skill advances the *tool's capability*; it does **not** validate the originating
 Maturity rises **only** through external evidence — **E2** (a non-author-authored benchmark
 with real margin to disagree) + **E3** (naive-agent inter-rater **κ ≥ 0.60**). Status (2026-07-09):
 **E2 = not done**; **E3 = partially advanced, NOT closed** — `scripts/e3_kappa.py` (a reusable,
-tested Fleiss'/Cohen's-κ harness) now exists and a *lean pilot* scored **κ = 0.96 (almost-perfect)**
-on the D/T/J typing (`E3-PILOT.md`), BUT the 3 raters were independent **samples of the same model**
-(correlated by construction) → it measures **self-consistency, not diverse-rater reliability**;
-genuine E3 still needs **cross-model / human** raters + larger n + non-author constructs. So: the
+tested Fleiss'/Cohen's-κ harness) now exists and *two lean pilots* ran (`E3-PILOT.md`): a same-model
+pilot scored **κ = 0.96** (self-consistency) and a within-Anthropic **cross-model** pilot (Opus 4.8 ·
+Sonnet 5 · Fable 5) scored **κ = 1.0** — but that perfect agreement, *even on items the fixture designed
+to split raters*, is **empirical evidence of same-vendor correlation** (`convergence-engine §4.7.5`),
+NOT a pass. Both used **correlated** raters → genuine E3 still needs **cross-VENDOR (GPT/Gemini) / human**
+raters + larger n + non-author constructs. So: the
 defensible claim is **bounded, per structural class** (additive-decomposable
 constructs only — Step 5b); **Tier-Professional is BLOCKED** until E2/E3; there is **no definitive
 public name** yet. A better *method* is not a validation.

--- a/skills/decompose-abstract-to-measurable/tests/e3_crossmodel_labels.json
+++ b/skills/decompose-abstract-to-measurable/tests/e3_crossmodel_labels.json
@@ -1,0 +1,206 @@
+{
+  "categories": [
+    "D",
+    "T",
+    "J"
+  ],
+  "raters": [
+    "opus-4-8",
+    "sonnet-5",
+    "fable-5"
+  ],
+  "items": [
+    {
+      "id": "c1.l1",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c1.l2",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c1.l3",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    },
+    {
+      "id": "c1.l4",
+      "labels": {
+        "opus-4-8": "J",
+        "sonnet-5": "J",
+        "fable-5": "J"
+      }
+    },
+    {
+      "id": "c2.l1",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c2.l2",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c2.l3",
+      "labels": {
+        "opus-4-8": "J",
+        "sonnet-5": "J",
+        "fable-5": "J"
+      }
+    },
+    {
+      "id": "c2.l4",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    },
+    {
+      "id": "c3.l1",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c3.l2",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    },
+    {
+      "id": "c3.l3",
+      "labels": {
+        "opus-4-8": "J",
+        "sonnet-5": "J",
+        "fable-5": "J"
+      }
+    },
+    {
+      "id": "c3.l4",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c4.l1",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    },
+    {
+      "id": "c4.l2",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c4.l3",
+      "labels": {
+        "opus-4-8": "J",
+        "sonnet-5": "J",
+        "fable-5": "J"
+      }
+    },
+    {
+      "id": "c4.l4",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    },
+    {
+      "id": "c5.l1",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c5.l2",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c5.l3",
+      "labels": {
+        "opus-4-8": "J",
+        "sonnet-5": "J",
+        "fable-5": "J"
+      }
+    },
+    {
+      "id": "c5.l4",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c6.l1",
+      "labels": {
+        "opus-4-8": "D",
+        "sonnet-5": "D",
+        "fable-5": "D"
+      }
+    },
+    {
+      "id": "c6.l2",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    },
+    {
+      "id": "c6.l3",
+      "labels": {
+        "opus-4-8": "J",
+        "sonnet-5": "J",
+        "fable-5": "J"
+      }
+    },
+    {
+      "id": "c6.l4",
+      "labels": {
+        "opus-4-8": "T",
+        "sonnet-5": "T",
+        "fable-5": "T"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
**[PR-as-Documentation-Prompt]**

## Context
Prisma v1.2.0 (#229) shipped the E3 kappa-harness (`scripts/e3_kappa.py`) + a lean **same-model** pilot (kappa=0.96 = self-consistency). This PR records a **cross-model** E3 pilot and its honest interpretation. Docs + test fixture only — no engine/behavior change.

## What changed
- **E3-PILOT.md** — cross-model addendum: Opus 4.8 / Sonnet 5 / Fable 5 as 3 independent raters over the 24-item D/T/J fixture -> **kappa=1.0**, with the interpretation.
- **tests/e3_crossmodel_labels.json** — the 3-model raw labels (re-runnable).
- **SKILL.md** — honesty-gate note (within-vendor cross-model is NOT enough); version 1.2.0 -> 1.2.1.

## The finding (honest)
Perfect agreement (kappa=1.0) **even on the items the fixture designed to split raters** is empirical evidence of **same-vendor correlation** (convergence-engine 4.7.5), **NOT** an E3 pass. It sharpens the gap: genuine E3 needs **cross-VENDOR (GPT/Gemini) / human** raters — now *demonstrated*, not just argued.

## Honesty gate preserved
capability != validation. E2 (external non-author benchmark) + genuine cross-vendor/human E3 remain **open** (#230). No Tier-Professional, no definitive public name.

## Acceptance
- [x] Tests 31/31 green (10 aggregate + 12 e3_kappa + 9 structural_route)
- [x] gitleaks clean
- [x] docs + test-fixture only (no engine/behavior change)
- [x] finding also durable in #230

## Cross-links
- Tracker: #230 (E2 + genuine cross-vendor E3)
- Skill: `maos:decompose-abstract-to-measurable` (Prisma)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pg3DJQyh8BUDZTyEqGaUbM
