### PR TITLE
feat(system-health-responder): EKO-90 round-4 — threshold false-positive fixes (v1.6.0)

### DIFF
--- a/skills/system-health-responder/SKILL.md
+++ b/skills/system-health-responder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: system-health-responder
 description: End-of-action reflex that reads the system-health contract, engage-locks, Eisenhower-ranks the warnings, does MODERATE non-destructive auto-heal (autonomous reversible renice of a clear cpu runaway + `uv cache prune` producer-hygiene), responds to the new `agentic_tools` branch (`claude doctor` runtime health + cache-producer pressure), reads the reclaim-aware `burn_down` disk forecast (observe-only leading indicator → seed+notify before crisis), and escalate-seeds the HITL residue (security · malware · kill · disk→disk-guardian · no-source-fix offender containment). EKO-90 part-2 — the responder half of the health suite.
-version: 1.6.0
+version: 1.6.1
 allowed-tools: Read, Bash
 ---
 
@@ -187,12 +187,12 @@ before anyone noticed. The collector (v1.2.0 → **v1.3.0**) now emits a structu
 DISK_GUARDIAN_LOG=<log> "$COLLECTOR" --burndown   # forecast-only (no probing, no contract write) — testable
 ```
 
-### Threshold false-positive fixes (v1.6.0, round-4, 2026-07-14) — honest classification, not more theater
+### Threshold false-positive fixes (v1.6.1, round-4, 2026-07-14) — honest classification, not more theater
 
 An OODA review after the round-3 merge surfaced **two false-positive classes** the collector's thresholds
 mis-classified — both empirically observed this session. A false `crit`/`warn` isn't cosmetic: it makes the
 responder engage spuriously, which erodes the trust the operator needs to let the auto-heal run unattended.
-So this is squarely an **enhance-autonomy** fix (collector **v1.3.2 → v1.4.0**):
+So this is squarely an **enhance-autonomy** fix (collector **v1.3.2 → v1.4.1**):
 
 - **CPU transient false-crit** — `cpu_load_status()`. `vm.loadavg` carries three averages `{1min 5min 15min}`;
   the collector keyed **both** warn and crit off `load1` (the *spikiest* metric), so a transient burst
@@ -202,17 +202,22 @@ So this is squarely an **enhance-autonomy** fix (collector **v1.3.2 → v1.4.0**
   leaf now also exposes `load5` + `load5_ratio` for honest drill-down.
 - **XProtect chronic false-warn** — `xprotect_status()`. Age-alone conflates "genuinely stale" with "Apple
   hasn't shipped a newer signature" (XProtect ships on Apple's cadence, routinely >30d). Fix: gate on the
-  **auto-update channel** (cheap ~20ms `softwareupdate --schedule` read, no-sudo): auto-update **ON** ⇒
+  **auto-update channel** (cheap ~20ms `softwareupdate --schedule` read, no-sudo — a **proxy**, not a direct
+  XProtect read; modern macOS updates XProtect via `XProtectUpdateService`): auto-update **ON** ⇒
   self-healing ⇒ caps at `warn` past a generous 60d window, **never crit** (the next signature lands
   automatically); auto-update **OFF** ⇒ the real risk ⇒ full 30/60 age escalation. Empirical: 5347 (47d) **is**
   Apple's latest for macOS 26.5.2 with auto-update on → honestly `ok`, not `warn`. The leaf now exposes
-  `auto_update`.
+  `auto_update` (`on|off|unknown`). **v1.4.1 (CodeRabbit finding)**: the probe is capture-then-classified into
+  a third `unknown` state, so a *probe failure* degrades **fail-safe** (warn-capable, **never crit**) instead
+  of collapsing to `off` and manufacturing a false-crit — the residual false-positive hiding in this fix's own
+  error path.
 - Both extracted as **pure functions** (mirroring `compute_burndown`) with **test entrypoints**
   (`--cpu-load-status` / `--xprotect-status`) so they're exercised, not eyeballed. **Anti-theater**: this did
   not mark anything healthy — it fixed *what "healthy" means*; the contract went `crit → ok` by correct
   classification, and `auto-OFF 65d → crit` still fires (real risk preserved).
-- **Tested**: `bin/threshold-test.sh` — 13 assertions (burst→warn-not-crit · sustained-load5→crit ·
-  auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing). Round-3 suites regress clean (16+5).
+- **Tested**: `bin/threshold-test.sh` — 16 assertions (burst→warn-not-crit · sustained-load5→crit ·
+  auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing · **unknown-9999d→warn-never-crit**).
+  Round-3 suites regress clean (16+5).
 
 ## Composition (reuse, not reinvent — Strata)
 
@@ -229,7 +234,7 @@ So this is squarely an **enhance-autonomy** fix (collector **v1.3.2 → v1.4.0**
 - `references/no-source-fix-registry.md` — the ADR evidence gate (vetted no-source-fix offenders + dossiers).
 - `references/offender-containment-33-socratic.md` — round-1 design-reasoning (33 Socratic Q&A; the *why* behind the tiers).
 - `references/offender-containment-round2-33-socratic.md` — round-2 operational-reasoning (33 non-duplicate Q&A; sibling-falsification · transient-vs-persistent producers · attribution · warn/HITL boundary · unknown-offender handling).
-- `bin/offender-containment.sh` — the containment executor · `collectors/system-health-guardian.sh` — the extended Phase-1 collector (v1.3.x = burn-down · **v1.4.0 = round-4 threshold fixes**).
+- `bin/offender-containment.sh` — the containment executor · `collectors/system-health-guardian.sh` — the extended Phase-1 collector (v1.3.x = burn-down · **v1.4.1 = round-4 threshold fixes + probe fail-safe**).
 - `bin/burndown-test.sh` — round-3 collector unit tests (drives `--burndown`; 16 assertions: reclaim-jump-not-misread · short-tail-honest-unknown · `+0000`/`+00:00`/`Z` tz variants).
 - `bin/responder-burndown-test.sh` — round-3 responder wiring tests (5 assertions: `warn`/`crit`→seed · `ok`/`unknown`→quiet — proves `.burn_down` is read, not just documented).
 - `bin/threshold-test.sh` — round-4 threshold unit tests (drives `--cpu-load-status`/`--xprotect-status`; 13 assertions: CPU burst→warn-not-crit · sustained-load5→crit · XProtect auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing).

--- a/skills/system-health-responder/SKILL.md
+++ b/skills/system-health-responder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: system-health-responder
 description: End-of-action reflex that reads the system-health contract, engage-locks, Eisenhower-ranks the warnings, does MODERATE non-destructive auto-heal (autonomous reversible renice of a clear cpu runaway + `uv cache prune` producer-hygiene), responds to the new `agentic_tools` branch (`claude doctor` runtime health + cache-producer pressure), reads the reclaim-aware `burn_down` disk forecast (observe-only leading indicator → seed+notify before crisis), and escalate-seeds the HITL residue (security · malware · kill · disk→disk-guardian · no-source-fix offender containment). EKO-90 part-2 — the responder half of the health suite.
-version: 1.5.1
+version: 1.6.0
 allowed-tools: Read, Bash
 ---
 
@@ -187,6 +187,33 @@ before anyone noticed. The collector (v1.2.0 → **v1.3.0**) now emits a structu
 DISK_GUARDIAN_LOG=<log> "$COLLECTOR" --burndown   # forecast-only (no probing, no contract write) — testable
 ```
 
+### Threshold false-positive fixes (v1.6.0, round-4, 2026-07-14) — honest classification, not more theater
+
+An OODA review after the round-3 merge surfaced **two false-positive classes** the collector's thresholds
+mis-classified — both empirically observed this session. A false `crit`/`warn` isn't cosmetic: it makes the
+responder engage spuriously, which erodes the trust the operator needs to let the auto-heal run unattended.
+So this is squarely an **enhance-autonomy** fix (collector **v1.3.2 → v1.4.0**):
+
+- **CPU transient false-crit** — `cpu_load_status()`. `vm.loadavg` carries three averages `{1min 5min 15min}`;
+  the collector keyed **both** warn and crit off `load1` (the *spikiest* metric), so a transient burst
+  (IDE compile / Spotlight indexer) tripped `crit`. Fix: **WARN keyed on `load1`** (early signal),
+  **CRIT keyed on `load5`** (sustained) — a 1-min burst warns but never crits; crit now requires ~5 min of
+  real overload. Empirical: `load1=27.33/12cores` (2.28×) crit that settled to `warn` in ~4 min. The `load1`
+  leaf now also exposes `load5` + `load5_ratio` for honest drill-down.
+- **XProtect chronic false-warn** — `xprotect_status()`. Age-alone conflates "genuinely stale" with "Apple
+  hasn't shipped a newer signature" (XProtect ships on Apple's cadence, routinely >30d). Fix: gate on the
+  **auto-update channel** (cheap ~20ms `softwareupdate --schedule` read, no-sudo): auto-update **ON** ⇒
+  self-healing ⇒ caps at `warn` past a generous 60d window, **never crit** (the next signature lands
+  automatically); auto-update **OFF** ⇒ the real risk ⇒ full 30/60 age escalation. Empirical: 5347 (47d) **is**
+  Apple's latest for macOS 26.5.2 with auto-update on → honestly `ok`, not `warn`. The leaf now exposes
+  `auto_update`.
+- Both extracted as **pure functions** (mirroring `compute_burndown`) with **test entrypoints**
+  (`--cpu-load-status` / `--xprotect-status`) so they're exercised, not eyeballed. **Anti-theater**: this did
+  not mark anything healthy — it fixed *what "healthy" means*; the contract went `crit → ok` by correct
+  classification, and `auto-OFF 65d → crit` still fires (real risk preserved).
+- **Tested**: `bin/threshold-test.sh` — 13 assertions (burst→warn-not-crit · sustained-load5→crit ·
+  auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing). Round-3 suites regress clean (16+5).
+
 ## Composition (reuse, not reinvent — Strata)
 
 - **Part-1 contract** (`~/.local/state/system-health/health-contract.json`) — the input it responds to.
@@ -202,9 +229,10 @@ DISK_GUARDIAN_LOG=<log> "$COLLECTOR" --burndown   # forecast-only (no probing, n
 - `references/no-source-fix-registry.md` — the ADR evidence gate (vetted no-source-fix offenders + dossiers).
 - `references/offender-containment-33-socratic.md` — round-1 design-reasoning (33 Socratic Q&A; the *why* behind the tiers).
 - `references/offender-containment-round2-33-socratic.md` — round-2 operational-reasoning (33 non-duplicate Q&A; sibling-falsification · transient-vs-persistent producers · attribution · warn/HITL boundary · unknown-offender handling).
-- `bin/offender-containment.sh` — the containment executor · `collectors/system-health-guardian.sh` — the extended Phase-1 collector (v1.3.0 = burn-down).
+- `bin/offender-containment.sh` — the containment executor · `collectors/system-health-guardian.sh` — the extended Phase-1 collector (v1.3.x = burn-down · **v1.4.0 = round-4 threshold fixes**).
 - `bin/burndown-test.sh` — round-3 collector unit tests (drives `--burndown`; 16 assertions: reclaim-jump-not-misread · short-tail-honest-unknown · `+0000`/`+00:00`/`Z` tz variants).
 - `bin/responder-burndown-test.sh` — round-3 responder wiring tests (5 assertions: `warn`/`crit`→seed · `ok`/`unknown`→quiet — proves `.burn_down` is read, not just documented).
+- `bin/threshold-test.sh` — round-4 threshold unit tests (drives `--cpu-load-status`/`--xprotect-status`; 13 assertions: CPU burst→warn-not-crit · sustained-load5→crit · XProtect auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing).
 - EKO-90 (Linear, team EKO) — the parent ticket; part-1 = the collector, part-2 = this responder + this v1.2.0 ext.
 - `~/.claude/rules/loose-end-triage-queue.md` (Taxis) · `~/.claude/rules/agentic-observability-protocol.md`
   (Metron measure→respond) · `~/.claude/rules/standing-autonomous-operation-authorization.md` (READY gate).

--- a/skills/system-health-responder/bin/threshold-test.sh
+++ b/skills/system-health-responder/bin/threshold-test.sh
@@ -39,6 +39,11 @@ ck "auto-OFF 47d → warn (the real risk surfaces)"                      "$(xp 4
 ck "auto-OFF 65d → crit (real-risk escalation)"                        "$(xp 65 off 30 60 60)" "crit"
 ck "auto-OFF 10d → ok"                                                 "$(xp 10 off 30 60 60)" "ok"
 
+echo "── xprotect_status UNKNOWN (probe failed → fail-safe, warn-capable NEVER crit) [v1.4.1, CodeRabbit] ──"
+ck "unknown 10d → ok (below warn)"                                     "$(xp 10 unknown 30 60 60)"   "ok"
+ck "unknown 47d → warn (past warn horizon)"                            "$(xp 47 unknown 30 60 60)"   "warn"
+ck "unknown 9999d → warn (NEVER crit — probe error ≠ false-crit)"      "$(xp 9999 unknown 30 60 60)" "warn"
+
 echo
 echo "threshold-test: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/skills/system-health-responder/bin/threshold-test.sh
+++ b/skills/system-health-responder/bin/threshold-test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# threshold-test.sh — unit tests for the round-4 threshold decision cores (EKO-90-round4).
+# Drives the collector's `--cpu-load-status` / `--xprotect-status` entrypoints with synthetic inputs (no
+# awk/logic duplication — the test exercises the EXACT production cpu_load_status() / xprotect_status()).
+#
+# Two false-positive classes this session surfaced, and the assertions that pin their fixes:
+#   • CPU: a transient 1-min burst (load1 high, load5 settled) must WARN, never CRIT — crit requires
+#     SUSTAINED load5. (Empirical: load1=27.33/12cores tripped a false-crit that settled in ~4 min.)
+#   • XProtect: age-alone conflates "genuinely stale" with "Apple hasn't shipped". With auto-update ON the
+#     freshness self-heals → 47d-but-latest is honestly OK, never crit; with auto-update OFF (the real risk)
+#     the full age escalation applies. (Empirical: 5347 IS Apple's latest for macOS 26.5.2, auto-update on.)
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COLLECTOR="${THRESHOLD_COLLECTOR:-$DIR/../collectors/system-health-guardian.sh}"
+[ -f "$COLLECTOR" ] || { echo "FATAL: collector not found: $COLLECTOR" >&2; exit 2; }
+
+PASS=0; FAIL=0
+ck() { # ck "<label>" "<got>" "<want>"
+  if [ "$2" = "$3" ]; then PASS=$((PASS+1)); else FAIL=$((FAIL+1)); echo "  FAIL: $1 → got '$2' want '$3'"; fi
+}
+cpu() { "$COLLECTOR" --cpu-load-status "$@" 2>/dev/null; }   # load1 load5 ncpu warn_ratio crit_ratio
+xp()  { "$COLLECTOR" --xprotect-status "$@" 2>/dev/null; }   # age autoupdate warn crit selfheal
+
+echo "── cpu_load_status (warn=load1 spiky · crit=load5 sustained) ──"
+ck "burst load1=27 load5=6 12c → warn (NOT crit) [the false-crit fix]" "$(cpu 27.33 6.0 12 0.90 1.50)" "warn"
+ck "sustained load5=20 12c → crit"                                     "$(cpu 20 20 12 0.90 1.50)"    "crit"
+ck "calm load1=2 load5=2 12c → ok"                                     "$(cpu 2 2 12 0.90 1.50)"      "ok"
+ck "warn-load1 + crit-load5 → crit"                                    "$(cpu 15 19 12 0.90 1.50)"    "crit"
+ck "just-over-warn load1=11 load5=3 12c → warn"                        "$(cpu 11 3 12 0.90 1.50)"     "warn"
+ck "load5 alone crit, load1 calm → crit (sustained detected)"          "$(cpu 3 19 12 0.90 1.50)"     "crit"
+ck "at-warn-boundary load1=10.8 (0.90*12) → warn"                      "$(cpu 10.8 5 12 0.90 1.50)"   "warn"
+
+echo "── xprotect_status (auto-update-gated freshness) ──"
+ck "auto-ON 47d → ok (self-healing, <60 window) [the false-warn fix]"  "$(xp 47 on 30 60 60)"  "ok"
+ck "auto-ON 65d → warn (unusually long)"                               "$(xp 65 on 30 60 60)"  "warn"
+ck "auto-ON 9999d → warn (NEVER crit while self-healing)"              "$(xp 9999 on 30 60 60)" "warn"
+ck "auto-OFF 47d → warn (the real risk surfaces)"                      "$(xp 47 off 30 60 60)" "warn"
+ck "auto-OFF 65d → crit (real-risk escalation)"                        "$(xp 65 off 30 60 60)" "crit"
+ck "auto-OFF 10d → ok"                                                 "$(xp 10 off 30 60 60)" "ok"
+
+echo
+echo "threshold-test: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/skills/system-health-responder/collectors/system-health-guardian.sh
+++ b/skills/system-health-responder/collectors/system-health-guardian.sh
@@ -83,9 +83,15 @@ cpu_load_status() { # $1=load1 $2=load5 $3=ncpu $4=warn_ratio $5=crit_ratio
   worst "$s1" "$s5"
 }
 # xprotect_status: age-alone conflates "stale" with "Apple hasn't shipped". Gate on the auto-update
-# channel — ON ⇒ self-healing (caps at WARN past a generous window, never crit); OFF ⇒ the real risk (full escalation).
-xprotect_status() { # $1=age_days $2=autoupdate(on|off) $3=warn_days $4=crit_days $5=selfheal_warn_days
-  if [ "$2" = "on" ]; then st_hi "$1" "$5" "999999"; else st_hi "$1" "$3" "$4"; fi
+# channel — ON ⇒ self-healing (caps at WARN past a generous window, never crit); OFF ⇒ the real risk (full
+# escalation); UNKNOWN (probe failed/unreadable) ⇒ fail-safe: WARN-capable but NEVER crit — a transient
+# probe error must not manufacture a false-crit (the very false-positive class this round exists to kill).
+xprotect_status() { # $1=age_days $2=autoupdate(on|off|unknown) $3=warn_days $4=crit_days $5=selfheal_warn_days
+  case "$2" in
+    on)  st_hi "$1" "$5" "999999" ;;   # confirmed self-healing → warn only past selfheal window, never crit
+    off) st_hi "$1" "$3" "$4"     ;;   # confirmed off (the real risk) → full warn/crit age escalation
+    *)   st_hi "$1" "$3" "999999" ;;   # unknown → warn at warn_days, crit unreachable (fail-safe on probe error)
+  esac
 }
 
 # ── BURN-DOWN forecast (EKO-90-round3 2026-07-14) — reclaim-aware disk-exhaustion prediction ──
@@ -200,9 +206,16 @@ XP_VER="$(defaults read "$XP_BUNDLE/Contents/Info.plist" CFBundleShortVersionStr
 XP_MTIME="$(stat -f %m "$XP_BUNDLE" 2>/dev/null || echo 0)"
 NOW_EPOCH="$(date +%s)"
 XP_AGE_DAYS="$(awk -v m="$XP_MTIME" -v n="$NOW_EPOCH" 'BEGIN{printf "%.0f", (m>0)?(n-m)/86400:9999}')"
-# auto-update channel (cheap ~20ms, no-sudo, local --schedule read). ON ⇒ freshness self-heals →
-# 47d-but-latest is honestly ok (Apple cadence), not warn. OFF ⇒ the real risk → full age escalation.
-XP_AUTOUPDATE="$("$SWUPDATE" --schedule 2>/dev/null | grep -qi 'turned on' && echo on || echo off)"
+# auto-update channel — a PROXY (cheap ~20ms, no-sudo, local `softwareupdate --schedule` read), NOT a
+# direct XProtect signal (modern macOS updates XProtect via XProtectUpdateService; --schedule is the
+# general auto-update toggle). ON ⇒ freshness self-heals → 47d-but-latest is honestly ok (Apple cadence).
+# OFF ⇒ the real risk → full age escalation. Capture-then-classify so a probe FAILURE degrades to
+# "unknown" (fail-safe, no false-crit) instead of collapsing to "off" (which would age-escalate).
+XP_SCHED="$("$SWUPDATE" --schedule 2>/dev/null)"; XP_SCHED_RC=$?
+if [ "$XP_SCHED_RC" -ne 0 ] || [ -z "$XP_SCHED" ]; then XP_AUTOUPDATE="unknown"      # probe errored/empty
+elif printf '%s' "$XP_SCHED" | grep -qi 'turned on';  then XP_AUTOUPDATE="on"
+elif printf '%s' "$XP_SCHED" | grep -qi 'turned off'; then XP_AUTOUPDATE="off"
+else XP_AUTOUPDATE="unknown"; fi                                                      # unrecognized output
 MAL_ST="$(xprotect_status "$XP_AGE_DAYS" "$XP_AUTOUPDATE" "$XPROTECT_STALE_WARN_DAYS" "$XPROTECT_STALE_CRIT_DAYS" "$XPROTECT_SELFHEAL_WARN_DAYS")"
 
 # ── PROCESS / THREADS ─────────────────────────────────────────────────────────
@@ -320,7 +333,7 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
   --arg at_st "$AT_ST" --argjson at_rf "$AT_RF" --arg claude_st "$CLAUDE_ST" --arg claude_ver "$CLAUDE_VER" --arg claude_health "$CLAUDE_HEALTH" --arg producer_st "$PRODUCER_ST" --arg uv_objs "$UV_ARCHIVE_OBJS" --arg uvx_latest "$UVX_LATEST_PROCS" --arg uvx_producers "$UVX_PRODUCERS" \
 'def n(v): (v|tonumber?) // v;
 {
-  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.4.0", secret_free: true,
+  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.4.1", secret_free: true,
           note: "world-readable, secret-free (metadata only: counts/%/names/versions/booleans; process=comm-name never argv)" },
   system: {
     status: $sys_st, tag: "resource.system", root_fail: $sys_rf,

--- a/skills/system-health-responder/collectors/system-health-guardian.sh
+++ b/skills/system-health-responder/collectors/system-health-guardian.sh
@@ -45,16 +45,18 @@ STDOUT=0
 INTERVAL_SEC="${HEALTH_INTERVAL_SEC:-600}"   # informational; launchd owns the cadence
 
 # ── Thresholds (env-overridable) ──────────────────────────────────────────────
-CPU_LOAD_WARN_RATIO="${CPU_LOAD_WARN_RATIO:-0.90}"   # load1 / ncpu
-CPU_LOAD_CRIT_RATIO="${CPU_LOAD_CRIT_RATIO:-1.50}"
+CPU_LOAD_WARN_RATIO="${CPU_LOAD_WARN_RATIO:-0.90}"   # load1/ncpu → early WARN (spiky-OK, 1-min)
+CPU_LOAD_CRIT_RATIO="${CPU_LOAD_CRIT_RATIO:-1.50}"   # load5/ncpu → CRIT (SUSTAINED, 5-min) — round-4 false-crit fix
 MEM_AVAIL_WARN_PCT="${MEM_AVAIL_WARN_PCT:-15}"
 MEM_AVAIL_CRIT_PCT="${MEM_AVAIL_CRIT_PCT:-8}"
 DISK_FREE_WARN_GB="${DISK_FREE_WARN_GB:-15}"
 DISK_FREE_CRIT_GB="${DISK_FREE_CRIT_GB:-8}"
 PROC_CPU_WARN="${PROC_CPU_WARN:-70}"                 # single-proc %cpu (feeds responder renice target)
 PROC_CPU_CRIT="${PROC_CPU_CRIT:-90}"
-XPROTECT_STALE_WARN_DAYS="${XPROTECT_STALE_WARN_DAYS:-30}"
-XPROTECT_STALE_CRIT_DAYS="${XPROTECT_STALE_CRIT_DAYS:-60}"
+XPROTECT_STALE_WARN_DAYS="${XPROTECT_STALE_WARN_DAYS:-30}"      # auto-update OFF → WARN at Nd (the real risk)
+XPROTECT_STALE_CRIT_DAYS="${XPROTECT_STALE_CRIT_DAYS:-60}"      # auto-update OFF → CRIT at Nd
+XPROTECT_SELFHEAL_WARN_DAYS="${XPROTECT_SELFHEAL_WARN_DAYS:-60}" # auto-update ON → only >Nd WARNs, never crit (self-healing; Apple cadence)
+SWUPDATE="${SWUPDATE:-/usr/sbin/softwareupdate}"                 # abs path (launchd minimal PATH); read-only --schedule
 
 # jq / yq (mise installs — resolve absolute for launchd's minimal PATH)
 JQ="$(command -v jq || echo /Users/$USER/.local/share/mise/installs/jq/1.7/jq)"
@@ -68,6 +70,23 @@ worst() { local w=ok; for s in "$@"; do case "$s" in crit) echo crit; return;; w
 st_hi() { awk -v v="$1" -v w="$2" -v c="$3" 'BEGIN{ if(v>=c)print"crit"; else if(v>=w)print"warn"; else print"ok"}'; }
 # status_from_num LOWER-is-worse: st_lo VALUE WARN CRIT  (lower = worse; e.g. free space)
 st_lo() { awk -v v="$1" -v w="$2" -v c="$3" 'BEGIN{ if(v<=c)print"crit"; else if(v<=w)print"warn"; else print"ok"}'; }
+
+# ── round-4 pure decision cores (unit-testable; mirror compute_burndown pattern) ──
+# cpu_load_status: WARN keyed on load1 (spiky 1-min, early); CRIT keyed on load5 (sustained 5-min).
+# A transient 1-min burst (IDE compile / indexer) WARNs but NEVER crits — the round-4 false-crit fix.
+cpu_load_status() { # $1=load1 $2=load5 $3=ncpu $4=warn_ratio $5=crit_ratio
+  local warn crit s1 s5
+  warn="$(awk -v r="$4" -v n="$3" 'BEGIN{printf "%.4f", r*n}')"
+  crit="$(awk -v r="$5" -v n="$3" 'BEGIN{printf "%.4f", r*n}')"
+  s1="$(st_hi "$1" "$warn" "999999")"   # load1 → WARN band only (crit unreachable)
+  s5="$(st_hi "$2" "$crit" "$crit")"    # load5 → CRIT band only (warn==crit threshold)
+  worst "$s1" "$s5"
+}
+# xprotect_status: age-alone conflates "stale" with "Apple hasn't shipped". Gate on the auto-update
+# channel — ON ⇒ self-healing (caps at WARN past a generous window, never crit); OFF ⇒ the real risk (full escalation).
+xprotect_status() { # $1=age_days $2=autoupdate(on|off) $3=warn_days $4=crit_days $5=selfheal_warn_days
+  if [ "$2" = "on" ]; then st_hi "$1" "$5" "999999"; else st_hi "$1" "$3" "$4"; fi
+}
 
 # ── BURN-DOWN forecast (EKO-90-round3 2026-07-14) — reclaim-aware disk-exhaustion prediction ──
 # The PROACTIVE half of the guardian: predicts days-until-DISK_FREE_WARN_GB from the recent NATURAL drain
@@ -125,14 +144,20 @@ EOF
 # testable entrypoint: `--burndown` runs ONLY the forecast (no probing, no contract write) — the unit test
 # (bin/burndown-test.sh) drives this with a synthetic DISK_GUARDIAN_LOG (no awk duplication).
 if [ "${1:-}" = "--burndown" ]; then compute_burndown; echo; exit 0; fi
+# testable entrypoints for the round-4 pure decision cores (bin/threshold-test.sh drives these — no logic dup):
+if [ "${1:-}" = "--cpu-load-status" ]; then cpu_load_status "${2:-0}" "${3:-0}" "${4:-1}" "${5:-0.90}" "${6:-1.50}"; exit 0; fi
+if [ "${1:-}" = "--xprotect-status" ]; then xprotect_status "${2:-0}" "${3:-on}" "${4:-30}" "${5:-60}" "${6:-60}"; exit 0; fi
 
 # ── CPU ───────────────────────────────────────────────────────────────────────
 NCPU="$(sysctl -n hw.ncpu 2>/dev/null || echo 1)"
-LOAD1="$(sysctl -n vm.loadavg 2>/dev/null | awk '{print $2}')"; LOAD1="${LOAD1:-0}"
+# vm.loadavg → "{ 1.23 4.56 7.89 }" (1/5/15-min averages): $2=load1 (spiky), $3=load5 (sustained).
+LOADAVG="$(sysctl -n vm.loadavg 2>/dev/null)"
+LOAD1="$(awk '{print $2}' <<<"$LOADAVG")"; LOAD1="${LOAD1:-0}"
+LOAD5="$(awk '{print $3}' <<<"$LOADAVG")"; LOAD5="${LOAD5:-$LOAD1}"
 LOAD_RATIO="$(awk -v l="$LOAD1" -v n="$NCPU" 'BEGIN{printf "%.2f", (n>0)?l/n:l}')"
-CPU_WARN_LOAD="$(awk -v r="$CPU_LOAD_WARN_RATIO" -v n="$NCPU" 'BEGIN{printf "%.2f", r*n}')"
-CPU_CRIT_LOAD="$(awk -v r="$CPU_LOAD_CRIT_RATIO" -v n="$NCPU" 'BEGIN{printf "%.2f", r*n}')"
-CPU_LOAD_ST="$(st_hi "$LOAD1" "$CPU_WARN_LOAD" "$CPU_CRIT_LOAD")"
+LOAD5_RATIO="$(awk -v l="$LOAD5" -v n="$NCPU" 'BEGIN{printf "%.2f", (n>0)?l/n:l}')"
+# WARN on load1 (early), CRIT only on SUSTAINED load5 — a 1-min burst warns, never crits (round-4).
+CPU_LOAD_ST="$(cpu_load_status "$LOAD1" "$LOAD5" "$NCPU" "$CPU_LOAD_WARN_RATIO" "$CPU_LOAD_CRIT_RATIO")"
 # top cpu consumer (comm ONLY — never argv). Capture ps fully first (no head-on-pipe → no SIGPIPE under pipefail).
 PS_BY_CPU="$(ps -A -r -o pid=,%cpu=,comm= 2>/dev/null || true)"
 TOP_CPU_LINE="$(awk 'NR==1{pid=$1;cpu=$2;$1="";$2="";c=$0;sub(/^ +/,"",c);n=split(c,a,"/");print pid"|"cpu"|"a[n]; exit}' <<<"$PS_BY_CPU")"
@@ -175,7 +200,10 @@ XP_VER="$(defaults read "$XP_BUNDLE/Contents/Info.plist" CFBundleShortVersionStr
 XP_MTIME="$(stat -f %m "$XP_BUNDLE" 2>/dev/null || echo 0)"
 NOW_EPOCH="$(date +%s)"
 XP_AGE_DAYS="$(awk -v m="$XP_MTIME" -v n="$NOW_EPOCH" 'BEGIN{printf "%.0f", (m>0)?(n-m)/86400:9999}')"
-MAL_ST="$(st_hi "$XP_AGE_DAYS" "$XPROTECT_STALE_WARN_DAYS" "$XPROTECT_STALE_CRIT_DAYS")"
+# auto-update channel (cheap ~20ms, no-sudo, local --schedule read). ON ⇒ freshness self-heals →
+# 47d-but-latest is honestly ok (Apple cadence), not warn. OFF ⇒ the real risk → full age escalation.
+XP_AUTOUPDATE="$("$SWUPDATE" --schedule 2>/dev/null | grep -qi 'turned on' && echo on || echo off)"
+MAL_ST="$(xprotect_status "$XP_AGE_DAYS" "$XP_AUTOUPDATE" "$XPROTECT_STALE_WARN_DAYS" "$XPROTECT_STALE_CRIT_DAYS" "$XPROTECT_SELFHEAL_WARN_DAYS")"
 
 # ── PROCESS / THREADS ─────────────────────────────────────────────────────────
 PROC_COUNT="$(ps -A -o pid= 2>/dev/null | wc -l | tr -d ' ')"
@@ -281,24 +309,24 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
 "$JQ" -n \
   --arg gen "$GEN" --arg host "$HOST" --argjson interval "$INTERVAL_SEC" \
   --arg sys_st "$SYS_ST" --argjson sys_rf "$SYS_RF" \
-  --arg cpu_st "$CPU_ST" --argjson cpu_rf "$CPU_RF" --arg ncpu "$NCPU" --arg load1 "$LOAD1" --arg load_ratio "$LOAD_RATIO" --arg cpu_load_st "$CPU_LOAD_ST" --arg top_cpu_comm "${TOP_CPU_COMM:-none}" --arg top_cpu_pct "$TOP_CPU_PCT" --arg top_cpu_pid "${TOP_CPU_PID:-0}" --arg cpu_proc_st "$CPU_PROC_ST" \
+  --arg cpu_st "$CPU_ST" --argjson cpu_rf "$CPU_RF" --arg ncpu "$NCPU" --arg load1 "$LOAD1" --arg load_ratio "$LOAD_RATIO" --arg load5 "$LOAD5" --arg load5_ratio "$LOAD5_RATIO" --arg cpu_load_st "$CPU_LOAD_ST" --arg top_cpu_comm "${TOP_CPU_COMM:-none}" --arg top_cpu_pct "$TOP_CPU_PCT" --arg top_cpu_pid "${TOP_CPU_PID:-0}" --arg cpu_proc_st "$CPU_PROC_ST" \
   --arg mem_st "$MEM_ST" --argjson mem_rf "$MEM_RF" --arg mem_avail_pct "$MEM_AVAIL_PCT" --arg top_mem_comm "${TOP_MEM_COMM:-none}" --arg top_mem_pct "$TOP_MEM_PCT" \
   --arg disk_st "$DISK_ST" --argjson disk_rf "$DISK_RF" --arg disk_free_gb "$DISK_FREE_GB" --arg dg_live "$DG_LIVE" \
   --arg sec_st "$SEC_ST" --argjson sec_rf "$SEC_RF" --arg sip "$SIP" --arg gk "$GK" --arg fw "$FW" \
-  --arg mal_st "$MAL_ST" --argjson mal_rf "$MAL_RF" --arg xp_ver "$XP_VER" --arg xp_age "$XP_AGE_DAYS" \
+  --arg mal_st "$MAL_ST" --argjson mal_rf "$MAL_RF" --arg xp_ver "$XP_VER" --arg xp_age "$XP_AGE_DAYS" --arg xp_au "$XP_AUTOUPDATE" \
   --arg proc_st "$PROC_ST" --argjson proc_rf "$PROC_RF" --arg proc_count "$PROC_COUNT" --arg thread_count "$THREAD_COUNT" --arg zombie "$ZOMBIE_COUNT" \
   --arg net_st "$NET_ST" --argjson net_rf "$NET_RF" --arg listeners "$LISTENERS" --arg estab "$ESTAB" \
   --argjson burn "$BURN_DOWN" \
   --arg at_st "$AT_ST" --argjson at_rf "$AT_RF" --arg claude_st "$CLAUDE_ST" --arg claude_ver "$CLAUDE_VER" --arg claude_health "$CLAUDE_HEALTH" --arg producer_st "$PRODUCER_ST" --arg uv_objs "$UV_ARCHIVE_OBJS" --arg uvx_latest "$UVX_LATEST_PROCS" --arg uvx_producers "$UVX_PRODUCERS" \
 'def n(v): (v|tonumber?) // v;
 {
-  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.3.2", secret_free: true,
+  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.4.0", secret_free: true,
           note: "world-readable, secret-free (metadata only: counts/%/names/versions/booleans; process=comm-name never argv)" },
   system: {
     status: $sys_st, tag: "resource.system", root_fail: $sys_rf,
     branches: {
       cpu:     { status: $cpu_st, tag: "resource.cpu", root_fail: $cpu_rf, leaves: {
-                  load1:        { status: $cpu_load_st, tag: "resource.cpu.load1", value: n($load1), ncpu: n($ncpu), load_ratio: n($load_ratio) },
+                  load1:        { status: $cpu_load_st, tag: "resource.cpu.load1", value: n($load1), load5: n($load5), ncpu: n($ncpu), load_ratio: n($load_ratio), load5_ratio: n($load5_ratio) },
                   top_consumer: { status: $cpu_proc_st, tag: "resource.cpu.top_consumer", comm: $top_cpu_comm, pct: n($top_cpu_pct), pid: n($top_cpu_pid) } } },
       memory:  { status: $mem_st, tag: "resource.memory", root_fail: $mem_rf, leaves: {
                   available_pct: { status: $mem_st, tag: "resource.memory.available_pct", value: n($mem_avail_pct), top_consumer: $top_mem_comm, top_pct: n($top_mem_pct) } } },
@@ -309,7 +337,7 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
                   gatekeeper: { status: (if $gk=="disabled" then "warn" else "ok" end), tag: "resource.security.gatekeeper", value: $gk },
                   firewall: { status: (if $fw=="disabled" then "warn" else "ok" end), tag: "resource.security.firewall", value: $fw } } },
       malware: { status: $mal_st, tag: "resource.malware", root_fail: $mal_rf, leaves: {
-                  xprotect_freshness: { status: $mal_st, tag: "resource.malware.xprotect_freshness", version: $xp_ver, age_days: n($xp_age) } } },
+                  xprotect_freshness: { status: $mal_st, tag: "resource.malware.xprotect_freshness", version: $xp_ver, age_days: n($xp_age), auto_update: $xp_au } } },
       process: { status: $proc_st, tag: "resource.process", root_fail: $proc_rf, leaves: {
                   runaway:  { status: $cpu_proc_st, tag: "resource.process.runaway", comm: $top_cpu_comm, cpu_pct: n($top_cpu_pct), pid: n($top_cpu_pid) },
                   counts:   { status: "ok", tag: "resource.process.counts", processes: n($proc_count), threads: n($thread_count), zombies: n($zombie) } } },

--- a/skills/system-health-responder/references/auto-heal-safety-matrix.md
+++ b/skills/system-health-responder/references/auto-heal-safety-matrix.md
@@ -99,6 +99,12 @@ The responder does **not** re-derive any threshold. Part-1's collector already c
 `XPROTECT_STALE_WARN_DAYS`, …). The responder gates purely on the **computed leaf status** — single owner,
 zero drift.
 
+> **Round-4 (collector v1.4.0)** refined two of those thresholds to kill false-positives (transparent to the
+> responder — it still just reads `status`): CPU **crit** now keys on `load5` (sustained) not `load1` (spiky)
+> — a transient burst warns, never crits; XProtect freshness is gated on the auto-update channel
+> (`XPROTECT_SELFHEAL_WARN_DAYS=60` when auto-update is ON ⇒ never crit / self-healing; full
+> `XPROTECT_STALE_WARN_DAYS`/`_CRIT_DAYS` escalation only when auto-update is OFF — the real risk).
+
 ## What the responder will NEVER do (⛔ absolute)
 
 - Kill / `pkill` / force-quit any process.

--- a/skills/system-health-responder/references/auto-heal-safety-matrix.md
+++ b/skills/system-health-responder/references/auto-heal-safety-matrix.md
@@ -99,11 +99,16 @@ The responder does **not** re-derive any threshold. Part-1's collector already c
 `XPROTECT_STALE_WARN_DAYS`, …). The responder gates purely on the **computed leaf status** — single owner,
 zero drift.
 
-> **Round-4 (collector v1.4.0)** refined two of those thresholds to kill false-positives (transparent to the
-> responder — it still just reads `status`): CPU **crit** now keys on `load5` (sustained) not `load1` (spiky)
-> — a transient burst warns, never crits; XProtect freshness is gated on the auto-update channel
+> **Round-4 (collector v1.4.0→v1.4.1)** refined two of those thresholds to kill false-positives (transparent
+> to the responder — it still just reads `status`): CPU **crit** now keys on `load5` (sustained) not `load1`
+> (spiky) — a transient burst warns, never crits; XProtect freshness is gated on the auto-update channel
 > (`XPROTECT_SELFHEAL_WARN_DAYS=60` when auto-update is ON ⇒ never crit / self-healing; full
 > `XPROTECT_STALE_WARN_DAYS`/`_CRIT_DAYS` escalation only when auto-update is OFF — the real risk).
+> The auto-update signal is a **proxy** (`softwareupdate --schedule`), NOT a direct XProtect read (modern
+> macOS updates XProtect via `XProtectUpdateService`); **v1.4.1** threads a third `unknown` state so a
+> *probe failure* degrades **fail-safe** (warn-capable, **never crit**) instead of collapsing to `off` and
+> manufacturing a false-crit — the leaf `xprotect_freshness.auto_update` carries `on|off|unknown` for
+> drill-down transparency regardless of the roll-up.
 
 ## What the responder will NEVER do (⛔ absolute)
 


### PR DESCRIPTION
## [PR-as-Enhancement-Prompt] EKO-90 round-4 — threshold false-positive fixes

**Context** — A `/quiesce --scope [linear:EKO-90] --now` OODA pass after the round-3 merge (#257). Two false-positive classes, both **empirically observed this session**, made the health-contract mis-classify — which would make the end-of-action responder engage spuriously. A false `crit`/`warn` isn't cosmetic: it erodes the trust needed to let the auto-heal run unattended, so this is squarely an **enhance-autonomy** fix. Collector `v1.3.2 → v1.4.0` · skill `v1.5.1 → v1.6.0`.

**Objectives** — kill the two false-positives *without* weakening real-risk detection; keep it Gordian (2 threshold cores, no scope-creep).

| Gap (empirical) | Root cause | Fix |
|---|---|---|
| CPU `crit` on a transient burst (`load1=27.33/12c`, settled to `warn` in ~4 min) | both warn+crit keyed on `load1` — the *spikiest* (1-min) metric | `cpu_load_status()`: **WARN on load1** (early), **CRIT on load5** (sustained). A 1-min burst warns, never crits. |
| XProtect chronic `warn` (5347 @ 47d) even though 5347 **is** Apple's latest | age-alone conflates "stale" with "Apple hasn't shipped" | `xprotect_status()`: gate on the **auto-update channel** (~20ms `softwareupdate --schedule`, no-sudo). ON ⇒ self-healing (caps at `warn` past 60d, never crit); OFF ⇒ full 30/60 escalation (the real risk). |

Both extracted as **pure functions** (mirroring `compute_burndown`) + **test entrypoints** (`--cpu-load-status` / `--xprotect-status`) so they're exercised, not eyeballed. New drill-down fields: `load5`, `load5_ratio`, `auto_update`.

**Acceptance**
- [x] `bin/threshold-test.sh` — 13 assertions (burst→warn-not-crit · sustained-load5→crit · auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing)
- [x] Round-3 suites regress clean: `burndown-test.sh` 16/16 · `responder-burndown-test.sh` 5/5
- [x] Live collector run → contract `v1.4.0`, `secret_free:true`, gitleaks clean, contract now honestly `ok`
- [x] **Real-risk preserved** — `auto-OFF 65d → crit` still fires (not a blanket relax)
- [x] Anti-theater — fixes *what "healthy" means*, does not mark-healthy

**Test plan** — `bin/threshold-test.sh && bin/burndown-test.sh && bin/responder-burndown-test.sh` (34/34).

**Risk / rollback** — threshold-only; reversible (`git revert`). Machine-local collector backed up (`.bak-round4-*`). Responder dispositions unchanged (it still gates purely on computed leaf status — DRY, single-owner).

**Out of scope** — network-branch expansion, burn-down (correct as-is); deferred, not gaps.

**Cross-links** — EKO-90 (Linear, team EKO, Done — this is a hardening increment) · round-3 #257 · collector `~/.local/bin/system-health-guardian.sh` v1.4.0 (live, validated).

---
> 🤖 agent-authored — Claude Opus 4.8 under operator `/quiesce round-4` directive 2026-07-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYY7MuHqYHm6fKNLjrrU2Z
