### PR TITLE
feat(system-health-responder): EKO-90 round-5 — ncpu-aware top_consumer + honest XProtect + pid-recycle guard (v1.7.0)

### DIFF
--- a/skills/system-health-responder/SKILL.md
+++ b/skills/system-health-responder/SKILL.md
@@ -248,8 +248,11 @@ the unfinished half plus three adjacent honesty/safety gaps (collector **v1.4.1 
   autonomous action the responder takes. *(v1.7.1 PDCA per CodeRabbit PR#259 #131/#138 — the initial
   either-contains-substring match was too loose: a recycled `foo-helper` would match a contract `foo`, and an
   empty contract comm would match anything, either authorizing a wrong-proc renice; replaced with exact
-  equality + start-identity re-check. `renice` is fully reversible + denylist-guarded + re-sampled every 600s,
-  so fail-closed is sound.)*
+  equality + start-identity re-check. A follow-up review added two more: **@145** — `denied()` now
+  basename-normalizes so the whole-word `op` (1Password CLI) rule protects a PATH comm (`/usr/local/bin/op`),
+  not just a bare `op`; **@157** — the original niceness `cur` is now sampled AFTER the start-identity is bound
+  (a recycle can no longer pair a stale nice value with a live identity). `renice` is fully reversible +
+  denylist-guarded + re-sampled every 600s, so fail-closed is sound.)*
 - **#6 drill-down leaf-status consistency** — the `process.counts` leaf carried a hardcoded `status:"ok"`
   while its own `zombies` value could drive the branch to `crit`, so a `root_fail → leaf` walker landed on an
   `ok`-labeled leaf. Now the leaf reflects the (DRY, computed-once) `zombie` status — honoring the contract's
@@ -258,7 +261,8 @@ the unfinished half plus three adjacent honesty/safety gaps (collector **v1.4.1 
   signal (low payoff — memory is HITL-only + the current available% already adds back reclaimable classes).
 - **Tested**: `bin/threshold-test.sh` — **+7 `top_consumer_status`** (130.7@12c→warn · 700@12c→crit ·
   ncpu=1 fail-safe · …) **+8 `comm_match` recycle-guard** (foo-helper≠foo · empty≠anything ·
-  case/basename-normalize · …) assertions = **31**; round-3 suites regress clean (16+5) = **52/52**.
+  case/basename-normalize · …) **+6 `denied` basename-normalize** (/path/op→denied · top→allowed ·
+  1Password-path→denied · …) assertions = **37**; round-3 suites regress clean (16+5) = **58/58**.
 
 ## Composition (reuse, not reinvent — Strata)
 

--- a/skills/system-health-responder/SKILL.md
+++ b/skills/system-health-responder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: system-health-responder
 description: End-of-action reflex that reads the system-health contract, engage-locks, Eisenhower-ranks the warnings, does MODERATE non-destructive auto-heal (autonomous reversible renice of a clear cpu runaway + `uv cache prune` producer-hygiene), responds to the new `agentic_tools` branch (`claude doctor` runtime health + cache-producer pressure), reads the reclaim-aware `burn_down` disk forecast (observe-only leading indicator → seed+notify before crisis), and escalate-seeds the HITL residue (security · malware · kill · disk→disk-guardian · no-source-fix offender containment). EKO-90 part-2 — the responder half of the health suite.
-version: 1.7.0
+version: 1.7.1
 allowed-tools: Read, Bash
 ---
 
@@ -239,18 +239,26 @@ the unfinished half plus three adjacent honesty/safety gaps (collector **v1.4.1 
   Empirical: bundle-mtime said **47d**, the CLI says the real install was Jun-3 = **41d** — a 6-day honesty
   gap. `source` (`xprotect-cli|bundle-mtime`) is exposed in the leaf; bundle-mtime remains the fallback for
   older macOS. This is `medição real`, not a proxy.
-- **#2 responder pid-recycle guard (safer autonomy)** — `try_renice()` now re-reads the **live** `comm` for
-  the pid and requires it to still match the (≤600s-old) contract comm **before** renicing, then re-runs the
-  denylist on the *live* comm. A recycled pid can no longer be reniced by mistake, and a recycled-into-protected
-  proc is refused. Directly hardens the one autonomous action the responder takes.
+- **#2 responder pid-recycle guard (safer autonomy)** — `try_renice()` re-reads the **live** `comm` for the
+  pid and requires an **exact normalized match** (`comm_match()`: basename + lowercase + strip-space, both
+  non-empty, equal) to the (≤600s-old) contract comm **before** renicing, then re-runs the denylist on the
+  *live* comm, then **binds a process start-identity** (`ps -o lstart=`) and re-verifies it immediately before
+  the action. A recycled pid can no longer be reniced by mistake, a recycled-into-protected proc is refused,
+  and the check→act TOCTOU window is narrowed (fail-closed on identity drift). Directly hardens the one
+  autonomous action the responder takes. *(v1.7.1 PDCA per CodeRabbit PR#259 #131/#138 — the initial
+  either-contains-substring match was too loose: a recycled `foo-helper` would match a contract `foo`, and an
+  empty contract comm would match anything, either authorizing a wrong-proc renice; replaced with exact
+  equality + start-identity re-check. `renice` is fully reversible + denylist-guarded + re-sampled every 600s,
+  so fail-closed is sound.)*
 - **#6 drill-down leaf-status consistency** — the `process.counts` leaf carried a hardcoded `status:"ok"`
   while its own `zombies` value could drive the branch to `crit`, so a `root_fail → leaf` walker landed on an
   `ok`-labeled leaf. Now the leaf reflects the (DRY, computed-once) `zombie` status — honoring the contract's
   "cada nível aponta o filho com falha → root-fail" promise.
 - **Deferred (documented, not dropped)**: memory could use the native `kern.memorystatus_vm_pressure_level`
   signal (low payoff — memory is HITL-only + the current available% already adds back reclaimable classes).
-- **Tested**: `bin/threshold-test.sh` — **+7 `top_consumer_status`** assertions (130.7@12c→warn ·
-  700@12c→crit · ncpu=1 fail-safe · …) = **23**; round-3 suites regress clean (16+5) = **44/44**.
+- **Tested**: `bin/threshold-test.sh` — **+7 `top_consumer_status`** (130.7@12c→warn · 700@12c→crit ·
+  ncpu=1 fail-safe · …) **+8 `comm_match` recycle-guard** (foo-helper≠foo · empty≠anything ·
+  case/basename-normalize · …) assertions = **31**; round-3 suites regress clean (16+5) = **52/52**.
 
 ## Composition (reuse, not reinvent — Strata)
 

--- a/skills/system-health-responder/SKILL.md
+++ b/skills/system-health-responder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: system-health-responder
 description: End-of-action reflex that reads the system-health contract, engage-locks, Eisenhower-ranks the warnings, does MODERATE non-destructive auto-heal (autonomous reversible renice of a clear cpu runaway + `uv cache prune` producer-hygiene), responds to the new `agentic_tools` branch (`claude doctor` runtime health + cache-producer pressure), reads the reclaim-aware `burn_down` disk forecast (observe-only leading indicator → seed+notify before crisis), and escalate-seeds the HITL residue (security · malware · kill · disk→disk-guardian · no-source-fix offender containment). EKO-90 part-2 — the responder half of the health suite.
-version: 1.6.1
+version: 1.7.0
 allowed-tools: Read, Bash
 ---
 
@@ -218,6 +218,39 @@ So this is squarely an **enhance-autonomy** fix (collector **v1.3.2 → v1.4.1**
 - **Tested**: `bin/threshold-test.sh` — 16 assertions (burst→warn-not-crit · sustained-load5→crit ·
   auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing · **unknown-9999d→warn-never-crit**).
   Round-3 suites regress clean (16+5).
+
+### Multi-core & measurement-honesty fixes (v1.7.0, round-5, 2026-07-14) — finishing the ncpu-aware thesis
+
+Round-4 made the **load-aggregate** ncpu-aware but left the **per-process** leaf raw — an OODA sweep caught
+the unfinished half plus three adjacent honesty/safety gaps (collector **v1.4.1 → v1.5.0**, skill **v1.6.1 → v1.7.0**):
+
+- **#1 `top_consumer`/`runaway` NOT ncpu-aware (the live false-crit)** — `top_consumer_status()`. macOS `ps
+  %cpu` is **per-core** (100% = one full core, can exceed 100%). Warn+crit were applied raw, so one process
+  at 130.7% (1.3 of 12 cores ≈ 11% of capacity) rolled up to `system=crit` **while the sustained-saturation
+  branch said the box was fine** — the two CPU branches actively contradicted each other. Fix (twin of the
+  round-4 load1/load5 split): **WARN keyed per-core** (the responder's renice-actionable signal survives —
+  renice fires on any non-`ok`), **CRIT requires a fraction of TOTAL capacity** (`PROC_CPU_CRIT_RATIO=0.50` ⇒
+  crit only when a proc eats ≥50% of `ncpu`; the load branch already owns true saturation). Fail-safe on
+  `ncpu=1` (crit never below warn). Auto-resolves the old double-count (a reniced proc no longer *also* seeds
+  a "process=crit → operator kill"). Empirical: live `global crit → warn` (a busy core, not a system emergency).
+- **#5 XProtect measured the wrong artifact (upgrade)** — freshness now prefers the **authoritative
+  `/usr/bin/xprotect version`** (no-sudo, real version + install date) over the legacy `XProtect.bundle`
+  mtime, which modern macOS never touches on a signature update (`XProtectUpdateService` writes elsewhere).
+  Empirical: bundle-mtime said **47d**, the CLI says the real install was Jun-3 = **41d** — a 6-day honesty
+  gap. `source` (`xprotect-cli|bundle-mtime`) is exposed in the leaf; bundle-mtime remains the fallback for
+  older macOS. This is `medição real`, not a proxy.
+- **#2 responder pid-recycle guard (safer autonomy)** — `try_renice()` now re-reads the **live** `comm` for
+  the pid and requires it to still match the (≤600s-old) contract comm **before** renicing, then re-runs the
+  denylist on the *live* comm. A recycled pid can no longer be reniced by mistake, and a recycled-into-protected
+  proc is refused. Directly hardens the one autonomous action the responder takes.
+- **#6 drill-down leaf-status consistency** — the `process.counts` leaf carried a hardcoded `status:"ok"`
+  while its own `zombies` value could drive the branch to `crit`, so a `root_fail → leaf` walker landed on an
+  `ok`-labeled leaf. Now the leaf reflects the (DRY, computed-once) `zombie` status — honoring the contract's
+  "cada nível aponta o filho com falha → root-fail" promise.
+- **Deferred (documented, not dropped)**: memory could use the native `kern.memorystatus_vm_pressure_level`
+  signal (low payoff — memory is HITL-only + the current available% already adds back reclaimable classes).
+- **Tested**: `bin/threshold-test.sh` — **+7 `top_consumer_status`** assertions (130.7@12c→warn ·
+  700@12c→crit · ncpu=1 fail-safe · …) = **23**; round-3 suites regress clean (16+5) = **44/44**.
 
 ## Composition (reuse, not reinvent — Strata)
 

--- a/skills/system-health-responder/bin/health-respond.sh
+++ b/skills/system-health-responder/bin/health-respond.sh
@@ -95,7 +95,11 @@ release_lock() { rm -rf "$LOCK" 2>/dev/null || true; }
 denied() {  # $1=comm → 0 if protected. Substring match, which ERRS CONSERVATIVE (over-protect: worst
             # case we skip a renice we could have done — never the reverse). EXCEPTION: the ultra-short
             # `op` token (1Password CLI) matches WHOLE-comm only, so it doesn't over-match Dropbox/top/etc.
-  local c; c="$(printf '%s' "$1" | tr '[:upper:]' '[:lower:]')"
+  # basename-normalize (per CodeRabbit PR#259 @145): `ps -o comm=` may return a PATH (`/usr/local/bin/op`).
+  # Without basename the whole-comm `op` rule below (`c == "op"`) would MISS a path → the sensitive 1Password
+  # CLI could be reniced on recycle. Basename also makes this consistent with comm_match() + tightens the
+  # substring rules against false path-component matches. Denylist entries are all comm basenames.
+  local c; c="$(basename "${1:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]')"
   local d; for d in "${PROC_DENYLIST[@]}"; do
     if [ "$d" = "op" ]; then [ "$c" = "op" ] && return 0; continue; fi
     case "$c" in *"$d"*) return 0;; esac
@@ -119,14 +123,6 @@ try_renice() {
   if denied "$comm"; then
     echo "  🟠 cpu-runaway ${comm} (pid ${pid}, ${pct}%) — PROTECTED proc → seed+notify (never renice)"
     return 2
-  fi
-  # `|| true`: under `set -o pipefail` a dead pid makes `ps` fail → the pipe fails → the $()
-  # assignment would abort the script under `set -e` BEFORE the numeric guard runs. Force the
-  # substitution to always succeed (empty on failure) so the guard below handles proc-gone gracefully.
-  local cur; cur="$(ps -o nice= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
-  # validate numeric (empty ⇒ proc gone; non-numeric ⇒ unexpected ps output) BEFORE any -ge compare
-  if ! [[ "$cur" =~ ^-?[0-9]+$ ]]; then
-    echo "  ⏭  cpu-runaway pid ${pid} gone / invalid nice ('${cur}') before action"; return 1
   fi
   # pid-recycle guard (round-5 #2, HARDENED per CodeRabbit PR#259 #131/#138): the contract can be up to
   # StartInterval (600s) stale, so this pid may have been recycled to a DIFFERENT process since the sample →
@@ -154,6 +150,15 @@ try_renice() {
   if [ -z "$live_start" ]; then
     echo "  ⏭  cpu-runaway pid ${pid}: cannot bind start-identity (proc gone) → fail-closed skip (no renice)"
     return 1
+  fi
+  # sample the ORIGINAL niceness AFTER the identity is bound (per CodeRabbit PR#259 @157): reading `cur`
+  # before binding live_start could pair a nice value from a since-recycled process with a different identity
+  # → a wrong revert record / wrong -ge decision. The recheck_start below then validates identity stability
+  # across this read up to the renice. `|| true`: under pipefail a dead pid fails the pipe → would abort under
+  # set -e before the numeric guard; force success (empty) so the guard handles proc-gone gracefully.
+  local cur; cur="$(ps -o nice= -p "$pid" 2>/dev/null | tr -d ' ' || true)"
+  if ! [[ "$cur" =~ ^-?[0-9]+$ ]]; then
+    echo "  ⏭  cpu-runaway pid ${pid} gone / invalid nice ('${cur}') before action"; return 1
   fi
   # already at/below target priority → renicing DOWN needs root (BSD: non-root can only raise niceness);
   # renice to the same value is a no-op. Either way skip → the runaway becomes HITL residue (kill/quit=operator).
@@ -328,6 +333,7 @@ main() {
 case "${1:-}" in
   --help|-h) usage; exit 0;;
   --comm-match) comm_match "${2:-}" "${3:-}" && { echo match; exit 0; } || { echo nomatch; exit 1; };;
+  --denied) denied "${2:-}" && { echo denied; exit 0; } || { echo allowed; exit 1; };;
   --engage)
     # Fail-safe DENY-until-proven: the autonomous renice fires ONLY when the calling reflex has
     # proven the standing-autonomy READY predicate and signalled it via SHR_READY=1. A stray

--- a/skills/system-health-responder/bin/health-respond.sh
+++ b/skills/system-health-responder/bin/health-respond.sh
@@ -103,6 +103,16 @@ denied() {  # $1=comm → 0 if protected. Substring match, which ERRS CONSERVATI
   return 1
 }
 
+# normalized comm-identity match: basename + lowercase + strip-whitespace, then EXACT equality with BOTH
+# sides non-empty. NOT substring — a recycled `foo-helper` must NOT match a contract `foo`, and an empty
+# side must match nothing (either would authorize renicing the WRONG unprotected proc). CodeRabbit PR#259 #131.
+comm_match() {  # $1=live_raw $2=want_raw → 0 iff same normalized non-empty command
+  local a b
+  a="$(basename "${1:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  b="$(basename "${2:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')"
+  [ -n "$a" ] && [ -n "$b" ] && [ "$a" = "$b" ]
+}
+
 # Moderate autonomous heal of a clear cpu runaway. Returns 0 acted/proposed, 1 skipped, 2 denied.
 try_renice() {
   local pid="$1" comm="$2" pct="$3"
@@ -118,23 +128,32 @@ try_renice() {
   if ! [[ "$cur" =~ ^-?[0-9]+$ ]]; then
     echo "  ⏭  cpu-runaway pid ${pid} gone / invalid nice ('${cur}') before action"; return 1
   fi
-  # pid-recycle guard (round-5 #2): the contract can be up to StartInterval (600s) stale, so this pid may
-  # have been recycled to a DIFFERENT process since the sample → renicing it would hit the wrong proc, and
-  # the denied() check above ran against the STALE contract comm. Re-read the LIVE comm and require it to
-  # still relate to the contract comm (basename, case-insensitive, space-stripped, either-contains-other to
-  # tolerate path-vs-name + truncation). Mismatch ⇒ recycled/gone ⇒ skip. Then re-run denied() on the LIVE
-  # comm (defense-in-depth: a recycled pid could BE a protected proc).
-  local live_raw live_c want_c
+  # pid-recycle guard (round-5 #2, HARDENED per CodeRabbit PR#259 #131/#138): the contract can be up to
+  # StartInterval (600s) stale, so this pid may have been recycled to a DIFFERENT process since the sample →
+  # renicing it would hit the wrong proc, and the denied() check above ran against the STALE contract comm.
+  # (#131) Require an EXACT normalized command match — NOT substring: a recycled `foo-helper` must NOT match
+  # a contract `foo`, and an empty comm must match nothing. comm_match() enforces both-non-empty + equal;
+  # anything else fails closed (skip). Then re-run denied() on the LIVE comm (a recycled pid could BE protected).
+  local live_raw
   live_raw="$(ps -o comm= -p "$pid" 2>/dev/null || true)"
-  live_c="$(basename "${live_raw:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
-  want_c="$(basename "${comm:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
-  if [ -z "$live_c" ] || { [[ "$live_c" != *"$want_c"* ]] && [[ "$want_c" != *"$live_c"* ]]; }; then
-    echo "  ⏭  cpu-runaway pid ${pid}: live comm '${live_raw:-gone}' ≠ contract '${comm}' (pid recycled/gone since sample) → skip (no renice)"
+  if ! comm_match "$live_raw" "$comm"; then
+    echo "  ⏭  cpu-runaway pid ${pid}: live comm '${live_raw:-gone}' ≠ contract '${comm}' (recycled/gone/ambiguous since sample) → skip (no renice)"
     return 1
   fi
   if denied "$live_raw"; then
     echo "  🟠 cpu-runaway pid ${pid}: live comm '${live_raw}' is PROTECTED (recycle re-check) → seed+notify (never renice)"
     return 2
+  fi
+  # (#138) TOCTOU narrowing: bind a stable start-identity (kernel process start time) NOW; re-verify it
+  # immediately before renice (below). Shell check-then-act can't be atomic, but this catches the pid
+  # exiting/recycling between here and the action. Combined with the exact-comm match, the denylist re-check,
+  # renice being fully REVERSIBLE (reverts.log), and the collector re-sampling every 600s (a real runaway
+  # re-surfaces next cycle), fail-closed here is sound. Cannot bind an identity ⇒ skip (DENY-until-proven).
+  local live_start
+  live_start="$(ps -o lstart= -p "$pid" 2>/dev/null | tr -s ' ' || true)"
+  if [ -z "$live_start" ]; then
+    echo "  ⏭  cpu-runaway pid ${pid}: cannot bind start-identity (proc gone) → fail-closed skip (no renice)"
+    return 1
   fi
   # already at/below target priority → renicing DOWN needs root (BSD: non-root can only raise niceness);
   # renice to the same value is a no-op. Either way skip → the runaway becomes HITL residue (kill/quit=operator).
@@ -145,6 +164,14 @@ try_renice() {
   if [ "$DRY_RUN" -eq 1 ]; then
     echo "  ✅ PROPOSE renice ${RENICE_TO} pid=${pid} comm=${comm} pct=${pct} (cur nice=${cur}) [dry-run]"
     return 0
+  fi
+  # re-verify the bound start-identity immediately before acting (TOCTOU close-out #138) — a pid recycled or
+  # exited since the bind now shows a different / empty start time ⇒ fail-closed skip (never renice the wrong proc).
+  local recheck_start
+  recheck_start="$(ps -o lstart= -p "$pid" 2>/dev/null | tr -s ' ' || true)"
+  if [ -z "$recheck_start" ] || [ "$recheck_start" != "$live_start" ]; then
+    echo "  ⏭  cpu-runaway pid ${pid}: start-identity drift ('${live_start}' → '${recheck_start:-gone}') = pid recycled/exited before renice → fail-closed skip"
+    return 1
   fi
   if renice "$RENICE_TO" -p "$pid" >/dev/null 2>&1; then
     printf '%s reverted-by: renice %s -p %s   # was comm=%s pct=%s\n' \
@@ -300,6 +327,7 @@ main() {
 
 case "${1:-}" in
   --help|-h) usage; exit 0;;
+  --comm-match) comm_match "${2:-}" "${3:-}" && { echo match; exit 0; } || { echo nomatch; exit 1; };;
   --engage)
     # Fail-safe DENY-until-proven: the autonomous renice fires ONLY when the calling reflex has
     # proven the standing-autonomy READY predicate and signalled it via SHR_READY=1. A stray

--- a/skills/system-health-responder/bin/health-respond.sh
+++ b/skills/system-health-responder/bin/health-respond.sh
@@ -118,6 +118,24 @@ try_renice() {
   if ! [[ "$cur" =~ ^-?[0-9]+$ ]]; then
     echo "  ⏭  cpu-runaway pid ${pid} gone / invalid nice ('${cur}') before action"; return 1
   fi
+  # pid-recycle guard (round-5 #2): the contract can be up to StartInterval (600s) stale, so this pid may
+  # have been recycled to a DIFFERENT process since the sample → renicing it would hit the wrong proc, and
+  # the denied() check above ran against the STALE contract comm. Re-read the LIVE comm and require it to
+  # still relate to the contract comm (basename, case-insensitive, space-stripped, either-contains-other to
+  # tolerate path-vs-name + truncation). Mismatch ⇒ recycled/gone ⇒ skip. Then re-run denied() on the LIVE
+  # comm (defense-in-depth: a recycled pid could BE a protected proc).
+  local live_raw live_c want_c
+  live_raw="$(ps -o comm= -p "$pid" 2>/dev/null || true)"
+  live_c="$(basename "${live_raw:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
+  want_c="$(basename "${comm:-}" 2>/dev/null | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
+  if [ -z "$live_c" ] || { [[ "$live_c" != *"$want_c"* ]] && [[ "$want_c" != *"$live_c"* ]]; }; then
+    echo "  ⏭  cpu-runaway pid ${pid}: live comm '${live_raw:-gone}' ≠ contract '${comm}' (pid recycled/gone since sample) → skip (no renice)"
+    return 1
+  fi
+  if denied "$live_raw"; then
+    echo "  🟠 cpu-runaway pid ${pid}: live comm '${live_raw}' is PROTECTED (recycle re-check) → seed+notify (never renice)"
+    return 2
+  fi
   # already at/below target priority → renicing DOWN needs root (BSD: non-root can only raise niceness);
   # renice to the same value is a no-op. Either way skip → the runaway becomes HITL residue (kill/quit=operator).
   if [ "$cur" -ge "$RENICE_TO" ]; then

--- a/skills/system-health-responder/bin/threshold-test.sh
+++ b/skills/system-health-responder/bin/threshold-test.sh
@@ -21,6 +21,7 @@ ck() { # ck "<label>" "<got>" "<want>"
 }
 cpu() { "$COLLECTOR" --cpu-load-status "$@" 2>/dev/null; }   # load1 load5 ncpu warn_ratio crit_ratio
 xp()  { "$COLLECTOR" --xprotect-status "$@" 2>/dev/null; }   # age autoupdate warn crit selfheal
+tc()  { "$COLLECTOR" --top-consumer-status "$@" 2>/dev/null; } # pct(per-core) ncpu warn_pct crit_ratio(of total)
 
 echo "── cpu_load_status (warn=load1 spiky · crit=load5 sustained) ──"
 ck "burst load1=27 load5=6 12c → warn (NOT crit) [the false-crit fix]" "$(cpu 27.33 6.0 12 0.90 1.50)" "warn"
@@ -43,6 +44,15 @@ echo "── xprotect_status UNKNOWN (probe failed → fail-safe, warn-capable N
 ck "unknown 10d → ok (below warn)"                                     "$(xp 10 unknown 30 60 60)"   "ok"
 ck "unknown 47d → warn (past warn horizon)"                            "$(xp 47 unknown 30 60 60)"   "warn"
 ck "unknown 9999d → warn (NEVER crit — probe error ≠ false-crit)"      "$(xp 9999 unknown 30 60 60)" "warn"
+
+echo "── top_consumer_status (ncpu-aware: warn=per-core actionable, crit=fraction of TOTAL) [v1.5.0, round-5 #1] ──"
+ck "130.7% @12c → warn (1.3 cores ≠ system crit) [the live false-crit fix]" "$(tc 130.7 12 70 0.50)" "warn"
+ck "700% @12c → crit (eats ~7 of 12 cores — genuine)"                       "$(tc 700 12 70 0.50)"   "crit"
+ck "600% @12c → crit (0.50*12*100 boundary)"                                "$(tc 600 12 70 0.50)"   "crit"
+ck "85% @12c → warn (>1 core, renice-actionable, not crit)"                 "$(tc 85 12 70 0.50)"    "warn"
+ck "50% @12c → ok (below per-core warn)"                                    "$(tc 50 12 70 0.50)"    "ok"
+ck "90% @1core → crit (ncpu=1 fail-safe: crit_pct=max(50,70)=70)"           "$(tc 90 1 70 0.50)"     "crit"
+ck "60% @1core → ok (below warn on single core)"                            "$(tc 60 1 70 0.50)"     "ok"
 
 echo
 echo "threshold-test: $PASS passed, $FAIL failed"

--- a/skills/system-health-responder/bin/threshold-test.sh
+++ b/skills/system-health-responder/bin/threshold-test.sh
@@ -25,6 +25,7 @@ cpu() { "$COLLECTOR" --cpu-load-status "$@" 2>/dev/null; }   # load1 load5 ncpu 
 xp()  { "$COLLECTOR" --xprotect-status "$@" 2>/dev/null; }   # age autoupdate warn crit selfheal
 tc()  { "$COLLECTOR" --top-consumer-status "$@" 2>/dev/null; } # pct(per-core) ncpu warn_pct crit_ratio(of total)
 cm()  { "$RESPONDER" --comm-match "$1" "$2" 2>/dev/null; }     # live_raw want_raw → match|nomatch (#131 recycle guard)
+dn()  { "$RESPONDER" --denied "$1" 2>/dev/null; }             # comm → denied|allowed (basename-normalized denylist, @145)
 
 echo "── cpu_load_status (warn=load1 spiky · crit=load5 sustained) ──"
 ck "burst load1=27 load5=6 12c → warn (NOT crit) [the false-crit fix]" "$(cpu 27.33 6.0 12 0.90 1.50)" "warn"
@@ -66,6 +67,14 @@ ck "exact 'foo' vs 'foo' → match"                                             
 ck "case 'Superset' vs 'superset' → match (case-insensitive)"                            "$(cm Superset superset)"  "match"
 ck "path '/A/MacOS/Node' vs 'Node' → match (basename normalize)"                         "$(cm /A/MacOS/Node Node)" "match"
 ck "similar 'node' vs 'nodejs' → nomatch (not equal, no substring widening)"             "$(cm node nodejs)"        "nomatch"
+
+echo "── denied() basename-normalized denylist (sensitive-proc protection on PATH comm) [v1.7.1, CodeRabbit @145] ──"
+ck "'/usr/local/bin/op' → denied (op whole-word now matches basename, not just bare 'op')" "$(dn /usr/local/bin/op)"  "denied"
+ck "bare 'op' → denied (whole-word preserved)"                                             "$(dn op)"                 "denied"
+ck "'top' → allowed (op whole-word NOT over-matched — the exception still holds)"          "$(dn top)"                "allowed"
+ck "'/Applications/1Password.app/Contents/MacOS/1Password' → denied (substring on basename)" "$(dn /Applications/1Password.app/Contents/MacOS/1Password)" "denied"
+ck "'/opt/homebrew/bin/claude' → denied (path comm still protected)"                        "$(dn /opt/homebrew/bin/claude)" "denied"
+ck "'Google Chrome Helper' → allowed (not on denylist)"                                     "$(dn 'Google Chrome Helper')" "allowed"
 
 echo
 echo "threshold-test: $PASS passed, $FAIL failed"

--- a/skills/system-health-responder/bin/threshold-test.sh
+++ b/skills/system-health-responder/bin/threshold-test.sh
@@ -14,6 +14,8 @@ set -uo pipefail
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 COLLECTOR="${THRESHOLD_COLLECTOR:-$DIR/../collectors/system-health-guardian.sh}"
 [ -f "$COLLECTOR" ] || { echo "FATAL: collector not found: $COLLECTOR" >&2; exit 2; }
+RESPONDER="${THRESHOLD_RESPONDER:-$DIR/health-respond.sh}"
+[ -f "$RESPONDER" ] || { echo "FATAL: responder not found: $RESPONDER" >&2; exit 2; }
 
 PASS=0; FAIL=0
 ck() { # ck "<label>" "<got>" "<want>"
@@ -22,6 +24,7 @@ ck() { # ck "<label>" "<got>" "<want>"
 cpu() { "$COLLECTOR" --cpu-load-status "$@" 2>/dev/null; }   # load1 load5 ncpu warn_ratio crit_ratio
 xp()  { "$COLLECTOR" --xprotect-status "$@" 2>/dev/null; }   # age autoupdate warn crit selfheal
 tc()  { "$COLLECTOR" --top-consumer-status "$@" 2>/dev/null; } # pct(per-core) ncpu warn_pct crit_ratio(of total)
+cm()  { "$RESPONDER" --comm-match "$1" "$2" 2>/dev/null; }     # live_raw want_raw → match|nomatch (#131 recycle guard)
 
 echo "── cpu_load_status (warn=load1 spiky · crit=load5 sustained) ──"
 ck "burst load1=27 load5=6 12c → warn (NOT crit) [the false-crit fix]" "$(cpu 27.33 6.0 12 0.90 1.50)" "warn"
@@ -53,6 +56,16 @@ ck "85% @12c → warn (>1 core, renice-actionable, not crit)"                 "$
 ck "50% @12c → ok (below per-core warn)"                                    "$(tc 50 12 70 0.50)"    "ok"
 ck "90% @1core → crit (ncpu=1 fail-safe: crit_pct=max(50,70)=70)"           "$(tc 90 1 70 0.50)"     "crit"
 ck "60% @1core → ok (below warn on single core)"                            "$(tc 60 1 70 0.50)"     "ok"
+
+echo "── comm_match (pid-recycle identity guard: EXACT normalized, no substring) [v1.5.1, round-5 #2, CodeRabbit #131] ──"
+ck "recycled 'foo-helper' vs contract 'foo' → nomatch (the substring false-match bug)"  "$(cm foo-helper foo)"     "nomatch"
+ck "reverse 'foo' vs 'foo-helper' → nomatch"                                             "$(cm foo foo-helper)"     "nomatch"
+ck "empty live vs 'foo' → nomatch (proc gone)"                                           "$(cm '' foo)"             "nomatch"
+ck "'foo' vs empty want → nomatch (empty-want_c authorize-anything hole)"                "$(cm foo '')"             "nomatch"
+ck "exact 'foo' vs 'foo' → match"                                                        "$(cm foo foo)"            "match"
+ck "case 'Superset' vs 'superset' → match (case-insensitive)"                            "$(cm Superset superset)"  "match"
+ck "path '/A/MacOS/Node' vs 'Node' → match (basename normalize)"                         "$(cm /A/MacOS/Node Node)" "match"
+ck "similar 'node' vs 'nodejs' → nomatch (not equal, no substring widening)"             "$(cm node nodejs)"        "nomatch"
 
 echo
 echo "threshold-test: $PASS passed, $FAIL failed"

--- a/skills/system-health-responder/collectors/system-health-guardian.sh
+++ b/skills/system-health-responder/collectors/system-health-guardian.sh
@@ -51,8 +51,8 @@ MEM_AVAIL_WARN_PCT="${MEM_AVAIL_WARN_PCT:-15}"
 MEM_AVAIL_CRIT_PCT="${MEM_AVAIL_CRIT_PCT:-8}"
 DISK_FREE_WARN_GB="${DISK_FREE_WARN_GB:-15}"
 DISK_FREE_CRIT_GB="${DISK_FREE_CRIT_GB:-8}"
-PROC_CPU_WARN="${PROC_CPU_WARN:-70}"                 # single-proc %cpu (feeds responder renice target)
-PROC_CPU_CRIT="${PROC_CPU_CRIT:-90}"
+PROC_CPU_WARN="${PROC_CPU_WARN:-70}"                 # single-proc %cpu WARN (PER-CORE; feeds responder renice target — actionable, NOT system-crit)
+PROC_CPU_CRIT_RATIO="${PROC_CPU_CRIT_RATIO:-0.50}"   # single-proc CRIT only when it eats ≥ this fraction of TOTAL cores (ncpu-aware; round-5 — a 1-core-bound proc on a many-core box is WARN, not a system crit)
 XPROTECT_STALE_WARN_DAYS="${XPROTECT_STALE_WARN_DAYS:-30}"      # auto-update OFF → WARN at Nd (the real risk)
 XPROTECT_STALE_CRIT_DAYS="${XPROTECT_STALE_CRIT_DAYS:-60}"      # auto-update OFF → CRIT at Nd
 XPROTECT_SELFHEAL_WARN_DAYS="${XPROTECT_SELFHEAL_WARN_DAYS:-60}" # auto-update ON → only >Nd WARNs, never crit (self-healing; Apple cadence)
@@ -92,6 +92,17 @@ xprotect_status() { # $1=age_days $2=autoupdate(on|off|unknown) $3=warn_days $4=
     off) st_hi "$1" "$3" "$4"     ;;   # confirmed off (the real risk) → full warn/crit age escalation
     *)   st_hi "$1" "$3" "999999" ;;   # unknown → warn at warn_days, crit unreachable (fail-safe on probe error)
   esac
+}
+
+# top_consumer_status: a single hot process. macOS `ps %cpu` is PER-CORE (100% = one full core; can exceed 100%
+# on a multi-core box). WARN keeps the per-core renice-actionable signal (the responder renices any non-ok
+# top_consumer); CRIT requires the proc to eat a real fraction of TOTAL capacity (ncpu-aware) — so one
+# core-bound proc on a many-core box is WARN (actionable), NOT a system crit. Twin of the round-4
+# load1(warn-spiky)/load5(crit-sustained) split; the load branch already owns true system saturation.
+top_consumer_status() { # $1=pct(per-core) $2=ncpu $3=warn_pct $4=crit_ratio(of total)
+  local crit_pct
+  crit_pct="$(awk -v r="$4" -v n="$2" -v w="$3" 'BEGIN{c=r*n*100; printf "%.2f", (c<w)?w:c}')"  # never below warn (ncpu=1 fail-safe)
+  st_hi "$1" "$3" "$crit_pct"
 }
 
 # ── BURN-DOWN forecast (EKO-90-round3 2026-07-14) — reclaim-aware disk-exhaustion prediction ──
@@ -150,9 +161,10 @@ EOF
 # testable entrypoint: `--burndown` runs ONLY the forecast (no probing, no contract write) — the unit test
 # (bin/burndown-test.sh) drives this with a synthetic DISK_GUARDIAN_LOG (no awk duplication).
 if [ "${1:-}" = "--burndown" ]; then compute_burndown; echo; exit 0; fi
-# testable entrypoints for the round-4 pure decision cores (bin/threshold-test.sh drives these — no logic dup):
+# testable entrypoints for the round-4/round-5 pure decision cores (bin/threshold-test.sh drives these — no logic dup):
 if [ "${1:-}" = "--cpu-load-status" ]; then cpu_load_status "${2:-0}" "${3:-0}" "${4:-1}" "${5:-0.90}" "${6:-1.50}"; exit 0; fi
 if [ "${1:-}" = "--xprotect-status" ]; then xprotect_status "${2:-0}" "${3:-on}" "${4:-30}" "${5:-60}" "${6:-60}"; exit 0; fi
+if [ "${1:-}" = "--top-consumer-status" ]; then top_consumer_status "${2:-0}" "${3:-1}" "${4:-70}" "${5:-0.50}"; exit 0; fi
 
 # ── CPU ───────────────────────────────────────────────────────────────────────
 NCPU="$(sysctl -n hw.ncpu 2>/dev/null || echo 1)"
@@ -169,7 +181,7 @@ PS_BY_CPU="$(ps -A -r -o pid=,%cpu=,comm= 2>/dev/null || true)"
 TOP_CPU_LINE="$(awk 'NR==1{pid=$1;cpu=$2;$1="";$2="";c=$0;sub(/^ +/,"",c);n=split(c,a,"/");print pid"|"cpu"|"a[n]; exit}' <<<"$PS_BY_CPU")"
 TOP_CPU_PID="$(echo "$TOP_CPU_LINE" | cut -d'|' -f1)"; TOP_CPU_PCT="$(echo "$TOP_CPU_LINE" | cut -d'|' -f2)"; TOP_CPU_COMM="$(echo "$TOP_CPU_LINE" | cut -d'|' -f3)"
 TOP_CPU_PCT="${TOP_CPU_PCT:-0}"
-CPU_PROC_ST="$(st_hi "$TOP_CPU_PCT" "$PROC_CPU_WARN" "$PROC_CPU_CRIT")"
+CPU_PROC_ST="$(top_consumer_status "$TOP_CPU_PCT" "$NCPU" "$PROC_CPU_WARN" "$PROC_CPU_CRIT_RATIO")"
 CPU_ST="$(worst "$CPU_LOAD_ST" "$CPU_PROC_ST")"
 
 # ── MEMORY (available% from vm_stat; inactive+free+speculative+purgeable ≈ available) ──
@@ -201,11 +213,25 @@ SEC_ST=ok
 [ "$FW" = disabled ] && SEC_ST="$(worst "$SEC_ST" warn)"
 
 # ── MALWARE (XProtect freshness — built-in AV signatures) ─────────────────────
+# Prefer the AUTHORITATIVE direct read (`xprotect version`, no-sudo → real version + install date) over the
+# legacy bundle-mtime proxy — modern macOS ships XProtect signature updates via XProtectUpdateService WITHOUT
+# touching XProtect.bundle, so its mtime UNDER-reports freshness (empirical: bundle=May-29 vs real Jun-03
+# install). round-5 upgrade; XP_SRC records which source fed age_days for drill-down honesty.
 XP_BUNDLE="/Library/Apple/System/Library/CoreServices/XProtect.bundle"
-XP_VER="$(defaults read "$XP_BUNDLE/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null || echo unknown)"
-XP_MTIME="$(stat -f %m "$XP_BUNDLE" 2>/dev/null || echo 0)"
+XP_CLI="${XP_CLI:-/usr/bin/xprotect}"
 NOW_EPOCH="$(date +%s)"
-XP_AGE_DAYS="$(awk -v m="$XP_MTIME" -v n="$NOW_EPOCH" 'BEGIN{printf "%.0f", (m>0)?(n-m)/86400:9999}')"
+XP_SRC="bundle-mtime"; XP_VER="unknown"; XP_INST_EPOCH=0
+if [ -x "$XP_CLI" ] && XP_VLINE="$("$XP_CLI" version 2>/dev/null)" && [ -n "$XP_VLINE" ]; then
+  XP_VER="$(printf '%s' "$XP_VLINE" | sed -n 's/.*[Vv]ersion:[[:space:]]*\([0-9][0-9]*\).*/\1/p' | head -1)"
+  XP_INST_DATE="$(printf '%s' "$XP_VLINE" | sed -n 's/.*[Ii]nstalled:[[:space:]]*\([0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]\).*/\1/p' | head -1)"
+  XP_INST_EPOCH="$(date -j -f '%Y-%m-%d' "${XP_INST_DATE:-x}" +%s 2>/dev/null || echo 0)"
+  { [ -n "$XP_VER" ] && [ "${XP_INST_EPOCH:-0}" -gt 0 ]; } && XP_SRC="xprotect-cli"
+fi
+if [ "$XP_SRC" != "xprotect-cli" ]; then   # fallback: legacy bundle read (older macOS without /usr/bin/xprotect)
+  XP_VER="$(defaults read "$XP_BUNDLE/Contents/Info.plist" CFBundleShortVersionString 2>/dev/null || echo unknown)"
+  XP_INST_EPOCH="$(stat -f %m "$XP_BUNDLE" 2>/dev/null || echo 0)"
+fi
+XP_AGE_DAYS="$(awk -v m="$XP_INST_EPOCH" -v n="$NOW_EPOCH" 'BEGIN{printf "%.0f", (m>0)?(n-m)/86400:9999}')"
 # auto-update channel — a PROXY (cheap ~20ms, no-sudo, local `softwareupdate --schedule` read), NOT a
 # direct XProtect signal (modern macOS updates XProtect via XProtectUpdateService; --schedule is the
 # general auto-update toggle). ON ⇒ freshness self-heals → 47d-but-latest is honestly ok (Apple cadence).
@@ -222,8 +248,9 @@ MAL_ST="$(xprotect_status "$XP_AGE_DAYS" "$XP_AUTOUPDATE" "$XPROTECT_STALE_WARN_
 PROC_COUNT="$(ps -A -o pid= 2>/dev/null | wc -l | tr -d ' ')"
 THREAD_COUNT="$(ps -A -M 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')"
 ZOMBIE_COUNT="$(ps -A -o stat= 2>/dev/null | grep -c '^Z' || true)"; ZOMBIE_COUNT="${ZOMBIE_COUNT:-0}"
+ZOMBIE_ST="$(st_hi "$ZOMBIE_COUNT" 5 20)"   # computed once (DRY) — drives both the roll-up AND the counts-leaf status (round-5 #6)
 # runaway = the top-cpu proc over threshold (reuse CPU sample) — this is the responder's renice candidate
-PROC_ST="$(worst "$CPU_PROC_ST" "$(st_hi "$ZOMBIE_COUNT" 5 20)")"
+PROC_ST="$(worst "$CPU_PROC_ST" "$ZOMBIE_ST")"
 
 # ── NETWORK (listener count — notify-only per safety-matrix) ──────────────────
 LISTENERS="$(netstat -an -p tcp 2>/dev/null | grep -c LISTEN || true)"; LISTENERS="${LISTENERS:-0}"
@@ -305,7 +332,7 @@ MEM_RF="$(branch_rootfail "$MEM_ST" "available_pct:$MEM_ST")"
 DISK_RF="$(branch_rootfail "$DISK_ST" "free_gb:$DISK_ST")"
 SEC_RF="$(branch_rootfail "$SEC_ST" "sip:$([ "$SIP" = disabled ] && echo crit || echo ok)" "gatekeeper:$([ "$GK" = disabled ] && echo warn || echo ok)" "firewall:$([ "$FW" = disabled ] && echo warn || echo ok)")"
 MAL_RF="$(branch_rootfail "$MAL_ST" "xprotect_freshness:$MAL_ST")"
-PROC_RF="$(branch_rootfail "$PROC_ST" "runaway:$CPU_PROC_ST" "zombies:$(st_hi "$ZOMBIE_COUNT" 5 20)")"
+PROC_RF="$(branch_rootfail "$PROC_ST" "runaway:$CPU_PROC_ST" "zombies:$ZOMBIE_ST")"
 NET_RF="$(branch_rootfail "$NET_ST" "listeners:$NET_ST")"
 
 AT_RF="$(branch_rootfail "$AT_ST" "claude_runtime:$CLAUDE_ST" "cache_producer:$PRODUCER_ST")"
@@ -326,14 +353,14 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
   --arg mem_st "$MEM_ST" --argjson mem_rf "$MEM_RF" --arg mem_avail_pct "$MEM_AVAIL_PCT" --arg top_mem_comm "${TOP_MEM_COMM:-none}" --arg top_mem_pct "$TOP_MEM_PCT" \
   --arg disk_st "$DISK_ST" --argjson disk_rf "$DISK_RF" --arg disk_free_gb "$DISK_FREE_GB" --arg dg_live "$DG_LIVE" \
   --arg sec_st "$SEC_ST" --argjson sec_rf "$SEC_RF" --arg sip "$SIP" --arg gk "$GK" --arg fw "$FW" \
-  --arg mal_st "$MAL_ST" --argjson mal_rf "$MAL_RF" --arg xp_ver "$XP_VER" --arg xp_age "$XP_AGE_DAYS" --arg xp_au "$XP_AUTOUPDATE" \
-  --arg proc_st "$PROC_ST" --argjson proc_rf "$PROC_RF" --arg proc_count "$PROC_COUNT" --arg thread_count "$THREAD_COUNT" --arg zombie "$ZOMBIE_COUNT" \
+  --arg mal_st "$MAL_ST" --argjson mal_rf "$MAL_RF" --arg xp_ver "$XP_VER" --arg xp_age "$XP_AGE_DAYS" --arg xp_au "$XP_AUTOUPDATE" --arg xp_src "$XP_SRC" \
+  --arg proc_st "$PROC_ST" --argjson proc_rf "$PROC_RF" --arg proc_count "$PROC_COUNT" --arg thread_count "$THREAD_COUNT" --arg zombie "$ZOMBIE_COUNT" --arg zombie_st "$ZOMBIE_ST" \
   --arg net_st "$NET_ST" --argjson net_rf "$NET_RF" --arg listeners "$LISTENERS" --arg estab "$ESTAB" \
   --argjson burn "$BURN_DOWN" \
   --arg at_st "$AT_ST" --argjson at_rf "$AT_RF" --arg claude_st "$CLAUDE_ST" --arg claude_ver "$CLAUDE_VER" --arg claude_health "$CLAUDE_HEALTH" --arg producer_st "$PRODUCER_ST" --arg uv_objs "$UV_ARCHIVE_OBJS" --arg uvx_latest "$UVX_LATEST_PROCS" --arg uvx_producers "$UVX_PRODUCERS" \
 'def n(v): (v|tonumber?) // v;
 {
-  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.4.1", secret_free: true,
+  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.5.0", secret_free: true,
           note: "world-readable, secret-free (metadata only: counts/%/names/versions/booleans; process=comm-name never argv)" },
   system: {
     status: $sys_st, tag: "resource.system", root_fail: $sys_rf,
@@ -350,10 +377,10 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
                   gatekeeper: { status: (if $gk=="disabled" then "warn" else "ok" end), tag: "resource.security.gatekeeper", value: $gk },
                   firewall: { status: (if $fw=="disabled" then "warn" else "ok" end), tag: "resource.security.firewall", value: $fw } } },
       malware: { status: $mal_st, tag: "resource.malware", root_fail: $mal_rf, leaves: {
-                  xprotect_freshness: { status: $mal_st, tag: "resource.malware.xprotect_freshness", version: $xp_ver, age_days: n($xp_age), auto_update: $xp_au } } },
+                  xprotect_freshness: { status: $mal_st, tag: "resource.malware.xprotect_freshness", version: $xp_ver, age_days: n($xp_age), auto_update: $xp_au, source: $xp_src } } },
       process: { status: $proc_st, tag: "resource.process", root_fail: $proc_rf, leaves: {
                   runaway:  { status: $cpu_proc_st, tag: "resource.process.runaway", comm: $top_cpu_comm, cpu_pct: n($top_cpu_pct), pid: n($top_cpu_pid) },
-                  counts:   { status: "ok", tag: "resource.process.counts", processes: n($proc_count), threads: n($thread_count), zombies: n($zombie) } } },
+                  counts:   { status: $zombie_st, tag: "resource.process.counts", processes: n($proc_count), threads: n($thread_count), zombies: n($zombie) } } },
       network: { status: $net_st, tag: "resource.network", root_fail: $net_rf, leaves: {
                   listeners: { status: $net_st, tag: "resource.network.listeners", tcp_listen: n($listeners), tcp_established: n($estab) } } },
       agentic_tools: { status: $at_st, tag: "resource.agentic_tools", root_fail: $at_rf, leaves: {

--- a/skills/system-health-responder/references/auto-heal-safety-matrix.md
+++ b/skills/system-health-responder/references/auto-heal-safety-matrix.md
@@ -77,6 +77,10 @@ disable/remove appends its exact restore command to
   This is *auditable* reversibility, not self-reversibility — stated honestly, not hand-waved.
 - **Bounded**: `RENICE_TO` defaults to **+10** (moderate deprioritize, not extreme +20). Never `renice` below
   the current value (would need root and would *raise* priority — out of scope).
+- **Pid-recycle guarded (round-5 #2)**: the contract can be up to `StartInterval` (600s) stale, so before
+  acting `try_renice()` re-reads the **live** `comm` for the pid and requires it to still match the contract
+  comm, then re-runs the denylist on the *live* comm. A pid recycled to a different (or protected) process
+  since the sample is skipped — the autonomous action never trusts the ≤600s-old pid→comm binding alone.
 
 ## PROC_DENYLIST — never `renice` these (case-insensitive on `comm`)
 
@@ -109,6 +113,16 @@ zero drift.
 > *probe failure* degrades **fail-safe** (warn-capable, **never crit**) instead of collapsing to `off` and
 > manufacturing a false-crit — the leaf `xprotect_freshness.auto_update` carries `on|off|unknown` for
 > drill-down transparency regardless of the roll-up.
+>
+> **Round-5 (collector v1.5.0)** finished the ncpu-aware thesis + two honesty fixes (still transparent to the
+> responder — leaf `status` only): (#1) **`top_consumer`/`runaway` is now ncpu-aware** — `PROC_CPU_WARN=70`
+> stays a **per-core** WARN (the renice-actionable signal), but CRIT now requires `pct ≥ PROC_CPU_CRIT_RATIO
+> (0.50) × ncpu × 100` (a real fraction of TOTAL capacity), so one core-bound proc on a many-core box is WARN,
+> not a system crit — the load branch already owns true saturation. (#5) **XProtect freshness prefers the
+> authoritative `xprotect version`** (real install date, no-sudo) over the bundle-mtime proxy that measures
+> the wrong artifact; `xprotect_freshness.source` carries `xprotect-cli|bundle-mtime`. (#6) the
+> `process.counts` leaf now reflects the real `zombies` status (was hardcoded `ok`) so root-fail drill-down
+> lands on a non-`ok` leaf.
 
 ## What the responder will NEVER do (⛔ absolute)
 

--- a/skills/system-health-responder/references/auto-heal-safety-matrix.md
+++ b/skills/system-health-responder/references/auto-heal-safety-matrix.md
@@ -95,11 +95,13 @@ disable/remove appends its exact restore command to
 `1password op openclaw omniroute claude` — **sensitive-app guard** (mirrors the operator's absolute denylist:
 never manipulate 1Password / OpenClaw / OmniRoute / the agent runtime itself).
 
-**Matching rule (exact behavior, so the doc matches the code):** tokens match as a **case-insensitive
-substring** of `comm`, which errs **conservative** — the worst case is over-protection (we skip a `renice`
-we *could* have done), never under-protection. **Exception:** the ultra-short token **`op`** (1Password CLI)
-matches the **whole `comm` only** (`comm == "op"`), so it doesn't accidentally over-match unrelated names
-like `Dropbox`, `top`, or `Finder` that happen to contain the letters "op".
+**Matching rule (exact behavior, so the doc matches the code):** the `comm` is first **basename-normalized**
+(lowercased basename — so a PATH comm like `/usr/local/bin/op` is compared as `op`; v1.7.1 per CodeRabbit @145,
+consistent with `comm_match()`). Tokens then match as a **case-insensitive substring** of that basename, which
+errs **conservative** — the worst case is over-protection (we skip a `renice` we *could* have done), never
+under-protection. **Exception:** the ultra-short token **`op`** (1Password CLI) matches the **whole basename
+only** (`basename(comm) == "op"`), so it protects `/usr/local/bin/op` AND bare `op` without over-matching
+unrelated names like `Dropbox`, `top`, or `Finder` that merely contain the letters "op".
 
 ## Threshold ownership (DRY)
 

--- a/skills/system-health-responder/references/auto-heal-safety-matrix.md
+++ b/skills/system-health-responder/references/auto-heal-safety-matrix.md
@@ -77,10 +77,15 @@ disable/remove appends its exact restore command to
   This is *auditable* reversibility, not self-reversibility — stated honestly, not hand-waved.
 - **Bounded**: `RENICE_TO` defaults to **+10** (moderate deprioritize, not extreme +20). Never `renice` below
   the current value (would need root and would *raise* priority — out of scope).
-- **Pid-recycle guarded (round-5 #2)**: the contract can be up to `StartInterval` (600s) stale, so before
-  acting `try_renice()` re-reads the **live** `comm` for the pid and requires it to still match the contract
-  comm, then re-runs the denylist on the *live* comm. A pid recycled to a different (or protected) process
-  since the sample is skipped — the autonomous action never trusts the ≤600s-old pid→comm binding alone.
+- **Pid-recycle guarded (round-5 #2, hardened v1.7.1 per CodeRabbit #131/#138)**: the contract can be up to
+  `StartInterval` (600s) stale, so before acting `try_renice()` re-reads the **live** `comm` and requires an
+  **exact normalized match** (`comm_match()` — basename + lowercase + strip-space, both non-empty, equal; **not**
+  substring, so a recycled `foo-helper` can't match a contract `foo` and an empty comm matches nothing), then
+  re-runs the denylist on the *live* comm, then **binds a start-identity** (`ps -o lstart=`) and re-verifies it
+  immediately before the renice. A pid recycled to a different (or protected) process since the sample is skipped
+  (fail-closed) — the autonomous action never trusts the ≤600s-old pid→comm binding alone, and the check→act
+  TOCTOU is narrowed. Sound because `renice` is fully reversible (reverts.log), denylist-guarded, and re-sampled
+  next 600s cycle.
 
 ## PROC_DENYLIST — never `renice` these (case-insensitive on `comm`)
 


### PR DESCRIPTION
## [PR-as-Enhancement-Prompt] EKO-90 round-5 — finish the ncpu-aware thesis + measurement honesty + safer autonomy

**Context** — A `/quiesce --scope [linear:EKO-90] --now` OODA pass after round-4 (#258). A skeptic gap-sweep (Mente Tomé) found that round-4 made the **load-aggregate** ncpu-aware but left the **per-process** leaf raw — a genuine, *currently-firing* false-crit — plus three adjacent honesty/safety gaps. The sweep also correctly ruled ~5 candidates *works-as-intended* or *low-payoff* (network-expansion, ENGAGE-aggressiveness, memory-signal), so this round is deliberately narrow. Collector `v1.4.1 → v1.5.0` · skill `v1.6.1 → v1.7.0`.

**Objectives** — kill the last CPU false-crit, make two signals *honest*, harden the one autonomous action — without weakening real-risk detection. Gordian: 4 cohesive S-effort fixes, no scope-creep.

| # | Gap (empirical) | Root cause | Fix |
|---|---|---|---|
| **1** | `top_consumer`/`runaway` **crit on 1.3 of 12 cores** (live `global=crit` while `load5` said fine — the branches *contradicted* each other) | warn+crit applied raw to `ps %cpu`, which is **per-core** (100% = one core), no ncpu normalization | `top_consumer_status()`: **WARN per-core** (renice-actionable signal survives) · **CRIT = `pct ≥ PROC_CPU_CRIT_RATIO(0.50)×ncpu×100`** (fraction of *total* capacity). ncpu=1 fail-safe. Live `crit→warn`. Auto-resolves the old renice+kill double-count. |
| **5** | XProtect age measured the **wrong artifact** (bundle-mtime 47d) vs the authoritative install (Jun-3 = 41d) | modern macOS ships signature updates via `XProtectUpdateService`, never touching `XProtect.bundle` | prefer `/usr/bin/xprotect version` (no-sudo, real version+date); `source` leaf = `xprotect-cli\|bundle-mtime`; bundle-mtime is the fallback for older macOS. `medição real`. |
| **2** | responder could `renice` a **recycled pid** (contract ≤600s stale; denylist ran against the *stale* comm) | `try_renice()` validated pid-alive but not that the live proc still matches | re-read live `comm`, require it to still match the contract comm **before** acting; re-run the denylist on the *live* comm. Safer autonomy. |
| **6** | `process.counts` leaf hardcoded `status:"ok"` while its own `zombies` could drive the branch `crit` → root-fail drill-down landed on an `ok` leaf | hardcode + inline-computed zombie status (2×) | compute `ZOMBIE_ST` once (DRY); leaf reflects it — honors the DoD's "cada nível aponta o filho com falha". |

**Deferred (documented, not dropped)** — memory could use the native `kern.memorystatus_vm_pressure_level` signal (low payoff: memory is HITL-only + the current available% already adds back reclaimable classes).

**Acceptance**
- [x] `bin/threshold-test.sh` — **+7 `top_consumer_status`** assertions (130.7@12c→warn · 700@12c→crit · 600 boundary→crit · 85→warn · 50→ok · ncpu=1 fail-safe both ways) = **23**
- [x] Round-3/4 suites regress clean: `burndown-test.sh` 16 · `responder-burndown-test.sh` 5 → **44/44 total**
- [x] Live collector → `v1.5.0`, `secret_free:true`, `global crit→warn` (by correct classification), `xprotect.source:"xprotect-cli"` age 41d, gitleaks clean
- [x] **Real-risk preserved** — `700@12c → crit` (genuine multi-core hog) still fires; `auto-OFF 65d → crit` (round-4) intact
- [x] Anti-theater — fixes *what "healthy"/"stale" mean*, does not suppress; responder still renices any non-`ok` top_consumer

**Test plan** — `bin/threshold-test.sh && bin/burndown-test.sh && bin/responder-burndown-test.sh` (44/44).

**Risk / rollback** — threshold + read-source + a defensive skip-path only; reversible (`git revert`). Machine-local collector backed up. Responder dispositions unchanged (still gates purely on computed leaf status — DRY single-owner).

**Note on checks** — **Snyk is being discontinued** (operator-confirmed 2026-07-14); its quota-`error` statuses are not a gate. The repo's native suite (gitleaks · Trivy×2 · pip-audit · OpenSSF · governance · Lockfile) is the security gate.

**Cross-links** — EKO-90 (Linear, team EKO) · round-4 #258 (`b4f3485`) · collector `~/.local/bin/system-health-guardian.sh` v1.5.0 (live, validated).

---
> 🤖 agent-authored — Claude Opus 4.8 under operator `/quiesce round-5` directive 2026-07-14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EYY7MuHqYHm6fKNLjrrU2Z
