### PR TITLE
feat(system-health): EKO-90 round-6 — anti-theater honesty + harmonization (F1 silent-drop, mem-pressure, network-honest; 80/80)

### DIFF
--- a/skills/system-health-responder/SKILL.md
+++ b/skills/system-health-responder/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: system-health-responder
 description: End-of-action reflex that reads the system-health contract, engage-locks, Eisenhower-ranks the warnings, does MODERATE non-destructive auto-heal (autonomous reversible renice of a clear cpu runaway + `uv cache prune` producer-hygiene), responds to the new `agentic_tools` branch (`claude doctor` runtime health + cache-producer pressure), reads the reclaim-aware `burn_down` disk forecast (observe-only leading indicator → seed+notify before crisis), and escalate-seeds the HITL residue (security · malware · kill · disk→disk-guardian · no-source-fix offender containment). EKO-90 part-2 — the responder half of the health suite.
-version: 1.7.1
+version: 1.8.0
 allowed-tools: Read, Bash
 ---
 
@@ -264,6 +264,44 @@ the unfinished half plus three adjacent honesty/safety gaps (collector **v1.4.1 
   case/basename-normalize · …) **+6 `denied` basename-normalize** (/path/op→denied · top→allowed ·
   1Password-path→denied · …) assertions = **37**; round-3 suites regress clean (16+5) = **58/58**.
 
+### Honesty + harmonization pass (v1.8.0, round-6, 2026-07-14) — fix what "healthy/ok" *means*, not the labels
+
+An anti-theater OODA over the converged suite (two skeptical Explore agents, told to name what's *already*
+honest and reject cosmetic gaps) surfaced six genuine substance-fixes — headlined by a **HIGH** no-silent-drop
+bug that `guardian.log` proved firing live (collector **v1.5.0 → v1.6.0**):
+
+- **F1 (HIGH — the silent drop)**: the responder read only `cpu.leaves.top_consumer.status`, never the `cpu`
+  **branch**. A crit driven by *sustained system load* (`root_fail=load1/load5`, no single runaway to renice)
+  surfaced **zero** residue and returned 0 — a real crit dropped. Now it reads the branch and seeds a HITL
+  residue for load saturation (not auto-healable: no single proc to renice → operator reduces load).
+- **F2**: `claude_runtime` used a bare `command -v claude` — launchd's minimal PATH excludes `~/.local/bin`, so
+  the probe was **dead** (perpetual `absent`) under the production cadence. Now resolved to an absolute path
+  like jq/softwareupdate/timeout (interactive `command -v` still wins).
+- **F3**: `network` was hardcoded `ok` (listeners collected, never thresholded) — an `ok` with no measurement.
+  Now honestly labelled `informational` (root_fail→null; the responder treats it as no-residue).
+- **F4**: `process.counts.status` derived from **zombies only** (a thread/proc leak read `ok`); zombie
+  thresholds were the only non-env-overridable ones; `THREAD_COUNT` over-counted (procs+threads). Now:
+  env-overridable `ZOMBIE_WARN/CRIT`, threads-only count, optional `THREAD_WARN/CRIT` high-water (0 = disabled,
+  no invented default), honest `counts_status()` blend.
+- **F5 (highest-value false-ok)**: `memory.available%` adds back inactive/speculative/purgeable → can read `ok`
+  while the kernel signals pressure. Now blends `kern.memorystatus_vm_pressure_level` (1/2/4 → ok/warn/crit;
+  unreadable → neutral, never fabricated) via `worst()`, + a new `pressure` leaf. *(Caught in the act:
+  available=ok 21.5% while pressure=warn → memory honestly warn.)*
+- **F6**: the header/`meta.note` "reads comm ONLY — never argv" claim was overstated — the `<pkg>@latest`
+  producer-attribution reads argv (safely, via `^[alnum][alnum._-]*@latest$` rejecting any flag/value). The
+  claim now states the true, safe behavior.
+- **H1 (harmonize)**: the sensitive-app safelist core (`1password openclaw omniroute claude`) was duplicated
+  across `denied()` (responder) + `protected()` (offender-containment). Now a single labelled **SSOT core** in
+  both, kept *inline* (fail-safe: a missing sourced lib = an empty safelist = the unsafe direction), with drift
+  caught deterministically by a test — each script keeps its legit scope-specific entries.
+- **Cores extracted** for unit-testing (Strata): `counts_status()` (F4) + `mem_pressure_status()` (F5), each
+  with a `--*-status` hook — same "exercise the EXACT production logic" pattern as the round-4/5 cores.
+- **Tested**: `bin/threshold-test.sh` — **+7 `counts_status`** (thread-0=disabled · zombie-env-override ·
+  thread-high-water) **+6 `mem_pressure_status`** (level-2→warn · 99/empty→ok never-crit) **+2 F1** (load-driven
+  crit surfaces · root_fail=top_consumer→no double-report) **+2 F3** (informational→no-residue · warn→still-surfaces)
+  **+4 H1 SSOT** (core-line-intact both files · denied() openclaw/omniroute) **+1 machine-local↔mirror md5** =
+  **59**; round-3 suites regress clean (16+5) = **80/80**.
+
 ## Composition (reuse, not reinvent — Strata)
 
 - **Part-1 contract** (`~/.local/state/system-health/health-contract.json`) — the input it responds to.
@@ -279,10 +317,10 @@ the unfinished half plus three adjacent honesty/safety gaps (collector **v1.4.1 
 - `references/no-source-fix-registry.md` — the ADR evidence gate (vetted no-source-fix offenders + dossiers).
 - `references/offender-containment-33-socratic.md` — round-1 design-reasoning (33 Socratic Q&A; the *why* behind the tiers).
 - `references/offender-containment-round2-33-socratic.md` — round-2 operational-reasoning (33 non-duplicate Q&A; sibling-falsification · transient-vs-persistent producers · attribution · warn/HITL boundary · unknown-offender handling).
-- `bin/offender-containment.sh` — the containment executor · `collectors/system-health-guardian.sh` — the extended Phase-1 collector (v1.3.x = burn-down · **v1.4.1 = round-4 threshold fixes + probe fail-safe**).
+- `bin/offender-containment.sh` — the containment executor · `collectors/system-health-guardian.sh` — the extended Phase-1 collector (v1.3.x = burn-down · v1.4.1 = round-4 threshold fixes · v1.5.0 = round-5 ncpu/measurement-honesty · **v1.6.0 = round-6 honesty: mem-pressure blend · network-informational · thread-count-honest · claude-abs-path**).
 - `bin/burndown-test.sh` — round-3 collector unit tests (drives `--burndown`; 16 assertions: reclaim-jump-not-misread · short-tail-honest-unknown · `+0000`/`+00:00`/`Z` tz variants).
 - `bin/responder-burndown-test.sh` — round-3 responder wiring tests (5 assertions: `warn`/`crit`→seed · `ok`/`unknown`→quiet — proves `.burn_down` is read, not just documented).
-- `bin/threshold-test.sh` — round-4 threshold unit tests (drives `--cpu-load-status`/`--xprotect-status`; 13 assertions: CPU burst→warn-not-crit · sustained-load5→crit · XProtect auto-ON-47d→ok · auto-OFF-65d→crit · never-crit-while-self-healing).
+- `bin/threshold-test.sh` — round-4→6 unit + integration tests (**59 assertions**): drives the collector cores `--cpu-load-status`/`--xprotect-status`/`--top-consumer-status`/`--counts-status`/`--mem-pressure-status` + the responder guards `--comm-match`/`--denied` + F1/F3 synthetic-contract responder integration + H1 SSOT-core drift-guard + machine-local↔mirror md5 byte-identity. (3 suites total = 59 + burndown 16 + responder-burndown 5 = **80/80**.)
 - EKO-90 (Linear, team EKO) — the parent ticket; part-1 = the collector, part-2 = this responder + this v1.2.0 ext.
 - `~/.claude/rules/loose-end-triage-queue.md` (Taxis) · `~/.claude/rules/agentic-observability-protocol.md`
   (Metron measure→respond) · `~/.claude/rules/standing-autonomous-operation-authorization.md` (READY gate).

--- a/skills/system-health-responder/bin/health-respond.sh
+++ b/skills/system-health-responder/bin/health-respond.sh
@@ -33,10 +33,18 @@ RENICE_TO="${SHR_RENICE_TO:-10}"                  # moderate deprioritize (not e
 DRY_RUN=1
 NOTIFY=1; [ "${SHR_NO_NOTIFY:-0}" = "1" ] && NOTIFY=0
 
+# SENSITIVE-APP SAFELIST — SSOT CORE (round-6 H1): the 4 tokens `1password openclaw omniroute claude` MUST
+# stay identical in BOTH this PROC_DENYLIST and offender-containment.sh PROTECTED — the runtime + the
+# secrets/sovereignty managers that NEITHER effector may ever touch (renice OR contain). Kept INLINE in each
+# script (NOT a sourced lib) ON PURPOSE: a safety-critical safelist must be fail-safe/self-contained — a
+# missing/empty sourced lib would be the UNSAFE direction (an empty safelist). Drift is caught deterministically
+# by threshold-test.sh (`SSOT sensitive-app core` assertion), not by faith.
 PROC_DENYLIST=(
+  # OS daemons — renice-protected (responder-scope; not relevant to containment)
   kernel_task launchd windowserver loginwindow coreaudiod configd hidd powerd
   bluetoothd cfprefsd mds mds_stores mdworker syslogd distnoted securityd trustd
-  1password op openclaw omniroute claude
+  1password openclaw omniroute claude   # ← SSOT sensitive-app core (sync ↔ offender-containment.sh PROTECTED)
+  op                                    # responder-scope extra: 1Password CLI (whole-word match in denied())
 )
 
 usage() {
@@ -251,6 +259,20 @@ main() {
       residue="${residue}- 🟠 cpu=${cs}: runaway flagged but no pid in contract (comm=${comm}, ${pct}%) → operator review (no-silent-drop).\n"
     fi
   fi
+  # cpu BRANCH-level load saturation (round-6 F1): the block above acts on the single top_consumer, but a crit
+  # driven by SUSTAINED SYSTEM LOAD (root_fail=load1/load5 — no single runaway to renice) was previously read
+  # by NOTHING → silently dropped (guardian.log showed `system=crit cpu=crit` surfacing zero residue). Surface
+  # it as HITL residue: load saturation is NOT auto-healable (no single proc to renice; reducing load = operator
+  # closing apps). Skip when root_fail IS the top_consumer (already handled above → no double-report).
+  local cpu_br cpu_rf; cpu_br="$(jq -r '.system.branches.cpu.status // "ok"' "$CONTRACT" 2>/dev/null)"
+  cpu_rf="$(jq -r '.system.branches.cpu.root_fail // ""' "$CONTRACT" 2>/dev/null)"
+  if [ "$cpu_br" != "ok" ] && [ "$cpu_rf" != "top_consumer" ]; then
+    local l1 l5 nc
+    l1="$(jq -r '.system.branches.cpu.leaves.load1.value // "?"' "$CONTRACT" 2>/dev/null)"
+    l5="$(jq -r '.system.branches.cpu.leaves.load1.load5 // "?"' "$CONTRACT" 2>/dev/null)"
+    nc="$(jq -r '.system.branches.cpu.leaves.load1.ncpu // "?"' "$CONTRACT" 2>/dev/null)"
+    residue="${residue}- 🟠 cpu=${cpu_br} load-driven (root_fail=${cpu_rf}, load1=${l1} / load5=${l5} over ${nc} cores): sustained saturation, no single runaway to renice → operator review (reduce load / close apps = HITL).\n"
+  fi
   # disk → DELEGATED to disk-health-guardian (no dup)
   local ds; ds="$(jq -r '.system.branches.disk.status // "ok"' "$CONTRACT" 2>/dev/null)"
   [ "$ds" != "ok" ] && echo "  ↪  disk=${ds} → delegated to disk-health-guardian (it owns disk; no action here)"
@@ -272,7 +294,9 @@ main() {
   local ps_; ps_="$(jq -r '.system.branches.process.status // "ok"' "$CONTRACT" 2>/dev/null)"
   [ "$ps_" != "ok" ] && residue="${residue}- 🟠 process=${ps_}: zombie/runaway-count anomaly → operator review (kill = HITL).\n"
   local net; net="$(jq -r '.system.branches.network.status // "ok"' "$CONTRACT" 2>/dev/null)"
-  [ "$net" != "ok" ] && residue="${residue}- 🟠 network=${net}: unexpected listener → operator review (never auto-close).\n"
+  # round-6 F3: the collector emits "informational" (listeners collected, NOT thresholded) — treat it as
+  # no-residue explicitly (it is NOT a measured "ok", but it is also NOT a fault to surface).
+  [ "$net" != "ok" ] && [ "$net" != "informational" ] && residue="${residue}- 🟠 network=${net}: unexpected listener → operator review (never auto-close).\n"
 
   # ── agentic-tools (EKO-90-ext v1.2.0): cache-producer + claude-runtime ─────────
   # The 2026-07-14 lesson: the disk-guardian cleaned caches but could not beat a LIVE producer

--- a/skills/system-health-responder/bin/offender-containment.sh
+++ b/skills/system-health-responder/bin/offender-containment.sh
@@ -39,8 +39,14 @@ LOG="${OFC_LOG:-$STATE_DIR/containment.log}"
 mkdir -p "$STATE_DIR" 2>/dev/null || true
 
 MODE="dry-run"; DO_PRUNE=0; ALLOW_UNINSTALL="${OFC_ALLOW_UNINSTALL:-0}"
-# operator-protected — NEVER contain these (case-insensitive substring; the runtime + secrets managers)
-PROTECTED=(1password openclaw omniroute claude op-service keychain)
+# operator-protected — NEVER contain these (case-insensitive substring; the runtime + secrets managers).
+# SSOT sensitive-app core (round-6 H1): `1password openclaw omniroute claude` MUST stay identical to
+# health-respond.sh PROC_DENYLIST — see the SSOT note there (inline-not-sourced = fail-safe); drift caught
+# by threshold-test.sh.
+PROTECTED=(
+  1password openclaw omniroute claude   # ← SSOT sensitive-app core (sync ↔ health-respond.sh PROC_DENYLIST)
+  op-service keychain                   # containment-scope extras: secrets-manager tokens
+)
 
 log() { printf '%s %s\n' "$(date -u +%FT%TZ)" "$*" >>"$LOG" 2>/dev/null || true; }
 

--- a/skills/system-health-responder/bin/threshold-test.sh
+++ b/skills/system-health-responder/bin/threshold-test.sh
@@ -26,6 +26,16 @@ xp()  { "$COLLECTOR" --xprotect-status "$@" 2>/dev/null; }   # age autoupdate wa
 tc()  { "$COLLECTOR" --top-consumer-status "$@" 2>/dev/null; } # pct(per-core) ncpu warn_pct crit_ratio(of total)
 cm()  { "$RESPONDER" --comm-match "$1" "$2" 2>/dev/null; }     # live_raw want_raw → match|nomatch (#131 recycle guard)
 dn()  { "$RESPONDER" --denied "$1" 2>/dev/null; }             # comm → denied|allowed (basename-normalized denylist, @145)
+cst() { "$COLLECTOR" --counts-status "$@" 2>/dev/null; }      # zombie_ct thread_ct z_warn z_crit t_warn t_crit → status (round-6 F4)
+mps() { "$COLLECTOR" --mem-pressure-status "$1" 2>/dev/null; } # dispatch-level → status (round-6 F5)
+OFC="$DIR/offender-containment.sh"
+hashf() { md5 -q "$1" 2>/dev/null || md5sum "$1" 2>/dev/null | awk '{print $1}'; }  # portable md5 (macOS md5 / Linux md5sum)
+# responder integration: run against a SYNTHETIC contract, hermetically (temp contract + temp state, no notify),
+# in the default dry-run — residue is still COMPUTED + printed even when seed-throttled, so grepping stdout is sound.
+respond_out() { local tc ts; tc="$(mktemp)"; ts="$(mktemp -d)"; printf '%s' "$1" >"$tc"
+  SHR_CONTRACT="$tc" SHR_STATE_DIR="$ts" SHR_NO_NOTIFY=1 bash "$RESPONDER" 2>/dev/null; rm -f "$tc"; rm -rf "$ts"; }
+ck_has()    { case "$2" in *"$3"*) PASS=$((PASS+1));; *) FAIL=$((FAIL+1)); echo "  FAIL: $1 → missing '$3'";; esac; }
+ck_hasnot() { case "$2" in *"$3"*) FAIL=$((FAIL+1)); echo "  FAIL: $1 → unexpectedly present '$3'";; *) PASS=$((PASS+1));; esac; }
 
 echo "── cpu_load_status (warn=load1 spiky · crit=load5 sustained) ──"
 ck "burst load1=27 load5=6 12c → warn (NOT crit) [the false-crit fix]" "$(cpu 27.33 6.0 12 0.90 1.50)" "warn"
@@ -75,6 +85,49 @@ ck "'top' → allowed (op whole-word NOT over-matched — the exception still ho
 ck "'/Applications/1Password.app/Contents/MacOS/1Password' → denied (substring on basename)" "$(dn /Applications/1Password.app/Contents/MacOS/1Password)" "denied"
 ck "'/opt/homebrew/bin/claude' → denied (path comm still protected)"                        "$(dn /opt/homebrew/bin/claude)" "denied"
 ck "'Google Chrome Helper' → allowed (not on denylist)"                                     "$(dn 'Google Chrome Helper')" "allowed"
+
+echo "── counts_status (F4: env-thresholded zombies ⊕ optional thread high-water) [round-6] ──"
+ck "z=3 t=8000 zw=5 → ok (below zombie warn; threads disabled)"          "$(cst 3 8000 5 20 0 0)"       "ok"
+ck "z=7 → warn (zombie env threshold, was hardcoded pre-round-6)"        "$(cst 7 8000 5 20 0 0)"       "warn"
+ck "z=25 → crit (zombie crit)"                                           "$(cst 25 1 5 20 0 0)"         "crit"
+ck "thread threshold 0 = DISABLED → ok even at 9000 threads (no false default)" "$(cst 0 9000 5 20 0 0)" "ok"
+ck "thread high-water ENABLED (tw=8000) → warn at 9000"                  "$(cst 0 9000 5 20 8000 12000)" "warn"
+ck "thread high-water crit (tc=8000) → crit at 9000"                     "$(cst 0 9000 5 20 4000 8000)" "crit"
+ck "zombie env-override zw=1 → warn at 2 zombies"                        "$(cst 2 10 1 3 0 0)"          "warn"
+
+echo "── mem_pressure_status (F5: kern dispatch level → status, never-fabricate-crit) [round-6] ──"
+ck "level 1 → ok (normal)"                                    "$(mps 1)"   "ok"
+ck "level 2 → warn (the false-ok fix: available% can read ok here)" "$(mps 2)" "warn"
+ck "level 4 → crit (kernel critical)"                         "$(mps 4)"   "crit"
+ck "level 99 → ok (unexpected → NEVER fabricate crit)"        "$(mps 99)"  "ok"
+ck "empty → ok (sysctl unreadable → neutral, available% governs)" "$(mps '')" "ok"
+ck "non-numeric 'xyz' → ok (fail-safe)"                       "$(mps xyz)" "ok"
+
+echo "── F1 responder: cpu BRANCH load-driven crit must SURFACE (was silently dropped) [round-6] ──"
+F1_LOAD='{"system":{"status":"crit","branches":{"cpu":{"status":"crit","root_fail":"load1","leaves":{"load1":{"value":20,"load5":19,"ncpu":12},"top_consumer":{"status":"ok"}}}}}}'
+ck_has "load-driven crit (root_fail=load1, top_consumer ok) → HITL residue surfaces" "$(respond_out "$F1_LOAD")" "cpu=crit load-driven"
+F1_TOP='{"system":{"status":"warn","branches":{"cpu":{"status":"warn","root_fail":"top_consumer","leaves":{"load1":{"value":5,"load5":5,"ncpu":12},"top_consumer":{"status":"warn","comm":"x","pct":80}}}}}}'
+ck_hasnot "root_fail=top_consumer → NO load-driven line (already handled above, no double-report)" "$(respond_out "$F1_TOP")" "load-driven"
+
+echo "── F3 responder: network 'informational' = no residue; a real fault still surfaces [round-6] ──"
+F3_INFO='{"system":{"status":"ok","branches":{"network":{"status":"informational"}}}}'
+ck_hasnot "network=informational → NO residue (honest not-thresholded label)" "$(respond_out "$F3_INFO")" "network="
+F3_WARN='{"system":{"status":"warn","branches":{"network":{"status":"warn"}}}}'
+ck_has "network=warn → residue still surfaces (real fault not suppressed)" "$(respond_out "$F3_WARN")" "network=warn"
+
+echo "── H1 SSOT sensitive-app core (1password openclaw omniroute claude) in BOTH safelists [round-6] ──"
+ck "SSOT core line intact in responder PROC_DENYLIST" "$(grep -cE '1password openclaw omniroute claude.*SSOT sensitive-app core' "$RESPONDER")" "1"
+ck "SSOT core line intact in offender PROTECTED"      "$(grep -cE '1password openclaw omniroute claude.*SSOT sensitive-app core' "$OFC")"      "1"
+ck "denied() openclaw (SSOT core, behavioral)"        "$(dn openclaw)"   "denied"
+ck "denied() omniroute (SSOT core, behavioral)"       "$(dn omniroute)"  "denied"
+
+echo "── machine-local ↔ skill-mirror collector byte-identity (the recon-relied-on invariant) [round-6] ──"
+LOCAL="$HOME/.local/bin/system-health-guardian.sh"
+if [ -f "$LOCAL" ]; then
+  ck "collector machine-local == skill mirror (md5)" "$(hashf "$LOCAL")" "$(hashf "$COLLECTOR")"
+else
+  echo "  SKIP: machine-local collector absent (CI / non-deploy host) — byte-identity invariant N/A here"
+fi
 
 echo
 echo "threshold-test: $PASS passed, $FAIL failed"

--- a/skills/system-health-responder/collectors/system-health-guardian.sh
+++ b/skills/system-health-responder/collectors/system-health-guardian.sh
@@ -14,8 +14,11 @@
 #  *          Emits a world-readable, SECRET-FREE health-contract for all ai-agents. */
 #
 # SECRET-SAFETY MODEL (⛔ absolute — the contract is world-readable):
-#   • process sampling reads `comm` (executable NAME) ONLY — NEVER `command`/argv,
-#     which routinely carries secrets (--api-key=…). No env dumps, no file contents.
+#   • health signals read `comm` (executable NAME) ONLY — NEVER `command`/argv, which
+#     routinely carries secrets (--api-key=…). No env dumps, no file contents.
+#   • ONE narrow exception: the uv-cache PRODUCER attribution reads argv, but a strict
+#     grammar (`^[alnum][alnum._-]*@latest$`) accepts ONLY public `<pkg>@latest` tokens and
+#     rejects any flag (`-…`) or value (`=…`) — so a secret can never be emitted (round-6 F6).
 #   • only metadata is emitted: counts · percentages · names · versions · booleans.
 #   • security/malware surface = STATUS flags (enabled/stale), never a scanned value.
 #
@@ -53,6 +56,10 @@ DISK_FREE_WARN_GB="${DISK_FREE_WARN_GB:-15}"
 DISK_FREE_CRIT_GB="${DISK_FREE_CRIT_GB:-8}"
 PROC_CPU_WARN="${PROC_CPU_WARN:-70}"                 # single-proc %cpu WARN (PER-CORE; feeds responder renice target — actionable, NOT system-crit)
 PROC_CPU_CRIT_RATIO="${PROC_CPU_CRIT_RATIO:-0.50}"   # single-proc CRIT only when it eats ≥ this fraction of TOTAL cores (ncpu-aware; round-5 — a 1-core-bound proc on a many-core box is WARN, not a system crit)
+ZOMBIE_WARN="${ZOMBIE_WARN:-5}"                      # zombie procs WARN (round-6 F4: now env-overridable — was hardcoded)
+ZOMBIE_CRIT="${ZOMBIE_CRIT:-20}"                     # zombie procs CRIT (round-6 F4)
+THREAD_WARN="${THREAD_WARN:-0}"                      # optional thread high-water WARN — 0 = DISABLED (no arbitrary universal default; per-machine baseline differs)
+THREAD_CRIT="${THREAD_CRIT:-0}"                      # optional thread high-water CRIT — 0 = DISABLED (round-6 F4)
 XPROTECT_STALE_WARN_DAYS="${XPROTECT_STALE_WARN_DAYS:-30}"      # auto-update OFF → WARN at Nd (the real risk)
 XPROTECT_STALE_CRIT_DAYS="${XPROTECT_STALE_CRIT_DAYS:-60}"      # auto-update OFF → CRIT at Nd
 XPROTECT_SELFHEAL_WARN_DAYS="${XPROTECT_SELFHEAL_WARN_DAYS:-60}" # auto-update ON → only >Nd WARNs, never crit (self-healing; Apple cadence)
@@ -70,6 +77,22 @@ worst() { local w=ok; for s in "$@"; do case "$s" in crit) echo crit; return;; w
 st_hi() { awk -v v="$1" -v w="$2" -v c="$3" 'BEGIN{ if(v>=c)print"crit"; else if(v>=w)print"warn"; else print"ok"}'; }
 # status_from_num LOWER-is-worse: st_lo VALUE WARN CRIT  (lower = worse; e.g. free space)
 st_lo() { awk -v v="$1" -v w="$2" -v c="$3" 'BEGIN{ if(v<=c)print"crit"; else if(v<=w)print"warn"; else print"ok"}'; }
+
+# ── round-6 pure decision cores (unit-testable via the --*-status hooks below) ──
+# counts_status (F4): process-counts status = zombies (env-thresholded) worst-blended with an OPTIONAL thread
+# high-water. A thread threshold of 0/unset = DISABLED (→ st_hi never warns): there is no honest universal
+# thread default, so we don't invent one (that would be theater). Args: zombie_ct thread_ct z_warn z_crit t_warn t_crit
+counts_status() {
+  local zc="$1" tc="$2" zw="$3" zcr="$4" tw="$5" tcr="$6" zst tst
+  zst="$(st_hi "$zc" "$zw" "$zcr")"
+  { [ "$tw"  -gt 0 ] 2>/dev/null; } || tw=999999999    # 0/unset/non-numeric → disabled (never "warn at 0")
+  { [ "$tcr" -gt 0 ] 2>/dev/null; } || tcr=999999999
+  tst="$(st_hi "$tc" "$tw" "$tcr")"
+  worst "$zst" "$tst"
+}
+# mem_pressure_status (F5): kern.memorystatus_vm_pressure_level dispatch level → status. 1=normal 2=warn
+# 4=critical; ANY unreadable/unexpected value → ok (NEVER fabricate a crit from a probe miss — Mente Tomé).
+mem_pressure_status() { case "$1" in 1) echo ok;; 2) echo warn;; 4) echo crit;; *) echo ok;; esac; }
 
 # ── round-4 pure decision cores (unit-testable; mirror compute_burndown pattern) ──
 # cpu_load_status: WARN keyed on load1 (spiky 1-min, early); CRIT keyed on load5 (sustained 5-min).
@@ -165,6 +188,8 @@ if [ "${1:-}" = "--burndown" ]; then compute_burndown; echo; exit 0; fi
 if [ "${1:-}" = "--cpu-load-status" ]; then cpu_load_status "${2:-0}" "${3:-0}" "${4:-1}" "${5:-0.90}" "${6:-1.50}"; exit 0; fi
 if [ "${1:-}" = "--xprotect-status" ]; then xprotect_status "${2:-0}" "${3:-on}" "${4:-30}" "${5:-60}" "${6:-60}"; exit 0; fi
 if [ "${1:-}" = "--top-consumer-status" ]; then top_consumer_status "${2:-0}" "${3:-1}" "${4:-70}" "${5:-0.50}"; exit 0; fi
+if [ "${1:-}" = "--counts-status" ]; then counts_status "${2:-0}" "${3:-0}" "${4:-5}" "${5:-20}" "${6:-0}" "${7:-0}"; exit 0; fi
+if [ "${1:-}" = "--mem-pressure-status" ]; then mem_pressure_status "${2:-}"; exit 0; fi
 
 # ── CPU ───────────────────────────────────────────────────────────────────────
 NCPU="$(sysctl -n hw.ncpu 2>/dev/null || echo 1)"
@@ -192,7 +217,15 @@ pg() { echo "$VMS" | awk -F: -v k="$1" '$0 ~ k {gsub(/[^0-9]/,"",$2); print $2; 
 P_FREE="$(pg 'Pages free')"; P_INACT="$(pg 'Pages inactive')"; P_SPEC="$(pg 'Pages speculative')"; P_PURG="$(pg 'Pages purgeable')"
 AVAIL_BYTES="$(awk -v f="${P_FREE:-0}" -v i="${P_INACT:-0}" -v s="${P_SPEC:-0}" -v p="${P_PURG:-0}" -v ps="$PAGE_SZ" 'BEGIN{print (f+i+s+p)*ps}')"
 MEM_AVAIL_PCT="$(awk -v a="$AVAIL_BYTES" -v t="$MEM_TOTAL" 'BEGIN{printf "%.1f", (t>0)?a*100/t:0}')"
-MEM_ST="$(st_lo "$MEM_AVAIL_PCT" "$MEM_AVAIL_WARN_PCT" "$MEM_AVAIL_CRIT_PCT")"
+MEM_AVAIL_ST="$(st_lo "$MEM_AVAIL_PCT" "$MEM_AVAIL_WARN_PCT" "$MEM_AVAIL_CRIT_PCT")"
+# kern.memorystatus_vm_pressure_level (dispatch: 1=normal 2=warn 4=critical) — the AUTHORITATIVE
+# kernel pressure signal. available% adds back inactive/speculative/purgeable → can read "ok" while
+# the kernel is signalling pressure (false-ok, round-6 F5). Blend both via worst(); an unreadable/
+# unexpected value → neutral (available% governs) — never fabricate a crit (Mente Tomé).
+MEM_PRESSURE="$(sysctl -n kern.memorystatus_vm_pressure_level 2>/dev/null || echo '')"
+MEM_PRESS_ST="$(mem_pressure_status "$MEM_PRESSURE")"   # SSOT status (unit-tested via --mem-pressure-status)
+case "$MEM_PRESSURE" in 1) MEM_PRESS_LABEL=normal;; 2) MEM_PRESS_LABEL=warn;; 4) MEM_PRESS_LABEL=critical;; *) MEM_PRESS_LABEL=unknown;; esac
+MEM_ST="$(worst "$MEM_AVAIL_ST" "$MEM_PRESS_ST")"
 PS_BY_MEM="$(ps -A -m -o pid=,%mem=,comm= 2>/dev/null || true)"
 TOP_MEM_LINE="$(awk 'NR==1{pid=$1;m=$2;$1="";$2="";c=$0;sub(/^ +/,"",c);n=split(c,a,"/");print pid"|"m"|"a[n]; exit}' <<<"$PS_BY_MEM")"
 TOP_MEM_COMM="$(echo "$TOP_MEM_LINE" | cut -d'|' -f3)"; TOP_MEM_PCT="$(echo "$TOP_MEM_LINE" | cut -d'|' -f2)"; TOP_MEM_PCT="${TOP_MEM_PCT:-0}"
@@ -245,17 +278,22 @@ else XP_AUTOUPDATE="unknown"; fi                                                
 MAL_ST="$(xprotect_status "$XP_AGE_DAYS" "$XP_AUTOUPDATE" "$XPROTECT_STALE_WARN_DAYS" "$XPROTECT_STALE_CRIT_DAYS" "$XPROTECT_SELFHEAL_WARN_DAYS")"
 
 # ── PROCESS / THREADS ─────────────────────────────────────────────────────────
-PROC_COUNT="$(ps -A -o pid= 2>/dev/null | wc -l | tr -d ' ')"
-THREAD_COUNT="$(ps -A -M 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')"
+PROC_COUNT="$(ps -A -o pid= 2>/dev/null | wc -l | tr -d ' ')"; PROC_COUNT="${PROC_COUNT:-0}"
+# `ps -A -M` = 1 process line + N thread lines per process → total data lines = procs + threads.
+# THREAD_COUNT is threads-ONLY (subtract the process lines); the raw line-count over-counts by ~procs (round-6 F4).
+_M_LINES="$(ps -A -M 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')"; _M_LINES="${_M_LINES:-0}"
+THREAD_COUNT="$(( _M_LINES > PROC_COUNT ? _M_LINES - PROC_COUNT : _M_LINES ))"
 ZOMBIE_COUNT="$(ps -A -o stat= 2>/dev/null | grep -c '^Z' || true)"; ZOMBIE_COUNT="${ZOMBIE_COUNT:-0}"
-ZOMBIE_ST="$(st_hi "$ZOMBIE_COUNT" 5 20)"   # computed once (DRY) — drives both the roll-up AND the counts-leaf status (round-5 #6)
+# counts-leaf status: env-thresholded zombies worst-blended with the OPTIONAL thread high-water (round-6 F4).
+# Logic lives in counts_status() (SSOT, unit-tested via --counts-status) — no duplication here.
+COUNTS_ST="$(counts_status "$ZOMBIE_COUNT" "$THREAD_COUNT" "$ZOMBIE_WARN" "$ZOMBIE_CRIT" "$THREAD_WARN" "$THREAD_CRIT")"
 # runaway = the top-cpu proc over threshold (reuse CPU sample) — this is the responder's renice candidate
-PROC_ST="$(worst "$CPU_PROC_ST" "$ZOMBIE_ST")"
+PROC_ST="$(worst "$CPU_PROC_ST" "$COUNTS_ST")"
 
 # ── NETWORK (listener count — notify-only per safety-matrix) ──────────────────
 LISTENERS="$(netstat -an -p tcp 2>/dev/null | grep -c LISTEN || true)"; LISTENERS="${LISTENERS:-0}"
 ESTAB="$(netstat -an -p tcp 2>/dev/null | grep -c ESTABLISHED || true)"; ESTAB="${ESTAB:-0}"
-NET_ST=ok   # MVP: informational; responder is notify-only for network
+NET_ST=informational   # listeners collected but NOT thresholded → honest label, NOT a measured "ok" (round-6 F3); responder treats informational as no-residue
 
 # ── AGENTIC-TOOLS health (EKO-90 ext v1.1.0 — operator /quiesce 2026-07-14) ────
 # Adds `claude doctor` as a read-only "unattended show-only" probe (the BARE form is
@@ -268,10 +306,15 @@ for _c in /opt/homebrew/bin/timeout /opt/homebrew/bin/gtimeout /usr/local/bin/ti
 done
 run_bounded() { if [ -n "$TIMEOUT_BIN" ]; then "$TIMEOUT_BIN" "$1" "${@:2}" 2>/dev/null; else shift; "$@" 2>/dev/null; fi; }
 
-# claude doctor — read-only agentic-runtime health (timeout-bounded; MUST NOT hang a 10-min cycle)
+# claude doctor — read-only agentic-runtime health (timeout-bounded; MUST NOT hang a 10-min cycle).
+# Resolve `claude` to an ABSOLUTE path like jq/softwareupdate/timeout — launchd's minimal PATH excludes
+# ~/.local/bin, so a bare `command -v claude` MISSES under the production cadence → the probe was DEAD
+# (perpetually health:absent) in launchd. Interactive `command -v` still wins; explicit fallbacks cover launchd. (round-6 F2)
+CLAUDE_BIN="$(command -v claude 2>/dev/null || true)"
+if [ -z "$CLAUDE_BIN" ]; then for _c in "$HOME/.local/bin/claude" /opt/homebrew/bin/claude /usr/local/bin/claude; do [ -x "$_c" ] && { CLAUDE_BIN="$_c"; break; }; done; fi
 CLAUDE_ST=ok; CLAUDE_VER="unknown"; CLAUDE_HEALTH="absent"
-if command -v claude >/dev/null 2>&1; then
-  DOC_OUT="$(run_bounded 20 claude doctor || true)"
+if [ -n "$CLAUDE_BIN" ]; then
+  DOC_OUT="$(run_bounded 20 "$CLAUDE_BIN" doctor || true)"
   CLAUDE_VER="$(printf '%s\n' "$DOC_OUT" | awk -F'[()]' '/^Running:/{print $2; exit}')"; CLAUDE_VER="${CLAUDE_VER:-unknown}"
   if printf '%s' "$DOC_OUT" | grep -qi 'No installation issues found'; then CLAUDE_HEALTH="healthy"; CLAUDE_ST=ok
   elif [ -n "$DOC_OUT" ]; then CLAUDE_HEALTH="issues-found"; CLAUDE_ST=warn
@@ -323,16 +366,16 @@ BURN_DOWN="$(compute_burndown)"
 # each branch root_fail = its own worst leaf id; system root_fail = worst branch id
 branch_rootfail() { # $1=branch-status ; $2..=leaf "id:status" pairs
   local bs="$1"; shift; local rf="null" id s
-  [ "$bs" = ok ] && { echo null; return; }
+  case "$bs" in ok|informational) echo null; return;; esac   # informational = collected-not-thresholded → no root_fail (round-6 F3)
   for pair in "$@"; do id="${pair%%:*}"; s="${pair##*:}"; [ "$s" = "$bs" ] && { rf="\"$id\""; break; }; done
   echo "$rf"
 }
 CPU_RF="$(branch_rootfail "$CPU_ST" "load1:$CPU_LOAD_ST" "top_consumer:$CPU_PROC_ST")"
-MEM_RF="$(branch_rootfail "$MEM_ST" "available_pct:$MEM_ST")"
+MEM_RF="$(branch_rootfail "$MEM_ST" "available_pct:$MEM_AVAIL_ST" "pressure:$MEM_PRESS_ST")"
 DISK_RF="$(branch_rootfail "$DISK_ST" "free_gb:$DISK_ST")"
 SEC_RF="$(branch_rootfail "$SEC_ST" "sip:$([ "$SIP" = disabled ] && echo crit || echo ok)" "gatekeeper:$([ "$GK" = disabled ] && echo warn || echo ok)" "firewall:$([ "$FW" = disabled ] && echo warn || echo ok)")"
 MAL_RF="$(branch_rootfail "$MAL_ST" "xprotect_freshness:$MAL_ST")"
-PROC_RF="$(branch_rootfail "$PROC_ST" "runaway:$CPU_PROC_ST" "zombies:$ZOMBIE_ST")"
+PROC_RF="$(branch_rootfail "$PROC_ST" "runaway:$CPU_PROC_ST" "counts:$COUNTS_ST")"
 NET_RF="$(branch_rootfail "$NET_ST" "listeners:$NET_ST")"
 
 AT_RF="$(branch_rootfail "$AT_ST" "claude_runtime:$CLAUDE_ST" "cache_producer:$PRODUCER_ST")"
@@ -350,18 +393,18 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
   --arg gen "$GEN" --arg host "$HOST" --argjson interval "$INTERVAL_SEC" \
   --arg sys_st "$SYS_ST" --argjson sys_rf "$SYS_RF" \
   --arg cpu_st "$CPU_ST" --argjson cpu_rf "$CPU_RF" --arg ncpu "$NCPU" --arg load1 "$LOAD1" --arg load_ratio "$LOAD_RATIO" --arg load5 "$LOAD5" --arg load5_ratio "$LOAD5_RATIO" --arg cpu_load_st "$CPU_LOAD_ST" --arg top_cpu_comm "${TOP_CPU_COMM:-none}" --arg top_cpu_pct "$TOP_CPU_PCT" --arg top_cpu_pid "${TOP_CPU_PID:-0}" --arg cpu_proc_st "$CPU_PROC_ST" \
-  --arg mem_st "$MEM_ST" --argjson mem_rf "$MEM_RF" --arg mem_avail_pct "$MEM_AVAIL_PCT" --arg top_mem_comm "${TOP_MEM_COMM:-none}" --arg top_mem_pct "$TOP_MEM_PCT" \
+  --arg mem_st "$MEM_ST" --argjson mem_rf "$MEM_RF" --arg mem_avail_pct "$MEM_AVAIL_PCT" --arg mem_avail_st "$MEM_AVAIL_ST" --arg mem_press_st "$MEM_PRESS_ST" --arg mem_press "$MEM_PRESS_LABEL" --arg top_mem_comm "${TOP_MEM_COMM:-none}" --arg top_mem_pct "$TOP_MEM_PCT" \
   --arg disk_st "$DISK_ST" --argjson disk_rf "$DISK_RF" --arg disk_free_gb "$DISK_FREE_GB" --arg dg_live "$DG_LIVE" \
   --arg sec_st "$SEC_ST" --argjson sec_rf "$SEC_RF" --arg sip "$SIP" --arg gk "$GK" --arg fw "$FW" \
   --arg mal_st "$MAL_ST" --argjson mal_rf "$MAL_RF" --arg xp_ver "$XP_VER" --arg xp_age "$XP_AGE_DAYS" --arg xp_au "$XP_AUTOUPDATE" --arg xp_src "$XP_SRC" \
-  --arg proc_st "$PROC_ST" --argjson proc_rf "$PROC_RF" --arg proc_count "$PROC_COUNT" --arg thread_count "$THREAD_COUNT" --arg zombie "$ZOMBIE_COUNT" --arg zombie_st "$ZOMBIE_ST" \
+  --arg proc_st "$PROC_ST" --argjson proc_rf "$PROC_RF" --arg proc_count "$PROC_COUNT" --arg thread_count "$THREAD_COUNT" --arg zombie "$ZOMBIE_COUNT" --arg counts_st "$COUNTS_ST" \
   --arg net_st "$NET_ST" --argjson net_rf "$NET_RF" --arg listeners "$LISTENERS" --arg estab "$ESTAB" \
   --argjson burn "$BURN_DOWN" \
   --arg at_st "$AT_ST" --argjson at_rf "$AT_RF" --arg claude_st "$CLAUDE_ST" --arg claude_ver "$CLAUDE_VER" --arg claude_health "$CLAUDE_HEALTH" --arg producer_st "$PRODUCER_ST" --arg uv_objs "$UV_ARCHIVE_OBJS" --arg uvx_latest "$UVX_LATEST_PROCS" --arg uvx_producers "$UVX_PRODUCERS" \
 'def n(v): (v|tonumber?) // v;
 {
-  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.5.0", secret_free: true,
-          note: "world-readable, secret-free (metadata only: counts/%/names/versions/booleans; process=comm-name never argv)" },
+  meta: { generated: $gen, host: $host, interval_sec: $interval, collector: "system-health-guardian", version: "1.6.0", secret_free: true,
+          note: "world-readable, secret-free (metadata only: counts/%/names/versions/booleans; comm-name for health signals — argv read ONLY for the uv-producer <pkg>@latest attribution via a strict grammar that rejects flags/values, never a secret)" },
   system: {
     status: $sys_st, tag: "resource.system", root_fail: $sys_rf,
     branches: {
@@ -369,7 +412,8 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
                   load1:        { status: $cpu_load_st, tag: "resource.cpu.load1", value: n($load1), load5: n($load5), ncpu: n($ncpu), load_ratio: n($load_ratio), load5_ratio: n($load5_ratio) },
                   top_consumer: { status: $cpu_proc_st, tag: "resource.cpu.top_consumer", comm: $top_cpu_comm, pct: n($top_cpu_pct), pid: n($top_cpu_pid) } } },
       memory:  { status: $mem_st, tag: "resource.memory", root_fail: $mem_rf, leaves: {
-                  available_pct: { status: $mem_st, tag: "resource.memory.available_pct", value: n($mem_avail_pct), top_consumer: $top_mem_comm, top_pct: n($top_mem_pct) } } },
+                  available_pct: { status: $mem_avail_st, tag: "resource.memory.available_pct", value: n($mem_avail_pct), top_consumer: $top_mem_comm, top_pct: n($top_mem_pct) },
+                  pressure:      { status: $mem_press_st, tag: "resource.memory.pressure", level: $mem_press } } },
       disk:    { status: $disk_st, tag: "resource.disk", root_fail: $disk_rf, delegated_to: $dg_live, leaves: {
                   free_gb: { status: $disk_st, tag: "resource.disk.free_gb", value: n($disk_free_gb) } } },
       security:{ status: $sec_st, tag: "resource.security", root_fail: $sec_rf, leaves: {
@@ -380,7 +424,7 @@ HOST="$(scutil --get LocalHostName 2>/dev/null || hostname -s 2>/dev/null || ech
                   xprotect_freshness: { status: $mal_st, tag: "resource.malware.xprotect_freshness", version: $xp_ver, age_days: n($xp_age), auto_update: $xp_au, source: $xp_src } } },
       process: { status: $proc_st, tag: "resource.process", root_fail: $proc_rf, leaves: {
                   runaway:  { status: $cpu_proc_st, tag: "resource.process.runaway", comm: $top_cpu_comm, cpu_pct: n($top_cpu_pct), pid: n($top_cpu_pid) },
-                  counts:   { status: $zombie_st, tag: "resource.process.counts", processes: n($proc_count), threads: n($thread_count), zombies: n($zombie) } } },
+                  counts:   { status: $counts_st, tag: "resource.process.counts", processes: n($proc_count), threads: n($thread_count), zombies: n($zombie) } } },
       network: { status: $net_st, tag: "resource.network", root_fail: $net_rf, leaves: {
                   listeners: { status: $net_st, tag: "resource.network.listeners", tcp_listen: n($listeners), tcp_established: n($estab) } } },
       agentic_tools: { status: $at_st, tag: "resource.agentic_tools", root_fail: $at_rf, leaves: {

--- a/skills/system-health-responder/references/auto-heal-safety-matrix.md
+++ b/skills/system-health-responder/references/auto-heal-safety-matrix.md
@@ -20,20 +20,22 @@
 | **cpu — runaway** | `branches.cpu.leaves.top_consumer.status != ok` AND `comm ∉ PROC_DENYLIST` AND `nice < RENICE_TO` | `renice RENICE_TO -p <pid>` (deprioritize) + record revert | ✅ **AUTONOMOUS (Moderate)** |
 | cpu — protected runaway | runaway but `comm ∈ PROC_DENYLIST` | seed + notify (never touch) | 🟠 HITL |
 | cpu — already-deprioritized | runaway but `nice ≥ RENICE_TO` (renice-down needs root) | seed + notify (kill/quit = operator) | 🟠 HITL |
+| **cpu — load saturation** (round-6 F1) | `branches.cpu.status ∈ {warn, crit}` AND `root_fail ≠ top_consumer` (SUSTAINED system load `load1`/`load5`, no single runaway) | seed + notify — **not auto-healable** (there is no single proc to renice; reducing load = operator closes apps). Was silently dropped pre-round-6 (the responder read only the `top_consumer` leaf, never the branch). | 🟠 HITL |
 | **disk** | `branches.disk.status != ok` | **DELEGATE to `disk-health-guardian`** — it owns disk (Tier-1/2 reclaim + its own escalate-seed). Zero duplication. | delegated |
 | **burn_down — forecast** (top-level `burn_down`, round-3) | `burn_down.status ∈ {warn, crit}` AND `burn_down.trend == "draining"` (reclaim-aware: sloped over the post-reclaim-jump tail, so a guardian cache-deletion up-jump can't mask a genuine drain) | **seed + notify** — `health-respond.sh main()` reads the top-level `.burn_down` **independently of `.system.status`** (it is NOT a `.system.branches` leaf, so it does not feed the roll-up — the early-return is gated on it too) and surfaces `days_to_threshold` + `drain_gb_per_hr` so a session/operator acts *before* the crisis the 2026-07-14 drain reached. **Observe-only leading indicator — a forecast NEVER auto-deletes; the disk *branch* (above) owns actual reclaim.** `unknown` (thin/absent log) → no action, no seed (never a fabricated number). | 🟠 seed + notify (no new autonomous action) |
 | **security** | firewall / SIP / gatekeeper off | seed + notify — re-enabling security = operator (System Settings) | 🟠 HITL |
 | **malware** | XProtect stale / detection | seed + notify — OS security update / quarantine = operator | 🟠 HITL |
-| **memory** | available < threshold | seed + notify — freeing memory means killing a proc (destructive) | 🟠 HITL |
-| **process** | zombie / runaway-count anomaly | seed + notify — kill = operator judgment | 🟠 HITL |
-| **network** | unexpected listener | seed + notify — never auto-close a socket | 🟠 HITL |
+| **memory** | available% low **OR** kernel `pressure` warn/crit (round-6 F5: available% adds back inactive/purgeable → can read ok while the kernel signals pressure; blended via `worst()`) | seed + notify — freeing memory means killing a proc (destructive) | 🟠 HITL |
+| **process** | zombie (env-thresholded) **or** optional thread high-water anomaly (round-6 F4: `counts.status` = zombies ⊕ threads, no longer zombies-only) | seed + notify — kill = operator judgment | 🟠 HITL |
+| **network** | `informational` (round-6 F3: listeners collected but NOT thresholded → honest non-`ok` label, **no residue** — never a false `ok`, never a false HITL seed) | **none** (observe-only; never auto-close a socket) | ⚪ informational |
 | **agentic-tools — cache-producer** | `branches.agentic_tools.leaves.cache_producer.status != ok` | `uv cache prune` (non-destructive; removes ONLY unreachable objects, keeps tool installs) | ✅ **AUTONOMOUS (Moderate)** |
 | **agentic-tools — live `@latest` producer** | `cache_producer.uvx_latest_procs > 0` (+ `uvx_latest_producers` = the argv-free `<pkg>@latest` name(s), when the spawn was alive long enough to `ps` — secret-safe by grammar) | **ENGAGE (SHR_READY proven)** → responder invokes `offender-containment.sh --engage` = DISABLE registry-vetted, present offenders (reversible; uninstall NOT auto-armed). **DRY-RUN / launchd (no SHR_READY)** → seed only (naming the producer in the seed). Un-vetted → always seed. Producers are **transient** (spawn-do-exit) → the lever is the source (disable) / the cache (prune), never the proc. | ✅ **AUTONOMOUS DISABLE (armed 2026-07-14)** / 🟠 seed |
 | **agentic-tools — claude runtime** | `claude_runtime.health != healthy` (from `claude doctor`) | seed + notify — fixing = operator `/doctor` in-session (the collector's probe is read-only) | 🟠 HITL |
 
 **Eisenhower ordering (deterministic):** cpu-runaway (urgent+important → autonomous) → disk (delegated) →
 agentic-tools cache-producer prune (Moderate autonomous) → security/malware (important, HITL) →
-memory/process/network + agentic-tools containment/runtime (HITL). crit outranks warn within a class.
+cpu-load-saturation / memory / process + agentic-tools containment/runtime (HITL). crit outranks warn within a
+class. `network` is observe-only `informational` (round-6 F3) — not in the action ordering.
 
 ## Offender-containment tiers (`bin/offender-containment.sh`) — above Moderate, separately armed (EKO-90-ext)
 
@@ -130,6 +132,18 @@ zero drift.
 > the wrong artifact; `xprotect_freshness.source` carries `xprotect-cli|bundle-mtime`. (#6) the
 > `process.counts` leaf now reflects the real `zombies` status (was hardcoded `ok`) so root-fail drill-down
 > lands on a non-`ok` leaf.
+>
+> **Round-6 (collector v1.5.0→v1.6.0)** — an anti-theater OODA that fixed what "ok" *means* rather than the
+> labels. One responder-side change (**F1**, the only new disposition above): the responder now reads the
+> `cpu` **branch** status, so a sustained-load crit (`root_fail=load1/load5`, no single runaway) is seeded to
+> HITL instead of silently dropped. Four collector honesty fixes (still leaf-`status`-transparent to the
+> responder): **F5** memory blends `kern.memorystatus_vm_pressure_level` (a false-`ok` caught live — available%
+> can read ok while the kernel signals pressure); **F4** `counts.status` = zombies (now env-overridable) ⊕ an
+> optional thread high-water (0 = disabled), and `thread_count` is threads-only (was procs+threads); **F3**
+> `network` is honestly `informational` (collected-not-thresholded), never a false `ok` nor a false HITL seed;
+> **F2** the `claude_runtime` probe resolves `claude` to an absolute path (launchd's minimal PATH had left it
+> perpetually `absent`). **H1** the sensitive-app safelist core (`1password openclaw omniroute claude`) is now a
+> single labelled SSOT in both `PROC_DENYLIST` (renice) and `PROTECTED` (containment), drift-guarded by a test.
 
 ## What the responder will NEVER do (⛔ absolute)
 


### PR DESCRIPTION
## PR-as-Enhancement — EKO-90 round-6: anti-theater honesty + harmonization

**Purpose-tag**: `[PR-as-Enhancement-Prompt]`

### Context
`/maos:quiesce --scope [linear:EKO-90] --condition=[/dod-recovery]` invoked another round with an explicit **anti-theater + harmonize/re-fatorar** framing. The honest risk of an Nth round on a converged goal is governance theater — so before planning, two skeptical Explore agents audited the whole suite (Mente Tomé, told to state what's *already* coherent/safe and reject invented gaps). They found **real substance**, headlined by a HIGH no-silent-drop bug that `guardian.log` proves was firing **live**.

**Already-honest machinery left untouched** (recon-confirmed): sensor/effector separation, threshold single-owner DRY, disk delegation, collector↔mirror byte-identity, the round-5 pid-recycle guard + `denied()` basename fix, autonomy gating (`SHR_READY` fail-safe, dry-run default), and secret-safety (no raw secret emitted anywhere).

### The genuine fixes
| # | Sev | Fix |
|---|---|---|
| **F1** | **HIGH** | Responder read only `cpu.top_consumer.status`, never the `cpu` **branch** → a crit driven by *sustained system load* (`root_fail=load1/load5`, no single runaway) surfaced **zero** residue. Now reads the branch + seeds HITL (not auto-healable). |
| F2 | MED | `claude_runtime` used bare `command -v claude` → launchd's minimal PATH left it perpetually `absent`. Now an absolute path. |
| F3 | MED | `network` hardcoded `ok` (never thresholded) → honest `informational` (no residue). |
| F4 | MED | `process.counts` was zombies-only; zombie thresholds now env-overridable; `thread_count` threads-only; optional thread high-water (0=disabled). |
| F5 | MED | `memory.available%` false-`ok` (caught live: available=ok 21.5% while kernel pressure=warn) → blends `kern.memorystatus_vm_pressure_level` via `worst()`; unreadable → neutral, never fabricated. |
| F6 | LOW | Tightened the "reads comm never argv" claim to match the true, safe `<pkg>@latest` argv-attribution grammar. |
| H1 | LOW-MED | Sensitive-app safelist core → single labelled **SSOT** in both `PROC_DENYLIST`+`PROTECTED`, drift-guarded by a test (inline-not-sourced = fail-safe). |
| H2 | LOW | SKILL.md + safety-matrix refreshed; assertion counts reconciled (37→59; 3 suites = 80/80). |

### Objectives / acceptance
- [x] Machine-local collector edited first, validated live, synced **byte-identical** to the mirror (`md5` asserted in tests)
- [x] Pure cores extracted (`counts_status`/`mem_pressure_status`) with `--*-status` hooks — same test pattern as round-4/5 (no logic dup)
- [x] `bin/threshold-test.sh` **59** + burndown 16 + responder-burndown 5 = **80/80**
- [x] F1 validated live against the current `cpu=crit root_fail=load1` contract (residue now surfaces)
- [x] collector v1.5.0→**v1.6.0**, SKILL v1.7.1→**v1.8.0**
- [x] gitleaks clean · commit unsigned per §6.1 (operator-authorized signing-bypass, signature-only)

### Anti-theater self-check (Layer-5 8/8)
R1 real ✅ (F1 empirically firing) · R2 theater ❌ (fixes *remove* theater — dead probes, false-ok labels) · R3 hallucinated ❌ (every finding file:line + log-verified) · R4 invented ❌ (recon rejected cosmetic gaps) · R5-R8 ✅. Scope bounded (Gordian): only the genuine fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
