### PR TITLE
feat(memory-curator): v2 sleep-time extension — deterministic sweep + 3 competencies (ADR-012)

### DIFF
--- a/agents/memory-curator.md
+++ b/agents/memory-curator.md
@@ -113,19 +113,13 @@ scheduler ──> bin/memory-curator-sweep.sh ──> work-queue JSON
                                      in-session gated apply (later)
 ```
 
-### Safety bounds (non-negotiable, per ADR-012)
+### Safety bounds (non-negotiable — verbatim from ADR-012 "Safety bounds")
 
-- **Read-only out-of-session.** The scheduled sweep + the sleep-time pass NEVER
-  mutate; they stage proposals.
-- **Tiering, never deletion.** An over-cap index is cured by moving detail to
-  topic files — content is never destroyed to satisfy a cap.
-- **Proposals-only for governance.** memory→rule elevation and rule→doc demotion
-  require operator confirmation — never auto-applied.
-- **Concurrency-safe.** Before any in-session mutation on a shared corpus, probe
-  for concurrent writers (fresh peer sessions / VCS index locks); defer or
-  worktree-isolate.
-- **Guardrail files are out of reach.** Safety-critical/absolute-guardrail
-  artifacts are never curated autonomously.
+- **Read-only out-of-session.** The scheduled sweep NEVER mutates; it stages proposals.
+- **Tiering, never deletion.** Detail moves to topic files; content is never destroyed to satisfy a cap.
+- **Proposals-only for governance.** memory→rule elevation and rule→doc demotion require operator confirmation (auto-edit of rule corpora is disabled by design).
+- **Concurrency-safe.** Before any in-session mutation on a shared corpus, probe for concurrent writers (fresh peer sessions / VCS index locks) and defer or worktree-isolate.
+- **Guardrail files are out of reach.** Safety-critical/absolute-guardrail artifacts are never curated autonomously.
 
 ## Audit Checklist
 

--- a/agents/memory-curator.md
+++ b/agents/memory-curator.md
@@ -5,6 +5,7 @@ tools: [Read, Grep, Glob, LS, Edit, Write]
 agnostic: [os, project]
 archetype: Mnemosyne — goddess of memory and mother of the Muses
 created_at: 2026-03-13
+updated_at: 2026-07-15  # v2 — sleep-time extension per ADR-012
 ---
 
 # Memory Curator (MNEMOSYNE)
@@ -47,6 +48,9 @@ MNEMOSYNE ensures that the knowledge graph remains **accurate, minimal, and navi
 | **Index Maintenance** | Keep MEMORY.md indexes accurate and within size limits | Read, Edit |
 | **Knowledge Classification** | Categorize memories by type (user, feedback, project, reference) and validate metadata | Read |
 | **Entropy Reporting** | Produce health reports on the state of the knowledge base | Write |
+| **Pointer-Freshness** (v2) | Verify the *not-forget invariants*: hub/roadmap rows link their delivered artifacts; `[[slug]]` cross-refs resolve (bidirectionally where mandated); keystone→hub→sub-artifact paths stay connected; `#TBD` placeholders whose deliverable exists get backfilled | Grep, Read, Edit |
+| **Promote/Demote Tiering** (v2) | Route knowledge to its correct tier: journal→topic-file promotion; over-cap index → one-line-per-entry with detail moved to topic files (tiering, NEVER deletion); flag memory→rule elevation and rule→doc demotion **as proposals only** | Read, Edit, Write |
+| **Sleep-Time Operation** (v2) | Consume the `bin/memory-curator-sweep.sh` work-queue (scheduled, out-of-session, READ-ONLY); stage a curation report + proposal queue; mutations happen later, in-session, under normal gates | Read, Write |
 
 ### OUT-OF-SCOPE
 
@@ -87,6 +91,41 @@ When contradictions are found, MNEMOSYNE resolves by hierarchy:
 
 Proposed deletions are flagged for review, not executed silently.
 Merges produce a new version, preserving the originals until confirmed.
+
+## Sleep-Time Operation (v2 — ADR-012)
+
+Mnemosyne v2 no longer depends on someone *remembering* to run it. A deterministic
+pre-scan — `bin/memory-curator-sweep.sh` — runs on a schedule (machine-local
+launchd/cron/session-start; scheduling is never versioned here) and emits a
+**work-queue JSON**: index-over-cap, dangling/orphan refs, stale re-validation
+markers, journal accumulation, duplicate titles, `#TBD` pending-artifact pointers.
+The agent consumes the queue and applies judgment only where the scan flagged work
+— *deterministic skeleton, probabilistic muscle*.
+
+```
+scheduler ──> bin/memory-curator-sweep.sh ──> work-queue JSON
+                                                   │
+                              MNEMOSYNE v2 ◄───────┘
+                                   │
+                    ┌──────────────┴──────────────┐
+             curation report                staged proposals
+                                                   │
+                                     in-session gated apply (later)
+```
+
+### Safety bounds (non-negotiable, per ADR-012)
+
+- **Read-only out-of-session.** The scheduled sweep + the sleep-time pass NEVER
+  mutate; they stage proposals.
+- **Tiering, never deletion.** An over-cap index is cured by moving detail to
+  topic files — content is never destroyed to satisfy a cap.
+- **Proposals-only for governance.** memory→rule elevation and rule→doc demotion
+  require operator confirmation — never auto-applied.
+- **Concurrency-safe.** Before any in-session mutation on a shared corpus, probe
+  for concurrent writers (fresh peer sessions / VCS index locks); defer or
+  worktree-isolate.
+- **Guardrail files are out of reach.** Safety-critical/absolute-guardrail
+  artifacts are never curated autonomously.
 
 ## Audit Checklist
 

--- a/bin/memory-curator-sweep.sh
+++ b/bin/memory-curator-sweep.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+# MAOS — memory-curator-sweep · deterministic READ-ONLY pre-scan (ADR-012)
+# ----------------------------------------------------------------------------
+# WHY: the memory-curator agent (Mnemosyne) is on-demand only — someone must
+#   remember to run it, and in an amnesic-agent ecosystem "someone must
+#   remember" is the failure mode itself. This script is the deterministic
+#   skeleton of the sleep-time extension: a no-LLM pre-scan that emits a
+#   WORK-QUEUE JSON of curation findings. The agent (probabilistic muscle)
+#   consumes the queue and applies judgment ONLY where the scan flagged work.
+#
+# GUARANTEES (the ADR-012 safety bounds):
+#   READ-ONLY — this script NEVER mutates the corpus. Its only output is the
+#   JSON envelope on stdout (+ a 1-line human summary on stderr). Mutations
+#   happen later, in-session, under the normal gates.
+#
+# Checks (each finding: {check, severity, path, detail}):
+#   index-over-cap        index file size vs --cap-bytes (skipped if no cap)
+#   dangling-ref          index links pointing at files that do not exist
+#   orphan-file           corpus .md files not referenced by the index
+#   stale-marker          re-validation dates in the past
+#   journal-accumulation  journal session-dirs with more than --journal-threshold files
+#   dup-title             identical H1 titles across different files
+#   pending-artifact      "#TBD" placeholders (pointer-freshness detector v1)
+#
+# Portability: AAIF cross-vendor — POSIX Bash 3.2 + jq only. stat is probed
+#   (BSD -f%z vs GNU -c%s), never assumed. Dates compare lexicographically
+#   (ISO YYYY-MM-DD), no date-math dependency.
+# Exit codes ([C06]): 0 clean · 1 usage/validation error · 2 findings present
+#   (non-fatal signal: there is curation work in the queue).
+set -euo pipefail
+
+command -v jq >/dev/null 2>&1 || { echo "memory-curator-sweep: jq is required" >&2; exit 1; }
+
+usage() {
+  cat <<EOF
+MAOS memory-curator-sweep — deterministic READ-ONLY pre-scan for Mnemosyne (ADR-012).
+
+USAGE
+  $(basename "$0") [--corpus <dir>] [--index <file>] [--cap-bytes N] [--journal-threshold N]
+
+  --corpus <dir>          corpus root to scan (default: current directory)
+  --index <file>          index file (default: <corpus>/MEMORY.md when present)
+  --cap-bytes <N>         index byte-cap; enables the index-over-cap check
+  --journal-threshold <N> flag journal session-dirs with more than N files (default 10)
+
+OUTPUT
+  Work-queue JSON envelope on stdout; 1-line summary on stderr.
+  Exit 0 = clean · 1 = error · 2 = findings present.
+EOF
+}
+
+CORPUS="$PWD"
+INDEX=""
+CAP_BYTES=""
+JOURNAL_THRESHOLD=10
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --corpus) CORPUS="${2:?--corpus needs a value}"; shift 2 ;;
+    --index) INDEX="${2:?--index needs a value}"; shift 2 ;;
+    --cap-bytes) CAP_BYTES="${2:?--cap-bytes needs a value}"; shift 2 ;;
+    --journal-threshold) JOURNAL_THRESHOLD="${2:?--journal-threshold needs a value}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "memory-curator-sweep: unknown option '$1'" >&2; usage >&2; exit 1 ;;
+  esac
+done
+
+[ -d "$CORPUS" ] || { echo "memory-curator-sweep: corpus dir not found: $CORPUS" >&2; exit 1; }
+CORPUS="$(cd "$CORPUS" && pwd)"
+[ -n "$INDEX" ] || { [ -f "$CORPUS/MEMORY.md" ] && INDEX="$CORPUS/MEMORY.md" || INDEX=""; }
+case "$JOURNAL_THRESHOLD" in (*[!0-9]*|'') echo "memory-curator-sweep: --journal-threshold must be a positive integer" >&2; exit 1 ;; esac
+if [ -n "$CAP_BYTES" ]; then
+  case "$CAP_BYTES" in (*[!0-9]*|'') echo "memory-curator-sweep: --cap-bytes must be a positive integer" >&2; exit 1 ;; esac
+fi
+
+# stat portability probe (never assume the platform flavor)
+file_size() {
+  stat -f%z "$1" 2>/dev/null || stat -c%s "$1" 2>/dev/null || wc -c < "$1" | tr -d ' '
+}
+
+TODAY="$(date +%Y-%m-%d)"
+QUEUE="$(mktemp -t mem-sweep.XXXXXX)"
+trap 'rm -f "$QUEUE"' EXIT
+
+emit() { # emit <check> <severity> <path> <detail>
+  jq -cn --arg c "$1" --arg s "$2" --arg p "$3" --arg d "$4" \
+    '{check:$c, severity:$s, path:$p, detail:$d}' >> "$QUEUE"
+}
+
+# Corpus .md inventory: top-level only (journal/archive handled separately).
+# NUL-safe iteration is overkill here (memory slugs are [word.-]), but names
+# with spaces must not silently skip — use find -print0 where iteration matters.
+
+# --- Check 1: index-over-cap ---------------------------------------------------
+if [ -n "$INDEX" ] && [ -f "$INDEX" ] && [ -n "$CAP_BYTES" ]; then
+  sz="$(file_size "$INDEX")"
+  if [ "$sz" -gt "$CAP_BYTES" ]; then
+    emit index-over-cap high "$INDEX" "index is ${sz}B > cap ${CAP_BYTES}B — respond by TIERING (move detail to topic files), never by deleting content"
+  fi
+fi
+
+# --- Check 2 + 3: dangling-ref / orphan-file (need an index) -------------------
+if [ -n "$INDEX" ] && [ -f "$INDEX" ]; then
+  index_dir="$(cd "$(dirname "$INDEX")" && pwd)"
+  refs="$(grep -o ']([A-Za-z0-9._/-]*\.md)' "$INDEX" 2>/dev/null | sed 's/^](//; s/)$//' | sort -u || true)"
+
+  # dangling: referenced but absent
+  if [ -n "$refs" ]; then
+    while IFS= read -r ref; do
+      [ -n "$ref" ] || continue
+      case "$ref" in /*) tgt="$ref" ;; *) tgt="$index_dir/$ref" ;; esac
+      [ -f "$tgt" ] || emit dangling-ref medium "$INDEX" "index references '$ref' which does not exist"
+    done <<EOF
+$refs
+EOF
+  fi
+
+  # orphan: present but unreferenced (top-level .md next to the index;
+  # journal/ + archives are excluded — they are lazily-loaded by design)
+  while IFS= read -r -d '' f; do
+    base="$(basename "$f")"
+    [ "$f" = "$INDEX" ] && continue
+    case "$base" in MEMORY*|*archive*|*Archive*) continue ;; esac
+    printf '%s\n' "$refs" | grep -qx "$base" || \
+      emit orphan-file low "$f" "not referenced by the index — candidate for an index line or explicit archive"
+  done < <(find "$index_dir" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
+fi
+
+# --- Check 4: stale-marker (re-validation dates in the past) -------------------
+while IFS= read -r -d '' f; do
+  # matches "re-validation: 2026-09-16" · "Calendar re-validation 2026-12-22" (case-insensitive)
+  hits="$(grep -in 're-validation:\{0,1\} *[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' "$f" 2>/dev/null || true)"
+  [ -n "$hits" ] || continue
+  while IFS= read -r line; do
+    d="$(printf '%s\n' "$line" | grep -o '[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}' | head -1)"
+    [ -n "$d" ] || continue
+    if [ "$d" \< "$TODAY" ]; then
+      ln="${line%%:*}"
+      emit stale-marker medium "$f" "re-validation date $d is past (line $ln) — re-validate, do NOT auto-delete"
+    fi
+  done <<EOF
+$hits
+EOF
+done < <(find "$CORPUS" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
+
+# --- Check 5: journal-accumulation ---------------------------------------------
+if [ -d "$CORPUS/journal" ]; then
+  while IFS= read -r -d '' d; do
+    n="$(find "$d" -maxdepth 1 -type f | wc -l | tr -d ' ')"
+    if [ "$n" -gt "$JOURNAL_THRESHOLD" ]; then
+      emit journal-accumulation low "$d" "$n files (> $JOURNAL_THRESHOLD) — promotion candidates: journal → topic files"
+    fi
+  done < <(find "$CORPUS/journal" -mindepth 1 -maxdepth 1 -type d -print0 2>/dev/null)
+fi
+
+# --- Check 6: dup-title (identical H1 across different files) -------------------
+TITLES="$(mktemp -t mem-sweep-titles.XXXXXX)"
+while IFS= read -r -d '' f; do
+  t="$(grep -m1 '^# ' "$f" 2>/dev/null | sed 's/^# *//' || true)"
+  [ -n "$t" ] && printf '%s\t%s\n' "$t" "$f" >> "$TITLES"
+done < <(find "$CORPUS" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
+if [ -s "$TITLES" ]; then
+  cut -f1 "$TITLES" | sort | uniq -d | while IFS= read -r dup; do
+    [ -n "$dup" ] || continue
+    files="$(grep -F "$dup	" "$TITLES" | cut -f2 | tr '\n' ' ')"
+    emit dup-title medium "$CORPUS" "H1 '$dup' appears in multiple files: ${files}— dedup/merge candidates"
+  done
+fi
+rm -f "$TITLES"
+
+# --- Check 7: pending-artifact (#TBD pointer-freshness detector) ----------------
+while IFS= read -r -d '' f; do
+  n="$(grep -c '#TBD' "$f" 2>/dev/null || true)"
+  [ -n "$n" ] && [ "$n" -gt 0 ] && \
+    emit pending-artifact low "$f" "$n '#TBD' placeholder(s) — deliverable may exist; backfill the pointer (never-backfilled placeholders are the pointer-freshness scar)"
+done < <(find "$CORPUS" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
+
+# --- Envelope -------------------------------------------------------------------
+count="$(wc -l < "$QUEUE" | tr -d ' ')"
+verdict="CLEAN"; [ "$count" -gt 0 ] && verdict="FINDINGS"
+jq -s --arg corpus "$CORPUS" --arg index "${INDEX:-}" --arg v "$verdict" \
+   --arg today "$TODAY" \
+  '{sweep:"memory-curator-sweep", version:"0.1.0", date:$today, corpus:$corpus,
+    index:(if $index=="" then null else $index end), verdict:$v,
+    counts:(group_by(.check) | map({key:.[0].check, value:length}) | from_entries),
+    findings:.}' "$QUEUE"
+echo "memory-curator-sweep: $verdict — $count finding(s) in $CORPUS (read-only; queue on stdout)" >&2
+
+[ "$count" -eq 0 ] && exit 0 || exit 2

--- a/bin/memory-curator-sweep.sh
+++ b/bin/memory-curator-sweep.sh
@@ -29,7 +29,8 @@
 #   (non-fatal signal: there is curation work in the queue).
 set -euo pipefail
 
-command -v jq >/dev/null 2>&1 || { echo "memory-curator-sweep: jq is required" >&2; exit 1; }
+# Resolve jq ONCE to an absolute path (PATH could mutate mid-run under a hook/scheduler)
+JQ="$(command -v jq)" || { echo "memory-curator-sweep: jq is required" >&2; exit 1; }
 
 usage() {
   cat <<EOF
@@ -83,7 +84,7 @@ QUEUE="$(mktemp -t mem-sweep.XXXXXX)"
 trap 'rm -f "$QUEUE"' EXIT
 
 emit() { # emit <check> <severity> <path> <detail>
-  jq -cn --arg c "$1" --arg s "$2" --arg p "$3" --arg d "$4" \
+  "$JQ" -cn --arg c "$1" --arg s "$2" --arg p "$3" --arg d "$4" \
     '{check:$c, severity:$s, path:$p, detail:$d}' >> "$QUEUE"
 }
 
@@ -116,12 +117,15 @@ EOF
   fi
 
   # orphan: present but unreferenced (top-level .md next to the index;
-  # journal/ + archives are excluded — they are lazily-loaded by design)
+  # journal/ + archives are excluded — they are lazily-loaded by design).
+  # Compare BASENAMES on both sides — an index ref written as `./file.md` or
+  # `sub/file.md` must not turn an existing file into a false orphan (qodo #268).
+  ref_basenames="$(printf '%s\n' "$refs" | sed 's|.*/||' | sort -u)"
   while IFS= read -r -d '' f; do
     base="$(basename "$f")"
     [ "$f" = "$INDEX" ] && continue
     case "$base" in MEMORY*|*archive*|*Archive*) continue ;; esac
-    printf '%s\n' "$refs" | grep -qx "$base" || \
+    printf '%s\n' "$ref_basenames" | grep -qx "$base" || \
       emit orphan-file low "$f" "not referenced by the index — candidate for an index line or explicit archive"
   done < <(find "$index_dir" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
 fi
@@ -178,7 +182,7 @@ done < <(find "$CORPUS" -maxdepth 1 -name '*.md' -print0 2>/dev/null)
 # --- Envelope -------------------------------------------------------------------
 count="$(wc -l < "$QUEUE" | tr -d ' ')"
 verdict="CLEAN"; [ "$count" -gt 0 ] && verdict="FINDINGS"
-jq -s --arg corpus "$CORPUS" --arg index "${INDEX:-}" --arg v "$verdict" \
+"$JQ" -s --arg corpus "$CORPUS" --arg index "${INDEX:-}" --arg v "$verdict" \
    --arg today "$TODAY" \
   '{sweep:"memory-curator-sweep", version:"0.1.0", date:$today, corpus:$corpus,
     index:(if $index=="" then null else $index end), verdict:$v,

--- a/bin/memory-curator-sweep.sh
+++ b/bin/memory-curator-sweep.sh
@@ -105,11 +105,24 @@ if [ -n "$INDEX" ] && [ -f "$INDEX" ]; then
   index_dir="$(cd "$(dirname "$INDEX")" && pwd)"
   refs="$(grep -o ']([A-Za-z0-9._/-]*\.md)' "$INDEX" 2>/dev/null | sed 's/^](//; s/)$//' | sort -u || true)"
 
-  # dangling: referenced but absent
+  # dangling: referenced but absent.
+  # Path-traversal guard (amazon-q #268): NEVER probe outside the corpus —
+  # a ref with a `..` component, or an absolute ref outside $CORPUS, is itself
+  # the finding (severity high) and is never stat'ed. Keeps the existence-probe
+  # oracle inside the corpus boundary (same class as script-safety safe_rm).
   if [ -n "$refs" ]; then
     while IFS= read -r ref; do
       [ -n "$ref" ] || continue
-      case "$ref" in /*) tgt="$ref" ;; *) tgt="$index_dir/$ref" ;; esac
+      out_of_corpus=0
+      case "/$ref/" in */../*) out_of_corpus=1 ;; esac
+      case "$ref" in
+        /*) case "$ref" in "$CORPUS"/*) ;; *) out_of_corpus=1 ;; esac; tgt="$ref" ;;
+        *) tgt="$index_dir/$ref" ;;
+      esac
+      if [ "$out_of_corpus" = 1 ]; then
+        emit dangling-ref medium "$INDEX" "index references '$ref' which resolves outside the corpus — not probed (path-traversal guard); the agent must verify the ref is intentional"
+        continue
+      fi
       [ -f "$tgt" ] || emit dangling-ref medium "$INDEX" "index references '$ref' which does not exist"
     done <<EOF
 $refs

--- a/tests/test-memory-curator-sweep.sh
+++ b/tests/test-memory-curator-sweep.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Test: bin/memory-curator-sweep.sh — deterministic READ-ONLY pre-scan (ADR-012).
+# Portable (bash 3.2 + jq). Exit 0 = all pass; 1 = a failure.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$HERE/bin/memory-curator-sweep.sh"
+FIX="$(mktemp -d)"
+trap 'rm -rf "$FIX"' EXIT
+fail=0
+ok() { printf '  ok   %s\n' "$1"; }
+no() { printf '  FAIL %s\n' "$1"; fail=1; }
+
+echo "test-memory-curator-sweep:"
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+mkdir -p "$FIX/corpus/journal/sess-aaaa"
+cat > "$FIX/corpus/MEMORY.md" <<'EOF'
+# Memory Index
+- [Topic A](topic_a.md) — a thing
+- [Ghost](ghost_file.md) — referenced but absent
+EOF
+cat > "$FIX/corpus/topic_a.md" <<'EOF'
+# Topic Alpha
+Content. PR ekson73/example#TBD.
+EOF
+cat > "$FIX/corpus/orphan_note.md" <<'EOF'
+# Orphan Note
+Not in the index.
+EOF
+cat > "$FIX/corpus/stale_rule.md" <<'EOF'
+# Stale Reference
+Calendar re-validation 2020-01-01 (long past).
+EOF
+cat > "$FIX/corpus/dup_one.md" <<'EOF'
+# Same Title Twice
+first body
+EOF
+cat > "$FIX/corpus/dup_two.md" <<'EOF'
+# Same Title Twice
+second body
+EOF
+i=0; while [ $i -lt 12 ]; do echo "note $i" > "$FIX/corpus/journal/sess-aaaa/e$i.md"; i=$((i+1)); done
+
+# ── 1. findings run: exit 2 + valid JSON envelope ──────────────────────────
+set +e
+out="$("$BIN" --corpus "$FIX/corpus" --cap-bytes 10 --journal-threshold 10 2>/dev/null)"
+rc=$?
+set -e
+[ "$rc" = "2" ] && ok "exit 2 when findings present" || no "exit code ($rc != 2)"
+echo "$out" | jq -e '.sweep=="memory-curator-sweep" and .verdict=="FINDINGS"' >/dev/null \
+  && ok "JSON envelope valid + verdict FINDINGS" || no "envelope/verdict"
+
+# ── 2. each check fires on its fixture ─────────────────────────────────────
+has() { echo "$out" | jq -e --arg c "$1" '[.findings[]|select(.check==$c)]|length > 0' >/dev/null; }
+has index-over-cap        && ok "index-over-cap fires (cap 10B)"        || no "index-over-cap"
+has dangling-ref          && ok "dangling-ref fires (ghost_file.md)"    || no "dangling-ref"
+has orphan-file           && ok "orphan-file fires (orphan_note.md)"    || no "orphan-file"
+has stale-marker          && ok "stale-marker fires (2020-01-01)"       || no "stale-marker"
+has journal-accumulation  && ok "journal-accumulation fires (12 > 10)"  || no "journal-accumulation"
+has dup-title             && ok "dup-title fires (Same Title Twice)"    || no "dup-title"
+has pending-artifact      && ok "pending-artifact fires (#TBD)"         || no "pending-artifact"
+
+# ── 3. READ-ONLY guarantee: corpus byte-identical after the sweep ───────────
+sum_before="$(find "$FIX/corpus" -type f -exec cat {} + | cksum)"
+"$BIN" --corpus "$FIX/corpus" --cap-bytes 10 >/dev/null 2>&1 || true
+sum_after="$(find "$FIX/corpus" -type f -exec cat {} + | cksum)"
+[ "$sum_before" = "$sum_after" ] && ok "read-only (corpus unchanged)" || no "read-only violated"
+
+# ── 4. clean corpus: exit 0 + CLEAN ─────────────────────────────────────────
+mkdir -p "$FIX/clean"
+cat > "$FIX/clean/MEMORY.md" <<'EOF'
+# Memory Index
+- [Solo](solo.md) — the only topic
+EOF
+cat > "$FIX/clean/solo.md" <<'EOF'
+# Solo Topic
+Nothing wrong here.
+EOF
+set +e
+cout="$("$BIN" --corpus "$FIX/clean" --cap-bytes 100000 2>/dev/null)"
+crc=$?
+set -e
+[ "$crc" = "0" ] && ok "exit 0 on clean corpus" || no "clean exit code ($crc != 0)"
+echo "$cout" | jq -e '.verdict=="CLEAN" and (.findings|length)==0' >/dev/null \
+  && ok "verdict CLEAN + zero findings" || no "clean verdict"
+
+# ── 5. no cap flag → index-over-cap skipped (opt-in check) ──────────────────
+set +e
+nout="$("$BIN" --corpus "$FIX/corpus" 2>/dev/null)"
+set -e
+echo "$nout" | jq -e '[.findings[]|select(.check=="index-over-cap")]|length == 0' >/dev/null \
+  && ok "index-over-cap skipped without --cap-bytes" || no "cap opt-in"
+
+# ── 6. usage errors: exit 1 ─────────────────────────────────────────────────
+set +e
+"$BIN" --corpus "$FIX/does-not-exist" >/dev/null 2>&1; e1=$?
+"$BIN" --cap-bytes abc >/dev/null 2>&1; e2=$?
+set -e
+[ "$e1" = "1" ] && ok "exit 1 on missing corpus" || no "missing-corpus exit ($e1)"
+[ "$e2" = "1" ] && ok "exit 1 on non-numeric cap" || no "bad-cap exit ($e2)"
+
+echo
+[ "$fail" = "0" ] && { echo "ALL PASS"; exit 0; } || { echo "FAILURES"; exit 1; }

--- a/tests/test-memory-curator-sweep.sh
+++ b/tests/test-memory-curator-sweep.sh
@@ -19,7 +19,9 @@ cat > "$FIX/corpus/MEMORY.md" <<'EOF'
 - [Topic A](topic_a.md) — a thing
 - [Ghost](ghost_file.md) — referenced but absent
 - [Dot-slash](./dotslash_ref.md) — referenced with ./ prefix (must NOT be a false orphan)
+- [Evil](../outside_evil.md) — traversal ref pointing OUTSIDE the corpus
 EOF
+echo "# Outside Evil" > "$FIX/outside_evil.md"   # exists OUTSIDE the corpus boundary
 cat > "$FIX/corpus/dotslash_ref.md" <<'EOF'
 # Dot Slash Ref
 Referenced as ./dotslash_ref.md in the index.
@@ -65,6 +67,9 @@ echo "$out" | jq -e '[.findings[]|select(.check=="orphan-file" and (.path|endswi
   && ok "no false orphan for ./-prefixed ref (dotslash_ref.md)" || no "false orphan on ./ ref"
 echo "$out" | jq -e '[.findings[]|select(.check=="dangling-ref" and (.detail|contains("dotslash")))]|length == 0' >/dev/null \
   && ok "no false dangling for ./-prefixed ref" || no "false dangling on ./ ref"
+# Path-traversal guard: ../ ref flagged + NOT probed (file exists outside — must not be silently OK'd)
+echo "$out" | jq -e '[.findings[]|select(.check=="dangling-ref" and (.detail|contains("outside the corpus")))]|length == 1' >/dev/null \
+  && ok "traversal ref (../outside_evil.md) flagged, not probed" || no "path-traversal guard"
 has stale-marker          && ok "stale-marker fires (2020-01-01)"       || no "stale-marker"
 has journal-accumulation  && ok "journal-accumulation fires (12 > 10)"  || no "journal-accumulation"
 has dup-title             && ok "dup-title fires (Same Title Twice)"    || no "dup-title"

--- a/tests/test-memory-curator-sweep.sh
+++ b/tests/test-memory-curator-sweep.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="$HERE/bin/memory-curator-sweep.sh"
-FIX="$(mktemp -d)"
+FIX="$(mktemp -d 2>/dev/null || mktemp -d -t 'mcsweep')"
 trap 'rm -rf "$FIX"' EXIT
 fail=0
 ok() { printf '  ok   %s\n' "$1"; }
@@ -18,6 +18,11 @@ cat > "$FIX/corpus/MEMORY.md" <<'EOF'
 # Memory Index
 - [Topic A](topic_a.md) — a thing
 - [Ghost](ghost_file.md) — referenced but absent
+- [Dot-slash](./dotslash_ref.md) — referenced with ./ prefix (must NOT be a false orphan)
+EOF
+cat > "$FIX/corpus/dotslash_ref.md" <<'EOF'
+# Dot Slash Ref
+Referenced as ./dotslash_ref.md in the index.
 EOF
 cat > "$FIX/corpus/topic_a.md" <<'EOF'
 # Topic Alpha
@@ -55,15 +60,25 @@ has() { echo "$out" | jq -e --arg c "$1" '[.findings[]|select(.check==$c)]|lengt
 has index-over-cap        && ok "index-over-cap fires (cap 10B)"        || no "index-over-cap"
 has dangling-ref          && ok "dangling-ref fires (ghost_file.md)"    || no "dangling-ref"
 has orphan-file           && ok "orphan-file fires (orphan_note.md)"    || no "orphan-file"
+# ./-prefixed index ref must NOT produce a false orphan NOR a false dangling (qodo #268 bug)
+echo "$out" | jq -e '[.findings[]|select(.check=="orphan-file" and (.path|endswith("dotslash_ref.md")))]|length == 0' >/dev/null \
+  && ok "no false orphan for ./-prefixed ref (dotslash_ref.md)" || no "false orphan on ./ ref"
+echo "$out" | jq -e '[.findings[]|select(.check=="dangling-ref" and (.detail|contains("dotslash")))]|length == 0' >/dev/null \
+  && ok "no false dangling for ./-prefixed ref" || no "false dangling on ./ ref"
 has stale-marker          && ok "stale-marker fires (2020-01-01)"       || no "stale-marker"
 has journal-accumulation  && ok "journal-accumulation fires (12 > 10)"  || no "journal-accumulation"
 has dup-title             && ok "dup-title fires (Same Title Twice)"    || no "dup-title"
 has pending-artifact      && ok "pending-artifact fires (#TBD)"         || no "pending-artifact"
 
 # ── 3. READ-ONLY guarantee: corpus byte-identical after the sweep ───────────
-sum_before="$(find "$FIX/corpus" -type f -exec cat {} + | cksum)"
+# Deterministic: sorted per-file checksum list (cksum includes path), then cksum
+# the list — immune to find traversal-order differences across platforms.
+corpus_sum() {
+  find "$1" -type f | LC_ALL=C sort | while IFS= read -r f; do cksum "$f"; done | cksum
+}
+sum_before="$(corpus_sum "$FIX/corpus")"
 "$BIN" --corpus "$FIX/corpus" --cap-bytes 10 >/dev/null 2>&1 || true
-sum_after="$(find "$FIX/corpus" -type f -exec cat {} + | cksum)"
+sum_after="$(corpus_sum "$FIX/corpus")"
 [ "$sum_before" = "$sum_after" ] && ok "read-only (corpus unchanged)" || no "read-only violated"
 
 # ── 4. clean corpus: exit 0 + CLEAN ─────────────────────────────────────────


### PR DESCRIPTION
[PR-as-Enhancement-Prompt]

## Context

ADR-012 (merged, #267) specified the sleep-time extension of Mnemosyne. This PR is the implementation — the remaining Phase-2 gate of the memory-architecture roadmap.

## Objectives

- **`bin/memory-curator-sweep.sh`** — READ-ONLY deterministic pre-scan (bash 3.2 + jq, ADR-005/011 pattern) emitting a work-queue JSON with 7 checks: `index-over-cap` · `dangling-ref` · `orphan-file` · `stale-marker` · `journal-accumulation` · `dup-title` · `pending-artifact` (#TBD pointer-freshness detector). Exit 0 clean / 1 error / 2 findings.
- **`tests/test-memory-curator-sweep.sh`** — 15 asserts, ALL PASS, including the **read-only guarantee** (corpus checksummed byte-identical post-sweep) and per-check fixture firing.
- **`agents/memory-curator.md` v2** — +3 IN-SCOPE competencies (pointer-freshness · promote/demote tiering · sleep-time operation) + the ADR-012 non-negotiable safety bounds.

## Evidence (dogfood run 1, real corpus, read-only)

First execution against a live memory corpus returned **6 genuine findings**: 2 `orphan-file` (unindexed files), 2 `dup-title`, 2 `pending-artifact` (#TBD) — real curation work detected on run 1, zero mutations (RC=2, corpus untouched).

## Acceptance

- [ ] Test suite green (15/15)
- [ ] Read-only guarantee test present and passing
- [ ] No personal paths versioned; scheduling stays machine-local per ADR-012
- [ ] Safety bounds verbatim in the agent (tiering-never-deletion · proposals-only governance · concurrency-safe · guardrails out of reach)

## Out of scope

Scheduling config (machine-local by design) · the ≥2-dogfood-cycles promotion gate (cycle 1 evidenced here; cycle 2 + `dogfood-mark` before any marketplace promotion).

## Cross-links

ADR: `docs/adrs/ADR-012-memory-curator-sleep-time.md` (#267) · Extends: `agents/memory-curator.md` (Mnemosyne) · Pattern: ADR-005/ADR-011 ledger bins · Session: 9bf1da6c

🤖 Generated with [Claude Code](https://claude.com/claude-code)
