### PR TITLE
chore(release): maos 1.21.0 — memory-hygiene trio (ADR-012 sweep + memory-curator v2 + ADR-013 gateway spec)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_comment": "MAOS plugin manifest. Edit version on release; see CHANGELOG.md. Namespacing + vendor-reserved details below.",
   "name": "maos",
-  "version": "1.20.0",
+  "version": "1.21.0",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.21.0] - 2026-07-15
+
+### Added — memory-hygiene trio: sleep-time curator (ADR-012) + gateway spec (ADR-013)
+
+- **`docs/adrs/ADR-012-memory-curator-sleep-time.md`** (#267) — accepts the Mnemosyne v2 *sleep-time* extension
+  (EXTEND, not re-forge): pointer-freshness · promote/demote tiering · deterministic read-only pre-scan, with
+  verbatim safety bounds (read-only out-of-session · tiering-never-deletion · proposals-only for governance).
+- **`bin/memory-curator-sweep.sh`** + **`tests/test-memory-curator-sweep.sh`** (18 asserts) + **`agents/memory-curator.md` v2** (#268) —
+  the ADR-012 forge: 7-check deterministic READ-ONLY sweep (dup-title · orphan-file · dangling-ref w/ path-traversal
+  guard · index drift · stale re-validation · `#TBD` refs · cap pressure), bash 3.2 + jq, JSON envelope, exit
+  `0 clean · 1 error · 2 findings`. Read-only guarantee cksum-locked by the test suite; false-orphan and
+  out-of-corpus-ref classes fixture-pinned. Dogfood cycle 1/2 ratified on the real corpus (6 genuine findings).
+- **`docs/adrs/ADR-013-memory-crud-gateway.md`** (#269) — accepts the Phase-3 *executor* design: ONE canonical
+  memory-CRUD owner ("others ask IT") — 7-verb narrow API (create/read/update/archive/search/neighborhood/index),
+  bin + skill (NOT a new MCP server; zero always-on cost), §I/O contract (single-JSON-stdout envelope; exit codes
+  aligned with the `bin/artifact-registry` CLI-mutator family, precedent #223), `archive` as the only removal verb,
+  advisory-first adoption (directed → WARN → BLOCK, operator-ratified). Build = next phase per the ADR's DoD.
+
 ## [1.20.0] - 2026-07-14
 
 ### Added — `artifact-registry`: dedup-memory for Anima (naming) & Forge (creation)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (EXTEND, not re-forge): pointer-freshness · promote/demote tiering · deterministic read-only pre-scan, with
   verbatim safety bounds (read-only out-of-session · tiering-never-deletion · proposals-only for governance).
 - **`bin/memory-curator-sweep.sh`** + **`tests/test-memory-curator-sweep.sh`** (18 asserts) + **`agents/memory-curator.md` v2** (#268) —
-  the ADR-012 forge: 7-check deterministic READ-ONLY sweep (dup-title · orphan-file · dangling-ref w/ path-traversal
-  guard · index drift · stale re-validation · `#TBD` refs · cap pressure), bash 3.2 + jq, JSON envelope, exit
+  the ADR-012 forge: 7-check deterministic READ-ONLY sweep (`index-over-cap` · `dangling-ref` w/ path-traversal
+  guard · `orphan-file` · `stale-marker` · `journal-accumulation` · `dup-title` · `pending-artifact`), bash 3.2 + jq, JSON envelope, exit
   `0 clean · 1 error · 2 findings`. Read-only guarantee cksum-locked by the test suite; false-orphan and
   out-of-corpus-ref classes fixture-pinned. Dogfood cycle 1/2 ratified on the real corpus (6 genuine findings).
 - **`docs/adrs/ADR-013-memory-crud-gateway.md`** (#269) — accepts the Phase-3 *executor* design: ONE canonical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,7 +351,7 @@ Entry points: skill `delegate-governance` (discoverable) + CLI `plugin-scripts/g
 
 ---
 
-*Multi-Agent OS v1.20.0 | Plugin for Claude Code*
+*Multi-Agent OS v1.21.0 | Plugin for Claude Code*
 *Analysis by: Claude-Analyst-c614-plugin | 2026-01-08T21:30:00-03:00*
 
 ## Branching & Release Model

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Plugin-blueviolet)](https://claude.ai/code)
-[![Version](https://img.shields.io/badge/Version-1.20.0-blue)](https://github.com/ekson73/multi-agent-os)
+[![Version](https://img.shields.io/badge/Version-1.21.0-blue)](https://github.com/ekson73/multi-agent-os)
 [![Sentinel](https://img.shields.io/badge/Sentinel-Protocol-green)](https://github.com/ekson73/multi-agent-os/tree/main/sentinel)
 [![Branching: GitHub Flow](https://img.shields.io/badge/branching-GitHub%20Flow%20(Class%20B)-0a7bbb)](./AGENTS.md)
 
@@ -264,4 +264,4 @@ MIT License - See LICENSE file for details.
 
 ---
 
-*Multi-Agent OS v1.20.0 | Created by Emilson Moraes | Powered by Claude Code*
+*Multi-Agent OS v1.21.0 | Created by Emilson Moraes | Powered by Claude Code*


### PR DESCRIPTION
[PR-as-Documentation-Prompt]

**Context**: `/maos:quiesce` effectivation pass (session 9bf1da6c). Today's 3 merges (#267 ADR-012 · #268 sweep+agent-v2 · #269 ADR-013) landed WITHOUT a CHANGELOG entry or version bump — so the `memory-curator` v2 feat never reaches the plugin runtime cache (plugin.json version is the cache discriminator; precedent: release 1.20.0 / #250).

**Objective**: effectivate the memory-hygiene trio in the runtime — CHANGELOG 1.21.0 section (3 entries) + plugin.json `1.20.0 → 1.21.0`.

**Acceptance**:
- [x] `bash tests/validate-plugin.sh` PASS
- [x] CHANGELOG follows Keep-a-Changelog; `[Unreleased]` left empty on top
- [x] Version-sync (plugin.json ↔ CHANGELOG latest section = 1.21.0)
- [x] Zero behavior change beyond version metadata
