### PR TITLE
feat(bin): plugin-cache-sweeper — reclaim orphaned Claude Code plugin staging clones

### DIFF
--- a/bin/plugin-cache-sweeper.sh
+++ b/bin/plugin-cache-sweeper.sh
@@ -47,12 +47,18 @@ set -uo pipefail
 CACHE="${PCS_CACHE:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache}"
 AGE_MIN="${PCS_AGE_MIN:-180}"
 APPLY=0
+BAD_OPT=""   # set by the arg loop when an option's value is absent/empty; gate -3 refuses on it
 
 while [ $# -gt 0 ]; do
   case "$1" in
     --apply)    APPLY=1 ;;
-    --age-min)  shift; AGE_MIN="${1:-180}" ;;
-    --cache)    shift; CACHE="${1:-$CACHE}" ;;
+    # ⛔ A MISSING value must NOT fall back to the default. `--cache` with nothing after it used to
+    #    silently keep the DEFAULT cache — so `--apply --cache` (value lost to a typo, an unquoted
+    #    empty shell var, or a truncated wrapper) aimed the deletion at the operator's REAL plugin
+    #    cache while the envelope reported that path as if it had been requested. `${1:-default}`
+    #    cannot distinguish "absent" from "empty"; both are refusals here (coderabbit #282 round 2).
+    --age-min)  if [ $# -ge 2 ] && [ -n "${2:-}" ]; then shift; AGE_MIN="$1"; else BAD_OPT="--age-min"; break; fi ;;
+    --cache)    if [ $# -ge 2 ] && [ -n "${2:-}" ]; then shift; CACHE="$1";   else BAD_OPT="--cache";   break; fi ;;
     -h|--help)  sed -n '2,45p' "$0"; exit 0 ;;
     *)          printf 'unknown argument: %s (try --help)\n' "$1" >&2; exit 0 ;;
   esac
@@ -62,6 +68,14 @@ done
 # JSON-escape a string field. The cache path is caller-supplied (--cache / PCS_CACHE)
 # and a quote or backslash in it would otherwise terminate the field early and emit
 # malformed JSON to a machine consumer.
+# JSON-escape a string field: backslash, quote, tab, and embedded newlines.
+# ⛔ RAW C0 CONTROL CHARS ARE REJECTED UPSTREAM, NOT ESCAPED HERE (see the reject gate below).
+#    RFC 8259 forbids U+0000-U+001F raw inside a string, and a `\uXXXX` escaper written in awk
+#    is a TRAP: awk strings cannot hold NUL, so a 32-entry lookup table silently SHIFTS and the
+#    envelope then parses cleanly while decoding the WRONG byte (measured: \x01 decoded as \x00,
+#    \x0b as \t — a collision). Valid JSON pointing at a byte the caller never passed is worse
+#    than invalid JSON: the first fails loudly, the second lies. A cache path has no legitimate
+#    use for a control char, so the honest handling is to refuse the input (Gordian).
 json_esc() {
   printf '%s' "$1" | awk 'BEGIN{ORS=""}
     { gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); gsub(/\t/,"\\t")
@@ -69,12 +83,40 @@ json_esc() {
       printf "%s", $0 }'
 }
 
+
 emit() { # emit <swept> <would> <young> <refused> <remaining> <freed_mb> <inuse> <note>
   printf '{"tool":"plugin-cache-sweeper","cache":"%s","mode":"%s","age_min":%s,' \
     "$(json_esc "$CACHE")" "$([ "$APPLY" -eq 1 ] && echo apply || echo report)" "$AGE_MIN"
   printf '"swept":%s,"would_sweep":%s,"too_young":%s,"refused":%s,' "$1" "$2" "$3" "$4"
   printf '"remaining":%s,"freed_mb":%s,"in_use":%s,"note":"%s"}\n' "$5" "$6" "$7" "$(json_esc "$8")"
 }
+
+# gate -3 — an option whose value was absent or empty. MUST come first: the later gates read
+# $CACHE/$AGE_MIN, and acting on a value the caller never supplied is the whole defect.
+if [ -n "$BAD_OPT" ]; then
+  emit 0 0 0 0 0 0 0 "missing-option-value"
+  printf 'plugin-cache-sweeper: %s requires a non-empty value — nothing swept\n' "$BAD_OPT" >&2
+  exit 0
+fi
+
+# gate -2 — refuse a CACHE path carrying a raw C0 control char. Fails CLOSED (sweeps nothing,
+# reports, exits 0) exactly like the age gate: a path we cannot faithfully serialize is a path we
+# must not act on. `tr -d` keeps the comparison byte-exact and needs no locale assumption.
+# ⛔ MUST sit AFTER emit() is defined — placed above it this called an undefined function and
+#    emitted NOTHING at all (measured: `emit: command not found`, empty stdout, so a machine
+#    consumer got no envelope instead of a refusal). A fail-closed gate that cannot report is a
+#    silent exit, not a guard.
+if [ "$(printf '%s' "$CACHE" | LC_ALL=C tr -d '\001-\037' | wc -c)" != "$(printf '%s' "$CACHE" | wc -c)" ]; then
+  # ⛔ SANITIZE BEFORE REPORTING — the refusal envelope must itself be parseable. Emitting the
+  #    offending path verbatim reproduced the exact defect being refused (measured: the gate fired
+  #    correctly, note=invalid-cache-path swept=0, yet `python json.load` still rejected the output
+  #    at the `cache` field). A guard whose own report is malformed hands the machine consumer
+  #    nothing to act on. `?` marks each removed byte so the path stays recognizable to a human.
+  CACHE="$(printf '%s' "$CACHE" | LC_ALL=C tr '\001-\037' '?')"
+  emit 0 0 0 0 0 0 0 "invalid-cache-path"
+  printf 'plugin-cache-sweeper: --cache contains a control character — nothing swept\n' >&2
+  exit 0
+fi
 
 # gate -1 — the age floor must be a non-negative integer BEFORE it reaches the
 # envelope. `age_min` is a JSON *number* field, so a non-numeric value is
@@ -132,7 +174,19 @@ if command -v lsof >/dev/null 2>&1; then
     # The candidate basename may carry a `.clone` suffix (temp_subdir_<ms>_<rand>.clone).
     # The pattern MUST admit it — gate 4 compares whole names, so a truncated capture
     # never matches its own candidate and silently exempts the .clone class.
-    INUSE="$(printf '%s\n' "$RAW" | grep -o "temp_[a-z]*_[0-9]*_[a-z0-9]*\(\.clone\)\?" | sort -u)"
+    # ⛔ SCOPE TO $BOUND BEFORE NAME-MATCHING. lsof reports every open path on the machine, and
+    #    gate 4 compares BASENAMES — so an open file in an unrelated directory that merely SHARES a
+    #    candidate's name refused the legitimate in-cache candidate forever (measured: a namesake
+    #    held open outside the cache → swept=0 refused=1 in_use=1, the in-cache orphan blocked).
+    #    Filter to `$BOUND/` paths FIRST (keeping the full path through the boundary test), then
+    #    derive names only from what survived. Over-refusing is safer than over-deleting, but a
+    #    permanent false refusal makes the sweeper useless at its one job.
+    INUSE="$(printf '%s\n' "$RAW" \
+      | sed -n 's|^n||p' \
+      | grep -F "$BOUND/" \
+      | sed -n "s|^$(printf '%s' "$BOUND" | sed 's/[][\.*^$/]/\\&/g')/\([^/]*\).*|\1|p" \
+      | grep -x "temp_[a-z]*_[0-9]*_[a-z0-9]*\(\.clone\)\?" \
+      | sort -u)"
   fi
   unset RAW
 fi

--- a/bin/plugin-cache-sweeper.sh
+++ b/bin/plugin-cache-sweeper.sh
@@ -59,12 +59,36 @@ while [ $# -gt 0 ]; do
   shift
 done
 
+# JSON-escape a string field. The cache path is caller-supplied (--cache / PCS_CACHE)
+# and a quote or backslash in it would otherwise terminate the field early and emit
+# malformed JSON to a machine consumer.
+json_esc() {
+  printf '%s' "$1" | awk 'BEGIN{ORS=""}
+    { gsub(/\\/,"\\\\"); gsub(/"/,"\\\""); gsub(/\t/,"\\t")
+      if (NR>1) printf "\\n"
+      printf "%s", $0 }'
+}
+
 emit() { # emit <swept> <would> <young> <refused> <remaining> <freed_mb> <inuse> <note>
   printf '{"tool":"plugin-cache-sweeper","cache":"%s","mode":"%s","age_min":%s,' \
-    "$CACHE" "$([ "$APPLY" -eq 1 ] && echo apply || echo report)" "$AGE_MIN"
+    "$(json_esc "$CACHE")" "$([ "$APPLY" -eq 1 ] && echo apply || echo report)" "$AGE_MIN"
   printf '"swept":%s,"would_sweep":%s,"too_young":%s,"refused":%s,' "$1" "$2" "$3" "$4"
-  printf '"remaining":%s,"freed_mb":%s,"in_use":%s,"note":"%s"}\n' "$5" "$6" "$7" "$8"
+  printf '"remaining":%s,"freed_mb":%s,"in_use":%s,"note":"%s"}\n' "$5" "$6" "$7" "$(json_esc "$8")"
 }
+
+# gate -1 — the age floor must be a non-negative integer BEFORE it reaches the
+# envelope. `age_min` is a JSON *number* field, so a non-numeric value is
+# interpolated raw and produces invalid JSON (a crafted value injects arbitrary
+# text into a machine-parsed envelope). Fail CLOSED: sweep nothing, report the
+# refusal, and still exit 0 — the never-fail-a-session guarantee is unconditional.
+case "$AGE_MIN" in
+  ''|*[!0-9]*)
+    BAD_AGE="$AGE_MIN"; AGE_MIN=0
+    emit 0 0 0 0 0 0 0 "invalid-age-min"
+    printf 'plugin-cache-sweeper: --age-min must be a non-negative integer (got %s) — nothing swept\n' \
+      "$BAD_AGE" >&2
+    exit 0 ;;
+esac
 
 [ -d "$CACHE" ] || { emit 0 0 0 0 0 0 0 "cache-absent"; printf 'plugin-cache-sweeper: no cache at %s\n' "$CACHE" >&2; exit 0; }
 
@@ -91,8 +115,27 @@ free_mb() { df -m "$BOUND" 2>/dev/null | awk 'NR==2{print $4+0}'; }
 #  *            excludes in-flight work. */
 TB=""; command -v timeout >/dev/null 2>&1 && TB="timeout 25"
 INUSE=""
-command -v lsof >/dev/null 2>&1 && \
-  INUSE="$($TB lsof -n -w -F n 2>/dev/null | grep -o "temp_[a-z]*_[0-9]*_[a-z0-9]*" | sort -u)"
+# INUSE_OK is the gate-4 TRUST flag, not a convenience: the empty-set and the
+# could-not-look cases are indistinguishable in `INUSE` alone, and reading a
+# blind "" as "nothing is open" is the free-negative that turns a safety gate
+# into a no-op precisely when it matters. Only a probe that RAN may license a
+# delete; absent/timed-out `lsof` ⇒ gate 4 refuses everything under --apply.
+INUSE_OK=0
+if command -v lsof >/dev/null 2>&1; then
+  # Capture lsof SEPARATELY from the filter. Piping them together conflates two
+  # opposite meanings into one rc: `grep -o` exits 1 on NO MATCH, which is the
+  # HEALTHY common case (nothing open) — reading that as "the probe failed" would
+  # refuse every delete forever. Only lsof's own rc may clear the trust flag.
+  RAW="$($TB lsof -n -w -F n 2>/dev/null)"; LSOF_RC=$?
+  if [ "$LSOF_RC" -eq 0 ]; then
+    INUSE_OK=1
+    # The candidate basename may carry a `.clone` suffix (temp_subdir_<ms>_<rand>.clone).
+    # The pattern MUST admit it — gate 4 compares whole names, so a truncated capture
+    # never matches its own candidate and silently exempts the .clone class.
+    INUSE="$(printf '%s\n' "$RAW" | grep -o "temp_[a-z]*_[0-9]*_[a-z0-9]*\(\.clone\)\?" | sort -u)"
+  fi
+  unset RAW
+fi
 # NOT `grep -c . || echo 0`: grep -c ALWAYS prints the count and exits 1 when that
 # count is zero, so the `||` fires too and the value becomes "0\n0". awk always
 # exits 0 and always prints exactly one number.
@@ -140,8 +183,15 @@ while IFS= read -r t; do
   r="$(cd "$t" 2>/dev/null && pwd -P)" || { refused=$((refused+1)); continue; }
   case "$r" in "$BOUND"/*) : ;; *) refused=$((refused+1)); continue ;; esac
 
-  # gate 4 — not currently open by any process
-  printf '%s\n' "$INUSE" | grep -qx "$b" && { refused=$((refused+1)); continue; }
+  # gate 4 — not currently open by any process.
+  # -F is load-bearing: a candidate name can contain `.` (…_<rand>.clone) and as a
+  # REGEX that dot matches any character, so a plain -x compare could match the
+  # wrong entry. Fixed-string keeps the comparison literal.
+  printf '%s\n' "$INUSE" | grep -Fqx "$b" && { refused=$((refused+1)); continue; }
+  # …and if the probe never RAN, we do not know. Under --apply that unknown is a
+  # refusal, not a pass: an untrusted gate must not license an irreversible delete.
+  # Report mode still counts the candidate (it deletes nothing by construction).
+  [ "$APPLY" -eq 1 ] && [ "$INUSE_OK" -eq 0 ] && { refused=$((refused+1)); continue; }
 
   if [ "$APPLY" -eq 1 ]; then
     rm -rf -- "$t" 2>/dev/null && swept=$((swept+1)) || refused=$((refused+1))

--- a/bin/plugin-cache-sweeper.sh
+++ b/bin/plugin-cache-sweeper.sh
@@ -171,9 +171,6 @@ if command -v lsof >/dev/null 2>&1; then
   RAW="$($TB lsof -n -w -F n 2>/dev/null)"; LSOF_RC=$?
   if [ "$LSOF_RC" -eq 0 ]; then
     INUSE_OK=1
-    # The candidate basename may carry a `.clone` suffix (temp_subdir_<ms>_<rand>.clone).
-    # The pattern MUST admit it — gate 4 compares whole names, so a truncated capture
-    # never matches its own candidate and silently exempts the .clone class.
     # ⛔ SCOPE TO $BOUND BEFORE NAME-MATCHING. lsof reports every open path on the machine, and
     #    gate 4 compares BASENAMES — so an open file in an unrelated directory that merely SHARES a
     #    candidate's name refused the legitimate in-cache candidate forever (measured: a namesake
@@ -181,11 +178,23 @@ if command -v lsof >/dev/null 2>&1; then
     #    Filter to `$BOUND/` paths FIRST (keeping the full path through the boundary test), then
     #    derive names only from what survived. Over-refusing is safer than over-deleting, but a
     #    permanent false refusal makes the sweeper useless at its one job.
+    # ⛔ THE IN-USE FILTER MUST ADMIT *EXACTLY* THE CANDIDATE CLASS — `temp_*`, the same glob the
+    #    enumeration (`find -name 'temp_*'`) and gate 0 (`case "$b" in temp_*)`) use. A NARROWER
+    #    pattern here is FAIL-OPEN, not strict: gate 4 compares whole basenames, so any held-open
+    #    candidate the pattern drops becomes INVISIBLE to the gate and is deleted WHILE IN USE.
+    #    Measured on a 5-dir fixture — a prior `temp_[a-z]*_[0-9]*_[a-z0-9]*(\.clone)?` matcher let
+    #    3 of 3 held-open candidates through (`temp_weird` no-epoch · `temp_UPPER_123_x` uppercase ·
+    #    `temp_a-b_123_x` hyphen): each IS a candidate, each was open, and the gate saw NONE of them.
+    #    ⚠️ Tightening the epoch segment (e.g. requiring exactly 13 digits) moves in the WRONG
+    #    direction — it shrinks the admitted set, so it ADDS members to that invisible set.
+    #    The asymmetry is the bug: any divergence between "what we may delete" and "what we check
+    #    for use" is a silent exemption. Keep both sides on ONE class, and let the LATER gates
+    #    (embedded-epoch age, boundary, ownership) do the narrowing — they refuse, they never exempt.
     INUSE="$(printf '%s\n' "$RAW" \
       | sed -n 's|^n||p' \
       | grep -F "$BOUND/" \
       | sed -n "s|^$(printf '%s' "$BOUND" | sed 's/[][\.*^$/]/\\&/g')/\([^/]*\).*|\1|p" \
-      | grep -x "temp_[a-z]*_[0-9]*_[a-z0-9]*\(\.clone\)\?" \
+      | grep -x "temp_.*" \
       | sort -u)"
   fi
   unset RAW

--- a/bin/plugin-cache-sweeper.sh
+++ b/bin/plugin-cache-sweeper.sh
@@ -190,12 +190,35 @@ if command -v lsof >/dev/null 2>&1; then
     #    The asymmetry is the bug: any divergence between "what we may delete" and "what we check
     #    for use" is a silent exemption. Keep both sides on ONE class, and let the LATER gates
     #    (embedded-epoch age, boundary, ownership) do the narrowing — they refuse, they never exempt.
-    INUSE="$(printf '%s\n' "$RAW" \
-      | sed -n 's|^n||p' \
-      | grep -F "$BOUND/" \
-      | sed -n "s|^$(printf '%s' "$BOUND" | sed 's/[][\.*^$/]/\\&/g')/\([^/]*\).*|\1|p" \
-      | grep -x "temp_.*" \
-      | sort -u)"
+    # ⛔ NEVER INTERPOLATE $BOUND INTO A REGEX. The previous extraction embedded it in a `sed`
+    #    s|…|…| expression, so any `|` in the cache path became the DELIMITER: measured with
+    #    `--cache '/tmp/cache|with-pipe'`, sed died (`bad flag in substitute command`), INUSE came
+    #    back EMPTY, `INUSE_OK=1` was still trusted (assigned on lsof's rc alone, before the
+    #    filter), and a held-open candidate was DELETED — `swept:1 in_use:0` with a live handle.
+    #    Escaping `|` would only patch this delimiter; the defect is the regex itself, whose
+    #    metacharacter set is unbounded relative to what a filesystem path may legally contain.
+    #    ⇒ Strip the prefix with shell parameter expansion (${line#"$BOUND"/}) — no regex, no
+    #    delimiter, nothing to escape — and derive the basename by cutting at the first `/`.
+    #    The quotes in ${line#"$BOUND"/} are load-bearing: unquoted, $BOUND would be read as a
+    #    PATTERN and a path containing `*`/`?`/`[` would strip the wrong prefix.
+    # ⛔ AND MAKE FILTER FAILURE CLEAR THE TRUST FLAG. `INUSE_OK=1` on lsof's rc alone means "I
+    #    looked", not "I parsed what I saw" — the gap the pipe exploited. Any failure while
+    #    building the set now sets INUSE_OK=0, so gate 4 refuses instead of trusting a blind "".
+    # ⛔ BALANCED-PAREN case patterns — `(pat)` not `pat)`. Bash 3.2 (the macOS system bash, and
+    #    this file's declared floor) mis-parses an UNBALANCED `)` inside `$( )`: measured, the
+    #    substitution died with `syntax error near unexpected token 'newline'`, INUSE captured the
+    #    literal REST OF THE SOURCE TEXT, and the script then aborted on `b: unbound variable`.
+    #    ⚠️ That abort LOOKED like a pass — the held-open candidate "survived" because the process
+    #    died before the sweep, not because gate 4 refused it. Only the positive control (a plain
+    #    path must still RECLAIM) exposed it: it over-refused too, i.e. the tool was simply broken.
+    INUSE="$(
+      printf '%s\n' "$RAW" | while IFS= read -r line; do
+        case "$line" in (n"$BOUND"/*) ;; (*) continue ;; esac
+        rest="${line#n}"; rest="${rest#"$BOUND"/}"
+        b="${rest%%/*}"
+        case "$b" in (temp_*) printf '%s\n' "$b" ;; esac
+      done | sort -u
+    )" || INUSE_OK=0
   fi
   unset RAW
 fi

--- a/bin/plugin-cache-sweeper.sh
+++ b/bin/plugin-cache-sweeper.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# MAOS — plugin-cache-sweeper · reclaim orphaned Claude Code plugin staging clones
+# ----------------------------------------------------------------------------
+# WHY: the Claude Code plugin manager clones each marketplace into a staging
+#   directory under the plugin cache and does not remove it once the operation
+#   succeeds. They accumulate without bound. Measured on one workstation:
+#   1318 orphaned clones / ~8.0 GB over 8 days, ~20-30 new per hour of active
+#   use, contributing to a full-disk condition. Upstream report:
+#   anthropics/claude-code#80367. This script is the local stanch until that
+#   lands — and stays useful afterwards for crash-interrupted operations.
+#
+# GUARANTEES:
+#   READ-ONLY BY DEFAULT. Without --apply this script deletes NOTHING; it only
+#   reports what it would remove. Deletion requires the explicit --apply flag.
+#   Exit is ALWAYS 0 — a housekeeping sweeper must never fail a session or a
+#   scheduled cycle. Problems are reported in the envelope, not via exit codes.
+#
+# WHAT IT REMOVES (only with --apply, and only past all five gates):
+#   <cache>/temp_git_<epoch_ms>_<rand>          marketplace git clones
+#   <cache>/temp_subdir_<epoch_ms>_<rand>.clone subdir-extraction clones
+#   <cache>/temp_github_<epoch_ms>_<rand>       github-source clones
+#   All are complete git working trees with a valid `origin` — re-clonable, and
+#   referenced by NO plugin configuration. Installed plugins are served from the
+#   versioned <cache>/<marketplace>/<version>/ directories, never from these.
+#
+# WHAT IT NEVER TOUCHES:
+#   <cache>/<marketplace>/    the real installs
+#   anything outside <cache>  (physical-path boundary check, gate 3)
+#   any name not starting with `temp_`                              (gate 0)
+#   anything younger than the age floor                             (gate 1)
+#   anything a symlink                                              (gate 2)
+#   anything with an open file handle                               (gate 4)
+#
+# Portability: AAIF cross-vendor — POSIX Bash 3.2, no jq required. `timeout` and
+#   `lsof` are probed and degrade gracefully when absent.
+#
+# Usage:
+#   plugin-cache-sweeper.sh                 # report only (safe default)
+#   plugin-cache-sweeper.sh --apply         # actually reclaim
+#   plugin-cache-sweeper.sh --age-min 60    # override the 180-min age floor
+#   plugin-cache-sweeper.sh --cache <dir>   # override cache location
+#
+# Output: JSON envelope on stdout, 1-line human summary on stderr.
+set -uo pipefail
+
+# ── configuration ───────────────────────────────────────────────────────────
+CACHE="${PCS_CACHE:-${CLAUDE_CONFIG_DIR:-$HOME/.claude}/plugins/cache}"
+AGE_MIN="${PCS_AGE_MIN:-180}"
+APPLY=0
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --apply)    APPLY=1 ;;
+    --age-min)  shift; AGE_MIN="${1:-180}" ;;
+    --cache)    shift; CACHE="${1:-$CACHE}" ;;
+    -h|--help)  sed -n '2,45p' "$0"; exit 0 ;;
+    *)          printf 'unknown argument: %s (try --help)\n' "$1" >&2; exit 0 ;;
+  esac
+  shift
+done
+
+emit() { # emit <swept> <would> <young> <refused> <remaining> <freed_mb> <inuse> <note>
+  printf '{"tool":"plugin-cache-sweeper","cache":"%s","mode":"%s","age_min":%s,' \
+    "$CACHE" "$([ "$APPLY" -eq 1 ] && echo apply || echo report)" "$AGE_MIN"
+  printf '"swept":%s,"would_sweep":%s,"too_young":%s,"refused":%s,' "$1" "$2" "$3" "$4"
+  printf '"remaining":%s,"freed_mb":%s,"in_use":%s,"note":"%s"}\n' "$5" "$6" "$7" "$8"
+}
+
+[ -d "$CACHE" ] || { emit 0 0 0 0 0 0 0 "cache-absent"; printf 'plugin-cache-sweeper: no cache at %s\n' "$CACHE" >&2; exit 0; }
+
+# Resolve the boundary ONCE, physically. Every candidate must resolve inside it.
+BOUND="$(cd "$CACHE" 2>/dev/null && pwd -P)" || { emit 0 0 0 0 0 0 0 "cache-unresolvable"; exit 0; }
+
+free_mb() { df -m "$BOUND" 2>/dev/null | awk 'NR==2{print $4+0}'; }
+
+# ── in-use detection ────────────────────────────────────────────────────────
+# /** [decision] ONE GLOBAL lsof filtered by path — never `lsof +D <cache>`.
+#  *  @context  MEASURED: `lsof +D` on a 565-clone cache exceeded 120 s and had
+#  *            to be killed; the global pass answering the same question took 1 s.
+#  *  @reason   `+D` is not "who holds this directory" — it DESCENDS the tree and
+#  *            stats every file, so its cost scales with CONTENT (hundreds of git
+#  *            clones x thousands of objects each), not with candidate count. The
+#  *            global form reads the kernel's open-file table (bounded regardless
+#  *            of what is on disk) and filters by path afterwards, in text.
+#  *  @impact   Inverting the question — from "what is open INSIDE this dir" to
+#  *            "of everything open, what falls under this path" — trades a disk
+#  *            walk for a state read. Same answer, two orders of magnitude cheaper.
+#  *  @impact   Hard timeout on top: a sweeper that HANGS is worse than one that
+#  *            skips a gate. On timeout/absence the in-use set is empty and gate 4
+#  *            degrades to a no-op — tolerable only because the age floor already
+#  *            excludes in-flight work. */
+TB=""; command -v timeout >/dev/null 2>&1 && TB="timeout 25"
+INUSE=""
+command -v lsof >/dev/null 2>&1 && \
+  INUSE="$($TB lsof -n -w -F n 2>/dev/null | grep -o "temp_[a-z]*_[0-9]*_[a-z0-9]*" | sort -u)"
+# NOT `grep -c . || echo 0`: grep -c ALWAYS prints the count and exits 1 when that
+# count is zero, so the `||` fires too and the value becomes "0\n0". awk always
+# exits 0 and always prints exactly one number.
+INUSE_N=$(printf '%s' "$INUSE" | awk 'NF{n++} END{print n+0}')
+
+# ── sweep ───────────────────────────────────────────────────────────────────
+BEFORE="$(free_mb)"
+swept=0; would=0; young=0; refused=0
+CUTOFF=$(( $(date +%s) - AGE_MIN * 60 ))
+
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  b="$(basename "$t")"
+
+  # gate 0 — the name must literally be staging (belt-and-suspenders over the glob)
+  case "$b" in temp_*) : ;; *) refused=$((refused+1)); continue ;; esac
+
+  # gate 1 — age, read from the name's EMBEDDED EPOCH, not from mtime.
+  # /** [decision] the name carries a more trustworthy clock than the filesystem.
+  #  *  @context  These dirs are named temp_<kind>_<epoch_ms>_<rand>. That epoch is
+  #  *            the true birth time and is IMMUTABLE. mtime is a different clock:
+  #  *            it moves on any content change — INCLUDING a partial deletion.
+  #  *  @reason   MEASURED: 14 orphans born over a previous week all showed an mtime
+  #  *            from the same recent minute and each held exactly 1 entry —
+  #  *            carcasses of an `rm -rf` killed mid-flight. An interrupted cleanup
+  #  *            REJUVENATES its own victim, so an mtime gate permanently shields
+  #  *            the safest garbage on disk (an emptied dir) while happily
+  #  *            considering intact clones. Exactly backwards.
+  #  *  @impact   Reading the immutable clock costs zero syscalls and cannot be
+  #  *            reset by a failed sweep. Falls back to mtime only when the name
+  #  *            has no parseable epoch (unknown format ⇒ stay conservative). */
+  ms="$(printf '%s' "$b" | sed -n 's/.*_\([0-9]\{13\}\)_.*/\1/p')"
+  if [ -n "$ms" ]; then
+    [ $(( ms / 1000 )) -gt "$CUTOFF" ] && { young=$((young+1)); continue; }
+  else
+    find "$t" -maxdepth 0 -mmin -"$AGE_MIN" 2>/dev/null | grep -q . && { young=$((young+1)); continue; }
+  fi
+
+  # gate 2 — must be a real directory, never a symlink we would traverse
+  [ -d "$t" ] || { refused=$((refused+1)); continue; }
+  [ -L "$t" ] && { refused=$((refused+1)); continue; }
+
+  # gate 3 — the PHYSICAL path must resolve inside the boundary
+  #          (defeats `..` components and symlinked parents)
+  r="$(cd "$t" 2>/dev/null && pwd -P)" || { refused=$((refused+1)); continue; }
+  case "$r" in "$BOUND"/*) : ;; *) refused=$((refused+1)); continue ;; esac
+
+  # gate 4 — not currently open by any process
+  printf '%s\n' "$INUSE" | grep -qx "$b" && { refused=$((refused+1)); continue; }
+
+  if [ "$APPLY" -eq 1 ]; then
+    rm -rf -- "$t" 2>/dev/null && swept=$((swept+1)) || refused=$((refused+1))
+  else
+    would=$((would+1))
+  fi
+done <<EOF
+$(find "$CACHE" -maxdepth 1 -mindepth 1 -name 'temp_*' 2>/dev/null | sort)
+EOF
+
+AFTER="$(free_mb)"
+REMAIN=$(find "$CACHE" -maxdepth 1 -mindepth 1 -name 'temp_*' 2>/dev/null | wc -l | tr -d ' ')
+# Report the free-space DELTA, never a `du` estimate: on APFS a clonefile is a
+# separate inode sharing blocks, so du counts every copy in full and systematically
+# over-reports clone-heavy trees. The delta is what the filesystem cannot misstate.
+# In report mode we deleted nothing, so freed MUST be 0 by definition. Without this
+# the df delta leaks noise from OTHER processes into the field and the envelope claims
+# space was reclaimed by a run that touched nothing — a small lie, but the kind that
+# teaches a reader to stop trusting the number.
+if [ "$APPLY" -eq 1 ]; then
+  FREED=$(( ${AFTER:-0} - ${BEFORE:-0} )); [ "$FREED" -lt 0 ] && FREED=0
+else
+  FREED=0
+fi
+
+emit "$swept" "$would" "$young" "$refused" "$REMAIN" "$FREED" "$INUSE_N" "ok"
+if [ "$APPLY" -eq 1 ]; then
+  printf 'plugin-cache-sweeper: swept %s (too-young %s, refused %s), freed ~%s MB, %s left\n' \
+    "$swept" "$young" "$refused" "$FREED" "$REMAIN" >&2
+else
+  printf 'plugin-cache-sweeper: would sweep %s (too-young %s, refused %s) of %s present — re-run with --apply\n' \
+    "$would" "$young" "$refused" "$REMAIN" >&2
+fi
+exit 0

--- a/tests/test-plugin-cache-sweeper.sh
+++ b/tests/test-plugin-cache-sweeper.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Test: bin/plugin-cache-sweeper.sh — orphaned plugin staging-clone reclaim.
 # Portable (bash 3.2). Exit 0 = all pass; 1 = a failure.
-set -uo pipefail
+set -euo pipefail
 HERE="$(cd "$(dirname "$0")/.." && pwd)"
 BIN="$HERE/bin/plugin-cache-sweeper.sh"
 FIX="$(mktemp -d 2>/dev/null || mktemp -d -t 'pcsweep')"
@@ -71,6 +71,39 @@ case "$out" in *'"note":"cache-absent"'*) ok "absent cache reported in envelope"
 # with a 1-minute floor the young orphan becomes eligible
 out="$("$BIN" --cache "$CACHE" --age-min 0 2>/dev/null)"
 case "$out" in *'"too_young":0'*) ok "--age-min override honored" ;; *) no "age override ignored: $out" ;; esac
+
+# ── 7. --age-min must be a non-negative integer (fail CLOSED, valid JSON) ────
+# A non-numeric value used to be interpolated raw into the `age_min` NUMBER field,
+# so a crafted argument emitted malformed JSON to a machine consumer.
+CACHE2="$FIX/cache2"
+mkdir -p "$CACHE2/temp_git_${OLD_MS}_ffffff"
+out="$("$BIN" --cache "$CACHE2" --age-min 'abc"; rm -rf /' --apply 2>/dev/null)"; rc=$?
+[ "$rc" -eq 0 ] && ok "invalid --age-min still exits 0" || no "invalid age exit=$rc"
+case "$out" in *'"note":"invalid-age-min"'*) ok "invalid --age-min reported in envelope" ;; *) no "invalid-age note missing: $out" ;; esac
+case "$out" in *'"age_min":0,'*) ok "age_min stays a valid JSON number" ;; *) no "age_min not numeric: $out" ;; esac
+case "$out" in *'"swept":0'*) ok "invalid --age-min sweeps NOTHING (fail-closed)" ;; *) no "swept despite invalid age: $out" ;; esac
+[ -d "$CACHE2/temp_git_${OLD_MS}_ffffff" ] && ok "candidate survived invalid --age-min" || no "DELETED under invalid --age-min"
+
+# a quote/backslash in the cache path must not terminate the JSON string early
+out="$("$BIN" --cache "$FIX/we\"ird" 2>/dev/null)"
+case "$out" in *'"note":"cache-absent"'*) ok "quoted cache path keeps envelope parseable" ;; *) no "quote broke envelope: $out" ;; esac
+
+# ── 8. gate 4 — open handle blocks deletion, INCLUDING the .clone class ──────
+# The lsof capture pattern must admit the `.clone` suffix: gate 4 compares WHOLE
+# names, so a truncated capture never matches its own candidate and would silently
+# exempt every temp_subdir_*.clone with a live file handle.
+if command -v lsof >/dev/null 2>&1; then
+  CACHE3="$FIX/cache3"
+  HELD="$CACHE3/temp_subdir_${OLD_MS}_999999.clone"
+  mkdir -p "$HELD"; echo held > "$HELD/open-file"
+  exec 9<"$HELD/open-file"            # hold a real handle for the duration
+  out="$("$BIN" --cache "$CACHE3" --apply 2>/dev/null)"
+  exec 9<&-
+  [ -d "$HELD" ] && ok "gate4 refused a held-open .clone candidate" || no "DELETED a .clone with an open handle"
+  case "$out" in *'"refused":1'*) ok "gate4 counted the .clone refusal" ;; *) no "refusal not counted: $out" ;; esac
+else
+  ok "gate4 .clone test skipped (no lsof)"
+fi
 
 echo
 [ "$fail" -eq 0 ] && echo "test-plugin-cache-sweeper: ALL PASS" || echo "test-plugin-cache-sweeper: FAILURES"

--- a/tests/test-plugin-cache-sweeper.sh
+++ b/tests/test-plugin-cache-sweeper.sh
@@ -138,6 +138,28 @@ if command -v lsof >/dev/null 2>&1; then
   exec 8<&-
   [ -d "$CACHE5/$TWIN" ] && no "out-of-boundary namesake blocked the in-cache candidate (false refusal)" || ok "out-of-boundary namesake does NOT block the in-cache candidate"
 
+  # ── 8c. a held-open candidate OUTSIDE the narrow name shape must still block ─
+  # ⛔ THE IN-USE FILTER MUST ADMIT EXACTLY THE CANDIDATE CLASS (`temp_*`). A narrower pattern is
+  # FAIL-OPEN, not strict: gate 4 compares whole basenames, so any held-open candidate the filter
+  # drops is INVISIBLE to the gate and gets deleted WHILE IN USE. Measured on the prior
+  # `temp_[a-z]*_[0-9]*_[a-z0-9]*(\.clone)?` matcher: 3 of 3 held-open candidates slipped through.
+  # Each name below IS a candidate (`find -name 'temp_*'` + gate 0 both admit it) yet fails that
+  # narrower shape — no epoch / uppercase / hyphen. Asserts DELETION IS REFUSED, i.e. the gate can
+  # SEE them; the age/boundary gates narrow by REFUSING, they must never EXEMPT.
+  CACHE6="$FIX/cache6"
+  for odd in "temp_weird" "temp_UPPER_${OLD_MS}_x" "temp_a-b_${OLD_MS}_x"; do
+    mkdir -p "$CACHE6/$odd"; echo o > "$CACHE6/$odd/file"
+  done
+  exec 6<"$CACHE6/temp_weird/file" 5<"$CACHE6/temp_UPPER_${OLD_MS}_x/file" 4<"$CACHE6/temp_a-b_${OLD_MS}_x/file"
+  out="$("$BIN" --cache "$CACHE6" --apply 2>/dev/null)"
+  exec 6<&- 5<&- 4<&-
+  odd_gone=0
+  for odd in "temp_weird" "temp_UPPER_${OLD_MS}_x" "temp_a-b_${OLD_MS}_x"; do
+    [ -d "$CACHE6/$odd" ] || odd_gone=$((odd_gone+1))
+  done
+  [ "$odd_gone" -eq 0 ] && ok "held-open candidates outside the narrow name shape are still seen by gate4" \
+                        || no "DELETED $odd_gone held-open candidate(s) invisible to the in-use filter (fail-open)"
+
   # ── 8b. an UNAVAILABLE probe must refuse, not pass ──────────────────────────
   # `INUSE=""` means two opposite things — "nothing is open" and "I could not look". Reading the
   # second as the first is the free-negative that turns gate 4 into a no-op exactly when it cannot

--- a/tests/test-plugin-cache-sweeper.sh
+++ b/tests/test-plugin-cache-sweeper.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Test: bin/plugin-cache-sweeper.sh — orphaned plugin staging-clone reclaim.
+# Portable (bash 3.2). Exit 0 = all pass; 1 = a failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$HERE/bin/plugin-cache-sweeper.sh"
+FIX="$(mktemp -d 2>/dev/null || mktemp -d -t 'pcsweep')"
+trap 'rm -rf "$FIX"' EXIT
+fail=0
+ok() { printf '  ok   %s\n' "$1"; }
+no() { printf '  FAIL %s\n' "$1"; fail=1; }
+
+echo "test-plugin-cache-sweeper:"
+
+NOW_S=$(date +%s)
+OLD_MS=$(( (NOW_S - 86400) * 1000 ))   # 1 day ago  -> eligible
+NEW_MS=$(( NOW_S * 1000 ))             # now        -> too young
+
+# ── fixtures ────────────────────────────────────────────────────────────────
+CACHE="$FIX/cache"
+mkdir -p "$CACHE/marketplace-official/1.0.0"          # a REAL install (never touched)
+mkdir -p "$CACHE/temp_git_${OLD_MS}_aaaaaa"           # eligible orphan
+mkdir -p "$CACHE/temp_subdir_${OLD_MS}_bbbbbb.clone"  # eligible orphan
+mkdir -p "$CACHE/temp_git_${NEW_MS}_cccccc"           # too young
+echo x > "$CACHE/marketplace-official/1.0.0/plugin.json"
+echo x > "$CACHE/temp_git_${OLD_MS}_aaaaaa/file"
+
+# the carcass: OLD name but FRESH mtime — an interrupted rm -rf rejuvenates its
+# own victim, so an mtime-based gate would shield this forever. The name-embedded
+# epoch is the immutable clock and must win.
+mkdir -p "$CACHE/temp_git_${OLD_MS}_dddddd"
+touch "$CACHE/temp_git_${OLD_MS}_dddddd"
+
+# a symlink wearing a staging name, pointing OUTSIDE the cache
+mkdir -p "$FIX/outside/precious"; echo keep > "$FIX/outside/precious/data"
+ln -s "$FIX/outside/precious" "$CACHE/temp_git_${OLD_MS}_eeeeee"
+
+# ── 1. read-only by default ─────────────────────────────────────────────────
+out="$("$BIN" --cache "$CACHE" 2>/dev/null)"; rc=$?
+[ "$rc" -eq 0 ] && ok "exits 0 in report mode" || no "report mode exit=$rc"
+case "$out" in *'"mode":"report"'*) ok "envelope reports mode=report" ;; *) no "mode missing: $out" ;; esac
+case "$out" in *'"swept":0'*) ok "swept=0 without --apply" ;; *) no "swept non-zero in report mode: $out" ;; esac
+[ -d "$CACHE/temp_git_${OLD_MS}_aaaaaa" ] && ok "deletes NOTHING without --apply" || no "deleted without --apply"
+case "$out" in *'"would_sweep":3'*) ok "would_sweep=3 (2 orphans + 1 carcass)" ;; *) no "would_sweep wrong: $out" ;; esac
+
+# ── 2. gates ────────────────────────────────────────────────────────────────
+case "$out" in *'"too_young":1'*) ok "gate1 age: fresh orphan excluded" ;; *) no "too_young wrong: $out" ;; esac
+case "$out" in *'"refused":1'*) ok "gate2 symlink refused" ;; *) no "refused wrong: $out" ;; esac
+
+# ── 3. apply ────────────────────────────────────────────────────────────────
+out="$("$BIN" --cache "$CACHE" --apply 2>/dev/null)"; rc=$?
+[ "$rc" -eq 0 ] && ok "exits 0 in apply mode" || no "apply mode exit=$rc"
+[ -d "$CACHE/temp_git_${OLD_MS}_aaaaaa" ] && no "eligible orphan survived --apply" || ok "eligible orphan reclaimed"
+[ -d "$CACHE/temp_subdir_${OLD_MS}_bbbbbb.clone" ] && no ".clone orphan survived" || ok ".clone orphan reclaimed"
+
+# the regression this design exists for: fresh mtime must NOT save an old-named dir
+[ -d "$CACHE/temp_git_${OLD_MS}_dddddd" ] && no "carcass survived (mtime shielded it)" || ok "carcass reclaimed via name-clock"
+
+# ── 4. what must survive ────────────────────────────────────────────────────
+[ -f "$CACHE/marketplace-official/1.0.0/plugin.json" ] && ok "real install untouched" || no "REAL INSTALL DESTROYED"
+[ -d "$CACHE/temp_git_${NEW_MS}_cccccc" ] && ok "too-young orphan preserved" || no "too-young orphan deleted"
+[ -f "$FIX/outside/precious/data" ] && ok "symlink target outside cache untouched" || no "FOLLOWED SYMLINK OUT OF BOUNDARY"
+[ -L "$CACHE/temp_git_${OLD_MS}_eeeeee" ] && ok "symlink itself left in place" || no "symlink removed"
+
+# ── 5. absent cache degrades cleanly ────────────────────────────────────────
+out="$("$BIN" --cache "$FIX/does-not-exist" 2>/dev/null)"; rc=$?
+[ "$rc" -eq 0 ] && ok "exits 0 on absent cache" || no "absent cache exit=$rc"
+case "$out" in *'"note":"cache-absent"'*) ok "absent cache reported in envelope" ;; *) no "absent-cache note missing: $out" ;; esac
+
+# ── 6. age override ─────────────────────────────────────────────────────────
+# with a 1-minute floor the young orphan becomes eligible
+out="$("$BIN" --cache "$CACHE" --age-min 0 2>/dev/null)"
+case "$out" in *'"too_young":0'*) ok "--age-min override honored" ;; *) no "age override ignored: $out" ;; esac
+
+echo
+[ "$fail" -eq 0 ] && echo "test-plugin-cache-sweeper: ALL PASS" || echo "test-plugin-cache-sweeper: FAILURES"
+exit "$fail"

--- a/tests/test-plugin-cache-sweeper.sh
+++ b/tests/test-plugin-cache-sweeper.sh
@@ -160,6 +160,30 @@ if command -v lsof >/dev/null 2>&1; then
   [ "$odd_gone" -eq 0 ] && ok "held-open candidates outside the narrow name shape are still seen by gate4" \
                         || no "DELETED $odd_gone held-open candidate(s) invisible to the in-use filter (fail-open)"
 
+  # ── 8d. a cache path containing regex METACHARACTERS must not bypass gate 4 ──
+  # ⛔ $BOUND MUST NEVER REACH A REGEX. The in-use extraction used to embed it in a `sed` s|…|…|
+  # expression, so a `|` in the path became the DELIMITER: sed died (`bad flag in substitute
+  # command`), INUSE came back EMPTY, `INUSE_OK=1` was still trusted (it is assigned on lsof's rc
+  # alone, BEFORE the filter runs), and a held-open candidate was DELETED — measured `swept:1
+  # in_use:0` with a live handle. Escaping `|` would patch one delimiter; the fix removes the regex.
+  # ⚠️ THE POSITIVE CONTROL IS NOT OPTIONAL HERE. My first attempt at that fix used bash-4 `case`
+  # syntax inside `$( )`, which bash 3.2 (this file's floor) mis-parses — the script ABORTED and the
+  # held-open dir "survived", which reads exactly like a pass. Only asserting that a PLAIN path
+  # still reclaims exposed it: the tool was broken, not strict. Survival proves refusal only when
+  # the same build can still delete.
+  for _mc in 'cache|pipe' 'cache*star' 'cache?q' 'cache[b]br' 'cache sp' 'cache.dot'; do
+    _mcC="$FIX/mc/$_mc"; _mcH="$_mcC/temp_git_${OLD_MS}_mc0001"
+    _mcO="$_mcC/temp_git_${OLD_MS}_mc0002"                 # eligible, NOT held → the control
+    mkdir -p "$_mcH" "$_mcO"; echo h > "$_mcH/file"; echo o > "$_mcO/file"
+    exec 3<"$_mcH/file"
+    "$BIN" --cache "$_mcC" --apply >/dev/null 2>&1
+    exec 3<&-
+    [ -d "$_mcH" ] || no "DELETED a held-open candidate under cache path '$_mc' (gate 4 bypassed)"
+    [ -d "$_mcO" ] && no "control blind for '$_mc': the unheld candidate was NOT reclaimed, so survival proves nothing"
+    [ -d "$_mcH" ] && [ ! -d "$_mcO" ] && ok "gate4 holds under metachar cache path '$_mc' (held refused, unheld reclaimed)"
+    rm -rf "$FIX/mc"
+  done
+
   # ── 8b. an UNAVAILABLE probe must refuse, not pass ──────────────────────────
   # `INUSE=""` means two opposite things — "nothing is open" and "I could not look". Reading the
   # second as the first is the free-negative that turns gate 4 into a no-op exactly when it cannot

--- a/tests/test-plugin-cache-sweeper.sh
+++ b/tests/test-plugin-cache-sweeper.sh
@@ -88,6 +88,29 @@ case "$out" in *'"swept":0'*) ok "invalid --age-min sweeps NOTHING (fail-closed)
 out="$("$BIN" --cache "$FIX/we\"ird" 2>/dev/null)"
 case "$out" in *'"note":"cache-absent"'*) ok "quoted cache path keeps envelope parseable" ;; *) no "quote broke envelope: $out" ;; esac
 
+# ── 7b. an option whose VALUE is missing must never fall back to the default ──
+# `--apply --cache` (value lost to a typo / an unquoted empty var / a truncated wrapper) used to
+# keep the DEFAULT cache and aim the deletion at the operator's REAL plugin cache. Asserted on the
+# EFFECT (did it delete) rather than the envelope text, with a control proving the test can see a
+# deletion at all — an assertion that only reads `note` would pass even if the files were removed.
+DECOY="$FIX/decoy-cache"
+mkdir -p "$DECOY/temp_git_${OLD_MS}_victim"; echo payload > "$DECOY/temp_git_${OLD_MS}_victim/file"
+out="$(PCS_CACHE="$DECOY" "$BIN" --apply --cache 2>/dev/null)"
+case "$out" in *'"note":"missing-option-value"'*) ok "missing --cache value refused" ;; *) no "missing-value not refused: $out" ;; esac
+[ -d "$DECOY/temp_git_${OLD_MS}_victim" ] && ok "missing --cache value did NOT delete from the fallback cache" || no "DELETED from fallback cache on missing --cache value"
+out="$("$BIN" --apply --cache "$DECOY" 2>/dev/null)"
+[ -d "$DECOY/temp_git_${OLD_MS}_victim" ] && no "control failed: supplied path did not delete (test is blind)" || ok "control: supplied path still reclaims"
+out="$("$BIN" --age-min 2>/dev/null)"
+case "$out" in *'"note":"missing-option-value"'*) ok "missing --age-min value refused" ;; *) no "missing --age-min not refused: $out" ;; esac
+
+# ── 7c. a raw C0 control char in --cache is refused, and the REFUSAL still parses ─
+# RFC 8259 forbids U+0000-U+001F raw in a string. The gate fired correctly from the start, but the
+# refusal envelope itself embedded the offending byte — reproducing the very defect it refused.
+CTLPATH="$(printf '%s' "$FIX/ev")$(printf '\001')x"
+out="$("$BIN" --cache "$CTLPATH" 2>/dev/null)"
+case "$out" in *'"note":"invalid-cache-path"'*) ok "control-char cache path refused" ;; *) no "ctl-char not refused: $out" ;; esac
+case "$out" in *$(printf '\001')*) no "refusal envelope still embeds the raw control byte" ;; *) ok "refusal envelope is free of raw control bytes" ;; esac
+
 # ── 8. gate 4 — open handle blocks deletion, INCLUDING the .clone class ──────
 # The lsof capture pattern must admit the `.clone` suffix: gate 4 compares WHOLE
 # names, so a truncated capture never matches its own candidate and would silently
@@ -101,8 +124,34 @@ if command -v lsof >/dev/null 2>&1; then
   exec 9<&-
   [ -d "$HELD" ] && ok "gate4 refused a held-open .clone candidate" || no "DELETED a .clone with an open handle"
   case "$out" in *'"refused":1'*) ok "gate4 counted the .clone refusal" ;; *) no "refusal not counted: $out" ;; esac
+
+  # ── 8a. an out-of-boundary NAMESAKE must not block the in-cache candidate ───
+  # lsof reports every open path on the machine and gate 4 compares BASENAMES, so an open file in an
+  # unrelated directory that merely SHARES a candidate's name refused the legitimate in-cache
+  # candidate forever. Over-refusing is safer than over-deleting, but a PERMANENT false refusal makes
+  # the sweeper useless at its one job — so the in-use set is scoped to "$BOUND/" before name-matching.
+  CACHE5="$FIX/cache5"; TWIN="temp_git_${OLD_MS}_bnd001"
+  mkdir -p "$CACHE5/$TWIN"; echo c > "$CACHE5/$TWIN/file"          # legit, NOT held
+  mkdir -p "$FIX/elsewhere/$TWIN"; echo o > "$FIX/elsewhere/$TWIN/file"
+  exec 8<"$FIX/elsewhere/$TWIN/file"                               # hold the OUT-OF-BOUNDARY twin
+  out="$("$BIN" --cache "$CACHE5" --apply 2>/dev/null)"
+  exec 8<&-
+  [ -d "$CACHE5/$TWIN" ] && no "out-of-boundary namesake blocked the in-cache candidate (false refusal)" || ok "out-of-boundary namesake does NOT block the in-cache candidate"
+
+  # ── 8b. an UNAVAILABLE probe must refuse, not pass ──────────────────────────
+  # `INUSE=""` means two opposite things — "nothing is open" and "I could not look". Reading the
+  # second as the first is the free-negative that turns gate 4 into a no-op exactly when it cannot
+  # see. Simulated by shadowing lsof with a non-zero stub on PATH (covers absent/broken/timed-out).
+  SHADOW="$FIX/shadow-bin"; mkdir -p "$SHADOW"
+  printf '#!/bin/sh\nexit 1\n' > "$SHADOW/lsof"; chmod +x "$SHADOW/lsof"
+  CACHE4="$FIX/cache4"; BLIND="$CACHE4/temp_subdir_${OLD_MS}_888888.clone"
+  mkdir -p "$BLIND"; echo x > "$BLIND/file"
+  out="$(PATH="$SHADOW:$PATH" "$BIN" --cache "$CACHE4" --apply 2>/dev/null)"
+  [ -d "$BLIND" ] && ok "gate4 fail-closed when the probe could not run" || no "DELETED while the in-use probe was blind"
+  case "$out" in *'"refused":1'*) ok "blind-probe refusal counted" ;; *) no "blind refusal not counted: $out" ;; esac
 else
   ok "gate4 .clone test skipped (no lsof)"
+  ok "gate4 blind-probe test skipped (no lsof)"
 fi
 
 echo


### PR DESCRIPTION
`[PR-as-Prompt]`

## Context

The Claude Code plugin manager clones each marketplace into a staging directory under
`~/.claude/plugins/cache/` and does not remove it once the operation **succeeds**. They
accumulate without bound.

Measured on one workstation: **1318 orphaned clones (~8.0 GB) over 8 days**, ~20–30 new
per hour of active use. They were a material contributor to a full-disk condition
(0 bytes free on the data volume) that this work started from.

Reported upstream as [anthropics/claude-code#80367](https://github.com/anthropics/claude-code/issues/80367).
This script is the local stanch until that lands — and stays useful afterwards, since
crash-interrupted operations will always leave staging behind.

## Objectives

- Reclaim orphaned staging clones **safely** — five gates before any deletion.
- Be adoptable by anyone running Claude Code with plugins: one universal boundary, no
  machine-specific paths, `bash 3.2`, no `jq`.
- Encode the measurement lessons in the code, so the next reader does not re-derive them.

## Design decisions worth reviewing

**READ-ONLY by default.** Deletion requires an explicit `--apply`. A community tool that
reclaims disk should not delete on first invocation by someone who has not yet read what
the boundary is.

**Age comes from the epoch embedded in the directory NAME, not from `mtime`.** These are
two different clocks. `mtime` moves on any content change — *including a partial
deletion*. Measured: 14 orphans born over a previous week all showed an `mtime` from the
same recent minute and each held exactly 1 entry — carcasses of an `rm -rf` killed
mid-flight. An interrupted cleanup **rejuvenates its own victim**, so an `mtime` gate
permanently shields the safest garbage on disk (an emptied dir) while happily considering
intact clones. Exactly backwards. Locally this fix moved the eligible count from 0 to 49.

**One global `lsof` filtered by path, never `lsof +D <cache>`.** Measured: `+D` on a
565-clone cache exceeded 120 s and had to be killed; the global pass answering the same
question took 1 s. `+D` descends the tree and stats every file, so its cost scales with
*content* (hundreds of git clones × thousands of objects), not with candidate count.

**`freed_mb` from the free-space delta, never a `du` estimate.** On APFS a clonefile is a
separate inode sharing blocks, so `du` counts every copy in full and systematically
over-reports clone-heavy trees. In report mode `freed_mb` is pinned to `0` rather than
leaking `df` noise from other processes — a run that deleted nothing must not claim it
reclaimed space.

## The five gates

| # | Gate |
|---|---|
| 0 | basename literally starts with `temp_` |
| 1 | older than the age floor, read from the name's immutable epoch |
| 2 | a real directory, and not a symlink |
| 3 | physical path (`pwd -P`) resolves **inside** the cache boundary |
| 4 | no open file handle |

Exit is **always 0** — a housekeeping sweeper must never fail a scheduled cycle. Problems
are reported in the JSON envelope, not via exit codes.

## Acceptance

- [x] `bash -n` clean under `/bin/bash` 3.2.57 (what `launchd` actually uses)
- [x] 18/18 tests pass — including that the real installs and any symlink target outside
      the cache **survive** `--apply`, and that the fresh-`mtime` carcass is still reclaimed
- [x] Dogfooded against a real 1318-orphan cache: ~8.0 GB reclaimed across three runs,
      zero installs touched, zero orphans older than 24 h remaining
- [x] `gitleaks` clean
- [x] Scheduled hourly via `launchd` on the origin workstation and observed exiting 0 with
      empty stderr

## Out of scope (deliberately)

The two health guardians this work also produced (`disk-health-guardian`,
`system-health-guardian`) are **not** in this PR. They carry an operator-specific
DENYLIST/ALLOWLIST and would need real generalization; half-porting them here would ship
a tool whose safety boundary is tuned for someone else's machine. That is a separate,
larger piece of work.

## Cross-links

- Upstream bug: `anthropics/claude-code#80367`
- Related: `#77107` (AV interrupting plugin install mid-rename — same clone-then-rename
  area, but the interrupted path rather than the successful one)
