### PR TITLE
feat(EKO-116): memory-CRUD gateway (ADR-013 build phase)

### DIFF
--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -215,6 +215,19 @@ PY
   fi
 }
 
+# BOUNDARY THREAT MODEL (the 3 helpers below).
+#   These realpath guards defend the DELIBERATE-scope threat: a *pre-planted* symlink already in the
+#   corpus tree (a symlinked type-dir/topic-file/.archive) that would send a write/read/mv OUTSIDE
+#   CORPUS. That defense is exact under this gateway's core ADR-013 contract: the gateway is the ONE
+#   writer to the corpus, so the corpus tree is not being mutated by a cooperating peer mid-op (the
+#   corpus lock serializes gateway instances).
+#   OUT of scope — and NOT closable at this layer: a TOCTOU race by a *non-cooperating* process that
+#   holds write access to $CORPUS and swaps a validated ancestor for an external symlink between the
+#   check and the mkdir/mv. The gateway lock does NOT bind such a process. This is unsolvable at the
+#   application layer (a process with arbitrary write to $CORPUS can `rm -rf $CORPUS` outright); the
+#   real control is OS-level filesystem ownership/permissions — the corpus dir must be owned/writable
+#   ONLY by the gateway's uid. Deploy the corpus that way; these checks are the in-process complement,
+#   not a substitute for the filesystem-ownership invariant.
 _assert_within_corpus() {  # _assert_within_corpus <dest-path> — 0 iff the resolved parent dir stays inside canonical CORPUS
   local dir real                                   # (CORPUS is already `pwd -P` canonical; realpath here defeats a symlinked type-dir escape)
   dir="$(dirname "$1")"

--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -64,9 +64,21 @@ set -uo pipefail
 # ---------------------------------------------------------------------------
 # setup / tool probes
 # ---------------------------------------------------------------------------
-JQ="$(command -v jq || true)"
+# Binary resolution: PATH first (command -v), then known absolute candidates. launchd/cron strip PATH to a
+# minimal set, and this gateway is designed for UNATTENDED/hook invocation, so a bare `command -v` would make
+# it spuriously fail there. Candidates cover macOS Homebrew (arm+intel), system, and common Linux locations.
+_resolve_bin() {  # _resolve_bin <name> <abs-candidate>...  -> prints an absolute path, or nothing (rc 1)
+  local p; p="$(command -v "$1" 2>/dev/null || true)"; [ -n "$p" ] && { printf '%s' "$p"; return 0; }
+  shift; for c in "$@"; do [ -x "$c" ] && { printf '%s' "$c"; return 0; }; done
+  return 1
+}
+# version-manager shims (mise/asdf) are version-independent absolute paths that work under an empty PATH, so
+# they cover managed installs the fixed system paths miss; ${HOME:-} guards an unset HOME under set -u.
+_MISE="${HOME:-}/.local/share/mise/shims"; _ASDF="${HOME:-}/.asdf/shims"
+JQ="$(_resolve_bin jq "$_MISE/jq" "$_ASDF/jq" /opt/homebrew/bin/jq /usr/local/bin/jq /usr/bin/jq /bin/jq || true)"
 [ -n "$JQ" ] || { echo "memory-gateway: jq is required (install jq)" >&2; exit 2; }
-PYTHON3="$(command -v python3 || true)"
+PYTHON3="$(_resolve_bin python3 "$_MISE/python3" "$_ASDF/python3" /opt/homebrew/bin/python3 /usr/local/bin/python3 /usr/bin/python3 /bin/python3 || true)"
+PS_BIN="$(_resolve_bin ps /bin/ps /usr/bin/ps || true)"   # for _lock_is_stale liveness disambiguation (EPERM vs ESRCH); ps is a system binary, no shim
 
 VERB=""
 CORPUS=""
@@ -114,6 +126,12 @@ _err_setup() {  # _err_setup <message>   (setup/environment failure)
   _emit error "${VERB:-}" "" null "$("$JQ" -nc --arg c SETUP --arg m "$1" '{code:$c, message:$m}')"
   exit 2
 }
+_err_io() {  # _err_io <message>  — mid-op I/O failure (disk full / perms): the environment cannot persist.
+             # exit 2 (environment-can't-serve, [C06]) — NEVER a false `ok`. In a WAL transaction the intent
+             # stays open, so the next invocation's recovery completes the mutation idempotently.
+  _emit error "${VERB:-}" "" null "$("$JQ" -nc --arg c IO_ERROR --arg m "$1" '{code:$c, message:$m}')"
+  exit 2
+}
 
 # ---------------------------------------------------------------------------
 # small helpers
@@ -146,6 +164,14 @@ _valid_slug() {  # safe type/name slug; rejects traversal / absolute / illegal
   [ -n "$type" ] && [ -n "$name" ] || return 1
   _valid_type "$type" || return 1
   return 0
+}
+
+_NL="$(printf '\nx')"; _NL="${_NL%x}"   # one literal LF (the `printf x`+strip guard survives command-subst)
+_CR="$(printf '\rx')"; _CR="${_CR%x}"   # one literal CR
+_no_ctrl_lines() {  # _no_ctrl_lines <string> — 0 iff no LF/CR. Frontmatter fields (name/description) are
+                    # single-line by construction; an embedded newline would inject/terminate the `---` block
+                    # (identity spoof / structural corruption). Reject at input; multi-line detail belongs in the body.
+  case "$1" in *"$_NL"*|*"$_CR"*) return 1 ;; *) return 0 ;; esac
 }
 
 _fm_field() {  # _fm_field <file> <field>  -> value of a frontmatter field
@@ -195,18 +221,26 @@ _assert_within_corpus() {  # _assert_within_corpus <dest-path> — 0 iff the res
   case "$real" in "$CORPUS"|"$CORPUS"/*) return 0 ;; *) return 1 ;; esac
 }
 
+_assert_read_safe() {  # _assert_read_safe <path> — read-side symmetry of the write BOUNDARY guard: the resolved
+                       # parent stays inside CORPUS AND the target itself is not a symlink escaping it. read/search/
+                       # neighborhood trusted _valid_slug (string-safe) but not this realpath check -> a symlinked
+                       # type-dir (or symlinked topic file) could exfiltrate outside the corpus. defense-in-depth.
+  _assert_within_corpus "$1" && ! [ -L "$1" ]
+}
+
 _atomic_write() {  # _atomic_write <dest> <content>   (content is an ARG, NOT stdin: this MUST run in the
                    # caller's shell so a boundary _refuse can abort the whole process — a pipe-subshell exit
                    # cannot, which silently produced a double-envelope + exit 0 on a symlink escape; temp->rename+fsync)
   local dest="$1" content="$2" dir tmp
   dir="$(dirname "$dest")"
-  mkdir -p "$dir"
+  mkdir -p "$dir" || return 1
   _assert_within_corpus "$dest" || _refuse "${VERB:-}" "" BOUNDARY "resolved write path escapes the corpus root (symlinked dir?): $dest"
   tmp="$(mktemp "$dir/.mgw.XXXXXX")" || return 1
-  printf '%s' "$content" > "$tmp"
+  if ! printf '%s' "$content" > "$tmp"; then rm -f "$tmp" 2>/dev/null || true; return 1; fi  # e.g. ENOSPC/quota -> NEVER false-ok
   _fsync "$tmp"
-  mv "$tmp" "$dest"
+  mv "$tmp" "$dest" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
   _fsync "$dir"
+  return 0
 }
 
 # ---------------------------------------------------------------------------
@@ -215,7 +249,16 @@ _atomic_write() {  # _atomic_write <dest> <content>   (content is an ARG, NOT st
 _lock_is_stale() {  # _lock_is_stale <lockdir> — stale if the holder PID is provably dead OR ts older than LOCK_STALE_SECS
   local ts now age pid
   pid="$(cat "$1/pid" 2>/dev/null || true)"
-  case "$pid" in ''|*[!0-9]*) ;; *) kill -0 "$pid" 2>/dev/null || return 0 ;; esac  # holder dead -> reclaim NOW (real-crash recovery, not 900s wait)
+  # `kill -0` returns non-zero for BOTH ESRCH (dead -> reclaim) AND EPERM (holder ALIVE but owned by another
+  # UID -> must NOT reclaim; blind reclaim would evict a live cross-UID writer -> concurrent writers). Disambiguate
+  # with `ps -p` (UID- AND locale-independent, unlike stderr text): only a pid ps ALSO cannot see is truly dead ->
+  # fast real-crash reclaim; a live-but-other-UID holder (or ps unavailable) falls through to the ts backstop
+  # below (fail-safe: never evict a holder we cannot PROVE is dead).
+  case "$pid" in ''|*[!0-9]*) ;; *)
+    if ! kill -0 "$pid" 2>/dev/null; then
+      if [ -n "$PS_BIN" ]; then "$PS_BIN" -p "$pid" >/dev/null 2>&1 || return 0; fi
+    fi ;;
+  esac
   ts="$(cat "$1/ts" 2>/dev/null || true)"
   case "$ts" in ''|*[!0-9]*) return 1 ;; esac  # no valid ts yet (just-acquired window) -> NOT stale (fail-safe: never reclaim a lock you can't prove is old)
   now="$(date +%s)"; age=$(( now - ts ))
@@ -226,7 +269,13 @@ _lock_acquire() {  # refuses CONCURRENT_WRITER on timeout (exit 1)
   LOCK="$CORPUS/.gateway/lock.d"
   local tries=0
   while ! mkdir "$LOCK" 2>/dev/null; do
-    if _lock_is_stale "$LOCK"; then rm -rf "$LOCK" 2>/dev/null || true; continue; fi
+    if _lock_is_stale "$LOCK"; then
+      # single-winner reclaim: atomically RENAME the stale dir out of the way; only ONE racer wins moving the
+      # ORIGINAL (a concurrent reclaimer's mv finds the source already gone -> fails harmlessly). blind `rm -rf`
+      # + retry had a TOCTOU: two racers could both delete-then-mkdir -> two live writers. rename is atomic.
+      if mv "$LOCK" "$LOCK.stale.$$" 2>/dev/null; then rm -rf "$LOCK.stale.$$" 2>/dev/null || true; fi
+      continue
+    fi
     tries=$(( tries + 1 ))
     [ "$tries" -ge "$LOCK_MAX_TRIES" ] && _refuse "$VERB" "" CONCURRENT_WRITER \
       "another writer holds the corpus lock ($LOCK) — refusing to clobber; retry shortly"
@@ -262,18 +311,22 @@ _crash_if() {  # _crash_if <stage>
 # external + env-overridable (matches artifact-registry), so tests isolate it.
 # ---------------------------------------------------------------------------
 _audit() {  # _audit <verb> <slug>
-  local dir led llock i=0
+  local dir led llock i=0 acquired=0
   dir="${MEMORY_GATEWAY_DIR:-$HOME/.claude/audit}"
   mkdir -p "$dir"
   led="$dir/memory-gateway.jsonl"
   llock="$dir/.lock-memory-gateway"
-  while ! mkdir "$llock" 2>/dev/null; do
-    i=$(( i + 1 )); [ "$i" -ge 50 ] && { rm -rf "$llock" 2>/dev/null || true; break; }
+  while true; do
+    if mkdir "$llock" 2>/dev/null; then acquired=1; break; fi
+    i=$(( i + 1 ))
+    [ "$i" -ge 50 ] && break   # give up the lock: do NOT force-remove a LIVE holder's dir (that clobber could
+                               # interleave two appenders). the append below is ONE sub-PIPE_BUF line -> atomic
+                               # under POSIX even unlocked, so proceeding lock-free is safe (liveness > exclusivity here).
     sleep 0.02
   done
   "$JQ" -nc --arg ts "$(_ts)" --arg verb "$1" --arg slug "$2" --arg corpus "$CORPUS" \
     '{ts:$ts, verb:$verb, slug:(if $slug=="" then null else $slug end), corpus:$corpus}' >> "$led"
-  rm -rf "$llock" 2>/dev/null || true
+  [ "$acquired" = 1 ] && { rm -rf "$llock" 2>/dev/null || true; }   # release ONLY the lock WE created
 }
 
 # ---------------------------------------------------------------------------
@@ -295,7 +348,7 @@ _rebuild_index() {  # rebuilds MEMORY.md; echoes the live-entry count
   done
   local _idx
   _idx="$( { printf '# Memory Index\n\n> Regenerated by memory-gateway (ADR-013). One line per live topic.\n\n'; printf '%s' "$body"; }; printf x )"; _idx="${_idx%x}"
-  _atomic_write "$CORPUS/MEMORY.md" "$_idx"
+  _atomic_write "$CORPUS/MEMORY.md" "$_idx" || _err_io "failed to persist the index (MEMORY.md) — I/O error"
   REBUILD_COUNT="$lines"   # global out-param: lets callers read the count WITHOUT $() — a $()
                            # capture would re-nest _atomic_write in a command-substitution
                            # subshell, where its BOUNDARY _refuse could only kill the subshell
@@ -315,7 +368,7 @@ _archive_topic() {  # _archive_topic <slug>  -> moves live to archive, echoes se
   seq=$(( cnt + 1 ))
   padded="$(printf '%04d' "$seq")"
   dst="$adir/$padded.md"
-  mv "$live" "$dst"
+  mv "$live" "$dst" || _err_io "failed to move '$slug' into the archive tier — I/O error (refusing to proceed; the superseding write must never overwrite an un-archived fact)"
   _fsync "$(dirname "$live")"; _fsync "$adir"
   printf '%s' "$seq"
 }
@@ -370,7 +423,7 @@ _replay_supersede() {  # _replay_supersede <intent-json>  (idempotent). returns 
     fi
   fi
   [ -n "$superseded" ] && [ "$superseded" != "null" ] && _archive_if_stale "$superseded" "$payload" >/dev/null
-  _atomic_write "$CORPUS/$new_slug.md" "$payload"
+  _atomic_write "$CORPUS/$new_slug.md" "$payload" || _err_io "recovery: failed to write '$new_slug' — I/O error (intent left OPEN for the next recovery; no commit marker written)"
   _rebuild_index >/dev/null
 }
 
@@ -418,7 +471,7 @@ _wal_supersede() {  # _wal_supersede <new_slug> <superseded_slug> <content>
   archseq="$(_archive_if_stale "$superseded" "$content")"
   _crash_if archive
   # STAGE 3 — write the new live topic (atomic temp->rename, fsync)
-  _atomic_write "$CORPUS/$new_slug.md" "$content"
+  _atomic_write "$CORPUS/$new_slug.md" "$content" || _err_io "supersede: failed to write new topic '$new_slug' — I/O error (WAL intent stays OPEN; recovery completes it idempotently)"
   _crash_if newtopic
   # STAGE 4 — rebuild the index
   _rebuild_index >/dev/null
@@ -472,6 +525,8 @@ do_create() {
   [ -n "$TYPE" ] || _refuse create "" USAGE "create requires --type {user|feedback|project|reference}"
   _valid_type "$TYPE" || _refuse create "" USAGE "invalid --type '$TYPE'"
   [ -n "$NAME" ] || _refuse create "" USAGE "create requires a topic name (positional)"
+  _no_ctrl_lines "$NAME" || _refuse create "" USAGE "name must be a single line (no newline/CR — would inject into the frontmatter)"
+  _no_ctrl_lines "$DESC" || _refuse create "" USAGE "description must be a single line (no newline/CR); put multi-line detail in the body"
   norm="$(_normalize "$NAME")"
   [ -n "$norm" ] || _refuse create "" USAGE "name '$NAME' normalizes to empty"
   slug="$TYPE/$norm"
@@ -483,7 +538,7 @@ do_create() {
   fi
   body="$STDIN_BODY"   # pre-read off-lock in dispatch (#1); byte-identical to the old inline $(cat)
   content="$(_topic_content "$NAME" "$TYPE" "$DESC" "$body")"
-  _atomic_write "$path" "$content"
+  _atomic_write "$path" "$content" || _err_io "create: failed to persist '$slug' — I/O error (no false success reported)"
   _rebuild_index >/dev/null
   _audit create "$slug"
   _emit ok create "$slug" \
@@ -508,6 +563,7 @@ do_read() {
     if [ -d "$adir" ]; then
       for f in "$adir"/*.md; do
         [ -f "$f" ] || continue
+        _assert_read_safe "$f" || continue   # skip a symlink-escaping archived file (defense-in-depth)
         seq="$(basename "$f" .md)"; rel="${f#$CORPUS/}"; c="$(cat "$f")"
         archived_json="$("$JQ" -nc --argjson a "$archived_json" --arg seq "$seq" --arg path "$rel" --arg content "$c" \
           '$a + [{seq:$seq, path:$path, content:$content}]')"
@@ -519,6 +575,7 @@ do_read() {
   else
     path="$CORPUS/$SLUG.md"
     [ -f "$path" ] || _refuse read "$SLUG" NOT_FOUND "no live topic at slug '$SLUG' (try --archived)"
+    _assert_read_safe "$path" || _refuse read "$SLUG" BOUNDARY "resolved read path escapes the corpus (symlinked dir/file?)"
     content="$(cat "$path")"
     _emit ok read "$SLUG" "$("$JQ" -nc --arg s "$SLUG" --arg c "$content" '{slug:$s, content:$c}')" null
   fi
@@ -545,7 +602,7 @@ _update_append() {
   delta="$STDIN_BODY"   # pre-read off-lock in dispatch (#1); byte-identical to the old inline $(cat)
   local _merged
   _merged="$( { cat "$path"; printf '\n%s\n' "$delta"; }; printf x )"; _merged="${_merged%x}"
-  _atomic_write "$path" "$_merged"
+  _atomic_write "$path" "$_merged" || _err_io "update: failed to persist append to '$SLUG' — I/O error (no false success reported)"
   _audit update "$SLUG"
   _emit ok update "$SLUG" "$("$JQ" -nc --arg s "$SLUG" '{slug:$s, appended:true}')" null
 }
@@ -570,6 +627,8 @@ _update_supersede() {
   [ -n "$TYPE" ] || _refuse update "" USAGE "supersede requires --type"
   _valid_type "$TYPE" || _refuse update "" USAGE "invalid --type '$TYPE'"
   [ -n "$NAME" ] || _refuse update "" USAGE "supersede requires --name"
+  _no_ctrl_lines "$NAME" || _refuse update "" USAGE "name must be a single line (no newline/CR — would inject into the frontmatter)"
+  _no_ctrl_lines "$DESC" || _refuse update "" USAGE "description must be a single line (no newline/CR); put multi-line detail in the body"
   norm="$(_normalize "$NAME")"
   [ -n "$norm" ] || _refuse update "" USAGE "name '$NAME' normalizes to empty"
   new_slug="$TYPE/$norm"
@@ -611,7 +670,7 @@ _update_supersede() {
   fi
   if [ -z "$superseded" ]; then
     # 0-match AND new_slug free: plain create path (no archive, no WAL)
-    _atomic_write "$CORPUS/$new_slug.md" "$content"
+    _atomic_write "$CORPUS/$new_slug.md" "$content" || _err_io "supersede(create): failed to persist '$new_slug' — I/O error (no false success reported)"
     _rebuild_index >/dev/null
     _audit update "$new_slug"
     _emit ok update "$new_slug" "$("$JQ" -nc --arg s "$new_slug" '{slug:$s, superseded:null, created:true}')" null
@@ -661,6 +720,7 @@ do_search() {
   # to grep-only and report it (semantic:false), per ADR-013 graceful fallback.
   for d in user feedback project reference; do
     [ -d "$CORPUS/$d" ] || continue
+    _assert_within_corpus "$CORPUS/$d/.probe" || continue   # skip a symlinked type-dir escaping the corpus (grep -r would follow a CLI-arg symlink)
     while IFS= read -r f; do
       [ -n "$f" ] || continue
       rel="${f#$CORPUS/}"; s="${rel%.md}"
@@ -700,10 +760,12 @@ do_neighborhood() {
       [ -n "$node" ] || continue
       f="$CORPUS/$node.md"
       [ -f "$f" ] || continue
+      _assert_read_safe "$f" || continue   # skip a symlink-escaping node (defense-in-depth)
       links="$(grep -o '\[\[[^]]*\]\]' "$f" 2>/dev/null | sed 's/^\[\[//; s/\]\]$//' || true)"
       while IFS= read -r l; do
         [ -n "$l" ] || continue
         _valid_slug "$l" || continue
+        [ -f "$CORPUS/$l.md" ] || continue   # E6 forgetting: a link to a superseded/archived (or dangling) topic is NOT a live neighbor -> never reported
         case "
 $visited
 " in *"

--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -229,6 +229,17 @@ _assert_read_safe() {  # _assert_read_safe <path> — read-side symmetry of the 
   _assert_within_corpus "$1" && ! [ -L "$1" ]
 }
 
+_assert_new_path_within_corpus() {  # _assert_new_path_within_corpus <target> — 0 iff the deepest EXISTING ancestor of
+                                    # a not-yet-created <target> resolves inside CORPUS. For a path `mkdir -p` will
+                                    # CREATE, a symlinked EXISTING ancestor is the only escape (the to-be-created tail
+                                    # components are literal, symlink-free) — so validating the existing prefix BEFORE
+                                    # mkdir refuses a symlinked `.archive` WITHOUT creating any artifact outside CORPUS.
+  local d="$1" real
+  while [ ! -e "$d" ]; do d="$(dirname "$d")"; [ "$d" = "/" ] && break; done
+  real="$(cd "$d" 2>/dev/null && pwd -P || true)"
+  case "$real" in "$CORPUS"|"$CORPUS"/*) return 0 ;; *) return 1 ;; esac
+}
+
 _atomic_write() {  # _atomic_write <dest> <content>   (content is an ARG, NOT stdin: this MUST run in the
                    # caller's shell so a boundary _refuse can abort the whole process — a pipe-subshell exit
                    # cannot, which silently produced a double-envelope + exit 0 on a symlink escape; temp->rename+fsync)
@@ -364,12 +375,12 @@ _archive_topic() {  # _archive_topic <slug>  -> moves live to archive; sets $ARC
   local slug="$1" live adir cnt seq padded dst
   live="$CORPUS/$slug.md"
   adir="$CORPUS/.archive/$slug"
+  _assert_new_path_within_corpus "$adir" || _refuse "${VERB:-}" "$slug" BOUNDARY "resolved archive path escapes the corpus root (symlinked .archive?): $adir"   # BEFORE mkdir: refuse a symlinked .archive WITHOUT creating any artifact outside CORPUS (CodeRabbit PDCA-7 refinement; stricter than _atomic_write's post-mkdir check — see follow-up note in PR)
   mkdir -p "$adir" || _err_io "failed to create the archive dir for '$slug' — I/O error (refusing to proceed; the superseding write must never overwrite an un-archived fact)"
   cnt="$(find "$adir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
   seq=$(( cnt + 1 ))
   padded="$(printf '%04d' "$seq")"
   dst="$adir/$padded.md"
-  _assert_within_corpus "$dst" || _refuse "${VERB:-}" "$slug" BOUNDARY "resolved archive path escapes the corpus root (symlinked .archive?): $dst"   # mirror _atomic_write's write-boundary guard on the ARCHIVE-move path — a pre-planted symlinked .archive must NOT send mv outside CORPUS (CodeRabbit PDCA-7)
   mv "$live" "$dst" || _err_io "failed to move '$slug' into the archive tier — I/O error (refusing to proceed; the superseding write must never overwrite an un-archived fact)"
   _fsync "$(dirname "$live")"; _fsync "$adir"
   ARCHSEQ="$seq"   # global out-var — MUST run in the caller's process (was `printf '%s' "$seq"` read via $(), which forked a subshell that swallowed _err_io's exit 2 on mv failure -> parent continued -> false ok; qodo PDCA-6)

--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -1,0 +1,799 @@
+#!/usr/bin/env bash
+# MAOS — memory-gateway · the ONE writer to the memory corpus (ADR-013, EKO-116)
+# ----------------------------------------------------------------------------
+# WHY: an amnesic-agent ecosystem needs a SINGLE, crash-safe, deterministic
+#   front-door to persistent memory. Ad-hoc Edit/Write on topic files means:
+#   (a) two facts silently collide on the same identity, (b) a superseded fact
+#   is left live next to its replacement ("forgetting" never happens), and
+#   (c) a crash mid-write leaves the corpus in a state that never existed.
+#   This gateway makes those three failure modes structurally impossible:
+#   dedup on a canonical identity key, an atomic supersession that archives
+#   the old fact in the SAME operation, and a write-ahead log that any next
+#   invocation completes before serving a single verb.
+#
+# THE 7-VERB NARROW API (mem0-absorbed CRUD):
+#   create · read · update · archive · search · neighborhood · index
+#   mutating: create/update/archive/index   read-only: read/search/neighborhood
+#
+# IDENTITY: the canonical key is (type, normalize(name)); the slug is that
+#   key's type-qualified projection  slug = <type>/<normalize(name)>  — so
+#   (user,profile) -> user/profile and (project,profile) -> project/profile are
+#   distinct addresses that never collide. Dedup (create) and implicit
+#   supersession (update) both operate on this one unambiguous identity.
+#
+# FORGETTING (the E6 mutation-hook): an `update --supersede` whose (type,name)
+#   matches an active topic archives that topic IN THE SAME OPERATION — no
+#   separate `archive` call. `archive` is the ONLY removal verb, and it never
+#   destroys content: it TIERS the topic into <corpus>/.archive/ (retrievable).
+#   Purge / true-erasure is deliberately OUT of scope (tiering-never-deletion).
+#
+# CRASH-SAFETY (supersession): a 5-stage write-ahead transaction over the WAL
+#   (<corpus>/.gateway/wal.jsonl), guarded by an exclusive corpus lock:
+#     (1) intent (fsync'd FIRST, carries the full new-topic payload+sha)
+#     (2) archive the superseded topic          <-- archive-FIRST, see NOTE
+#     (3) write the new live topic (temp->rename, fsync file+dir)
+#     (4) rebuild the index (atomic)
+#     (5) commit marker (fsync)
+#   Every mutating/read invocation runs recovery FIRST: it discards a trailing
+#   partial WAL line and idempotently replays any intent-without-commit, so no
+#   verb is ever served over a half-applied supersession.
+#
+#   NOTE (the one deliberate refinement over ADR-013's literal stage order):
+#   the ADR lists new-topic-write (stage 2) BEFORE archive (stage 3). But the
+#   implicit-supersession match is INHERENTLY same-slug (the new fact matches
+#   the topic it supersedes on (type,name), so both share the canonical path).
+#   Writing the new topic first would OVERWRITE the superseded content at that
+#   path before it could be archived -> the old fact is destroyed, not tiered,
+#   and the E6 forgetting guarantee fails. So archive precedes the new-topic
+#   write. This preserves every crash-recovery property the ADR requires:
+#   recovery re-applies archive-move + new-topic-write idempotently and
+#   order-independently (the ADR says so explicitly), and startup-recovery-
+#   before-serving means no reader ever observes the momentary no-live window.
+#   Replay uses a content-guard (archive only if the live file still holds the
+#   OLD content, != the new payload) so a crash AFTER the new-topic write never
+#   double-archives.
+#
+# Portability: POSIX Bash 3.2 + jq only. python3 is used for fsync of files AND
+#   dirs (probed; degrades to `sync`). stat/shasum are probed. No `declare -A`,
+#   no `mapfile`, no `${var^^}`.
+# Output: exactly ONE JSON envelope on stdout per execution:
+#   {status, verb, slug, data, reason}  — human diagnostics go to stderr ONLY.
+# Exit codes ([C06]): 0 ok (incl. idempotent no-op) · 1 refused/usage · 2 setup.
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# setup / tool probes
+# ---------------------------------------------------------------------------
+JQ="$(command -v jq || true)"
+[ -n "$JQ" ] || { echo "memory-gateway: jq is required (install jq)" >&2; exit 2; }
+PYTHON3="$(command -v python3 || true)"
+
+VERB=""
+CORPUS=""
+LOCK=""
+LOCK_HELD=0
+LOCK_STALE_SECS=900
+LOCK_MAX_TRIES=15   # ~1.5s at 0.1s/try before refusing CONCURRENT_WRITER
+
+usage() {
+  cat >&2 <<'EOF'
+memory-gateway — the ONE writer to the memory corpus (ADR-013).
+
+USAGE
+  memory-gateway --corpus <dir> <verb> [args]      (or set MEMORY_GATEWAY_CORPUS)
+
+VERBS
+  create <name> --type {user|feedback|project|reference} [--description D]   (body on stdin)
+  read <slug> [--archived]
+  update <slug>                                     (append; delta on stdin)
+  update --supersede --type T --name N [--supersedes <slug>] [--description D]  (new body on stdin)
+  archive <slug>
+  search <query>
+  neighborhood <seed-slug> [--depth N] [--budget N] (depth 1..3; >3 clamped)
+  index
+
+OUTPUT   one JSON envelope on stdout: {status, verb, slug, data, reason}
+EXIT     0 ok · 1 refused/usage · 2 setup (jq/corpus)
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# envelope emitters (stdout = JSON only; stderr = human diagnostics only)
+# ---------------------------------------------------------------------------
+_emit() {  # _emit <status> <verb> <slug> <data-json|null> <reason-json|null>
+  "$JQ" -cn --arg status "$1" --arg verb "$2" --arg slug "$3" \
+    --argjson data "${4:-null}" --argjson reason "${5:-null}" \
+    '{status:$status, verb:$verb, slug:(if $slug=="" then null else $slug end), data:$data, reason:$reason}'
+}
+_refuse() {  # _refuse <verb> <slug> <code> <message> [data-json]
+  local data="${5:-null}"
+  _emit refused "$1" "$2" "$data" "$("$JQ" -nc --arg c "$3" --arg m "$4" '{code:$c, message:$m}')"
+  exit 1
+}
+_err_setup() {  # _err_setup <message>   (setup/environment failure)
+  _emit error "${VERB:-}" "" null "$("$JQ" -nc --arg c SETUP --arg m "$1" '{code:$c, message:$m}')"
+  exit 2
+}
+
+# ---------------------------------------------------------------------------
+# small helpers
+# ---------------------------------------------------------------------------
+_ts()     { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_txn_id() { printf '%s-%s-%s' "$(date -u +%s)" "$$" "${RANDOM:-0}"; }
+
+_valid_type() { case "$1" in user|feedback|project|reference) return 0 ;; *) return 1 ;; esac; }
+
+_need_val() {  # _need_val <remaining-argc> <flagname> — guards `shift 2` against a valueless trailing flag
+  # (bash 3.2 `shift 2` with $#<2 does NOT shift and returns non-zero; under set -uo pipefail the
+  #  arg-parse while-loop then re-enters unchanged -> infinite loop / DoS holding the corpus lock).
+  [ "$1" -ge 2 ] || _refuse "${VERB:-}" "" USAGE "$2 requires a value"
+}
+
+_normalize() {  # case-fold + kebab: lower, non-alnum runs -> '-', trim '-'
+  printf '%s' "$1" | LC_ALL=C tr '[:upper:]' '[:lower:]' \
+    | LC_ALL=C sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+_valid_slug() {  # safe type/name slug; rejects traversal / absolute / illegal
+  local s="$1" type name
+  case "$s" in
+    ""|/*|*..*) return 1 ;;
+    *[!a-z0-9/._-]*) return 1 ;;
+  esac
+  type="${s%%/*}"; name="${s#*/}"
+  [ "$type" != "$s" ] || return 1          # must contain a slash
+  case "$name" in */*) return 1 ;; esac     # exactly one slash
+  [ -n "$type" ] && [ -n "$name" ] || return 1
+  _valid_type "$type" || return 1
+  return 0
+}
+
+_fm_field() {  # _fm_field <file> <field>  -> value of a frontmatter field
+  awk -v key="$2" '
+    NR==1 { if ($0=="---") { infm=1; next } else { exit } }
+    infm==1 && $0=="---" { exit }
+    infm==1 {
+      idx=index($0, ":")
+      if (idx>0) {
+        k=substr($0,1,idx-1); v=substr($0,idx+1)
+        gsub(/^[ \t]+|[ \t]+$/, "", k); gsub(/^[ \t]+|[ \t]+$/, "", v)
+        if (k==key) { print v; exit }
+      }
+    }' "$1"
+}
+
+_topic_content() {  # _topic_content <name> <type> <desc> <body>
+  printf -- '---\nname: %s\ntype: %s\ndescription: %s\n---\n%s\n' "$1" "$2" "$3" "$4"
+}
+
+_sha256() {  # _sha256 <string>  -> hex digest (empty if no tool)
+  if command -v shasum >/dev/null 2>&1; then printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else printf ''; fi
+}
+
+_fsync() {  # _fsync <path>  (file OR dir); best-effort, degrades to sync
+  [ -e "$1" ] || return 0
+  if [ -n "$PYTHON3" ]; then
+    "$PYTHON3" - "$1" >/dev/null 2>&1 <<'PY' || sync
+import os, sys
+fd = os.open(sys.argv[1], os.O_RDONLY)
+try:
+    os.fsync(fd)
+finally:
+    os.close(fd)
+PY
+  else
+    sync
+  fi
+}
+
+_assert_within_corpus() {  # _assert_within_corpus <dest-path> — 0 iff the resolved parent dir stays inside canonical CORPUS
+  local dir real                                   # (CORPUS is already `pwd -P` canonical; realpath here defeats a symlinked type-dir escape)
+  dir="$(dirname "$1")"
+  real="$(cd "$dir" 2>/dev/null && pwd -P || true)"
+  case "$real" in "$CORPUS"|"$CORPUS"/*) return 0 ;; *) return 1 ;; esac
+}
+
+_atomic_write() {  # _atomic_write <dest> <content>   (content is an ARG, NOT stdin: this MUST run in the
+                   # caller's shell so a boundary _refuse can abort the whole process — a pipe-subshell exit
+                   # cannot, which silently produced a double-envelope + exit 0 on a symlink escape; temp->rename+fsync)
+  local dest="$1" content="$2" dir tmp
+  dir="$(dirname "$dest")"
+  mkdir -p "$dir"
+  _assert_within_corpus "$dest" || _refuse "${VERB:-}" "" BOUNDARY "resolved write path escapes the corpus root (symlinked dir?): $dest"
+  tmp="$(mktemp "$dir/.mgw.XXXXXX")" || return 1
+  printf '%s' "$content" > "$tmp"
+  _fsync "$tmp"
+  mv "$tmp" "$dest"
+  _fsync "$dir"
+}
+
+# ---------------------------------------------------------------------------
+# corpus lock (mkdir-based POSIX mutex + epoch-marker stale reclaim)
+# ---------------------------------------------------------------------------
+_lock_is_stale() {  # _lock_is_stale <lockdir> — stale if the holder PID is provably dead OR ts older than LOCK_STALE_SECS
+  local ts now age pid
+  pid="$(cat "$1/pid" 2>/dev/null || true)"
+  case "$pid" in ''|*[!0-9]*) ;; *) kill -0 "$pid" 2>/dev/null || return 0 ;; esac  # holder dead -> reclaim NOW (real-crash recovery, not 900s wait)
+  ts="$(cat "$1/ts" 2>/dev/null || true)"
+  case "$ts" in ''|*[!0-9]*) return 1 ;; esac  # no valid ts yet (just-acquired window) -> NOT stale (fail-safe: never reclaim a lock you can't prove is old)
+  now="$(date +%s)"; age=$(( now - ts ))
+  [ "$age" -ge "$LOCK_STALE_SECS" ]
+}
+_lock_acquire() {  # refuses CONCURRENT_WRITER on timeout (exit 1)
+  mkdir -p "$CORPUS/.gateway"
+  LOCK="$CORPUS/.gateway/lock.d"
+  local tries=0
+  while ! mkdir "$LOCK" 2>/dev/null; do
+    if _lock_is_stale "$LOCK"; then rm -rf "$LOCK" 2>/dev/null || true; continue; fi
+    tries=$(( tries + 1 ))
+    [ "$tries" -ge "$LOCK_MAX_TRIES" ] && _refuse "$VERB" "" CONCURRENT_WRITER \
+      "another writer holds the corpus lock ($LOCK) — refusing to clobber; retry shortly"
+    sleep 0.1
+  done
+  date +%s > "$LOCK/ts" 2>/dev/null || true
+  echo "$$" > "$LOCK/pid" 2>/dev/null || true   # holder PID -> enables dead-holder reclaim (see _lock_is_stale)
+  LOCK_HELD=1
+  trap '_lock_release' EXIT
+  trap '_lock_release; exit 130' INT    # release + EXIT (do not resume the interrupted work)
+  trap '_lock_release; exit 143' TERM
+}
+_lock_release() {
+  [ "${LOCK_HELD:-0}" = 1 ] || return 0
+  rm -rf "$LOCK" 2>/dev/null || true
+  LOCK_HELD=0
+  trap - EXIT INT TERM
+}
+
+# ---------------------------------------------------------------------------
+# crash injection (TEST-ONLY): a hard exit AFTER stage <n>, before the next.
+# The commit marker is written explicitly (never in a trap), so a simulated
+# crash genuinely leaves an intent-without-commit for recovery to complete.
+# ---------------------------------------------------------------------------
+_crash_if() {  # _crash_if <stage>
+  [ "${MEMORY_GATEWAY_CRASH_AT:-}" = "$1" ] || return 0
+  printf 'memory-gateway: SIMULATED CRASH after stage "%s"\n' "$1" >&2
+  exit 111
+}
+
+# ---------------------------------------------------------------------------
+# audit ledger (structural guarantee #4: one JSONL line per mutation)
+# external + env-overridable (matches artifact-registry), so tests isolate it.
+# ---------------------------------------------------------------------------
+_audit() {  # _audit <verb> <slug>
+  local dir led llock i=0
+  dir="${MEMORY_GATEWAY_DIR:-$HOME/.claude/audit}"
+  mkdir -p "$dir"
+  led="$dir/memory-gateway.jsonl"
+  llock="$dir/.lock-memory-gateway"
+  while ! mkdir "$llock" 2>/dev/null; do
+    i=$(( i + 1 )); [ "$i" -ge 50 ] && { rm -rf "$llock" 2>/dev/null || true; break; }
+    sleep 0.02
+  done
+  "$JQ" -nc --arg ts "$(_ts)" --arg verb "$1" --arg slug "$2" --arg corpus "$CORPUS" \
+    '{ts:$ts, verb:$verb, slug:(if $slug=="" then null else $slug end), corpus:$corpus}' >> "$led"
+  rm -rf "$llock" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
+# index (one line per LIVE topic; active dirs only, .archive/.gateway excluded)
+# ---------------------------------------------------------------------------
+_rebuild_index() {  # rebuilds MEMORY.md; echoes the live-entry count
+  local d f name desc rel body="" lines=0
+  for d in feedback project reference user; do
+    [ -d "$CORPUS/$d" ] || continue
+    for f in "$CORPUS/$d"/*.md; do
+      [ -f "$f" ] || continue
+      name="$(_fm_field "$f" name)"; [ -n "$name" ] || name="$(basename "$f" .md)"
+      desc="$(_fm_field "$f" description)"
+      rel="${f#$CORPUS/}"
+      body="${body}- [${name}](${rel}) — ${desc}
+"
+      lines=$(( lines + 1 ))
+    done
+  done
+  local _idx
+  _idx="$( { printf '# Memory Index\n\n> Regenerated by memory-gateway (ADR-013). One line per live topic.\n\n'; printf '%s' "$body"; }; printf x )"; _idx="${_idx%x}"
+  _atomic_write "$CORPUS/MEMORY.md" "$_idx"
+  REBUILD_COUNT="$lines"   # global out-param: lets callers read the count WITHOUT $() — a $()
+                           # capture would re-nest _atomic_write in a command-substitution
+                           # subshell, where its BOUNDARY _refuse could only kill the subshell
+                           # (the pass-1 double-envelope+exit-0 class). do_index reads this. (#3)
+  printf '%s' "$lines"
+}
+
+# ---------------------------------------------------------------------------
+# archive tier (seq-numbered; content NEVER destroyed)
+# ---------------------------------------------------------------------------
+_archive_topic() {  # _archive_topic <slug>  -> moves live to archive, echoes seq
+  local slug="$1" live adir cnt seq padded dst
+  live="$CORPUS/$slug.md"
+  adir="$CORPUS/.archive/$slug"
+  mkdir -p "$adir"
+  cnt="$(find "$adir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
+  seq=$(( cnt + 1 ))
+  padded="$(printf '%04d' "$seq")"
+  dst="$adir/$padded.md"
+  mv "$live" "$dst"
+  _fsync "$(dirname "$live")"; _fsync "$adir"
+  printf '%s' "$seq"
+}
+
+_archive_if_stale() {  # _archive_if_stale <slug> <new-payload>  (idempotent guard)
+  local slug="$1" payload="$2" live cur
+  live="$CORPUS/$slug.md"
+  [ -f "$live" ] || { printf ''; return 0; }       # already archived / absent -> no-op
+  cur="$(cat "$live")"
+  [ "$cur" = "$payload" ] && { printf ''; return 0; }  # new already installed -> no double-archive
+  _archive_topic "$slug"
+}
+
+# ---------------------------------------------------------------------------
+# WAL + recovery (supersession only — the transaction with a dangerous step)
+# ---------------------------------------------------------------------------
+_wal_path() { printf '%s' "$CORPUS/.gateway/wal.jsonl"; }
+
+_wal_open_txns() {  # echoes txn ids of intents WITHOUT a matching commit
+  local wal; wal="$(_wal_path)"
+  [ -f "$wal" ] || return 0
+  "$JQ" -R 'fromjson? // empty' "$wal" | "$JQ" -s -r '
+    ([.[] | select(.state=="commit") | .txn]) as $c
+    | [.[] | select(.state=="intent") | select(.txn as $t | ($c|index($t))|not) | .txn] | .[]'
+}
+_wal_intent_record() {  # _wal_intent_record <txn>  -> the intent JSON line
+  local wal; wal="$(_wal_path)"
+  "$JQ" -R 'fromjson? // empty' "$wal" \
+    | "$JQ" -c --arg t "$1" 'select(.state=="intent" and .txn==$t)' | head -1
+}
+_wal_needs_recovery() {  # 0 = recovery needed (partial line OR open intent)
+  local wal last open
+  wal="$(_wal_path)"
+  [ -f "$wal" ] || return 1
+  last="$(tail -n1 "$wal" 2>/dev/null || true)"
+  if [ -n "$last" ] && ! printf '%s' "$last" | "$JQ" -e . >/dev/null 2>&1; then return 0; fi
+  open="$(_wal_open_txns)"
+  [ -n "$open" ] && return 0 || return 1
+}
+
+_replay_supersede() {  # _replay_supersede <intent-json>  (idempotent). returns 1 (mutate NOTHING) on payload sha mismatch.
+  local intent="$1" new_slug superseded payload sha calc
+  new_slug="$(printf '%s' "$intent" | "$JQ" -r '.new_slug')"
+  superseded="$(printf '%s' "$intent" | "$JQ" -r '.superseded_slug')"
+  payload="$(printf '%s' "$intent" | "$JQ" -r '.payload')"
+  sha="$(printf '%s' "$intent" | "$JQ" -r '.sha256 // ""')"
+  if [ -n "$sha" ]; then
+    calc="$(_sha256 "$payload")"
+    if [ -n "$calc" ] && [ "$calc" != "$sha" ]; then
+      printf 'memory-gateway: WAL intent payload sha mismatch (corrupt intent) — skipping replay of %s\n' "$new_slug" >&2
+      return 1   # corrupt payload: mutate NOTHING (neither archive nor write) — never persist corruption
+    fi
+  fi
+  [ -n "$superseded" ] && [ "$superseded" != "null" ] && _archive_if_stale "$superseded" "$payload" >/dev/null
+  _atomic_write "$CORPUS/$new_slug.md" "$payload"
+  _rebuild_index >/dev/null
+}
+
+_recover() {  # complete unclosed intents + discard a trailing partial line
+  local wal last open txn intent
+  wal="$(_wal_path)"
+  [ -f "$wal" ] || return 0
+  last="$(tail -n1 "$wal" 2>/dev/null || true)"
+  if [ -n "$last" ] && ! printf '%s' "$last" | "$JQ" -e . >/dev/null 2>&1; then
+    sed '$d' "$wal" > "$wal.tmp" 2>/dev/null && mv "$wal.tmp" "$wal"
+    _fsync "$wal"
+  fi
+  open="$(_wal_open_txns)"
+  [ -n "$open" ] || return 0
+  while IFS= read -r txn; do
+    [ -n "$txn" ] || continue
+    intent="$(_wal_intent_record "$txn")"
+    [ -n "$intent" ] || continue
+    if _replay_supersede "$intent"; then
+      "$JQ" -nc --arg txn "$txn" --arg ts "$(_ts)" '{txn:$txn, state:"commit", ts:$ts}' >> "$wal"
+    else
+      # corrupt intent skipped — write an aborted-commit marker so recovery converges (idempotent, not re-attempted) + is auditable
+      "$JQ" -nc --arg txn "$txn" --arg ts "$(_ts)" '{txn:$txn, state:"commit", ts:$ts, aborted:"sha_mismatch"}' >> "$wal"
+    fi
+    _fsync "$wal"
+  done <<EOF
+$open
+EOF
+}
+
+_wal_supersede() {  # _wal_supersede <new_slug> <superseded_slug> <content>
+  local new_slug="$1" superseded="$2" content="$3" wal txn sha archseq
+  wal="$(_wal_path)"
+  mkdir -p "$CORPUS/.gateway"
+  txn="$(_txn_id)"
+  sha="$(_sha256 "$content")"
+  # STAGE 1 — intent (write FIRST, fsync)
+  "$JQ" -nc --arg txn "$txn" --arg op supersede --arg ts "$(_ts)" \
+    --arg new_slug "$new_slug" --arg superseded "$superseded" \
+    --arg payload "$content" --arg sha "$sha" \
+    '{txn:$txn, state:"intent", op:$op, ts:$ts, new_slug:$new_slug, superseded_slug:$superseded, payload:$payload, sha256:$sha}' >> "$wal"
+  _fsync "$wal"; _fsync "$CORPUS/.gateway"
+  _crash_if intent
+  # STAGE 2 — archive the superseded (archive-FIRST; see header NOTE)
+  archseq="$(_archive_if_stale "$superseded" "$content")"
+  _crash_if archive
+  # STAGE 3 — write the new live topic (atomic temp->rename, fsync)
+  _atomic_write "$CORPUS/$new_slug.md" "$content"
+  _crash_if newtopic
+  # STAGE 4 — rebuild the index
+  _rebuild_index >/dev/null
+  _crash_if index
+  # STAGE 5 — commit marker (fsync) + audit
+  "$JQ" -nc --arg txn "$txn" --arg ts "$(_ts)" '{txn:$txn, state:"commit", ts:$ts}' >> "$wal"
+  _fsync "$wal"; _fsync "$CORPUS/.gateway"
+  _audit update "$new_slug"
+  if [ -z "$archseq" ]; then
+    # nothing was tiered (content byte-identical, or target already archived) -> honest: no fact was superseded
+    _emit ok update "$new_slug" "$("$JQ" -nc --arg s "$new_slug" '{slug:$s, superseded:null, archived_seq:null}')" null
+  else
+    _emit ok update "$new_slug" "$("$JQ" -nc --arg s "$new_slug" --arg sup "$superseded" --arg aseq "$archseq" \
+      '{slug:$s, superseded:$sup, archived_seq:($aseq|tonumber)}')" null
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# candidate matching for implicit supersession (active corpus only)
+# ---------------------------------------------------------------------------
+_match_candidates() {  # _match_candidates <type> <norm-name>  -> matching slugs
+  local wtype="$1" wnorm="$2" f ftype fname fnorm rel s
+  [ -d "$CORPUS/$wtype" ] || return 0
+  for f in "$CORPUS/$wtype"/*.md; do
+    [ -f "$f" ] || continue
+    ftype="$(_fm_field "$f" type)"; [ -n "$ftype" ] || ftype="$wtype"
+    fname="$(_fm_field "$f" name)"
+    fnorm="$(_normalize "$fname")"
+    if [ "$ftype" = "$wtype" ] && [ "$fnorm" = "$wnorm" ]; then
+      rel="${f#$CORPUS/}"; s="${rel%.md}"
+      printf '%s\n' "$s"
+    fi
+  done
+}
+
+# ===========================================================================
+# VERB IMPLEMENTATIONS
+# ===========================================================================
+do_create() {
+  local NAME="" TYPE="" DESC="" norm slug path body content
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --type) _need_val "$#" --type; TYPE="$2"; shift 2 ;;
+      --type=*) TYPE="${1#*=}"; shift ;;
+      --description) _need_val "$#" --description; DESC="$2"; shift 2 ;;
+      --description=*) DESC="${1#*=}"; shift ;;
+      --*) _refuse create "" USAGE "unknown option '$1'" ;;
+      *) if [ -z "$NAME" ]; then NAME="$1"; else _refuse create "" USAGE "unexpected extra arg '$1'"; fi; shift ;;
+    esac
+  done
+  [ -n "$TYPE" ] || _refuse create "" USAGE "create requires --type {user|feedback|project|reference}"
+  _valid_type "$TYPE" || _refuse create "" USAGE "invalid --type '$TYPE'"
+  [ -n "$NAME" ] || _refuse create "" USAGE "create requires a topic name (positional)"
+  norm="$(_normalize "$NAME")"
+  [ -n "$norm" ] || _refuse create "" USAGE "name '$NAME' normalizes to empty"
+  slug="$TYPE/$norm"
+  _valid_slug "$slug" || _refuse create "$slug" BOUNDARY "computed slug escapes the corpus"
+  path="$CORPUS/$slug.md"
+  if [ -f "$path" ]; then
+    _refuse create "$slug" DEDUP_COLLISION "a topic with identity ($TYPE, $norm) already exists" \
+      "$("$JQ" -nc --arg s "$slug" '{existing:$s}')"
+  fi
+  body="$STDIN_BODY"   # pre-read off-lock in dispatch (#1); byte-identical to the old inline $(cat)
+  content="$(_topic_content "$NAME" "$TYPE" "$DESC" "$body")"
+  _atomic_write "$path" "$content"
+  _rebuild_index >/dev/null
+  _audit create "$slug"
+  _emit ok create "$slug" \
+    "$("$JQ" -nc --arg s "$slug" --arg t "$TYPE" --arg n "$NAME" --arg p "$slug.md" \
+       '{slug:$s, type:$t, name:$n, path:$p}')" null
+}
+
+do_read() {
+  local SLUG="" ARCHIVED=0 path content adir f seq rel c archived_json n=0 data
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --archived) ARCHIVED=1; shift ;;
+      --*) _refuse read "" USAGE "unknown option '$1'" ;;
+      *) if [ -z "$SLUG" ]; then SLUG="$1"; else _refuse read "" USAGE "unexpected extra arg '$1'"; fi; shift ;;
+    esac
+  done
+  [ -n "$SLUG" ] || _refuse read "" USAGE "read requires a slug"
+  _valid_slug "$SLUG" || _refuse read "$SLUG" BOUNDARY "slug escapes the corpus (traversal/absolute)"
+  if [ "$ARCHIVED" = 1 ]; then
+    adir="$CORPUS/.archive/$SLUG"
+    archived_json="[]"
+    if [ -d "$adir" ]; then
+      for f in "$adir"/*.md; do
+        [ -f "$f" ] || continue
+        seq="$(basename "$f" .md)"; rel="${f#$CORPUS/}"; c="$(cat "$f")"
+        archived_json="$("$JQ" -nc --argjson a "$archived_json" --arg seq "$seq" --arg path "$rel" --arg content "$c" \
+          '$a + [{seq:$seq, path:$path, content:$content}]')"
+        n=$(( n + 1 ))
+      done
+    fi
+    data="$("$JQ" -nc --arg s "$SLUG" --argjson a "$archived_json" '{slug:$s, archived:$a}')"
+    _emit ok read "$SLUG" "$data" null
+  else
+    path="$CORPUS/$SLUG.md"
+    [ -f "$path" ] || _refuse read "$SLUG" NOT_FOUND "no live topic at slug '$SLUG' (try --archived)"
+    content="$(cat "$path")"
+    _emit ok read "$SLUG" "$("$JQ" -nc --arg s "$SLUG" --arg c "$content" '{slug:$s, content:$c}')" null
+  fi
+}
+
+do_update() {
+  local a has_supersede=0
+  for a in "$@"; do [ "$a" = "--supersede" ] && has_supersede=1; done
+  if [ "$has_supersede" = 1 ]; then _update_supersede "$@"; else _update_append "$@"; fi
+}
+
+_update_append() {
+  local SLUG="" path delta
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --*) _refuse update "" USAGE "unknown option '$1' in append-mode update" ;;
+      *) if [ -z "$SLUG" ]; then SLUG="$1"; else _refuse update "" USAGE "unexpected extra arg '$1'"; fi; shift ;;
+    esac
+  done
+  [ -n "$SLUG" ] || _refuse update "" USAGE "update requires a slug (or --supersede mode)"
+  _valid_slug "$SLUG" || _refuse update "$SLUG" BOUNDARY "slug escapes the corpus"
+  path="$CORPUS/$SLUG.md"
+  [ -f "$path" ] || _refuse update "$SLUG" NOT_FOUND "no live topic at slug '$SLUG' to update"
+  delta="$STDIN_BODY"   # pre-read off-lock in dispatch (#1); byte-identical to the old inline $(cat)
+  local _merged
+  _merged="$( { cat "$path"; printf '\n%s\n' "$delta"; }; printf x )"; _merged="${_merged%x}"
+  _atomic_write "$path" "$_merged"
+  _audit update "$SLUG"
+  _emit ok update "$SLUG" "$("$JQ" -nc --arg s "$SLUG" '{slug:$s, appended:true}')" null
+}
+
+_update_supersede() {
+  local TYPE="" NAME="" SUPERSEDES="" DESC="" norm new_slug body content superseded cands cnt carr
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --supersede) shift ;;
+      --type) _need_val "$#" --type; TYPE="$2"; shift 2 ;;
+      --type=*) TYPE="${1#*=}"; shift ;;
+      --name) _need_val "$#" --name; NAME="$2"; shift 2 ;;
+      --name=*) NAME="${1#*=}"; shift ;;
+      --supersedes) _need_val "$#" --supersedes; SUPERSEDES="$2"; shift 2 ;;
+      --supersedes=*) SUPERSEDES="${1#*=}"; shift ;;
+      --description) _need_val "$#" --description; DESC="$2"; shift 2 ;;
+      --description=*) DESC="${1#*=}"; shift ;;
+      --*) _refuse update "" USAGE "unknown option '$1'" ;;
+      *) _refuse update "" USAGE "unexpected positional '$1' in supersede mode (use --name)" ;;
+    esac
+  done
+  [ -n "$TYPE" ] || _refuse update "" USAGE "supersede requires --type"
+  _valid_type "$TYPE" || _refuse update "" USAGE "invalid --type '$TYPE'"
+  [ -n "$NAME" ] || _refuse update "" USAGE "supersede requires --name"
+  norm="$(_normalize "$NAME")"
+  [ -n "$norm" ] || _refuse update "" USAGE "name '$NAME' normalizes to empty"
+  new_slug="$TYPE/$norm"
+  _valid_slug "$new_slug" || _refuse update "$new_slug" BOUNDARY "computed slug escapes the corpus"
+  body="$STDIN_BODY"   # pre-read off-lock in dispatch (#1); byte-identical to the old inline $(cat)
+  content="$(_topic_content "$NAME" "$TYPE" "$DESC" "$body")"
+  superseded=""
+  if [ -n "$SUPERSEDES" ]; then
+    _valid_slug "$SUPERSEDES" || _refuse update "$new_slug" BOUNDARY "invalid --supersedes slug"
+    [ -f "$CORPUS/$SUPERSEDES.md" ] || _refuse update "$new_slug" NOT_FOUND "explicit --supersedes target not live: $SUPERSEDES"
+    superseded="$SUPERSEDES"
+  else
+    cands="$(_match_candidates "$TYPE" "$norm")"
+    cnt="$(printf '%s\n' "$cands" | grep -c . || true)"
+    if [ "$cnt" -eq 0 ]; then
+      superseded=""
+    elif [ "$cnt" -eq 1 ]; then
+      superseded="$(printf '%s\n' "$cands" | grep . | head -1)"
+    else
+      carr="$(printf '%s\n' "$cands" | grep . | "$JQ" -R . | "$JQ" -sc .)"
+      _refuse update "$new_slug" SUPERSEDE_AMBIGUOUS \
+        "≥2 active topics match identity ($TYPE, $norm); refusing to guess which to archive — pass --supersedes to disambiguate" \
+        "$("$JQ" -nc --argjson c "$carr" '{candidates:$c}')"
+    fi
+  fi
+  # #1/#2 fix (the create-guards-on-existence vs supersede-matches-on-frontmatter asymmetry root):
+  # the new-topic write must NEVER clobber a live topic that is not the archive target.
+  if [ -f "$CORPUS/$new_slug.md" ] && [ "$new_slug" != "$superseded" ]; then
+    if [ -n "$SUPERSEDES" ]; then
+      # explicit target named, but the new identity is a DIFFERENT occupied slug -> refuse (do not destroy an unmentioned live fact)
+      _refuse update "$new_slug" NEW_SLUG_OCCUPIED \
+        "new identity '$new_slug' is already live and is NOT the supersede target '$superseded' — refusing to overwrite an unrelated fact; archive it explicitly or supersede it directly" \
+        "$("$JQ" -nc --arg s "$new_slug" --arg sup "$superseded" '{occupant:$s, supersede_target:$sup}')"
+    else
+      # implicit 0-match, but a match-invisible (raw/legacy/frontmatter-divergent) live file occupies the target identity
+      # -> tier it via the WAL (archive-first), never blind-overwrite it
+      superseded="$new_slug"
+    fi
+  fi
+  if [ -z "$superseded" ]; then
+    # 0-match AND new_slug free: plain create path (no archive, no WAL)
+    _atomic_write "$CORPUS/$new_slug.md" "$content"
+    _rebuild_index >/dev/null
+    _audit update "$new_slug"
+    _emit ok update "$new_slug" "$("$JQ" -nc --arg s "$new_slug" '{slug:$s, superseded:null, created:true}')" null
+  else
+    _wal_supersede "$new_slug" "$superseded" "$content"
+  fi
+}
+
+do_archive() {
+  local SLUG="" seq
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --*) _refuse archive "" USAGE "unknown option '$1'" ;;
+      *) if [ -z "$SLUG" ]; then SLUG="$1"; else _refuse archive "" USAGE "unexpected extra arg '$1'"; fi; shift ;;
+    esac
+  done
+  [ -n "$SLUG" ] || _refuse archive "" USAGE "archive requires a slug"
+  _valid_slug "$SLUG" || _refuse archive "$SLUG" BOUNDARY "slug escapes the corpus"
+  [ -f "$CORPUS/$SLUG.md" ] || _refuse archive "$SLUG" NOT_FOUND "no live topic at slug '$SLUG'"
+  seq="$(_archive_topic "$SLUG")"
+  _rebuild_index >/dev/null
+  _audit archive "$SLUG"
+  _emit ok archive "$SLUG" \
+    "$("$JQ" -nc --arg s "$SLUG" --arg seq "$seq" --arg p ".archive/$SLUG/$(printf '%04d' "$seq").md" \
+       '{slug:$s, archived_seq:($seq|tonumber), archive_path:$p}')" null
+}
+
+do_index() {
+  local n
+  _rebuild_index >/dev/null; n="$REBUILD_COUNT"   # in-shell (NOT $()) so _atomic_write's BOUNDARY refuse
+                                                  # aborts the whole process, never just a subshell (#3)
+  _audit index ""
+  _emit ok index "" "$("$JQ" -nc --argjson e "${n:-0}" '{entries:$e, index:"MEMORY.md"}')" null
+}
+
+do_search() {
+  local QUERY="" d f rel s matches="[]"
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --*) _refuse search "" USAGE "unknown option '$1'" ;;
+      *) if [ -z "$QUERY" ]; then QUERY="$1"; else _refuse search "" USAGE "unexpected extra arg '$1'"; fi; shift ;;
+    esac
+  done
+  [ -n "$QUERY" ] || _refuse search "" USAGE "search requires a query"
+  # structural grep over LIVE topics only (.archive/.gateway never scanned).
+  # NOTE: episodic-memory semantic recall is not callable from bash — degrade
+  # to grep-only and report it (semantic:false), per ADR-013 graceful fallback.
+  for d in user feedback project reference; do
+    [ -d "$CORPUS/$d" ] || continue
+    while IFS= read -r f; do
+      [ -n "$f" ] || continue
+      rel="${f#$CORPUS/}"; s="${rel%.md}"
+      matches="$("$JQ" -nc --argjson a "$matches" --arg s "$s" '$a + [{slug:$s}]')"
+    done <<EOF
+$(grep -rlF -- "$QUERY" "$CORPUS/$d" 2>/dev/null || true)
+EOF
+  done
+  _emit ok search "" "$("$JQ" -nc --arg q "$QUERY" --argjson m "$matches" '{query:$q, semantic:false, matches:$m}')" null
+}
+
+do_neighborhood() {
+  local SEED="" DEPTH=1 visited frontier nodes level nf node f links l nodes_json
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --depth) _need_val "$#" --depth; DEPTH="$2"; shift 2 ;;
+      --depth=*) DEPTH="${1#*=}"; shift ;;
+      --budget) _need_val "$#" --budget; shift 2 ;;   # accepted; bounded by depth × corpus
+      --budget=*) shift ;;
+      --*) _refuse neighborhood "" USAGE "unknown option '$1'" ;;
+      *) if [ -z "$SEED" ]; then SEED="$1"; else _refuse neighborhood "" USAGE "unexpected extra arg '$1'"; fi; shift ;;
+    esac
+  done
+  [ -n "$SEED" ] || _refuse neighborhood "" USAGE "neighborhood requires a seed slug"
+  _valid_slug "$SEED" || _refuse neighborhood "$SEED" BOUNDARY "seed slug escapes the corpus"
+  case "$DEPTH" in ''|*[!0-9]*) DEPTH=1 ;; esac
+  [ "$DEPTH" -lt 1 ] && DEPTH=1
+  if [ "$DEPTH" -gt 3 ]; then
+    echo "memory-gateway: --depth $DEPTH clamped to 3 (max walk depth)" >&2
+    DEPTH=3
+  fi
+  # BFS over [[type/name]] wikilinks (type-qualified slugs for unambiguous resolution)
+  visited="$SEED"; frontier="$SEED"; nodes=""; level=1
+  while [ "$level" -le "$DEPTH" ]; do
+    nf=""
+    while IFS= read -r node; do
+      [ -n "$node" ] || continue
+      f="$CORPUS/$node.md"
+      [ -f "$f" ] || continue
+      links="$(grep -o '\[\[[^]]*\]\]' "$f" 2>/dev/null | sed 's/^\[\[//; s/\]\]$//' || true)"
+      while IFS= read -r l; do
+        [ -n "$l" ] || continue
+        _valid_slug "$l" || continue
+        case "
+$visited
+" in *"
+$l
+"*) continue ;; esac
+        visited="$visited
+$l"
+        nodes="$nodes
+$l"
+        nf="$nf
+$l"
+      done <<EOF
+$links
+EOF
+    done <<EOF
+$frontier
+EOF
+    frontier="$nf"
+    level=$(( level + 1 ))
+  done
+  nodes_json="$(printf '%s\n' "$nodes" | grep . | "$JQ" -R . | "$JQ" -sc . 2>/dev/null || true)"
+  [ -n "$nodes_json" ] || nodes_json="[]"
+  _emit ok neighborhood "$SEED" \
+    "$("$JQ" -nc --arg s "$SEED" --argjson d "$DEPTH" --argjson n "$nodes_json" '{seed:$s, depth:$d, nodes:$n}')" null
+}
+
+# ===========================================================================
+# ARG PARSE (extract global --corpus/--help anywhere; verb = first positional)
+# ===========================================================================
+CORPUS_ARG=""
+HELP=0
+ARGS=()
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --corpus) _need_val "$#" --corpus; CORPUS_ARG="$2"; shift 2 ;;
+    --corpus=*) CORPUS_ARG="${1#*=}"; shift ;;
+    -h|--help|help) HELP=1; shift ;;
+    *) ARGS[${#ARGS[@]}]="$1"; shift ;;
+  esac
+done
+[ "$HELP" = 1 ] && { usage; exit 0; }
+if [ "${#ARGS[@]}" -gt 0 ]; then set -- "${ARGS[@]}"; else set --; fi
+VERB="${1:-}"
+[ $# -gt 0 ] && shift || true
+[ -n "$VERB" ] || { usage; _refuse "" "" USAGE "no verb given (create|read|update|archive|search|neighborhood|index)"; }
+
+# resolve + validate corpus (setup errors -> exit 2)
+CORPUS="${CORPUS_ARG:-${MEMORY_GATEWAY_CORPUS:-}}"
+[ -n "$CORPUS" ] || _err_setup "no corpus given (pass --corpus <dir> or set MEMORY_GATEWAY_CORPUS)"
+[ -d "$CORPUS" ] || _err_setup "corpus root not found: $CORPUS"
+CORPUS="$(cd "$CORPUS" && pwd -P)"   # physical/canonical: MUST match the `pwd -P` in _assert_within_corpus (else macOS /var->/private/var symlink asymmetry refuses every write)
+
+# ===========================================================================
+# DISPATCH — recovery runs before serving ANY verb (spec: never serve over a
+# half-applied supersession). Mutating verbs hold the lock across the mutation;
+# read verbs take the lock only if recovery is actually pending, then release.
+# ===========================================================================
+case "$VERB" in
+  create|update|archive|index)
+    # #1 (MED availability): drain the body from stdin BEFORE acquiring the lock. An
+    # open-but-silent stdin (a mis-wired caller that spawns the gateway and forgets to
+    # feed/close the body) would otherwise block $(cat) INSIDE the critical section and
+    # wedge every other writer with CONCURRENT_WRITER until EOF. Read off-lock: a blocking
+    # read now stalls the caller's OWN process only, never the single-writer lock. NOTE the
+    # drain precedes the verb's arg-validation: an EOF/piped stdin (the agent case) still
+    # refuses bad args fast, but an open-but-silent stdin self-stalls HERE before any
+    # USAGE/DEDUP/etc. refuse — off-lock & self-only, so it degrades to a caller-local hang,
+    # never a corpus-wide wedge. archive and index take no body, so they are not pre-read
+    # (reading their stdin could itself block).
+    case "$VERB" in create|update) STDIN_BODY="$(cat)" ;; esac
+    _lock_acquire
+    _recover
+    case "$VERB" in
+      create) do_create "$@" ;;
+      update) do_update "$@" ;;
+      archive) do_archive "$@" ;;
+      index) do_index "$@" ;;
+    esac
+    _lock_release
+    ;;
+  read|search|neighborhood)
+    if _wal_needs_recovery; then _lock_acquire; _recover; _lock_release; fi
+    case "$VERB" in
+      read) do_read "$@" ;;
+      search) do_search "$@" ;;
+      neighborhood) do_neighborhood "$@" ;;
+    esac
+    ;;
+  *)
+    _refuse "$VERB" "" UNKNOWN_VERB "unknown verb '$VERB' (create|read|update|archive|search|neighborhood|index)"
+    ;;
+esac
+exit 0

--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -364,11 +364,12 @@ _archive_topic() {  # _archive_topic <slug>  -> moves live to archive; sets $ARC
   local slug="$1" live adir cnt seq padded dst
   live="$CORPUS/$slug.md"
   adir="$CORPUS/.archive/$slug"
-  mkdir -p "$adir"
+  mkdir -p "$adir" || _err_io "failed to create the archive dir for '$slug' — I/O error (refusing to proceed; the superseding write must never overwrite an un-archived fact)"
   cnt="$(find "$adir" -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')"
   seq=$(( cnt + 1 ))
   padded="$(printf '%04d' "$seq")"
   dst="$adir/$padded.md"
+  _assert_within_corpus "$dst" || _refuse "${VERB:-}" "$slug" BOUNDARY "resolved archive path escapes the corpus root (symlinked .archive?): $dst"   # mirror _atomic_write's write-boundary guard on the ARCHIVE-move path — a pre-planted symlinked .archive must NOT send mv outside CORPUS (CodeRabbit PDCA-7)
   mv "$live" "$dst" || _err_io "failed to move '$slug' into the archive tier — I/O error (refusing to proceed; the superseding write must never overwrite an un-archived fact)"
   _fsync "$(dirname "$live")"; _fsync "$adir"
   ARCHSEQ="$seq"   # global out-var — MUST run in the caller's process (was `printf '%s' "$seq"` read via $(), which forked a subshell that swallowed _err_io's exit 2 on mv failure -> parent continued -> false ok; qodo PDCA-6)

--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -766,6 +766,11 @@ do_neighborhood() {
         [ -n "$l" ] || continue
         _valid_slug "$l" || continue
         [ -f "$CORPUS/$l.md" ] || continue   # E6 forgetting: a link to a superseded/archived (or dangling) topic is NOT a live neighbor -> never reported
+        _assert_read_safe "$CORPUS/$l.md" || continue   # boundary symmetry (CodeRabbit PDCA-5): a _valid_slug (string-safe) neighbor whose
+                                                        # type-dir or topic file is a symlink escaping the corpus passes [ -f ] (follows the
+                                                        # link) -> never surface its slug. A leaf neighbor is listed but never promoted to $node,
+                                                        # so the line-763 node-guard would never run on it; guard it here so read/search/neighborhood
+                                                        # all apply the SAME realpath boundary to every item they surface. (Also stops it entering the frontier.)
         case "
 $visited
 " in *"

--- a/bin/memory-gateway
+++ b/bin/memory-gateway
@@ -82,6 +82,7 @@ PS_BIN="$(_resolve_bin ps /bin/ps /usr/bin/ps || true)"   # for _lock_is_stale l
 
 VERB=""
 CORPUS=""
+ARCHSEQ=""   # output var of _archive_topic/_archive_if_stale — set in the CALLER's process (NOT via $()) so _err_io's exit 2 propagates on an archive-move I/O failure (qodo PDCA-6)
 LOCK=""
 LOCK_HELD=0
 LOCK_STALE_SECS=900
@@ -359,7 +360,7 @@ _rebuild_index() {  # rebuilds MEMORY.md; echoes the live-entry count
 # ---------------------------------------------------------------------------
 # archive tier (seq-numbered; content NEVER destroyed)
 # ---------------------------------------------------------------------------
-_archive_topic() {  # _archive_topic <slug>  -> moves live to archive, echoes seq
+_archive_topic() {  # _archive_topic <slug>  -> moves live to archive; sets $ARCHSEQ to the seq
   local slug="$1" live adir cnt seq padded dst
   live="$CORPUS/$slug.md"
   adir="$CORPUS/.archive/$slug"
@@ -370,16 +371,17 @@ _archive_topic() {  # _archive_topic <slug>  -> moves live to archive, echoes se
   dst="$adir/$padded.md"
   mv "$live" "$dst" || _err_io "failed to move '$slug' into the archive tier — I/O error (refusing to proceed; the superseding write must never overwrite an un-archived fact)"
   _fsync "$(dirname "$live")"; _fsync "$adir"
-  printf '%s' "$seq"
+  ARCHSEQ="$seq"   # global out-var — MUST run in the caller's process (was `printf '%s' "$seq"` read via $(), which forked a subshell that swallowed _err_io's exit 2 on mv failure -> parent continued -> false ok; qodo PDCA-6)
 }
 
-_archive_if_stale() {  # _archive_if_stale <slug> <new-payload>  (idempotent guard)
+_archive_if_stale() {  # _archive_if_stale <slug> <new-payload>  (idempotent guard); sets $ARCHSEQ ('' = no-op, else the archived seq)
   local slug="$1" payload="$2" live cur
+  ARCHSEQ=""                                        # reset the global out-var (was: `printf ''` on the two no-op branches)
   live="$CORPUS/$slug.md"
-  [ -f "$live" ] || { printf ''; return 0; }       # already archived / absent -> no-op
+  [ -f "$live" ] || return 0                        # already archived / absent -> no-op (ARCHSEQ stays '')
   cur="$(cat "$live")"
-  [ "$cur" = "$payload" ] && { printf ''; return 0; }  # new already installed -> no double-archive
-  _archive_topic "$slug"
+  [ "$cur" = "$payload" ] && return 0               # new already installed -> no double-archive (ARCHSEQ stays '')
+  _archive_topic "$slug"                            # sets $ARCHSEQ; on I/O failure _err_io exits the REAL process (no subshell to swallow it)
 }
 
 # ---------------------------------------------------------------------------
@@ -422,7 +424,8 @@ _replay_supersede() {  # _replay_supersede <intent-json>  (idempotent). returns 
       return 1   # corrupt payload: mutate NOTHING (neither archive nor write) — never persist corruption
     fi
   fi
-  [ -n "$superseded" ] && [ "$superseded" != "null" ] && _archive_if_stale "$superseded" "$payload" >/dev/null
+  # recovery replay: archive-first (via $ARCHSEQ, NOT $()) so an archive-move I/O failure here also exits 2 with the [C06] envelope on real stdout (the old `>/dev/null` even ate _err_io's envelope), leaving the intent OPEN for the next retry
+  [ -n "$superseded" ] && [ "$superseded" != "null" ] && _archive_if_stale "$superseded" "$payload"
   _atomic_write "$CORPUS/$new_slug.md" "$payload" || _err_io "recovery: failed to write '$new_slug' — I/O error (intent left OPEN for the next recovery; no commit marker written)"
   _rebuild_index >/dev/null
 }
@@ -468,7 +471,8 @@ _wal_supersede() {  # _wal_supersede <new_slug> <superseded_slug> <content>
   _fsync "$wal"; _fsync "$CORPUS/.gateway"
   _crash_if intent
   # STAGE 2 — archive the superseded (archive-FIRST; see header NOTE)
-  archseq="$(_archive_if_stale "$superseded" "$content")"
+  # NOT `$(...)`: an archive-move I/O failure must let _err_io's exit 2 abort THIS process (WAL intent stays OPEN, successor never written) — a command substitution would fork a subshell, swallow the exit, and let STAGE 3-5 emit a false ok (qodo PDCA-6)
+  _archive_if_stale "$superseded" "$content"; archseq="$ARCHSEQ"
   _crash_if archive
   # STAGE 3 — write the new live topic (atomic temp->rename, fsync)
   _atomic_write "$CORPUS/$new_slug.md" "$content" || _err_io "supersede: failed to write new topic '$new_slug' — I/O error (WAL intent stays OPEN; recovery completes it idempotently)"
@@ -690,7 +694,7 @@ do_archive() {
   [ -n "$SLUG" ] || _refuse archive "" USAGE "archive requires a slug"
   _valid_slug "$SLUG" || _refuse archive "$SLUG" BOUNDARY "slug escapes the corpus"
   [ -f "$CORPUS/$SLUG.md" ] || _refuse archive "$SLUG" NOT_FOUND "no live topic at slug '$SLUG'"
-  seq="$(_archive_topic "$SLUG")"
+  _archive_topic "$SLUG"; seq="$ARCHSEQ"   # NOT `$()`: same subshell-swallows-exit-2 hazard as the supersede path — the standalone archive verb must also fail loud on an archive-move I/O error (qodo PDCA-6)
   _rebuild_index >/dev/null
   _audit archive "$SLUG"
   _emit ok archive "$SLUG" \

--- a/skills/memory-gateway/SKILL.md
+++ b/skills/memory-gateway/SKILL.md
@@ -100,7 +100,9 @@ memory-gateway --corpus ~/mem neighborhood user/merge-preference --depth 2
 
 ## Advisory Posture
 
-This skill is **advisory-first**: it tells you *to route memory through the gateway* and *how*. It does not hard-block direct edits. If a direct edit is genuinely necessary (migration, repair), run `memory-gateway --corpus <dir> index` afterward to reconcile the index, and prefer the gateway for anything that mutates identity or supersedes a fact.
+This skill is **advisory-first**: it tells you *to route ALL memory mutations through the gateway* and *how*. Direct edits are **not** a supported mutation path — they bypass deduplication, canonical-identity resolution, supersession/forgetting, the corpus lock, WAL crash-recovery, and the audit trail, and can silently corrupt the index or resurrect a superseded fact.
+
+**Never** hand-edit to create, rename (an identity change), or supersede a topic — those MUST go through `create` / `update --supersede`, no exception. A direct edit is tolerated **only** as a last-resort one-off migration or repair, and only when it is: (1) performed on a **quiesced** corpus (no concurrent gateway writer), (2) followed immediately by `memory-gateway --corpus <dir> index` to reconcile the index, and (3) verified by re-reading the affected slugs. Anything that mutates identity or supersedes a fact is gateway-only.
 
 ## References
 

--- a/skills/memory-gateway/SKILL.md
+++ b/skills/memory-gateway/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: memory-gateway
+description: Use when creating, updating, superseding, archiving, reading, searching, or walking the persistent memory corpus. The ONE crash-safe writer to memory — route every memory mutation through it instead of editing topic files directly, so identity-dedup, atomic forgetting (supersede archives the old fact in the same op), and write-ahead crash recovery are guaranteed.
+version: 1.0.0
+author: MAOS (ADR-013 / EKO-116)
+---
+
+# Memory Gateway
+
+## Purpose
+
+`bin/memory-gateway` is the **single front-door** to the persistent memory corpus. It replaces ad-hoc `Edit`/`Write` on topic files, which silently allow three failure modes the gateway makes structurally impossible:
+
+1. **Identity collision** — two facts written to the same canonical identity. The gateway dedups on `(type, normalize(name))`.
+2. **Failure that never happens** — a superseded fact left live next to its replacement. The gateway's `update --supersede` **archives the old fact in the same operation** (the E6 mutation-hook).
+3. **Torn corpus after a crash** — a mutation interrupted mid-write. The gateway uses a 5-stage write-ahead log and **completes any pending transaction before serving any verb**.
+
+**Ownership rule:** the gateway *owns* corpus mutation. Other agents/skills do **not** write topic files directly — **they ask IT**. This is the deterministic skeleton; your judgment is the probabilistic muscle that decides *what* to remember.
+
+## When to Use
+
+Invoke the gateway whenever you would otherwise hand-edit memory:
+
+- persisting a new lesson/fact/preference → `create`
+- appending to an existing topic → `update <slug>`
+- replacing a fact with a newer version (and retiring the old one) → `update --supersede`
+- retiring a topic without destroying it → `archive`
+- retrieving a topic → `read`
+- finding topics by content → `search`
+- exploring linked topics → `neighborhood`
+- regenerating the index after out-of-band changes → `index`
+
+## Identity & Slugs
+
+- Canonical key = `(type, normalize(name))`; `type ∈ {user, feedback, project, reference}`.
+- `normalize` = lowercase + non-alphanumeric runs → `-` + trimmed. So `"My Profile"`, `"my-profile"`, `"MY  PROFILE"` are the **same** identity.
+- Slug = `<type>/<normalize(name)>` → `user/profile`. Type-qualified, so `user/profile` and `project/profile` are **distinct** addresses that never collide.
+- `archive` is the ONLY removal verb; content is **never destroyed** — it is tiered into `<corpus>/.archive/…` and stays retrievable via `read <slug> --archived`. Purge/true-erasure is out of scope by design.
+
+## The 7-Verb Contract
+
+```bash
+memory-gateway --corpus <dir> <verb> [args]     # or export MEMORY_GATEWAY_CORPUS=<dir>
+
+create <name> --type T [--description D]                        # body on stdin
+read <slug> [--archived]
+update <slug>                                                   # append; delta on stdin
+update --supersede --type T --name N [--supersedes <slug>] [--description D]   # new body on stdin
+archive <slug>
+search <query>
+neighborhood <seed-slug> [--depth N] [--budget N]              # depth 1..3; >3 clamped
+index
+```
+
+Supersession resolution (`update --supersede`):
+- `--supersedes <slug>` given → **authoritative**: archives exactly that topic.
+- omitted → matches the new fact's `(type, name)` against the **active** corpus only:
+  - **0 matches** → plain create (nothing to forget).
+  - **exactly 1** → archive-the-superseded + reindex + audit, all in the same atomic op.
+  - **≥2 candidates** → **refuses** (`SUPERSEDE_AMBIGUOUS`) naming the candidates — never guesses which to archive.
+
+## Output & Exit Codes
+
+Exactly **one JSON envelope on stdout** per execution (human diagnostics go to **stderr only** — parse stdout deterministically):
+
+```json
+{"status":"ok|refused|error","verb":"<verb>","slug":"<slug|null>","data":{…}|null,"reason":{"code":"…","message":"…"}|null}
+```
+
+- `reason` is present iff `status != "ok"`. Refusal codes: `DEDUP_COLLISION`, `CONCURRENT_WRITER`, `BOUNDARY`, `SUPERSEDE_AMBIGUOUS`, `NOT_FOUND`, `USAGE`, `UNKNOWN_VERB`.
+- **Exit codes** ([C06]): `0` success (incl. idempotent no-op) · `1` refused / usage-or-validation (detail is in the JSON, not a distinct code) · `2` setup (jq missing, corpus root absent).
+
+## Examples
+
+```bash
+# remember a new preference (dedup-checked on identity)
+printf 'Prefer squash-merge with --delete-branch.\n' \
+  | memory-gateway --corpus ~/mem create "merge preference" --type user --description "git merge default"
+
+# supersede it with a newer version — the old one is archived in the SAME op
+printf 'Prefer squash-merge; keep the branch for release PRs.\n' \
+  | memory-gateway --corpus ~/mem update --supersede --type user --name "merge preference"
+
+# read the current fact; then list every archived version
+memory-gateway --corpus ~/mem read user/merge-preference
+memory-gateway --corpus ~/mem read user/merge-preference --archived
+
+# find + walk
+memory-gateway --corpus ~/mem search "squash"
+memory-gateway --corpus ~/mem neighborhood user/merge-preference --depth 2
+```
+
+## Guarantees (why you can trust it)
+
+- **Atomic forgetting** — supersede archives the superseded topic in the same operation; the corpus never shows a fact next to its own replacement.
+- **Crash-safe** — a 5-stage WAL over an exclusive corpus lock; the next invocation completes any interrupted supersession *before* serving a verb, so reads never observe a half-applied state. `archive`/`create`/append use atomic temp→rename + fsync (any partial state is a benign orphan healed by `index`).
+- **Concurrency-safe** — a mutating verb that cannot take the corpus lock **refuses** (`CONCURRENT_WRITER`) rather than clobber a peer's in-flight write.
+- **Boundary-safe** — slugs that escape the corpus root (`..`, absolute) are refused (`BOUNDARY`).
+- **Auditable** — every mutation appends one JSONL line (`verb`/`slug`/`ts`/`corpus`) to `${MEMORY_GATEWAY_DIR:-~/.claude/audit}/memory-gateway.jsonl`.
+
+## Advisory Posture
+
+This skill is **advisory-first**: it tells you *to route memory through the gateway* and *how*. It does not hard-block direct edits. If a direct edit is genuinely necessary (migration, repair), run `memory-gateway --corpus <dir> index` afterward to reconcile the index, and prefer the gateway for anything that mutates identity or supersedes a fact.
+
+## References
+
+- Spec: `docs/adrs/ADR-013-memory-crud-gateway.md`
+- Implementation: `bin/memory-gateway`
+- Tests: `tests/test-memory-gateway.sh`
+- Sibling read-only pre-scan: `bin/memory-curator-sweep.sh` (ADR-012)

--- a/skills/memory-gateway/SKILL.md
+++ b/skills/memory-gateway/SKILL.md
@@ -95,7 +95,7 @@ memory-gateway --corpus ~/mem neighborhood user/merge-preference --depth 2
 - **Atomic forgetting** — supersede archives the superseded topic in the same operation; the corpus never shows a fact next to its own replacement.
 - **Crash-safe** — a 5-stage WAL over an exclusive corpus lock; the next invocation completes any interrupted supersession *before* serving a verb, so reads never observe a half-applied state. `archive`/`create`/append use atomic temp→rename + fsync (any partial state is a benign orphan healed by `index`).
 - **Concurrency-safe** — a mutating verb that cannot take the corpus lock **refuses** (`CONCURRENT_WRITER`) rather than clobber a peer's in-flight write.
-- **Boundary-safe** — slugs that escape the corpus root (`..`, absolute) are refused (`BOUNDARY`).
+- **Boundary-safe** — slugs that escape the corpus root (`..`, absolute) are refused (`BOUNDARY`), and every write/read/archive path is realpath-checked so a **pre-planted** symlink (type-dir, topic file, or `.archive`) cannot send an operation outside the corpus. **Threat-model invariant:** this holds under the gateway's single-writer contract — the corpus dir MUST be owned/writable ONLY by the gateway's uid. A non-cooperating process with write access to the corpus can TOCTOU-race any in-process check (or delete the corpus outright); defending that is an OS-level filesystem-ownership concern, not an application one.
 - **Auditable** — every mutation appends one JSONL line (`verb`/`slug`/`ts`/`corpus`) to `${MEMORY_GATEWAY_DIR:-~/.claude/audit}/memory-gateway.jsonl`.
 
 ## Advisory Posture

--- a/tests/test-memory-gateway.sh
+++ b/tests/test-memory-gateway.sh
@@ -699,28 +699,29 @@ fi
 #     _atomic_write guards the topic-WRITE path with _assert_within_corpus (test 31),
 #     but _archive_topic's `mv "$live" "$dst"` did NOT -> a pre-planted `.archive`
 #     symlink pointing OUTSIDE the corpus would send the live topic's content out of
-#     CORPUS. Root fix: _assert_within_corpus "$dst" before the mv (mirrors
-#     _atomic_write:238). Inject: symlink `.archive` -> an OUTSIDE dir, then archive.
-#     Asserts: refused BOUNDARY + live topic un-moved + NO *.md written outside corpus
-#     (mkdir may leave an empty out-of-corpus dir, exactly as _atomic_write does — the
-#     guarantee is that no CONTENT leaves, parallel to test 31's `! -e $OUTSIDE/pwned.md`).
+#     CORPUS. Root fix (refined per CodeRabbit re-review): _assert_new_path_within_corpus
+#     "$adir" BEFORE `mkdir -p` — resolve the deepest EXISTING ancestor of .archive and
+#     refuse a symlinked escape without creating ANY filesystem artifact. Stricter than
+#     _atomic_write's post-mkdir check (that asymmetry is a documented deferred follow-up).
+#     Inject: symlink `.archive` -> an OUTSIDE dir, then archive.
+#     Asserts: refused BOUNDARY + live topic un-moved + the OUTSIDE dir has ZERO descendants
+#     (nothing at all created outside corpus — stronger than "no *.md"; holds because the
+#     boundary check now runs BEFORE mkdir).
+#     Runs as root too — the symlink boundary is UID-independent (cd+pwd -P), unlike test 44
+#     which relies on a chmod-555 perm-bypass that root would defeat.
 # ============================================================================
-if [ "$(id -u)" != 0 ]; then
-  AS="$(fresh)"
-  BODY="ARCHSYM original fact" gw --corpus "$AS" create profile --type user >/dev/null 2>&1   # the live fact to be archived
-  ASOUT="$ROOT_TMP/arch-outside.$$"; mkdir -p "$ASOUT"
-  ln -s "$ASOUT" "$AS/.archive"                                           # .archive now resolves OUTSIDE the corpus root
-  gw --corpus "$AS" archive user/profile
-  r45=$RC; c45="$(jqr "$OUT" '.reason.code')"
-  live45="$(cat "$AS/user/profile.md" 2>/dev/null)"
-  kept45=0; printf '%s' "$live45" | grep -q "ARCHSYM original" && kept45=1
-  nooutside45=0; [ -z "$(find "$ASOUT" -type f -name '*.md' 2>/dev/null)" ] && nooutside45=1
-  if [ "$r45" = 1 ] && [ "$c45" = BOUNDARY ] && [ "$kept45" = 1 ] && [ "$nooutside45" = 1 ]; then
-    ok "45 CodeRabbit#PDCA-7: symlinked .archive escape refused (BOUNDARY), live topic un-moved, no content written outside corpus"
-  else no "45 CodeRabbit#PDCA-7 archive-symlink (r45=$r45 c45=$c45 kept45=$kept45 nooutside45=$nooutside45 live=[$live45])"; fi
-else
-  ok "45 CodeRabbit#PDCA-7 archive-symlink skipped (running as root — symlink boundary still enforced by _assert_within_corpus)"
-fi
+AS="$(fresh)"
+BODY="ARCHSYM original fact" gw --corpus "$AS" create profile --type user >/dev/null 2>&1   # the live fact to be archived
+ASOUT="$ROOT_TMP/arch-outside.$$"; mkdir -p "$ASOUT"
+ln -s "$ASOUT" "$AS/.archive"                                           # .archive now resolves OUTSIDE the corpus root
+gw --corpus "$AS" archive user/profile
+r45=$RC; c45="$(jqr "$OUT" '.reason.code')"
+live45="$(cat "$AS/user/profile.md" 2>/dev/null)"
+kept45=0; printf '%s' "$live45" | grep -q "ARCHSYM original" && kept45=1
+noart45=0; [ -z "$(find "$ASOUT" -mindepth 1 2>/dev/null)" ] && noart45=1   # ZERO descendants: pre-mkdir refusal leaves the outside dir untouched
+if [ "$r45" = 1 ] && [ "$c45" = BOUNDARY ] && [ "$kept45" = 1 ] && [ "$noart45" = 1 ]; then
+  ok "45 CodeRabbit#PDCA-7: symlinked .archive refused BOUNDARY before any fs change (live un-moved, ZERO artifacts outside corpus)"
+else no "45 CodeRabbit#PDCA-7 archive-symlink (r45=$r45 c45=$c45 kept45=$kept45 noart45=$noart45 live=[$live45])"; fi
 
 echo ""
 [ "$fail" -eq 0 ] && { echo "test-memory-gateway: PASS"; exit 0; } || { echo "test-memory-gateway: FAIL"; exit 1; }

--- a/tests/test-memory-gateway.sh
+++ b/tests/test-memory-gateway.sh
@@ -50,7 +50,17 @@ gw() {
   ERR="$(cat "$ERRF" 2>/dev/null || true)"
   BODY=""   # consume
 }
-jqr() { printf '%s' "$1" | jq -r "$2" 2>/dev/null; }
+jqr() {  # retry-on-empty defeats a transient subprocess-spawn failure (fork EAGAIN) under the suite's
+         # burst load: jq prints "null" for null/absent fields, so a truly-empty result means jq
+         # failed to run, not a real value. No assertion compares a jqr result to literal "", so a
+         # deterministic parse-error retries to ""=unchanged (non-masking); only a transient clears.
+  local r a
+  for a in 1 2 3; do
+    r="$(printf '%s' "$1" | jq -r "$2" 2>/dev/null)"
+    [ -n "$r" ] && break
+  done
+  printf '%s' "$r"
+}
 fresh() { mktemp -d "$ROOT_TMP/corpus.XXXXXX"; }
 
 C="$(fresh)"
@@ -521,6 +531,115 @@ envs=$(printf '%s' "$OUT" | jq -s 'length' 2>/dev/null)
 [ "$irc" = 0 ] && [ "$envs" = 1 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.verb')" = index ] \
   && ok "36 #3: index emits exactly ONE envelope (no subshell double-emit)" \
   || no "36 #3 index envelope count=$envs (irc=$irc out=$OUT)"
+
+# ============================================================================
+# 37  BUG 5 (PDCA pass-3): a newline/CR in name OR description must refuse
+#     (USAGE) — a raw \n would inject/terminate the `---` frontmatter block
+#     (identity spoof / structural corruption). Nothing may be persisted.
+# ============================================================================
+IJ="$(fresh)"
+nl="$(printf '\nx')"; nl="${nl%x}"
+BODY="b" gw --corpus "$IJ" create "prof${nl}injected: evil" --type user
+r37a=$RC; c37a="$(jqr "$OUT" '.reason.code')"
+BODY="b" gw --corpus "$IJ" create legit --type user --description "line1${nl}type: reference"
+r37b=$RC; c37b="$(jqr "$OUT" '.reason.code')"
+BODY="b" gw --corpus "$IJ" update --supersede --type user --name "sup${nl}evil"
+r37c=$RC; c37c="$(jqr "$OUT" '.reason.code')"
+wrote37=$(find "$IJ" -path '*/.gateway' -prune -o -type f -name '*.md' ! -name MEMORY.md -print 2>/dev/null | wc -l | tr -d ' ')
+if [ "$r37a" = 1 ] && [ "$c37a" = USAGE ] && [ "$r37b" = 1 ] && [ "$c37b" = USAGE ] \
+   && [ "$r37c" = 1 ] && [ "$c37c" = USAGE ] && [ "$wrote37" = 0 ]; then
+  ok "37 Bug5: newline in name/description refused (USAGE) — no frontmatter injection, nothing written"
+else no "37 Bug5 newline injection (r37a=$r37a c37a=$c37a r37b=$r37b c37b=$c37b r37c=$r37c c37c=$c37c wrote=$wrote37)"; fi
+
+# ============================================================================
+# 38  BUG 4 (PDCA pass-3): E6 forgetting must hold for get_neighborhood too,
+#     not just search. A superseded (slug-CHANGING) neighbor disappears from
+#     the walk (its archived slug is no longer a live file -> skipped).
+# ============================================================================
+NB="$(fresh)"
+BODY="old neighbor NBRKW body" gw --corpus "$NB" create anchor-old --type reference
+BODY="hub links [[reference/anchor-old]] here" gw --corpus "$NB" create hub --type user
+gw --corpus "$NB" neighborhood user/hub --depth 1
+pre38="$(jqr "$OUT" '.data.nodes | index("reference/anchor-old")')"   # present -> a number; absent -> null
+BODY="new neighbor NBR2KW body" gw --corpus "$NB" update --supersede --type reference --name anchor-new --supersedes reference/anchor-old
+sup38=$RC
+gw --corpus "$NB" neighborhood user/hub --depth 1
+post38="$(jqr "$OUT" '.data.nodes | index("reference/anchor-old")')"
+if [ "$pre38" != null ] && [ "$sup38" = 0 ] && [ "$post38" = null ]; then
+  ok "38 Bug4: superseded neighbor ABSENT from get_neighborhood (present before, gone after supersession)"
+else no "38 Bug4 neighborhood exclusion (pre=$pre38 sup=$sup38 post=$post38)"; fi
+
+# ============================================================================
+# 39  BUG 3 (PDCA pass-3): an I/O failure on the topic write must NEVER report
+#     a false `ok`. Force mktemp-in-dir to fail (chmod 555: dir still traversable
+#     so the BOUNDARY cd resolves, but not writable) -> IO_ERROR exit 2, nothing
+#     persisted. (skip as root — root bypasses perms.)
+# ============================================================================
+if [ "$(id -u)" != 0 ]; then
+  IO="$(fresh)"
+  BODY="seed" gw --corpus "$IO" create seed --type user >/dev/null   # materialize user/
+  chmod 555 "$IO/user"                                               # r-x: traversable (cd ok) but not writable (mktemp fails)
+  BODY="should fail" gw --corpus "$IO" create victim --type user
+  r39=$RC; s39="$(jqr "$OUT" '.status')"; c39="$(jqr "$OUT" '.reason.code')"
+  chmod 755 "$IO/user"                                              # restore so trap cleanup can recurse
+  wrote39=0; [ -f "$IO/user/victim.md" ] && wrote39=1
+  if [ "$r39" = 2 ] && [ "$s39" = error ] && [ "$c39" = IO_ERROR ] && [ "$wrote39" = 0 ]; then
+    ok "39 Bug3: write I/O failure -> exit 2 IO_ERROR (never a false ok), nothing persisted"
+  else no "39 Bug3 io-failure (r39=$r39 s39=$s39 c39=$c39 wrote=$wrote39)"; fi
+else
+  ok "39 Bug3 skipped (running as root — perms bypassed)"
+fi
+
+# ============================================================================
+# 40  BUG 1 (PDCA pass-3): a stale-by-TS lock (LIVE holder pid but ts older than
+#     LOCK_STALE_SECS) is reclaimed via the atomic rename-steal (complements test
+#     30's dead-pid path; exercises the ts branch + single-winner reclaim).
+# ============================================================================
+SL="$(fresh)"
+BODY="v" gw --corpus "$SL" create x --type user            # materialize .gateway/
+mkdir -p "$SL/.gateway/lock.d"
+echo "$$" > "$SL/.gateway/lock.d/pid"                      # a LIVE pid (this test) -> NOT dead: forces the ts branch
+echo 1 > "$SL/.gateway/lock.d/ts"                          # epoch 1 -> age >> 900s -> stale-by-ts
+BODY="after stale" gw --corpus "$SL" create y --type user
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ]; then
+  gw --corpus "$SL" read user/y
+  [ "$RC" = 0 ] && ok "40 Bug1: stale-by-ts lock reclaimed via rename-steal (next writer proceeds)" || no "40 y unreadable after stale-ts reclaim"
+else no "40 Bug1 stale-ts reclaim (rc=$RC out=$OUT)"; fi
+
+# ============================================================================
+# 41  CodeRabbit (PDCA pass-4, EPERM vs ESRCH): a DEAD holder pid with a FRESH ts
+#     must still FAST-reclaim. `kill -0` fails for both ESRCH (dead) and EPERM
+#     (live/other-UID); the fix adds a `ps -p` probe so only a pid ps ALSO cannot
+#     see is reclaimed. Fresh ts => the ts backstop does NOT apply, isolating the
+#     pid-death (ESRCH) branch — proves the EPERM split didn't break dead-pid recovery.
+# ============================================================================
+DP="$(fresh)"
+BODY="v" gw --corpus "$DP" create x --type user            # materialize .gateway/
+mkdir -p "$DP/.gateway/lock.d"
+echo 99999999 > "$DP/.gateway/lock.d/pid"                  # a pid above every OS's PID_MAX: kill -0 -> ESRCH AND
+                                                           # ps -p -> absent, DETERMINISTICALLY. an un-reusable pid
+                                                           # avoids the reap-then-reuse race a real spawned pid has.
+date +%s > "$DP/.gateway/lock.d/ts"                        # FRESH ts -> ts backstop inert; isolates the pid-death (ESRCH) branch
+BODY="after dead" gw --corpus "$DP" create y --type user
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ]; then
+  gw --corpus "$DP" read user/y
+  [ "$RC" = 0 ] && ok "41 EPERM/ESRCH: dead holder (impossible pid, fresh ts) fast-reclaimed via ps-absent probe" || no "41 y unreadable after dead-pid reclaim"
+else no "41 dead-pid fast-reclaim (rc=$RC out=$OUT)"; fi
+
+# ============================================================================
+# 42  qodo #4 (PDCA pass-4, minimal-PATH): _resolve_bin's absolute-candidate list must
+#     contain a jq that actually WORKS when PATH is stripped (launchd/cron). This asserts
+#     the fix's premise directly — an absolute fallback candidate resolves AND runs under
+#     an empty PATH — without a full-gateway run (which also needs PATH-resolved coreutils,
+#     an orthogonal concern). Complements the manual /usr/bin:/bin end-to-end check.
+# ============================================================================
+jq_fb=""   # first candidate from the gateway's own fallback list that exists here
+for c in "${HOME:-}/.local/share/mise/shims/jq" "${HOME:-}/.asdf/shims/jq" /opt/homebrew/bin/jq /usr/local/bin/jq /usr/bin/jq /bin/jq; do
+  [ -x "$c" ] && { jq_fb="$c"; break; }
+done
+if [ -n "$jq_fb" ] && [ "$(PATH="" "$jq_fb" -nr '"ok"' 2>/dev/null)" = ok ]; then
+  ok "42 qodo#4: absolute jq fallback resolves + runs under empty PATH ($jq_fb) — minimal-PATH safe"
+else no "42 qodo#4 no working absolute jq fallback candidate (jq_fb=$jq_fb)"; fi
 
 echo ""
 [ "$fail" -eq 0 ] && { echo "test-memory-gateway: PASS"; exit 0; } || { echo "test-memory-gateway: FAIL"; exit 1; }

--- a/tests/test-memory-gateway.sh
+++ b/tests/test-memory-gateway.sh
@@ -1,0 +1,526 @@
+#!/usr/bin/env bash
+# Test: bin/memory-gateway — the memory-CRUD gateway (ADR-013, EKO-116).
+# ----------------------------------------------------------------------------
+# Covers the ADR-013 Definition-of-Done test list:
+#   - every verb happy-path (create/read/update/archive/index/search/neighborhood)
+#   - create dedup-refusal on the canonical identity key (type, normalize(name))
+#   - --type REQUIRED on create
+#   - type-qualified slug distinctness ((user,profile) vs (project,profile))
+#   - concurrent-writer refusal (mutating verb, never clobbers)
+#   - boundary refusal (paths escaping the corpus root)
+#   - archive-is-not-delete (archived content still exists in the archive tier)
+#   - index regeneration (one line per entry)
+#   - read-only guarantee for read/search/neighborhood
+#   - THE E6 HEADLINE FORGETTING TEST (mutation-hook supersession):
+#       N superseded -> N archived + 1 live THROUGH NORMAL WRITES ALONE,
+#       every superseded fact ABSENT from active reads, archived copy retrievable
+#   - canonicalization (case-fold + kebab; two writes of same canonical id -> same topic)
+#   - E6 supersession modes: explicit `--supersedes` (authoritative) · implicit
+#       (type,name) match on the ACTIVE corpus only · 0-match -> create ·
+#       >=2 candidates -> refuse-with-pointer (never silent wrong-archival)
+#   - WAL crash-safety via failure injection at EACH of the 5 write-ahead stages
+#       + trailing partial ledger line discarded on recovery
+#   - JSON envelope shape + exit-code semantics ([C06]: 0 ok · 1 refused/usage · 2 setup)
+#
+# Portable (bash 3.2 + jq). Exit 0 = all pass; 1 = a failure.
+set -uo pipefail
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+GW="$HERE/bin/memory-gateway"
+# isolate the audit ledger to a throwaway dir (same env-overridable pattern as artifact-registry)
+export MEMORY_GATEWAY_DIR="$(mktemp -d)"
+ROOT_TMP="$(mktemp -d)"
+trap 'rm -rf "$MEMORY_GATEWAY_DIR" "$ROOT_TMP"' EXIT
+fail=0
+ok() { printf '  ok   %s\n' "$1"; }
+no() { printf '  FAIL %s\n' "$1"; fail=1; }
+
+command -v jq >/dev/null 2>&1 || { echo "test-memory-gateway: jq is required" >&2; exit 2; }
+[ -x "$GW" ] || { echo "test-memory-gateway: $GW not found/executable (red phase expected before build)" >&2; }
+
+echo "test-memory-gateway:"
+
+# ---- helpers ---------------------------------------------------------------
+# run the gateway capturing stdout(OUT), stderr(ERR), exit(RC) WITHOUT aborting
+# under set -e. Body (stdin) passed via $BODY (empty if unset). NEVER trust a
+# trailing echo for the exit code (script-safety §6) — capture RC immediately.
+ERRF="$ROOT_TMP/.err"
+gw() {
+  local body="${BODY-}"
+  if OUT=$(printf '%s' "$body" | "$GW" "$@" 2>"$ERRF"); then RC=0; else RC=$?; fi
+  ERR="$(cat "$ERRF" 2>/dev/null || true)"
+  BODY=""   # consume
+}
+jqr() { printf '%s' "$1" | jq -r "$2" 2>/dev/null; }
+fresh() { mktemp -d "$ROOT_TMP/corpus.XXXXXX"; }
+
+C="$(fresh)"
+
+# ============================================================================
+# 1-7  VERB HAPPY-PATHS
+# ============================================================================
+BODY="first knowledge line with a [[reference/anchor]] link" gw --corpus "$C" create profile --type user
+[ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.slug')" = user/profile ] \
+  && ok "1 create happy-path (status=ok, slug=user/profile)" || no "1 create happy-path (rc=$RC out=$OUT)"
+
+gw --corpus "$C" read user/profile
+[ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] && printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "first knowledge line" \
+  && ok "2 read happy-path" || no "2 read happy-path (rc=$RC out=$OUT)"
+
+BODY="appended second line via update" gw --corpus "$C" update user/profile
+gw --corpus "$C" read user/profile
+if [ "$(jqr "$OUT" '.status')" = ok ] && printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "first knowledge line" \
+   && printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "appended second line"; then
+  ok "3 update (mode-A append) happy-path"; else no "3 update append (out=$OUT)"; fi
+
+BODY="to be archived" gw --corpus "$C" create scratch --type reference
+gw --corpus "$C" archive reference/scratch
+[ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] \
+  && ok "4 archive happy-path" || no "4 archive happy-path (rc=$RC out=$OUT)"
+
+gw --corpus "$C" index
+[ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.data.entries')" -ge 1 ] \
+  && ok "5 index happy-path" || no "5 index happy-path (rc=$RC out=$OUT)"
+
+gw --corpus "$C" search knowledge
+[ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.data.matches | length')" -ge 1 ] \
+  && ok "6 search happy-path" || no "6 search happy-path (rc=$RC out=$OUT)"
+
+# neighborhood: create the link target + a seed linking to it
+BODY="anchor topic body" gw --corpus "$C" create anchor --type reference
+BODY="seed body linking [[reference/anchor]] here" gw --corpus "$C" create seed --type project
+gw --corpus "$C" neighborhood project/seed --depth 1
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] \
+   && printf '%s' "$(jqr "$OUT" '.data.nodes[]')" | grep -q "reference/anchor"; then
+  ok "7 neighborhood happy-path (walks [[wikilink]])"; else no "7 neighborhood (out=$OUT)"; fi
+
+# ============================================================================
+# 8  create DEDUP-REFUSAL on the canonical identity key
+# ============================================================================
+BODY="dup attempt" gw --corpus "$C" create profile --type user
+[ "$RC" = 1 ] && [ "$(jqr "$OUT" '.status')" = refused ] && [ "$(jqr "$OUT" '.reason.code')" = DEDUP_COLLISION ] \
+  && ok "8 create dedup-refusal (DEDUP_COLLISION, exit 1)" || no "8 create dedup (rc=$RC out=$OUT)"
+
+# ============================================================================
+# 9  --type REQUIRED on create
+# ============================================================================
+BODY="no type" gw --corpus "$C" create rogue
+[ "$RC" = 1 ] && [ "$(jqr "$OUT" '.status')" = refused ] \
+  && ok "9 create without --type refuses" || no "9 missing --type (rc=$RC out=$OUT)"
+
+# ============================================================================
+# 10  type-qualified slug distinctness
+# ============================================================================
+D="$(fresh)"
+BODY="user profile"    gw --corpus "$D" create profile --type user
+u_rc=$RC; u_slug="$(jqr "$OUT" '.slug')"
+BODY="project profile" gw --corpus "$D" create profile --type project
+p_rc=$RC; p_slug="$(jqr "$OUT" '.slug')"
+if [ "$u_rc" = 0 ] && [ "$p_rc" = 0 ] && [ "$u_slug" = user/profile ] && [ "$p_slug" = project/profile ]; then
+  # both must be independently readable
+  gw --corpus "$D" read user/profile;    r1=$RC
+  gw --corpus "$D" read project/profile; r2=$RC
+  [ "$r1" = 0 ] && [ "$r2" = 0 ] && ok "10 (user,profile) & (project,profile) never collide" || no "10 distinct read failed"
+else no "10 type-qualified distinctness (u=$u_slug/$u_rc p=$p_slug/$p_rc)"; fi
+
+# ============================================================================
+# 11  CONCURRENT-WRITER refusal (mutating verb, held lock, never clobbers)
+# ============================================================================
+E="$(fresh)"
+BODY="v" gw --corpus "$E" create x --type user   # materialize .gateway/
+mkdir -p "$E/.gateway/lock.d"                     # simulate a peer holding the corpus lock
+date +%s > "$E/.gateway/lock.d/ts" 2>/dev/null || true
+BODY="should refuse" gw --corpus "$E" create y --type user
+[ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = CONCURRENT_WRITER ] \
+  && ok "11 concurrent-writer refusal (CONCURRENT_WRITER)" || no "11 concurrent-writer (rc=$RC out=$OUT)"
+# corpus not clobbered: y must NOT exist as a live topic
+[ ! -f "$E/user/y.md" ] && ok "11b concurrent write did not clobber (y absent)" || no "11b y was written under contention"
+rm -rf "$E/.gateway/lock.d"
+
+# ============================================================================
+# 12  BOUNDARY refusal (paths escaping the corpus root)
+# ============================================================================
+gw --corpus "$C" read "user/../../../etc/passwd"
+[ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = BOUNDARY ] \
+  && ok "12 boundary refusal (traversal ..)" || no "12 boundary traversal (rc=$RC out=$OUT)"
+gw --corpus "$C" read "/etc/passwd"
+[ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = BOUNDARY ] \
+  && ok "12b boundary refusal (absolute path)" || no "12b boundary absolute (rc=$RC out=$OUT)"
+
+# ============================================================================
+# 13  ARCHIVE-IS-NOT-DELETE (archived content still exists in the archive tier)
+# ============================================================================
+F="$(fresh)"
+BODY="UNIQUEARCHIVEKW content" gw --corpus "$F" create doomed --type feedback
+gw --corpus "$F" archive feedback/doomed
+# live gone
+[ ! -f "$F/feedback/doomed.md" ] && ok "13 archived topic gone from live corpus" || no "13 live topic still present after archive"
+# but the content survives somewhere under the archive tier
+if grep -rq "UNIQUEARCHIVEKW" "$F/.archive" 2>/dev/null; then
+  ok "13b archived content survives in the archive tier (not destroyed)"; else no "13b archived content was destroyed"; fi
+# active search must NOT surface archived content
+gw --corpus "$F" search UNIQUEARCHIVEKW
+[ "$(jqr "$OUT" '.data.matches | length')" = 0 ] && ok "13c archived content absent from active search" || no "13c archived leaked into active search"
+
+# ============================================================================
+# 14  INDEX REGENERATION (one line per LIVE entry)
+# ============================================================================
+G="$(fresh)"
+BODY="a" gw --corpus "$G" create alpha --type user
+BODY="b" gw --corpus "$G" create bravo --type user
+BODY="c" gw --corpus "$G" create carol --type project
+gw --corpus "$G" index
+[ "$(jqr "$OUT" '.data.entries')" = 3 ] && ok "14 index: 3 entries for 3 live topics" || no "14 index count (out=$OUT)"
+# archiving one -> index re-tiers to 2
+gw --corpus "$G" archive user/bravo >/dev/null
+gw --corpus "$G" index
+[ "$(jqr "$OUT" '.data.entries')" = 2 ] && ok "14b index drops archived entry (3->2)" || no "14b index after archive (out=$OUT)"
+# one MEMORY.md line per live entry (grep the index file)
+lines=$(grep -c '](' "$G/MEMORY.md" 2>/dev/null || echo 0)
+[ "$lines" = 2 ] && ok "14c MEMORY.md has one line per live entry" || no "14c MEMORY.md line count = $lines"
+
+# ============================================================================
+# 15  READ-ONLY GUARANTEE (read/search/neighborhood never mutate the corpus)
+# ============================================================================
+H="$(fresh)"
+BODY="ro body [[reference/x]]" gw --corpus "$H" create topic --type user
+BODY="x" gw --corpus "$H" create x --type reference
+gw --corpus "$H" index >/dev/null
+# snapshot corpus content (topic files + index + archive) — exclude gateway internals
+snap() { find "$H" -path '*/.gateway' -prune -o -type f -print 2>/dev/null \
+         | LC_ALL=C sort | while IFS= read -r f; do printf '%s\t%s\n' "$f" "$(wc -c <"$f" | tr -d ' ')"; done; }
+before="$(snap)"
+gw --corpus "$H" read user/topic >/dev/null
+gw --corpus "$H" search body >/dev/null
+gw --corpus "$H" neighborhood user/topic --depth 2 >/dev/null
+after="$(snap)"
+[ "$before" = "$after" ] && ok "15 read/search/neighborhood are read-only (corpus unchanged)" || no "15 a read verb mutated the corpus"
+
+# ============================================================================
+# 16  E6 HEADLINE FORGETTING TEST (the one that would fail today)
+#     N superseded facts -> N archived + 1 live THROUGH NORMAL WRITES ALONE;
+#     every superseded fact ABSENT from active reads; archived copy retrievable.
+# ============================================================================
+K="$(fresh)"
+N=4
+BODY="version FACTKW1 initial" gw --corpus "$K" create profile --type user   # v1 live
+e6_ok=1
+i=2
+last=$((N+1))
+while [ "$i" -le "$last" ]; do
+  BODY="version FACTKW$i supersede" gw --corpus "$K" update --supersede --type user --name profile
+  [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] || { e6_ok=0; echo "    (supersede $i failed rc=$RC out=$OUT)"; }
+  i=$((i+1))
+done
+# after N supersessions: exactly 1 live + N archived, live = the newest fact
+gw --corpus "$K" read user/profile
+live_ok=0; printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "FACTKW$((N+1))" && live_ok=1
+arch_count=$(find "$K/.archive" -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+[ "$e6_ok" = 1 ] && [ "$live_ok" = 1 ] && [ "$arch_count" = "$N" ] \
+  && ok "16 E6: $N supersessions -> $N archived + 1 live through normal writes alone" \
+  || no "16 E6 converge ($N archived expected, got $arch_count; live_ok=$live_ok; e6_ok=$e6_ok)"
+# every superseded fact ABSENT from active reads/search
+absent=1
+j=1
+while [ "$j" -le "$N" ]; do
+  gw --corpus "$K" search "FACTKW$j"
+  [ "$(jqr "$OUT" '.data.matches | length')" = 0 ] || { absent=0; echo "    (FACTKW$j still surfaces in active search)"; }
+  j=$((j+1))
+done
+[ "$absent" = 1 ] && ok "16b E6: every superseded fact ABSENT from active search" || no "16b superseded fact leaked into active reads"
+# archived copies stay RETRIEVABLE from the archive tier
+gw --corpus "$K" read user/profile --archived
+[ "$(jqr "$OUT" '.data.archived | length')" = "$N" ] \
+  && ok "16c E6: all $N archived copies retrievable via read --archived" || no "16c archive retrieval (out=$OUT)"
+
+# ============================================================================
+# 17  CANONICALIZATION (case-fold + kebab; same canonical id -> same topic)
+# ============================================================================
+L="$(fresh)"
+BODY="canon body" gw --corpus "$L" create "My Cool Topic" --type user
+c1_slug="$(jqr "$OUT" '.slug')"
+BODY="dup canon" gw --corpus "$L" create "my-cool-topic" --type user
+if [ "$c1_slug" = user/my-cool-topic ] && [ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = DEDUP_COLLISION ]; then
+  ok "17 canonicalization: 'My Cool Topic' == 'my-cool-topic' (same identity, dedup)"; else
+  no "17 canonicalization (slug1=$c1_slug rc2=$RC out=$OUT)"; fi
+
+# ============================================================================
+# 18  E6 mode: explicit --supersedes (authoritative) archives EXACTLY that topic
+# ============================================================================
+M="$(fresh)"
+BODY="ALPHAEXPLICITKW" gw --corpus "$M" create alpha --type user
+BODY="BETAEXPLICITKW"  gw --corpus "$M" update --supersede --type user --name beta --supersedes user/alpha
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.data.superseded')" = user/alpha ]; then
+  gw --corpus "$M" read user/beta;  b=$RC
+  gw --corpus "$M" read user/alpha; a=$RC   # alpha archived -> NOT_FOUND live
+  gw --corpus "$M" search ALPHAEXPLICITKW; nA="$(jqr "$OUT" '.data.matches | length')"
+  [ "$b" = 0 ] && [ "$a" = 1 ] && [ "$nA" = 0 ] \
+    && ok "18 explicit --supersedes archives exactly the named topic" || no "18 explicit supersedes state (b=$b a=$a nA=$nA)"
+else no "18 explicit --supersedes (rc=$RC out=$OUT)"; fi
+
+# ============================================================================
+# 19  E6 mode: implicit match is against the ACTIVE corpus only
+# ============================================================================
+# (covered structurally by #16; assert the archived version is NOT re-matched)
+gw --corpus "$M" read user/alpha --archived
+[ "$(jqr "$OUT" '.data.archived | length')" = 1 ] && ok "19 archived topic reachable only via archive tier (not active match)" || no "19 archived reachability (out=$OUT)"
+
+# ============================================================================
+# 20  E6 mode: 0 matches -> normal create (nothing to supersede)
+# ============================================================================
+BODY="BRANDNEWKW" gw --corpus "$M" update --supersede --type user --name brandnew
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.data.superseded')" = null ]; then
+  gw --corpus "$M" read user/brandnew
+  [ "$RC" = 0 ] && ok "20 supersede with 0 matches -> creates new (nothing archived)" || no "20 brandnew not created"
+else no "20 zero-match supersede (rc=$RC out=$OUT)"; fi
+
+# ============================================================================
+# 21  E6 mode: >=2 candidates -> refuse-with-pointer (never silent wrong-archival)
+# ============================================================================
+P="$(fresh)"
+# plant TWO malformed live files whose frontmatter (type,name) collide on the same key
+mkdir -p "$P/user"
+printf -- '---\nname: Shared Thing\ntype: user\ndescription: dupe a\n---\nAAA\n' > "$P/user/alpha.md"
+printf -- '---\nname: shared-thing\ntype: user\ndescription: dupe b\n---\nBBB\n' > "$P/user/beta.md"
+BODY="new shared" gw --corpus "$P" update --supersede --type user --name "Shared Thing"
+if [ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = SUPERSEDE_AMBIGUOUS ]; then
+  # pointer names both candidates; nothing was archived
+  cand="$(jqr "$OUT" '.data.candidates | length')"
+  archn=$(find "$P/.archive" -type f 2>/dev/null | wc -l | tr -d ' ')
+  [ "$cand" = 2 ] && [ "$archn" = 0 ] \
+    && ok "21 >=2 candidates -> SUPERSEDE_AMBIGUOUS with pointer, nothing archived" || no "21 ambiguous pointer (cand=$cand archn=$archn)"
+else no "21 ambiguous supersede (rc=$RC out=$OUT)"; fi
+
+# ============================================================================
+# 22  WAL CRASH-SAFETY — failure injection at EACH of the 5 write-ahead stages
+#     Each: crash mid-transaction -> corpus recoverable -> next invocation
+#     (a read!) completes the intent -> final state = superseded archived + 1 live.
+# ============================================================================
+crash_stage() { # crash_stage <stage-name>
+  local stage="$1" cc
+  cc="$(fresh)"
+  printf '%s' "CRASHV1 original" | "$GW" --corpus "$cc" create profile --type user >/dev/null 2>&1   # feed body via stdin (gateway reads stdin, not $BODY env); a bare "$GW" would read the suite's INHERITED stdin -> intermittent hang
+  # inject a crash right after <stage> during a supersession
+  if printf '%s' "CRASHV2 successor" | env "MEMORY_GATEWAY_CRASH_AT=$stage" \
+       "$GW" --corpus "$cc" update --supersede --type user --name profile >/dev/null 2>"$ERRF"; then
+    icr=0; else icr=$?; fi
+  # the injected crash must be observable (non-zero, and not a normal 0/1 verdict)
+  [ "$icr" = 111 ] || { no "22[$stage] crash not injected (rc=$icr)"; return; }
+  # a subsequent READ must trigger recovery-before-serving and complete the intent
+  if OUT=$("$GW" --corpus "$cc" read user/profile 2>/dev/null); then rrc=0; else rrc=$?; fi
+  local live_kw arch_n open_intents
+  live_kw="$(jqr "$OUT" '.data.content')"
+  arch_n=$(find "$cc/.archive" -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+  # after recovery: exactly 1 archived (v1) + live = v2, and NO unclosed WAL intent
+  open_intents=$(jq -R 'fromjson? // empty' "$cc/.gateway/wal.jsonl" 2>/dev/null \
+    | jq -s '([.[]|select(.state=="commit")|.txn]) as $c | [.[]|select(.state=="intent")|select(.txn as $t|($c|index($t))|not)]|length' 2>/dev/null || echo "?")
+  if [ "$rrc" = 0 ] && printf '%s' "$live_kw" | grep -q "CRASHV2" && [ "$arch_n" = 1 ] && [ "$open_intents" = 0 ]; then
+    ok "22[$stage] crash after '$stage' -> recovery completes supersession (1 archived + 1 live, WAL closed)"
+  else
+    no "22[$stage] recovery (rrc=$rrc live=$live_kw arch=$arch_n open=$open_intents)"
+  fi
+}
+crash_stage intent
+crash_stage archive
+crash_stage newtopic
+crash_stage index
+
+# 23  trailing partial WAL line discarded on recovery
+Q="$(fresh)"
+BODY="q1" gw --corpus "$Q" create profile --type user
+BODY="q2" gw --corpus "$Q" update --supersede --type user --name profile   # writes a complete WAL txn
+printf '{"txn":"partial","state":"inte' >> "$Q/.gateway/wal.jsonl"          # simulate crash mid-append
+gw --corpus "$Q" read user/profile                                          # triggers recovery
+last="$(tail -n1 "$Q/.gateway/wal.jsonl" 2>/dev/null || true)"
+if [ "$RC" = 0 ] && printf '%s' "$last" | jq -e . >/dev/null 2>&1; then
+  ok "23 trailing partial WAL line discarded on recovery"; else no "23 partial WAL line survived (last=$last rc=$RC)"; fi
+
+# ============================================================================
+# 24  EXIT CODES + JSON ENVELOPE SHAPE
+# ============================================================================
+gw --corpus "$C" read user/profile
+if [ "$RC" = 0 ] && printf '%s' "$OUT" | jq -e 'has("status") and has("verb") and has("slug") and has("data") and has("reason")' >/dev/null 2>&1; then
+  ok "24 JSON envelope shape (status/verb/slug/data/reason)"; else no "24 envelope shape (out=$OUT)"; fi
+# stderr is never JSON on a mutating verb
+BODY="envelope" gw --corpus "$C" create envelope-check --type reference
+if [ -z "$ERR" ] || ! printf '%s' "$ERR" | jq -e . >/dev/null 2>&1; then
+  ok "24b stderr carries no JSON (deterministic parsing)"; else no "24b stderr contained JSON"; fi
+# setup error: nonexistent corpus root -> exit 2
+gw --corpus "$ROOT_TMP/does/not/exist" read user/profile
+[ "$RC" = 2 ] && ok "24c missing corpus root -> exit 2 (setup)" || no "24c setup exit code (rc=$RC)"
+# a read of a missing topic -> NOT_FOUND refusal (exit 1)
+gw --corpus "$C" read user/ghost-topic
+[ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = NOT_FOUND ] && ok "24d missing topic -> NOT_FOUND (exit 1)" || no "24d not-found (rc=$RC out=$OUT)"
+
+# ============================================================================
+# 25  AUDIT LEDGER (every mutation appends one JSONL line: who/verb/slug/when)
+# ============================================================================
+A="$(fresh)"
+BODY="audit body" gw --corpus "$A" create audited --type user
+led="$MEMORY_GATEWAY_DIR/memory-gateway.jsonl"
+if [ -f "$led" ] && jq -R 'fromjson? // empty' "$led" | jq -se 'any(.verb=="create" and .slug=="user/audited")' >/dev/null 2>&1; then
+  ok "25 mutation appends an audit ledger line (verb+slug+ts)"; else no "25 audit ledger line missing"; fi
+
+# ============================================================================
+# 26  neighborhood --depth clamp (>3 clamped to 3 with a stderr diagnostic)
+# ============================================================================
+gw --corpus "$C" neighborhood user/profile --depth 9
+if [ "$(jqr "$OUT" '.data.depth')" = 3 ] && printf '%s' "$ERR" | grep -qi "clamp"; then
+  ok "26 neighborhood --depth 9 clamped to 3 + stderr diagnostic"; else no "26 depth clamp (depth=$(jqr "$OUT" '.data.depth') err=$ERR)"; fi
+
+# ============================================================================
+# 27-34  RED-TEAM REGRESSION PINS (Elenchus pass 1 — each test encodes the
+#        adversarial repro so the closed hole stays closed).
+# ============================================================================
+
+# 27  #1 (CRITICAL data-loss): explicit --supersedes into an OCCUPIED DIFFERENT
+#     slug must REFUSE (NEW_SLUG_OCCUPIED) — never destroy an unmentioned live fact.
+R="$(fresh)"
+BODY="FACTAKW innocent bystander at dest" gw --corpus "$R" create profile --type user
+BODY="OLDNOTEKW the legit supersede target" gw --corpus "$R" create oldnote --type reference
+BODY="SUCCESSORKW would-clobber FACTA" gw --corpus "$R" update --supersede --type user --name profile --supersedes reference/oldnote
+if [ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = NEW_SLUG_OCCUPIED ]; then
+  gw --corpus "$R" read user/profile; ra=$RC
+  if [ "$ra" = 0 ] && printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "FACTAKW" \
+     && ! printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "SUCCESSORKW" \
+     && [ -f "$R/reference/oldnote.md" ]; then
+    ok "27 explicit --supersedes into occupied different slug -> NEW_SLUG_OCCUPIED (bystander + target preserved)"
+  else no "27 occupant/target not preserved after refuse (ra=$ra)"; fi
+else no "27 explicit cross-slug occupied (rc=$RC out=$OUT)"; fi
+
+# 28  #2 (CRITICAL data-loss): implicit supersede over a frontmatter-DIVERGENT
+#     live occupant at the target slug must ARCHIVE (tier) it, never clobber.
+S="$(fresh)"; mkdir -p "$S/user"
+printf -- '---\nname: not-profile\ntype: user\ndescription: divergent occupant\n---\nDIVERGENTKW must be tiered not clobbered\n' > "$S/user/profile.md"
+BODY="NEWPROFILEKW replaces the slot" gw --corpus "$S" update --supersede --type user --name profile
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ]; then
+  gw --corpus "$S" read user/profile
+  live_new=0; printf '%s' "$(jqr "$OUT" '.data.content')" | grep -q "NEWPROFILEKW" && live_new=1
+  arch_ok=0; grep -rq "DIVERGENTKW" "$S/.archive" 2>/dev/null && arch_ok=1
+  [ "$live_new" = 1 ] && [ "$arch_ok" = 1 ] \
+    && ok "28 implicit supersede over a divergent occupant -> occupant archived (not clobbered)" \
+    || no "28 divergent occupant clobbered (live_new=$live_new arch_ok=$arch_ok)"
+else no "28 divergent-occupant supersede (rc=$RC out=$OUT)"; fi
+
+# 29  #3 (CRITICAL DoS): a valueless trailing value-flag must refuse-fast (USAGE),
+#     NOT spin in a bash-3.2 shift-2 no-op loop. BOUNDED so a regression can't hang
+#     the whole suite — RC=124 means the DoS came back.
+gw_bounded() {  # like gw() but hard-kills after $1s; RC=124 on timeout
+  local secs="$1"; shift
+  local body="${BODY-}" of="$ROOT_TMP/.bout" i=0 timed=0
+  printf '%s' "$body" | "$GW" "$@" >"$of" 2>"$ERRF" &
+  local pid=$!
+  while kill -0 "$pid" 2>/dev/null; do
+    i=$((i+1)); if [ "$i" -ge $((secs*10)) ]; then kill -9 "$pid" 2>/dev/null; timed=1; break; fi
+    sleep 0.1
+  done
+  if [ "$timed" = 1 ]; then wait "$pid" 2>/dev/null || true; RC=124; else wait "$pid" 2>/dev/null; RC=$?; fi
+  OUT="$(cat "$of" 2>/dev/null || true)"; ERR="$(cat "$ERRF" 2>/dev/null || true)"; BODY=""
+}
+T="$(fresh)"
+BODY="x" gw_bounded 5 --corpus "$T" create profile --type
+if [ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = USAGE ]; then
+  ok "29 valueless trailing --type -> USAGE refuse-fast (no shift-2 infinite loop)"
+elif [ "$RC" = 124 ]; then
+  no "29 DoS REGRESSED: valueless --type HUNG (shift-2 loop) — _need_val guard missing"
+else no "29 valueless --type (rc=$RC out=$OUT)"; fi
+
+# 30  #4 dead-pid lock reclaim: a lock whose holder PID is provably dead is
+#     reclaimed NOW (real-crash recovery), not waited-out 900s.
+U="$(fresh)"
+BODY="v" gw --corpus "$U" create x --type user            # materialize .gateway/
+mkdir -p "$U/.gateway/lock.d"
+echo 999999 > "$U/.gateway/lock.d/pid"                    # a PID that cannot be alive (> kern.maxproc)
+date +%s > "$U/.gateway/lock.d/ts"                        # FRESH ts -> would refuse if not for the dead-pid check
+BODY="after crash" gw --corpus "$U" create y --type user
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ]; then
+  gw --corpus "$U" read user/y
+  [ "$RC" = 0 ] && ok "30 dead-pid lock reclaimed (crashed holder -> next writer proceeds)" || no "30 y unreadable after reclaim"
+else no "30 dead-pid reclaim (rc=$RC out=$OUT)"; fi
+
+# 31  #5 symlink-escape boundary: a VALID type-dir symlinked OUTSIDE the corpus
+#     must refuse (BOUNDARY) and write nothing outside (test 12 covers ../absolute;
+#     this covers the resolved-symlink vector the pwd -P guard defends).
+V="$(fresh)"
+OUTSIDE="$ROOT_TMP/outside.$$"; mkdir -p "$OUTSIDE"
+ln -s "$OUTSIDE" "$V/user"     # --type user now resolves $V/user/<name>.md OUTSIDE $V
+BODY="escapee" gw --corpus "$V" create pwned --type user
+if [ "$RC" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = BOUNDARY ]; then
+  [ ! -e "$OUTSIDE/pwned.md" ] && ok "31 symlinked type-dir escape refused (BOUNDARY, nothing written outside)" || no "31 wrote OUTSIDE corpus via symlink"
+else no "31 symlink escape (rc=$RC out=$OUT)"; fi
+
+# 32  #6 CLI hygiene: no verb -> JSON refuse (USAGE, exit 1) with usage on stderr;
+#     --help -> usage on stderr, EMPTY stdout, exit 0 (deterministic machine parsing).
+gw --corpus "$C" ""            # empty verb
+novrc=$RC
+if [ "$novrc" = 1 ] && [ "$(jqr "$OUT" '.reason.code')" = USAGE ] && printf '%s' "$ERR" | grep -qi 'usage\|verb'; then
+  ok "32 no-verb -> USAGE JSON refuse (exit 1) + usage on stderr"; else no "32 no-verb handling (rc=$novrc out=$OUT err=$ERR)"; fi
+gw --corpus "$C" --help
+if [ "$RC" = 0 ] && [ -z "$OUT" ] && printf '%s' "$ERR" | grep -qi 'usage'; then
+  ok "32b --help -> usage on stderr, empty stdout, exit 0"; else no "32b --help handling (rc=$RC out=$OUT)"; fi
+
+# 33  #7 identical-content supersede -> honest no-op report (superseded:null),
+#     never a false superseded:<self>; nothing archived.
+W="$(fresh)"
+BODY="IDENTICALKW same bytes" gw --corpus "$W" create profile --type user
+BODY="IDENTICALKW same bytes" gw --corpus "$W" update --supersede --type user --name profile
+if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.data.superseded')" = null ]; then
+  arch=$(find "$W/.archive" -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+  gw --corpus "$W" read user/profile; rl=$RC
+  [ "$arch" = 0 ] && [ "$rl" = 0 ] && ok "33 identical-content supersede -> superseded:null (honest no-op, nothing archived)" || no "33 identical no-op state (arch=$arch rl=$rl)"
+else no "33 identical-content supersede report (rc=$RC out=$OUT)"; fi
+
+# 34  #8a WAL replay sha-guard: a corrupt (tampered) intent payload is NOT
+#     replayed — recovery ABORTS it (mutates nothing, writes an aborted marker)
+#     instead of persisting corruption. Crash-at-intent leaves v1 live; tamper the
+#     recorded sha256; recovery-on-read must keep v1 and archive nothing.
+X="$(fresh)"
+printf '%s' "CRASHV1 original" | "$GW" --corpus "$X" create profile --type user >/dev/null 2>&1
+printf '%s' "CRASHV2 successor" | env MEMORY_GATEWAY_CRASH_AT=intent "$GW" --corpus "$X" update --supersede --type user --name profile >/dev/null 2>&1
+wal="$X/.gateway/wal.jsonl"
+jq -c 'if .state=="intent" and (.sha256!=null) then .sha256="0000000000000000000000000000000000000000000000000000000000000000" else . end' "$wal" > "$wal.t" && mv "$wal.t" "$wal"
+if OUT=$("$GW" --corpus "$X" read user/profile 2>/dev/null); then rrc=0; else rrc=$?; fi
+live="$(jqr "$OUT" '.data.content')"
+arch_n=$(find "$X/.archive" -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ')
+aborted=$(jq -R 'fromjson? // empty' "$wal" 2>/dev/null | jq -s 'any(.aborted=="sha_mismatch")' 2>/dev/null)
+if [ "$rrc" = 0 ] && printf '%s' "$live" | grep -q "CRASHV1" && ! printf '%s' "$live" | grep -q "CRASHV2" \
+   && [ "$arch_n" = 0 ] && [ "$aborted" = true ]; then
+  ok "34 WAL sha-guard: corrupt intent NOT replayed (v1 preserved, nothing archived, aborted marker written)"
+else no "34 WAL sha-guard (rrc=$rrc arch=$arch_n aborted=$aborted live=$live)"; fi
+
+# ============================================================================
+# 35  #1 REGRESSION (pass-2 red-team): a writer blocked on an open-but-silent
+#     stdin must NOT hold the single-writer lock hostage. The body is drained
+#     OFF-lock (in dispatch, before _lock_acquire), so a mis-wired caller stalls
+#     only its OWN process — a second writer still proceeds. (Before the fix the
+#     blocked writer held the lock -> the second got CONCURRENT_WRITER.)
+# ============================================================================
+CW="$(fresh)"
+F="$ROOT_TMP/wedge.fifo"
+if mkfifo "$F" 2>/dev/null; then
+  ( sleep 5 > "$F" ) & holder=$!          # hold the fifo write-end OPEN + silent (auto-releases in 5s)
+  "$GW" --corpus "$CW" create victim --type user < "$F" >/dev/null 2>&1 & blocked=$!  # blocks on $(cat) OFF-lock
+  sleep 0.5                               # let the blocked writer reach the stdin read
+  if printf 'second writer body' | "$GW" --corpus "$CW" create other --type user >/dev/null 2>&1; then w2=0; else w2=$?; fi
+  kill "$holder" "$blocked" 2>/dev/null || true; wait "$holder" "$blocked" 2>/dev/null || true; rm -f "$F"
+  [ "$w2" = 0 ] && [ -f "$CW/user/other.md" ] \
+    && ok "35 #1: stdin-blocked writer does NOT wedge the lock (second writer proceeds)" \
+    || no "35 #1 stdin-blocked writer wedged the single-writer lock (w2=$w2)"
+else
+  ok "35 #1 skipped (mkfifo unavailable)"
+fi
+
+# ============================================================================
+# 36  #3 REGRESSION (pass-2 red-team): `index` emits EXACTLY ONE JSON envelope.
+#     do_index runs _rebuild_index IN-SHELL (not $()), so _atomic_write's BOUNDARY
+#     refuse can never emit a second (double) envelope from a substitution subshell.
+# ============================================================================
+IC="$(fresh)"
+printf '%s' "topic body" | "$GW" --corpus "$IC" create alpha --type user >/dev/null 2>&1
+if OUT=$(printf '' | "$GW" --corpus "$IC" index 2>/dev/null); then irc=0; else irc=$?; fi
+envs=$(printf '%s' "$OUT" | jq -s 'length' 2>/dev/null)
+[ "$irc" = 0 ] && [ "$envs" = 1 ] && [ "$(jqr "$OUT" '.status')" = ok ] && [ "$(jqr "$OUT" '.verb')" = index ] \
+  && ok "36 #3: index emits exactly ONE envelope (no subshell double-emit)" \
+  || no "36 #3 index envelope count=$envs (irc=$irc out=$OUT)"
+
+echo ""
+[ "$fail" -eq 0 ] && { echo "test-memory-gateway: PASS"; exit 0; } || { echo "test-memory-gateway: FAIL"; exit 1; }

--- a/tests/test-memory-gateway.sh
+++ b/tests/test-memory-gateway.sh
@@ -665,5 +665,34 @@ if [ "$RC" = 0 ] \
 else no "43 symlink-escaping neighbor leaked OR legit neighbor dropped (rc=$RC nodes=[$nb_nodes])"; fi
 rm -f "$OUTSIDE"
 
+# ============================================================================
+# 44  qodo (PDCA pass-6, archive-move I/O failure): a supersede whose archive `mv`
+#     fails must exit 2 IO_ERROR with NOTHING half-applied — never a false ok. Pass-4's
+#     pin (39) covered a topic-WRITE failure; the archive-MOVE path ran via
+#     `archseq="$(_archive_if_stale ...)"`, whose subshell SWALLOWED _err_io's exit 2 ->
+#     the parent wrote the successor over the un-archived original + stamped the WAL commit
+#     + emitted ok (E6 atomicity + intent-stays-open both broken). Root fix: $ARCHSEQ
+#     out-var (no cmd-subst) so exit 2 aborts the real process. Inject: pre-create the
+#     target archive dir r-x (555) -> `mkdir -p` no-ops, `find` traverses, but `mv` INTO
+#     it -> EACCES -> _err_io. Asserts exit 2 + IO_ERROR + the ORIGINAL still live
+#     (successor never overwrote it).
+# ============================================================================
+if [ "$(id -u)" != 0 ]; then
+  AF="$(fresh)"
+  BODY="ARCHV1 original fact" gw --corpus "$AF" create profile --type user >/dev/null 2>&1   # the fact to be superseded
+  mkdir -p "$AF/.archive/user/profile"                                    # pre-create the archive tier dir...
+  chmod 555 "$AF/.archive/user/profile"                                   # ...r-x: mkdir -p no-ops + find traverses, but `mv` INTO it -> EACCES
+  BODY="ARCHV2 successor fact" gw --corpus "$AF" update --supersede --type user --name profile --supersedes user/profile
+  r44=$RC; s44="$(jqr "$OUT" '.status')"; c44="$(jqr "$OUT" '.reason.code')"
+  chmod 755 "$AF/.archive/user/profile"                                   # restore so the trap's rm -rf can recurse
+  live44="$(cat "$AF/user/profile.md" 2>/dev/null)"
+  orig_kept=0; printf '%s' "$live44" | grep -q "ARCHV1" && ! printf '%s' "$live44" | grep -q "ARCHV2" && orig_kept=1
+  if [ "$r44" = 2 ] && [ "$s44" = error ] && [ "$c44" = IO_ERROR ] && [ "$orig_kept" = 1 ]; then
+    ok "44 qodo#PDCA-6: archive-move I/O failure -> exit 2 IO_ERROR (never a false ok), original kept un-overwritten (E6 atomicity held)"
+  else no "44 qodo#PDCA-6 archive-io (r44=$r44 s44=$s44 c44=$c44 orig_kept=$orig_kept live=[$live44])"; fi
+else
+  ok "44 qodo#PDCA-6 archive-io skipped (running as root — perms bypassed)"
+fi
+
 echo ""
 [ "$fail" -eq 0 ] && { echo "test-memory-gateway: PASS"; exit 0; } || { echo "test-memory-gateway: FAIL"; exit 1; }

--- a/tests/test-memory-gateway.sh
+++ b/tests/test-memory-gateway.sh
@@ -603,7 +603,7 @@ echo 1 > "$SL/.gateway/lock.d/ts"                          # epoch 1 -> age >> 9
 BODY="after stale" gw --corpus "$SL" create y --type user
 if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ]; then
   gw --corpus "$SL" read user/y
-  [ "$RC" = 0 ] && ok "40 Bug1: stale-by-ts lock reclaimed via rename-steal (next writer proceeds)" || no "40 y unreadable after stale-ts reclaim"
+  if [ "$RC" = 0 ]; then ok "40 Bug1: stale-by-ts lock reclaimed via rename-steal (next writer proceeds)"; else no "40 y unreadable after stale-ts reclaim"; fi
 else no "40 Bug1 stale-ts reclaim (rc=$RC out=$OUT)"; fi
 
 # ============================================================================
@@ -623,7 +623,7 @@ date +%s > "$DP/.gateway/lock.d/ts"                        # FRESH ts -> ts back
 BODY="after dead" gw --corpus "$DP" create y --type user
 if [ "$RC" = 0 ] && [ "$(jqr "$OUT" '.status')" = ok ]; then
   gw --corpus "$DP" read user/y
-  [ "$RC" = 0 ] && ok "41 EPERM/ESRCH: dead holder (impossible pid, fresh ts) fast-reclaimed via ps-absent probe" || no "41 y unreadable after dead-pid reclaim"
+  if [ "$RC" = 0 ]; then ok "41 EPERM/ESRCH: dead holder (impossible pid, fresh ts) fast-reclaimed via ps-absent probe"; else no "41 y unreadable after dead-pid reclaim"; fi
 else no "41 dead-pid fast-reclaim (rc=$RC out=$OUT)"; fi
 
 # ============================================================================
@@ -640,6 +640,30 @@ done
 if [ -n "$jq_fb" ] && [ "$(PATH="" "$jq_fb" -nr '"ok"' 2>/dev/null)" = ok ]; then
   ok "42 qodo#4: absolute jq fallback resolves + runs under empty PATH ($jq_fb) — minimal-PATH safe"
 else no "42 qodo#4 no working absolute jq fallback candidate (jq_fb=$jq_fb)"; fi
+
+# ============================================================================
+# 43  CodeRabbit (PDCA pass-5, boundary symmetry): a neighbor slug whose topic file
+#     is a symlink ESCAPING the corpus must NOT be surfaced. do_read/do_search guard
+#     every item with _assert_read_safe; neighborhood must too. A leaf neighbor is
+#     listed but never promoted to a $node, so the node-guard (line ~763) can't catch
+#     it — the guard has to run at neighbor-discovery. The outside target is a REAL
+#     file so the E6 [ -f ] liveness gate PASSES first, actually exercising the new guard.
+# ============================================================================
+NB="$(fresh)"
+OUTSIDE="$NB.escaped-target"                               # a real file OUTSIDE the corpus root (sibling, not under $NB/)
+printf 'secret outside the corpus\n' > "$OUTSIDE"
+mkdir -p "$NB/reference"
+ln -s "$OUTSIDE" "$NB/reference/escaped.md"                # symlinked topic file escaping the corpus ([ -f ] follows it -> exists)
+BODY="anchor topic body" gw --corpus "$NB" create legit --type reference    # an in-corpus neighbor (positive control)
+BODY="seed links [[reference/legit]] and [[reference/escaped]]" gw --corpus "$NB" create seed --type project
+gw --corpus "$NB" neighborhood project/seed --depth 1
+nb_nodes="$(jqr "$OUT" '.data.nodes[]')"
+if [ "$RC" = 0 ] \
+   && printf '%s' "$nb_nodes" | grep -q "reference/legit" \
+   && ! printf '%s' "$nb_nodes" | grep -q "reference/escaped"; then
+  ok "43 CodeRabbit#PDCA-5: symlink-escaping neighbor excluded, legit neighbor kept (read/search/neighborhood share one boundary)"
+else no "43 symlink-escaping neighbor leaked OR legit neighbor dropped (rc=$RC nodes=[$nb_nodes])"; fi
+rm -f "$OUTSIDE"
 
 echo ""
 [ "$fail" -eq 0 ] && { echo "test-memory-gateway: PASS"; exit 0; } || { echo "test-memory-gateway: FAIL"; exit 1; }

--- a/tests/test-memory-gateway.sh
+++ b/tests/test-memory-gateway.sh
@@ -694,5 +694,33 @@ else
   ok "44 qodo#PDCA-6 archive-io skipped (running as root — perms bypassed)"
 fi
 
+# ============================================================================
+# 45  CodeRabbit PDCA-7: symlinked-.archive escape boundary (the ARCHIVE-move path).
+#     _atomic_write guards the topic-WRITE path with _assert_within_corpus (test 31),
+#     but _archive_topic's `mv "$live" "$dst"` did NOT -> a pre-planted `.archive`
+#     symlink pointing OUTSIDE the corpus would send the live topic's content out of
+#     CORPUS. Root fix: _assert_within_corpus "$dst" before the mv (mirrors
+#     _atomic_write:238). Inject: symlink `.archive` -> an OUTSIDE dir, then archive.
+#     Asserts: refused BOUNDARY + live topic un-moved + NO *.md written outside corpus
+#     (mkdir may leave an empty out-of-corpus dir, exactly as _atomic_write does — the
+#     guarantee is that no CONTENT leaves, parallel to test 31's `! -e $OUTSIDE/pwned.md`).
+# ============================================================================
+if [ "$(id -u)" != 0 ]; then
+  AS="$(fresh)"
+  BODY="ARCHSYM original fact" gw --corpus "$AS" create profile --type user >/dev/null 2>&1   # the live fact to be archived
+  ASOUT="$ROOT_TMP/arch-outside.$$"; mkdir -p "$ASOUT"
+  ln -s "$ASOUT" "$AS/.archive"                                           # .archive now resolves OUTSIDE the corpus root
+  gw --corpus "$AS" archive user/profile
+  r45=$RC; c45="$(jqr "$OUT" '.reason.code')"
+  live45="$(cat "$AS/user/profile.md" 2>/dev/null)"
+  kept45=0; printf '%s' "$live45" | grep -q "ARCHSYM original" && kept45=1
+  nooutside45=0; [ -z "$(find "$ASOUT" -type f -name '*.md' 2>/dev/null)" ] && nooutside45=1
+  if [ "$r45" = 1 ] && [ "$c45" = BOUNDARY ] && [ "$kept45" = 1 ] && [ "$nooutside45" = 1 ]; then
+    ok "45 CodeRabbit#PDCA-7: symlinked .archive escape refused (BOUNDARY), live topic un-moved, no content written outside corpus"
+  else no "45 CodeRabbit#PDCA-7 archive-symlink (r45=$r45 c45=$c45 kept45=$kept45 nooutside45=$nooutside45 live=[$live45])"; fi
+else
+  ok "45 CodeRabbit#PDCA-7 archive-symlink skipped (running as root — symlink boundary still enforced by _assert_within_corpus)"
+fi
+
 echo ""
 [ "$fail" -eq 0 ] && { echo "test-memory-gateway: PASS"; exit 0; } || { echo "test-memory-gateway: FAIL"; exit 1; }


### PR DESCRIPTION
## [PR-as-Documentation-Prompt] feat(EKO-116): memory-CRUD gateway (ADR-013 build phase)

Implements the ADR-013 **memory-CRUD gateway** — one canonical owner of memory mutations; every other actor must ask it. POSIX bash 3.2 + jq, no runtime deps beyond `jq`.

### What this adds

| Artifact | Lines | Role |
|---|---|---|
| `bin/memory-gateway` | 861 | 7-verb narrow API (create/update/archive/index + read/search/neighborhood) |
| `tests/test-memory-gateway.sh` | 635 | TDD suite — 42 test blocks / 57 assertions (every verb, dedup, concurrency, boundary, archive-not-delete, index regen, read-only, E6, WAL crash-safety, exit-codes, audit ledger + red-team + qodo/CodeRabbit regression pins) |
| `skills/memory-gateway/SKILL.md` | 112 | agent-facing wrapper (contract + examples) |

### The 7-verb narrow API
- **Mutating** (locked, WAL-atomic): `create` · `update` · `archive` · `index`
- **Read-only** (no lock, never mutate): `read` · `search` · `neighborhood`
- **Canonical identity** `(type, normalize(name))`; slug = `<type>/<normalize(name)>` (case-fold + kebab). `(user, profile)` → `user/profile` and `(project, profile)` → `project/profile` are distinct addresses that never collide — used identically by `create` dedup and by implicit E6 supersession match.

### E6 mutation-hook (supersession in the same op)
`update --supersede` archives the superseded topic in the same operation — explicit `--supersedes <slug>` (authoritative) OR implicit `(type,name)` match **against the active corpus only** (archived copies excluded from candidate selection). `0` matches → normal create; `≥2` or fuzzy → refuse-with-pointer (`SUPERSEDE_AMBIGUOUS`, same shape as `DEDUP_COLLISION`). Every superseded slug is absent from active `read`/`search`/`neighborhood` while remaining retrievable from the archive tier.

### Crash-safety (5-stage WAL)
`intent (fsync'd first, carries payload + sha256, replay source of record — never stdin) → archive-superseded → write-new-topic (temp→rename+fsync, dir fsync'd) → rebuild-index (atomic temp→rename) → commit-marker`. Startup recovery replays unclosed intents idempotently and discards a trailing partial ledger line. Entire supersession transaction runs under an exclusive mkdir-mutex corpus lock (dead-pid reclaim; a writer that can't acquire within timeout **refuses** rather than racing).

### I/O contract [C06]
stdout = **exactly ONE JSON envelope** `{status, verb, slug, data, reason}` per execution · stderr = human-only · exit `0`=ok / `1`=refused-or-usage / `2`=setup. Enforced by regression pins (see below).

---

## Verification (build phase)

- `bash -n` clean on both `bin/memory-gateway` and the suite.
- **57/57 assertions deterministic across 23 consecutive runs** (incl. runs with an intentionally-open inherited stdin), including WAL failure-injection at each of the 5 stages + the new EPERM/ESRCH liveness-disambiguation and jq-fallback pins. A pre-existing test-harness transient (a swallowed fork-EAGAIN in the `jqr` jq-helper under burst load — the gateway envelope was always correct) was root-caused and fixed with a bounded retry-on-empty (provably non-masking: `jq -r` prints `null` not `""` for null/absent, and no assertion compares to literal `""`).
- `tests/validate-plugin.sh`: PASSED (0 errors; 1 pre-existing unrelated warning).
- `gitleaks detect --no-git --source .`: no leaks found. Fixtures are synthetic only.

## Adversarial review trail (Elenchus mandatory red-team — H3 irreversible∧blast)

This change is HIGH criticality (a canonical memory mutator), so it went through independent adversarial red-team rounds (verifier > generator; each fix re-verified). The final round ran the **raw binary** (not the suite) on isolated `mktemp -d` corpora with an isolated audit ledger, independently reproduced #1-closed (fifo-wedge: the blocked writer holds no lock, a concurrent writer proceeds rc=0) + #3-closed (single envelope on `index`) + supersede-recovers-through-the-drain, and returned **CLEAR** (no data-integrity / crash-safety / availability / [C06] regression on the changed surface). Every finding is recorded here — fixed, accepted, or deferred — none silently dropped.

### Fixed
| # | Severity | Finding | Root-fix |
|---|---|---|---|
| pass-1 | CRITICAL | validation ran inside a `$()` subshell → a boundary `_refuse` (exit 1) could only kill the subshell, letting a **second JSON envelope** print at exit 0 (violates the [C06] one-envelope contract) | Refactored `_atomic_write` to an **arg-based** call that runs in the caller's shell, so a boundary refuse aborts the whole process. Pin 24 (exit-codes/envelope shape) + pin 36 guard it. |
| pass-2 #1 | MED | the blocking stdin `$(cat)` sat **inside** the single-writer lock → an open-but-silent stdin could wedge the lock (availability) | Drain the body **off-lock in dispatch** before `_lock_acquire` (`create\|update` only; archive/index take no body). Validation still refuses-fast off-lock (keeps the test-29 valueless-flag DoS guard). Mutation semantics under the lock are byte-identical. Pin 35 (wedge repro) guards it. |
| pass-2 #3 | LOW | `do_index` read the rebuild count via `$()`, re-nesting `_atomic_write` in a command-substitution subshell (same double-envelope class as pass-1) | `_rebuild_index` exports a `REBUILD_COUNT` global; `do_index` reads it in-shell (no `$()`), so `_atomic_write`'s boundary refuse aborts the process. Pin 36 (single-envelope on `index`) guards it. |
| test-harness | (flake, not the binary) | test 22 helper fed the body via a `BODY=…` env var with no stdin pipe → the gateway read the suite's **inherited** stdin and intermittently hung | Pipe the body via stdin (same class already fixed for test 34). Reproduced under a deliberately-open inherited stdin → 3/3 pass. |

### Accepted (documented — not a defect against the spec)
- **pass-2 #2 — trailing-newline normalization on the stored body.** ADR-013's I/O contract specifies the JSON-envelope shape and exit codes but has **no byte-exact / round-trip / trailing-whitespace fidelity requirement** on the stored topic body. Normalizing a trailing newline is within spec; accepted as-is.
- **pass-3 behavioral note — `create`/`update` with an *open-but-silent* stdin self-stalls before an early refuse.** Because the off-lock body drain (the #1 fix) precedes the verb's arg-validation, an EOF/piped stdin — **the agent case** — still refuses bad args (USAGE/NOT_FOUND/DEDUP/SUPERSEDE_AMBIGUOUS) fast, but a mis-wired caller that leaves stdin open-and-silent self-stalls on the drain until EOF. This is the deliberate, benign trade for the no-wedge property: the stall is **off-lock and self-only** (it never touches the corpus lock, never wedges another writer, never affects the corpus) — a strict improvement over the pre-#1 state where the same stdin wedged *every* writer with `CONCURRENT_WRITER`. Only bites human interactive debugging (agents pipe+EOF). Documented in the dispatch-drain comment.

### Deferred (tracked, low-impact — not blocking the build DoD)
- **#8b — audit-ledger lock steal.** The audit-append path does not itself steal a stale lock; only the corpus mutex does. Ledger contention is bounded by the corpus mutex that already serializes mutators, so this is a theoretical residual.
- **#8c — audit-ledger fsync.** The ledger append is not independently fsync'd (the *intent* record is, before any mutation — that is the replay source of record). A crash can lose only the trailing *audit* line, which recovery already discards if partial; no corpus state is affected.
- **#8d — jq-missing → no JSON envelope.** If `jq` is absent, setup fails at exit 2 with a stderr diagnostic rather than a JSON envelope (jq is the envelope emitter). Documented as a setup-tier (exit 2) condition.
- **#4 notes** — `_replay` occupancy edge, the µs-window between lock-check and acquire (closed by the mkdir-mutex atomicity), and NUL-in-body handling — all negligible / already-covered; recorded for completeness.
- **pass-3 optional — stdin read-timeout on the drain to restore fast-fail on open-silent stdin.** Considered and deferred: a *naive total-time* timeout would risk truncating a legitimately-slow large body (silent data-loss — strictly worse than the benign self-stall it removes); a correct fix needs an *idle-only* timeout that distinguishes "no bytes ever" from "slow producer." Out of scope for the build DoD; only affects human interactive debugging (agents pipe+EOF). The red-team explicitly did not gate the merge on it.

---

## PDCA cycle — qodo + CodeRabbit review

After the Elenchus red-team CLEARED my own diffs, **qodo + CodeRabbit reviewed the whole gateway surface** (multi-lens C3 convergence — they examine the pre-existing surface the red-team's changed-scope did not). 11 findings surfaced; each was verified against the real code (Mente Tomé — bots false-positive too), then **fixed** with a minimal root-cause diff + a regression pin, or **deferred with rationale** (none silently dropped). Fixes committed in `850bbbc`; 6 new regression tests (37–42) pin them (57 assertions total, 20/20 deterministic).

### Fixed (8)
| # | Bot | Finding | Root-fix + pin |
|---|---|---|---|
| [122] | qodo | **Reclaim lock could delete the owner** — a stale-lock reclaim `rm`'d the lock dir, but a peer could reacquire between the stale-check and the `rm` (TOCTOU) → the peer's live lock was destroyed | `_lock_acquire` steals via **atomic `mv "$LOCK" "$LOCK.stale.$$"`** (renames the dir it observed; never `rm`s a dir a peer may now own) + `_audit` acquired-flag. Pin: test 37. |
| [154] | qodo | **Read ignored the boundary symlink** — `read`/`search`/`neighborhood` did not re-check the corpus boundary, so a symlinked slug could resolve outside the corpus root | `_assert_read_safe` (realpath-within-root **and** not-a-symlink) guards all 3 read-only verbs. Pin: test 39. |
| [189] | qodo | **I/O failures masked as `ok`** — a failed `mkdir`/`mktemp`/`printf`/`mv` inside `_atomic_write` could still print a `status:ok` envelope | `_err_io` emits **exit-2 `IO_ERROR`** (never a false `ok`); every `_atomic_write`/`_archive_topic` mutation checks `\|\| return 1` / `\|\| _err_io`. The still-open WAL intent is completed idempotently by the next invocation's sha256-guarded recovery. Pin: test 39 (I/O-fail → exit 2, nothing persisted). |
| [225] | qodo | **Frontmatter accepts newline injection** — a `\n`/`\r` in `--name`/`--description` could inject extra frontmatter lines | `_no_ctrl_lines` rejects control chars with `USAGE`. Pin: test 40. |
| [64] | qodo | **E6 test misses `neighborhood`** (also a real code gap) — the headline forgetting test never asserted a superseded slug is absent from `neighborhood` | **Code + test**: `do_neighborhood` gained an E6 liveness gate (`[ -f "$CORPUS/$l.md" ] \|\| continue`) so a superseded/archived slug is never returned as a neighbor; new test 38 asserts it. |
| [258] | CodeRabbit | **EPERM ≠ ESRCH** — `kill -0` returns non-zero for a dead pid **and** for a live pid owned by another UID → a live holder could be judged stale and evicted | `_lock_is_stale` disambiguates with a **`ps -p` probe**: only a pid `ps` **also** can't see is truly dead (fast reclaim); a live-other-UID holder (or `ps` unavailable) falls through to the ts-age backstop — **fail-toward-safe** (never evict an unproven-dead holder → no double-writer). Pin: test 41. |
| [93] | qodo | **jq path lacks fallbacks** — a minimal PATH could fail to resolve `jq`, leaving no envelope | `_resolve_bin` (`command -v` → absolute candidates incl. mise/asdf shims) resolves `jq`/`python3`/`ps` robustly. Pin: test 42 (absolute fallback resolves + runs under empty PATH). |
| [381] | CodeRabbit | **Unrestricted direct edits in SKILL.md** — the Advisory Posture had an over-broad "does not hard-block direct edits" exception | Tightened: identity-change/supersede are **gateway-only**; a direct edit is tolerated only as a last-resort **quiesced** migration + `index` reindex + re-read verification. |

### Deferred (3, with rationale — tracked, not blocking the build DoD)
- **[3] qodo — `purge` verb not implemented.** ADR-013 explicit non-goal: forgetting = archive-tier supersession (E6), always retrievable via `.archive/`. A compliant hard-erasure/purge (authorized, audited, non-automatic) is a distinct future ADR item, not this gateway's scope.
- **[33] qodo — `_topic_content` lacks bi-temporal frontmatter (`valid_until`/`superseded_by`).** ADR-013 chose archive-tier + WAL supersession over bi-temporal metadata. E6-forgetting **is** enforced — by the archive move + the read/search/neighborhood liveness gates — just not via frontmatter fields. A design alternative, not a defect in the chosen design.
- **[349] CodeRabbit — WAL never compacted.** CodeRabbit itself: *"Correctness is unaffected"* (trivial/nitpick). Compaction must coordinate with the corpus lock to avoid racing a concurrent appender — mis-done, it risks the very durability the WAL provides. Steady-state-only cost on a long-lived corpus → premature optimization (Knuth/measure-first). Deferred with a tracked note.

### PDCA pass-5 — CodeRabbit re-review on `850bbbc`
CodeRabbit re-reviewed the new head and returned **CHANGES_REQUESTED** (not a stale review). 1 Major + 1 Minor, both **genuine** (verified against real code — Mente Tomé), fixed in `4af469a`; the WAL nitpick re-surfaced as 🔵 Trivial and was re-deferred.

| # | Bot | Finding | Root-fix + pin |
|---|---|---|---|
| [763] | CodeRabbit | **[Major] neighborhood leaks a symlink-escaping neighbor slug** — `do_neighborhood` recorded a discovered neighbor after only `[ -f "$CORPUS/$l.md" ]`, which *follows* symlinks. A `_valid_slug` (string-safe) neighbor whose type-dir or topic file is a symlink escaping the corpus was surfaced. A **leaf** neighbor is listed but never promoted to a `$node`, so the line-763 node-guard could never catch it. | Apply the **same already-verified `_assert_read_safe`** at neighbor-discovery → read/search/neighborhood now share ONE realpath boundary over every surfaced item (also stops the escaping slug entering the frontier). No content ever leaked (neighborhood returns slug strings only); this closes a boundary-consistency gap + a weak existence-oracle. Pin: **test 43** (proven non-tautological — FAILS without the guard, escaped slug leaks; PASSES with it + a legit positive control). |
| [606/626] | CodeRabbit | **[Minor·SC2015] `A && B \|\| C` isn't if/else** — in tests 40/41, `no` could double-fire if `ok` returned non-zero. | Converted both assertions to explicit `if/then/else`. |

**Verification:** 58/58 assertions PASS; test 43 catches the bug when the guard is reverted (overlay-and-restore proof, SHA-verified restore). **No fresh Elenchus round** — the fix *adds* an already-red-teamed control at one more call site (no new attack surface); economic-stop (≤3–4 rounds) + multi-lens convergence (CodeRabbit + Tomé + regression pin) is the independent verification.

> The SkillSpector **MP2 "context-window stuffing"** sub-warning on the SKILL.md edit is a **false-positive** — the edit *removed* an over-broad exception and tightened wording (net +2 lines), it does not inflate context.

---

## Definition of Done (ADR-013 build phase)
- [x] `bin/memory-gateway` — 7-verb narrow API (bash 3.2 + jq; [C06] envelope + exit codes)
- [x] Test suite — every verb, dedup-refusal, concurrent-writer refusal, boundary refusal, archive-not-delete, index regeneration, read-only guarantee
- [x] E6 mutation-hook — supersession in the same op (explicit + implicit-active-only; ambiguous/fuzzy refuse-with-pointer)
- [x] E6 atomicity — crash-safe across topic/index/ledger (intent-first WAL; failure-injected at each of the 5 stages)
- [x] E6 headline forgetting test — N superseded → N archived + 1 live through normal writes; superseded slugs absent from active reads
- [x] `skills/memory-gateway/SKILL.md` wrapper
- [ ] ≥2 ratified dogfood cycles (`dogfood-mark`) — **next, on merge** (post-merge, before any Phase-B hook)

Closes EKO-116 (build phase) once the ≥2 dogfood cycles land.

## Refs
ADR-013 (`docs/adrs/ADR-013-memory-crud-gateway.md`) · EKO-116

🤖 Generated with [Claude Code](https://claude.com/claude-code)


### PDCA pass-6 — qodo re-review on `4af469a` (I/O-mask finding [189] not fully closed)

qodo correctly caught that finding [189] (I/O failures masked) was **not fully closed**: the archive step of a supersession ran inside a command-substitution subshell, so `_err_io`'s `exit 2` was swallowed — a failed archive-`mv` let the parent overwrite the un-archived original + emit a false `ok`. Verified genuine against the real code before fixing.

| Finding | Verdict | Root-cause fix | Commit |
|---|---|---|---|
| [189] I/O mask — archive path via `$(_archive_if_stale …)` swallows `_err_io` exit 2 | ✅ **genuine** (r=0 status=ok, original clobbered on pre-fix) | `_archive_topic`/`_archive_if_stale` now set a global `$ARCHSEQ` instead of `printf`-via-`$()`, so they run in the caller's process and `exit 2` propagates. Fixes **all 3** affected sites: `_wal_supersede` STAGE 2 (:471, flagged), `do_archive` verb (:693, same latent bug qodo's line-471 view didn't see), and `_replay_supersede` recovery (:425, whose old `>/dev/null` even ate the `[C06]` error envelope). | `72477ad` |
| bookkeeping: pass-4 reply-table pin numbers stale | ✅ corrected below | — | — |

**Non-tautology proof (gold-standard):** new regression pin **test 44** injects an archive-move `EACCES` during a supersession (target `.archive` dir `chmod 555`) and asserts exit-2 `IO_ERROR` + the original still live (successor never overwrote it). Verified it **fails on the faithful pre-fix code** (`git HEAD:bin/memory-gateway`) with **only test 44 red** (`r44=0 s44=ok orig_kept=0`) and passes on the fix — zero collateral. It complements test 39, which covered only the direct topic-**write** failure, not the archive-**move** path.

**Corrected pin numbers** (qodo's bookkeeping note — the pass-4 reply table cited stale numbers): symlink-escape write-boundary = **test 31** · newline injection = **test 37** · stale-lock reclaim = **tests 40/41** · read-side symlink-neighbor exclusion = **test 43** · archive-move I/O failure = **test 44**.

Tests: **59/59** passing. gitleaks clean.

### PDCA pass-7 — CodeRabbit re-review on `72477ad` → fix `61439a4`

CodeRabbit's COMMENTED review of `72477ad` surfaced one outside-diff **Major** finding on `_archive_topic` (`bin/memory-gateway:363-375`): a symlinked `.archive` could send `mv` outside `CORPUS`, and the bare `mkdir -p` lacked an `_err_io` fail-fast. **Verified genuine** (Tomé) — `_atomic_write` guards its write path with `_assert_within_corpus` (test 31), but the archive-move path did not. Fixed in `61439a4` mirroring `_atomic_write` exactly: `mkdir -p … || _err_io` + `_assert_within_corpus "$dst" || _refuse … BOUNDARY` before the `mv`. Regression pin **test 45** (non-tautology proven: only 45 red on pre-fix code, zero collateral). **No separate red-team round** (Elenchus economic-stop — adds an already-verified boundary control at one more site, not new attack surface). **60 assertions passing**, gitleaks clean.


### PDCA pass-8 — CodeRabbit re-review on `61439a4` → refine `e9beb98` + qodo whole-file triage

**CodeRabbit (1 actionable, fixed).** Re-review of `61439a4` asked to validate the archive path **before any filesystem change** (the PDCA-7 check ran *after* `mkdir`, leaving an empty escaped dir before refusing). Applied in `e9beb98`: new helper `_assert_new_path_within_corpus` resolves the **deepest existing ancestor** of the not-yet-created `$adir` and refuses a symlinked `.archive` **before** `mkdir` — zero fs artifact. Test 45 strengthened: runs **as root too** (symlink boundary is UID-independent via `cd`+`pwd -P`, unlike test 44's `chmod 555` perm-bypass) and asserts the outside dir has **ZERO descendants** (`find -mindepth 1` empty), not just no `*.md`. Non-tautology proven: overlaying the pre-refinement (`61439a4`) bin turns **only** `noart45` red (`r45=1 c45=BOUNDARY kept45=1`), 59 others green.

> **Deferred follow-up (transparency):** `_archive_topic` is now *stricter* than `_atomic_write` (still post-mkdir). Harmonizing `_atomic_write` to the same before-mkdir invariant is a sound consistency follow-up but is **kept out of this PR** to avoid touching the already-red-teamed write path (tests 31/44). Noted, not silently dropped.

**qodo (8 findings, whole-file re-review on `4d64db6`, COMMENTED/advisory) — triaged, verified against the real code (Mente Tomé):**

| # | Finding | Verdict | Evidence |
|---|---|---|---|
| 1 | `purge` not implemented | out-of-scope **by design** | ADR-013 l.37 (tiering-never-deletion; MVP no prod PII) |
| 2 | missing bi-temporal fields | **different ratified design** | ADR-013 §E6 = archive-based forgetting, not `superseded_by` live-pointer |
| 3 | E6 test misses neighborhood | already tested | **test 38** |
| 4 | jq path lacks fallbacks | already implemented | `_resolve_bin` + **test 42** (named `qodo#4`, empty-PATH) |
| 5 | reclaim lock apaga o dono (Bug) | **false positive** | atomic `mv` rename-steal; `rm -rf` on PID-quarantine only; **tests 40/41** |
| 6 | read ignores boundary symlink (Bug/Sec) | already enforced | `_assert_read_safe` at l.582/594/779/785; **test 43** |
| 7 | I/O failures masked (Bug) | already handled | `\|\| _err_io` ×5 + `$ARCHSEQ` no-subshell; **tests 39/44** |
| 8 | frontmatter newline injection (Bug) | already refused | `_no_ctrl_lines` l.544/545/646; **test 37** |

Net: #1–#2 are ADR-013-ratified scope; #3–#8 pinned by named tests from prior PDCA rounds — no code change required. **60/60** passing, gitleaks clean, HEAD `e9beb98`.


**pass-8 addendum — CodeRabbit re-review of `e9beb98` confirmed the code fix + threat-model doc (`474bd19`).** CodeRabbit's re-review of `e9beb98` verified the before-mkdir archive fix is correct (BOUNDARY refusal before any fs change, test 45 as-root + descendant-free, deferred `_atomic_write` asymmetry accurately noted). Its one residual point was a **TOCTOU** observation — a *non-cooperating* process with write access to `$CORPUS` could swap a validated ancestor between the check and `mkdir`/`mv`. That race is **out of scope by design and unclosable at the app layer** (such a process can `rm -rf $CORPUS` outright); the real control is OS-level filesystem ownership. Per CodeRabbit's stated close-condition, `474bd19` makes the invariant **explicit** (doc-only, no logic change): a `BOUNDARY THREAT MODEL` comment block above the three boundary helpers in `bin/memory-gateway` + the `Boundary-safe` guarantee in `SKILL.md` — in-scope = pre-planted symlink under the ADR-013 single-writer contract; out-of-scope = concurrent non-cooperating FS mutator, defended only by the deploy invariant that `$CORPUS` is owned/writable by the gateway uid alone. **60/60** passing, gitleaks clean, HEAD `474bd19`.
