### PR TITLE
feat(skills): chief-of-staff (Oikonomos) — operator work-focus conductor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `chief-of-staff` (Oikonomos): the operator work-focus conductor — human twin of `reactivate`/Entelecheia
+
+The operator-facing counterpart of the agent-facing `reactivate` conductor: **Entelecheia** orients a fresh
+amnesic **agent** at cold-wake; **Oikonomos** keeps the **operator** (human) on focus across live work. ONE
+front-door answering *"what should I focus on now? who asked me for what, by when? any loose ends?"*
+
+- **`skills/chief-of-staff/SKILL.md`** (v0.1.0, soul-name **Oikonomos** — Greek *οἰκονόμος*, the household
+  steward; root of both *economy* and *ecosystem*, resonating with the operator's Eko-System) — a **route-never-reimplement**
+  conductor with a 5-phase pipeline: **GATHER** (delegates `work-compass` — ONE N-Tree of all scattered work across the
+  7 CPT domains) → **PRIORITIZE** (delegates `pulse`'s Eisenhower 2×2, the maos-resident core; optionally the richer
+  user-scope `ops-strategist` 4-lens at `--depth full` **if present**) → **SURFACE** (the newly-authored people-ask view
+  *who·when·by-when*, a **read projection over EXISTING tracker fields** — Jira `reporter`/`duedate`, GitHub author/milestone
+  — NOT a new store) → **BRIEF** (`morning-briefing` 7-section SitRep contract) → **PRESENT** (one operator briefing:
+  ▶ next-action · Eisenhower quadrants · ⏰ who-asked/by-when · 🧹 loose-ends, read-only). Adds ONLY the genuinely-absent
+  pieces (the people-ask projection, the `tag`/`categorize` verbs, the unified front-door); reimplements no aggregation or
+  Eisenhower logic. **Read-only by default** (writes/notify/schedule printed for approval), **on-demand only** (no hooks —
+  MAOS stays the sole conductor), **Layer-pure** (runs fully on the maos-resident core; `ops-strategist` never a hard dep).
+- **`commands/chief-of-staff.md`** — thin `/chief-of-staff` wrapper delegating to the skill (`--mode
+  catch-up|drift|who-owes-me|full`, `--depth quick|full`, `--scope`, `--who`, `--lang`, `--json`).
+- Distinct from siblings: `maos-concierge` (framework-facing) · `work-compass` (aggregation engine it routes to) ·
+  `pulse` (single-session re-orientation) · `reactivate`/Entelecheia (the agent-facing twin) · `ops-strategist`
+  (the optional user-scope brain). Named by `skills/anima` per the naming authority.
+
 ### Added — deterministic session-handoff spine (auto-save-before-compact → auto-reload-after-compact) (#273)
 
 - **`plugin-scripts/governance/lib/seed-io.sh`** — shared multi-writer seed I/O lib: `seed_dir` (honors

--- a/commands/chief-of-staff.md
+++ b/commands/chief-of-staff.md
@@ -1,0 +1,53 @@
+---
+description: Operator work-focus conductor (Oikonomos) — "what should I focus on now, who asked me for what by when, any loose ends?" Aggregates all your backlogs, prioritizes (Eisenhower), surfaces the people-ask view, and presents one briefing. Composes work-compass + pulse + morning-briefing; reimplements nothing; read-only by default.
+argument-hint: "[--mode catch-up|drift|who-owes-me|full] [--depth quick|full] [--scope all|jira|github|linear|sessions] [--who <person>] [--lang pt|en|auto] [--json]"
+allowed-tools: Read, Grep, Glob, Bash, Task, AskUserQuestion
+---
+
+# /chief-of-staff — Oikonomos
+
+Thin wrapper that invokes `skills/chief-of-staff/SKILL.md`. The skill holds all logic
+(the 5-phase GATHER → PRIORITIZE → SURFACE → BRIEF → PRESENT pipeline, the invariants,
+the anti-patterns). **This file is the command surface only.**
+
+## Usage
+
+```
+/chief-of-staff                          # quick catch-up: landscape + next-action + who-asked + loose-ends
+/chief-of-staff --mode drift             # what am I slipping? loose-ends first
+/chief-of-staff --mode who-owes-me       # the people-ask view first (who asked · by-when)
+/chief-of-staff --depth full             # + ops-strategist 4-lens (if present) + full SitRep
+/chief-of-staff --who "the boss"         # filter the people-ask view to one person
+/chief-of-staff --scope jira             # restrict the gather to one backlog
+```
+
+## What it does
+
+Your operator-facing chief-of-staff — the human twin of `/reactivate` (Entelecheia, which
+orients a fresh **agent**). It answers *"what should I focus on now?"* by:
+
+1. **GATHER** — delegates `work-compass` to aggregate ALL scattered work into ONE N-Tree.
+2. **PRIORITIZE** — delegates `pulse` (Eisenhower 2×2; the maos-resident core). `--depth full`
+   optionally adds the richer user-scope `ops-strategist` 4-lens **if you have it**.
+3. **SURFACE** — the people-ask view (who asked · when · by-when) projected over existing
+   tracker fields (Jira `reporter`/`duedate`, GitHub author/milestone…). Newly authored.
+4. **BRIEF** — the `morning-briefing` 7-section SitRep contract.
+5. **PRESENT** — ONE briefing: ▶ next-action · Eisenhower quadrants · ⏰ who-asked/by-when ·
+   🧹 loose-ends. Read-only — any write/notify/schedule is PRINTED for your approval.
+
+## Sibling routing (don't reach for this if…)
+
+- Learn / route the MAOS **framework** itself → `/maos-concierge`.
+- Just the raw aggregated N-Tree, no prioritization → `/work-compass`.
+- Re-orient inside ONE session → `/pulse`.
+- A fresh **agent** woke with no context → `/reactivate` (the agent-facing twin).
+- Sort a raw brain-dump into tickets → `/directive-braindump-triage`.
+
+## Guarantees
+
+- **Route-never-reimplement** — composes the existing family; adds only the people-ask
+  projection + tag/categorize + the unified front-door.
+- **Read-only by default** — never executes a write/notify/schedule; prints for approval.
+- **On-demand only** — no hooks, no always-on runtime (MAOS stays the sole conductor).
+- **Layer-pure** — runs fully on the maos-resident core; `ops-strategist` is optional, never required.
+- **Explicit operator instruction wins** over every computed condition. ⛔ Never echoes secrets/PII.

--- a/commands/chief-of-staff.md
+++ b/commands/chief-of-staff.md
@@ -1,53 +1,59 @@
 ---
+name: chief-of-staff
 description: Operator work-focus conductor (Oikonomos) — "what should I focus on now, who asked me for what by when, any loose ends?" Aggregates all your backlogs, prioritizes (Eisenhower), surfaces the people-ask view, and presents one briefing. Composes work-compass + pulse + morning-briefing; reimplements nothing; read-only by default.
 argument-hint: "[--mode catch-up|drift|who-owes-me|full] [--depth quick|full] [--scope all|jira|github|linear|sessions] [--who <person>] [--lang pt|en|auto] [--json]"
-allowed-tools: Read, Grep, Glob, Bash, Task, AskUserQuestion
+allowed-tools: Read, Grep, Glob, Task, AskUserQuestion
 ---
 
-# /chief-of-staff — Oikonomos
+# /maos:chief-of-staff — Oikonomos
 
 Thin wrapper that invokes `skills/chief-of-staff/SKILL.md`. The skill holds all logic
 (the 5-phase GATHER → PRIORITIZE → SURFACE → BRIEF → PRESENT pipeline, the invariants,
 the anti-patterns). **This file is the command surface only.**
 
+> **Invocation**: canonical form is `/maos:chief-of-staff` (`plugin.json` sets
+> `command_namespace.prefix_required=true`). The bare `/chief-of-staff` also resolves via the
+> manifest's `permit_unprefixed_if_no_collision` fallback, but prefer the prefixed form in docs/scripts.
+
 ## Usage
 
 ```
-/chief-of-staff                          # quick catch-up: landscape + next-action + who-asked + loose-ends
-/chief-of-staff --mode drift             # what am I slipping? loose-ends first
-/chief-of-staff --mode who-owes-me       # the people-ask view first (who asked · by-when)
-/chief-of-staff --depth full             # + ops-strategist 4-lens (if present) + full SitRep
-/chief-of-staff --who "the boss"         # filter the people-ask view to one person
-/chief-of-staff --scope jira             # restrict the gather to one backlog
+/maos:chief-of-staff                          # quick catch-up: landscape + next-action + who-asked + loose-ends
+/maos:chief-of-staff --mode drift             # what am I slipping? loose-ends first
+/maos:chief-of-staff --mode who-owes-me       # the people-ask view first (who asked · by-when)
+/maos:chief-of-staff --depth full             # + ops-strategist 4-lens (if present) + full SitRep
+/maos:chief-of-staff --who "the boss"         # filter the people-ask view to one person
+/maos:chief-of-staff --scope jira             # restrict the gather to one backlog
 ```
 
 ## What it does
 
-Your operator-facing chief-of-staff — the human twin of `/reactivate` (Entelecheia, which
-orients a fresh **agent**). It answers *"what should I focus on now?"* by:
+Your operator-facing chief-of-staff — the human twin of the agent-facing `reactivate`/Entelecheia
+(which orients a fresh **agent**; incoming in PR #280). It answers *"what should I focus on now?"* by:
 
 1. **GATHER** — delegates `work-compass` to aggregate ALL scattered work into ONE N-Tree.
 2. **PRIORITIZE** — delegates `pulse` (Eisenhower 2×2; the maos-resident core). `--depth full`
    optionally adds the richer user-scope `ops-strategist` 4-lens **if you have it**.
-3. **SURFACE** — the people-ask view (who asked · when · by-when) projected over existing
-   tracker fields (Jira `reporter`/`duedate`, GitHub author/milestone…). Newly authored.
+3. **SURFACE** — the people-ask view (who asked · when · by-when) projected over the native tracker
+   fields `work-compass` already surfaces (Jira `reporter`/`duedate`, GitHub author/milestone…). Newly authored.
 4. **BRIEF** — the `morning-briefing` 7-section SitRep contract.
 5. **PRESENT** — ONE briefing: ▶ next-action · Eisenhower quadrants · ⏰ who-asked/by-when ·
    🧹 loose-ends. Read-only — any write/notify/schedule is PRINTED for your approval.
 
 ## Sibling routing (don't reach for this if…)
 
-- Learn / route the MAOS **framework** itself → `/maos-concierge`.
-- Just the raw aggregated N-Tree, no prioritization → `/work-compass`.
-- Re-orient inside ONE session → `/pulse`.
-- A fresh **agent** woke with no context → `/reactivate` (the agent-facing twin).
-- Sort a raw brain-dump into tickets → `/directive-braindump-triage`.
+- Learn / route the MAOS **framework** itself → `/maos:maos-concierge`.
+- Just the raw aggregated N-Tree, no prioritization → `/maos:work-compass`.
+- Re-orient inside ONE session → `/maos:pulse`.
+- A fresh **agent** woke with no context → `/maos:reactivate` (the agent-facing twin — incoming in PR #280).
+- Sort a raw brain-dump into tickets → `/maos:directive-braindump-triage`.
 
 ## Guarantees
 
 - **Route-never-reimplement** — composes the existing family; adds only the people-ask
   projection + tag/categorize + the unified front-door.
-- **Read-only by default** — never executes a write/notify/schedule; prints for approval.
+- **Read-only by default** — never executes a write/notify/schedule; prints for approval. No `Bash`
+  in `allowed-tools` (least-privilege — all tracker access is delegated to `work-compass`).
 - **On-demand only** — no hooks, no always-on runtime (MAOS stays the sole conductor).
 - **Layer-pure** — runs fully on the maos-resident core; `ops-strategist` is optional, never required.
 - **Explicit operator instruction wins** over every computed condition. ⛔ Never echoes secrets/PII.

--- a/skills/chief-of-staff/SKILL.md
+++ b/skills/chief-of-staff/SKILL.md
@@ -2,23 +2,17 @@
 name: chief-of-staff
 version: "0.1.0"
 description: |
-  Operator-facing work-focus conductor — the human twin of `reactivate`/Entelecheia (which orients a
-  fresh AGENT; this keeps the OPERATOR on focus). ONE front-door that answers "what should I focus on
-  now? who asked me for what, by when? any loose ends?" It GATHERS all scattered work (delegates
-  work-compass), PRIORITIZES it (delegates pulse's Eisenhower 2x2; optionally the richer ops-strategist
-  4-lens if the user has it), SURFACES a people-ask view (who asked / when / by-when) over existing
-  tracker fields, and PRESENTS one operator briefing (next-action · Eisenhower quadrants · who-asked ·
-  loose-ends). Composes the existing family and newly authors only what was genuinely absent: the
-  people-ask projection, the tag/categorize surface, and the unified operator front-door. Read-only by
-  default — any write/notify/schedule is PRINTED for approval, never executed. On-demand only (no hooks,
-  no always-on runtime — MAOS stays the sole conductor). Explicit operator instruction overrides every
-  computed condition.
-  Soul-name: Oikonomos (Greek οἰκονόμος, oikos "household" + nomos "management" — the classical household
-  steward / majordomo who administers the principal's whole household of affairs; root of both "economy"
-  and "ecosystem"). Triggers: "chief of staff", "keep me on track", "keep me focused", "what should I
-  focus on", "my priorities", "what's on my plate", "who asked me for what", "o que devo focar",
-  "me mantenha no foco", "minhas prioridades", "second brain", "baby-sit me".
-allowed-tools: Read, Grep, Glob, Bash, Task, AskUserQuestion
+  Operator-facing work-focus conductor — the human twin of the agent-facing reactivate/Entelecheia.
+  ONE front-door answering "what should I focus on now? who asked me for what, by when? any loose
+  ends?" GATHERS all scattered work (delegates work-compass), PRIORITIZES it (delegates pulse's
+  Eisenhower 2x2; optionally ops-strategist's 4-lens if present), SURFACES a people-ask view
+  (who / when / by-when) over existing tracker fields, and PRESENTS one operator briefing. Composes
+  the existing family; reimplements nothing. Read-only by default; on-demand only (MAOS stays sole
+  conductor). Soul-name: Oikonomos (the classical household steward). Triggers: "chief of staff",
+  "keep me on track", "keep me focused", "what should I focus on", "my priorities", "what's on my
+  plate", "who asked me for what", "o que devo focar", "me mantenha no foco", "minhas prioridades",
+  "second brain".
+allowed-tools: Read, Grep, Glob, Task, AskUserQuestion
 metadata:
   version: "0.1.0"
   scope: AAIF cross-vendor
@@ -36,7 +30,8 @@ metadata:
 > own **Eko-System** — *oikos* is the same root. *(Display-only name. The machine identifier is the
 > slug `chief-of-staff`.)*
 >
-> **Twin**: `reactivate`/**Entelecheia** orients a fresh amnesic **agent** at cold-wake. `chief-of-staff`/
+> **Twin** (the incoming agent-facing sibling, landing in PR #280 — may not be installed in this repo
+> version yet): `reactivate`/**Entelecheia** orients a fresh amnesic **agent** at cold-wake. `chief-of-staff`/
 > **Oikonomos** keeps the **operator** (human) on focus across live work. Same premise — correct
 > orientation over scattered state — pointed at the two different consumers.
 
@@ -50,7 +45,8 @@ metadata:
   - You just need the raw aggregated N-Tree of everything, no prioritization/briefing → `work-compass`
     directly (this routes TO it and adds the prioritize + people-ask + brief layer).
   - You are mid-task in ONE session and need re-orientation → `pulse` directly.
-  - A fresh **agent** woke with no context → `reactivate` (the agent-facing twin).
+  - A fresh **agent** woke with no context → `reactivate` (the agent-facing twin — incoming in PR #280;
+    once merged).
   - You have a raw brain-dump to sort into tickets → `directive-braindump-triage`.
 
 ## The pipeline (5 phases — lean by default, deepened on demand)
@@ -102,9 +98,11 @@ are already ≥2 prioritizers; a third would be entropy (anti-over-eng).
 ### PHASE 3 — SURFACE (newly authored — the people-ask view + tag/categorize)
 
 The genuine gap: no tool projects *"who asked ME for what, and by when?"* as a first-class view. Build it
-as a **read projection over EXISTING fields** — NOT a new store:
+as a **read projection over the fields PHASE-1 already surfaced** — NOT a new store, NOT a fresh tracker
+query (route-never-reimplement: `work-compass` is the tracker-access layer; pass it `--with-provenance`
+so its N-Tree carries these native fields, then project — never re-fetch here):
 
-| Field | Read from (existing, native) |
+| Field | Native source `work-compass` surfaces |
 |---|---|
 | `asked_by` (who asked) | Jira `reporter` · GitHub issue `author` · Linear `creator` · a memory `[[slug]]` note |
 | `asked_at` (when) | issue `created` timestamp |
@@ -202,7 +200,8 @@ absorbs it into a unified entry · operator retraction · ≥3 false-fires (fire
 - Composed (never reimplemented): `skills/work-compass` (GATHER) · `skills/pulse` (Eisenhower core) ·
   `skills/morning-briefing` (SitRep contract).
 - Optional (user-scope, probed-not-required): `ops-strategist` (the 4-lens TPM+CoS+SRE+Agentic brain).
-- Siblings (distinct): `skills/maos-concierge` (framework-facing) · `skills/reactivate` (Entelecheia —
+- Siblings (distinct): `skills/maos-concierge` (framework-facing) · `skills/reactivate` (Entelecheia,
+  incoming PR #280 —
   agent-facing twin) · `skills/session-reentry` (Anamnesis) · `skills/directive-braindump-triage`.
 - Governance: the host's end-of-action briefing protocol §7 (PRESENT format) · Cowork-Process-Topology §9
   (the 7 CPT domains work-compass renders) · loose-end-triage-queue / Taxis (the no-silent-drop discipline

--- a/skills/chief-of-staff/SKILL.md
+++ b/skills/chief-of-staff/SKILL.md
@@ -1,0 +1,211 @@
+---
+name: chief-of-staff
+version: "0.1.0"
+description: |
+  Operator-facing work-focus conductor — the human twin of `reactivate`/Entelecheia (which orients a
+  fresh AGENT; this keeps the OPERATOR on focus). ONE front-door that answers "what should I focus on
+  now? who asked me for what, by when? any loose ends?" It GATHERS all scattered work (delegates
+  work-compass), PRIORITIZES it (delegates pulse's Eisenhower 2x2; optionally the richer ops-strategist
+  4-lens if the user has it), SURFACES a people-ask view (who asked / when / by-when) over existing
+  tracker fields, and PRESENTS one operator briefing (next-action · Eisenhower quadrants · who-asked ·
+  loose-ends). Composes the existing family and newly authors only what was genuinely absent: the
+  people-ask projection, the tag/categorize surface, and the unified operator front-door. Read-only by
+  default — any write/notify/schedule is PRINTED for approval, never executed. On-demand only (no hooks,
+  no always-on runtime — MAOS stays the sole conductor). Explicit operator instruction overrides every
+  computed condition.
+  Soul-name: Oikonomos (Greek οἰκονόμος, oikos "household" + nomos "management" — the classical household
+  steward / majordomo who administers the principal's whole household of affairs; root of both "economy"
+  and "ecosystem"). Triggers: "chief of staff", "keep me on track", "keep me focused", "what should I
+  focus on", "my priorities", "what's on my plate", "who asked me for what", "o que devo focar",
+  "me mantenha no foco", "minhas prioridades", "second brain", "baby-sit me".
+allowed-tools: Read, Grep, Glob, Bash, Task, AskUserQuestion
+metadata:
+  version: "0.1.0"
+  scope: AAIF cross-vendor
+  soul-name: Oikonomos
+  register: agent
+  audience: operator-facing (human)
+---
+
+# chief-of-staff — the operator work-focus conductor
+
+> **Soul-name**: *Oikonomos* (Greek *οἰκονόμος*). In Xenophon's *Oeconomicus* the oikonomos is the
+> **steward of the household** — the one entrusted to keep the principal's whole estate of affairs in
+> order so the principal is free to act. This is the majordomo / chief-of-staff / right-hand: it does
+> not do the work, it keeps *you* pointed at the work that matters. It resonates with this operator's
+> own **Eko-System** — *oikos* is the same root. *(Display-only name. The machine identifier is the
+> slug `chief-of-staff`.)*
+>
+> **Twin**: `reactivate`/**Entelecheia** orients a fresh amnesic **agent** at cold-wake. `chief-of-staff`/
+> **Oikonomos** keeps the **operator** (human) on focus across live work. Same premise — correct
+> orientation over scattered state — pointed at the two different consumers.
+
+## When to use / not use
+
+- **Use**: you (the operator) want a single "keep-me-on-track" pass — *what matters now, what did boss/
+  cowork ask me and by when, what am I letting slip* — assembled across all your backlogs at once.
+- **Not use**:
+  - You want to LEARN / route the MAOS **framework** itself (which tool/protocol) → `maos-concierge`
+    (framework-facing). This is **work-item-facing**.
+  - You just need the raw aggregated N-Tree of everything, no prioritization/briefing → `work-compass`
+    directly (this routes TO it and adds the prioritize + people-ask + brief layer).
+  - You are mid-task in ONE session and need re-orientation → `pulse` directly.
+  - A fresh **agent** woke with no context → `reactivate` (the agent-facing twin).
+  - You have a raw brain-dump to sort into tickets → `directive-braindump-triage`.
+
+## The pipeline (5 phases — lean by default, deepened on demand)
+
+```
+PHASE 0  FRAME       classify the ask (daily catch-up? · drift/what-am-I-slipping? · who-owes-me? · full)
+PHASE 1  GATHER      work-compass ── ONE N-Tree of ALL scattered work (7 CPT domains), stale/orphan/pending
+PHASE 2  PRIORITIZE  pulse (Eisenhower 2x2, maos-resident) ──[--depth full]──► + ops-strategist 4-lens IF present
+PHASE 3  SURFACE     people-ask view (who · when · by-when) + tag/categorize      ◄── newly authored (the gap)
+PHASE 4  BRIEF       morning-briefing 7-section SitRep contract (state·done·in-flight·blockers·awaiting·risks·next)
+PHASE 5  PRESENT     ONE operator briefing → next-action · Eisenhower quadrants · who-asked/by-when · loose-ends
+```
+
+**Composition discipline**: PHASES 1, 2, and 4 **delegate** to skills that already exist and are never
+reimplemented here. Only PHASE 3 (people-ask projection + tag/categorize) and the PHASE-5 unified operator
+assembly are authored by this conductor — they were the genuinely absent pieces.
+
+**Proportionality** (over-engineering circuit-breaker): default depth is **quick** (0-1-2-3-5; PHASE 4
+folds its contract into PHASE 5 without a separate pass). `--depth full` adds the ops-strategist 4-lens
+brain + the full SitRep. Do not convene a strategy board to answer *"what's next?"*.
+
+---
+
+### PHASE 0 — FRAME (classify the ask, cheap)
+
+One token sets the depth + which lens dominates: `catch-up` (default — full landscape + next-action) ·
+`drift` (what am I slipping / loose-ends first) · `who-owes-me` (people-ask view first) · `full` (adds
+ops-strategist). `--mode` overrides. Explicit operator instruction always wins.
+
+### PHASE 1 — GATHER (delegate: `work-compass`)
+
+Delegate to `work-compass` to aggregate ALL scattered work (Jira/Linear/GitHub/sessions/git) into ONE
+N-Tree across the 7 CPT domains (ticket · worktree · branch · session · thread · process · graph-node),
+with stale/orphan/pending flags. **Read-only** — `work-compass` already prints, never executes.
+Re-use its output whole; do not re-aggregate.
+
+### PHASE 2 — PRIORITIZE (delegate: `pulse` core · `ops-strategist` optional)
+
+- **Core (maos-resident, always available)**: delegate to `pulse` — Eisenhower 2x2 classification, routing
+  each item ∈ {now · delegate · defer-trigger · backlog · drop}. This is the community-portable prioritizer.
+- **Richer (optional, user-scope)**: IF the user has `ops-strategist` (a user-scope agent — its 4-lens
+  TPM+CoS+SRE+Agentic Eisenhower over 7 sources), `--depth full` may route to it for a deeper read.
+  ⚠️ **Layer-purity**: `ops-strategist` is NOT a hard dependency — this skill is community-resident and
+  MUST run fully on the maos-resident core alone. Probe for it; use it only if present.
+
+**This conductor never computes its own Eisenhower.** It routes to `pulse` (or `ops-strategist`) — there
+are already ≥2 prioritizers; a third would be entropy (anti-over-eng).
+
+### PHASE 3 — SURFACE (newly authored — the people-ask view + tag/categorize)
+
+The genuine gap: no tool projects *"who asked ME for what, and by when?"* as a first-class view. Build it
+as a **read projection over EXISTING fields** — NOT a new store:
+
+| Field | Read from (existing, native) |
+|---|---|
+| `asked_by` (who asked) | Jira `reporter` · GitHub issue `author` · Linear `creator` · a memory `[[slug]]` note |
+| `asked_at` (when) | issue `created` timestamp |
+| `due` (by-when) | Jira `duedate` · GitHub milestone due · Linear `dueDate` · sprint end |
+
+- **Projection**: over the PHASE-1 items, surface those where `asked_by ≠ operator` (a boss/cowork ask),
+  sorted by `due` ascending, flagging overdue + due-soon.
+- **`tag`/`categorize`** (the missing verbs): for an item lacking native provenance (a brain-dump, a loose
+  note), the operator may attach `asked_by · asked_at · due · tags[] · category`. In this phase these are
+  **PRINTED as a suggested command for approval** (e.g. the Jira/Linear edit, or a one-line memory tag) —
+  never auto-written. No new store: native fields first, a light `[[slug]]` memory tag only for items with
+  no native home.
+- ⛔ **Never fabricate** a `due` or an `asked_by` that isn't in the source. An invented deadline is worse
+  than none (anti-theater). "no due found" is a valid, correct value.
+
+### PHASE 4 — BRIEF (contract: `morning-briefing`)
+
+Adopt the `morning-briefing` 7-section SitRep contract as the briefing shape — state · done · in-flight ·
+blockers · decisions-awaiting · risks · next-action — populated from PHASES 1-3. At quick depth this is a
+formatting contract folded into PHASE 5; at `--depth full` it is a full `morning-briefing` pass.
+
+### PHASE 5 — PRESENT (one operator briefing — read-only, review-before-act)
+
+Assemble ONE scannable operator briefing (per the host's end-of-action briefing protocol §7 — executive,
+recommended-first, risk-tagged):
+
+1. **▶ NEXT ACTION** — the single highest-priority item + why (from PHASE 2's `now` quadrant).
+2. **Eisenhower quadrants** — Q1/Q2/Q3/Q4 counts + top items (from `pulse`/`ops-strategist`, NOT recomputed).
+3. **⏰ Who asked you / by when** — the PHASE-3 people-ask view, overdue-first.
+4. **🧹 Loose ends** — stale/orphan/pending from PHASE-1 + any un-dispositioned item, per the host's
+   loose-end-triage-queue (Taxis) no-silent-drop discipline: each gets a disposition suggestion.
+5. **Compass footer** — one routing command per actionable node (delegate to the owning tool).
+
+⛔ **SANITIZE** (unconditional): never echo a secret · credential · token · personal identifier into the
+briefing — reference by name/location. **Read-only**: any write/notify/schedule is PRINTED for the operator
+to run/approve, never executed by this skill.
+
+---
+
+## Parameters
+
+| Param | Default | Meaning |
+|---|---|---|
+| `--mode` | `catch-up` | `catch-up` · `drift` · `who-owes-me` · `full`. **Explicit operator instruction wins.** |
+| `--depth` | `quick` | `quick` (0-1-2-3-5) · `full` (adds ops-strategist 4-lens IF present + full morning-briefing). |
+| `--scope` | `all` | Which backlogs to gather — `all` · `jira` · `github` · `linear` · `sessions` (passthrough to work-compass). |
+| `--who` | — | Filter the people-ask view to asks from one person. |
+| `--lang` | `auto` | `pt` · `en` · `auto` (pt-BR for the operator, en-US for a machine consumer). |
+| `--json` | off | Emit a typed briefing envelope for an agent consumer instead of prose. |
+
+## Invariants (non-negotiable)
+
+1. **Explicit operator instruction overrides every computed condition** — mode, depth, scope, language.
+2. **Route-never-reimplement** — GATHER=work-compass, PRIORITIZE=pulse/ops-strategist, BRIEF=morning-briefing.
+   This conductor authors ONLY the people-ask projection + tag/categorize + the unified assembly.
+3. **Layer-purity** — runs fully on the maos-resident core (`work-compass`+`pulse`+`morning-briefing`);
+   `ops-strategist` is an OPTIONAL user-scope enhancement, never a hard dependency.
+4. **Read-only by default** — writes / notify / schedule are PRINTED for approval, never executed.
+5. **On-demand only** — no hooks, no always-on runtime. MAOS stays the sole conductor (proactive firing /
+   calendar-ingest / notify-channel are a SEPARATE, operator-confirmed later phase — they touch settings).
+6. **Never fabricate** a `due`/`asked_by`/priority — "not found" is a valid value; SANITIZE is unconditional.
+7. **Never computes its own Eisenhower** — always routes to an existing prioritizer (anti-over-eng).
+8. **Bounded** — quick depth by default; do not convene ops-strategist to answer "what's next?".
+
+## Anti-patterns
+
+1. ❌ **Re-aggregating** — walking Jira/GitHub yourself instead of delegating `work-compass`.
+2. ❌ **A 5th Eisenhower generator** — computing priority here instead of routing to `pulse`/`ops-strategist`.
+3. ❌ **Hard-depending on `ops-strategist`** — it is user-scope; a community skill must not require it (Invariant 3).
+4. ❌ **Auto-executing a write/notify/schedule** — this front-door prints for approval; it never acts silently.
+5. ❌ **Installing an always-on hook** — that is a SEPARATE operator-confirmed phase, not this on-demand skill.
+6. ❌ **Fabricating a deadline / who-asked** — an invented due date is worse than none (anti-theater).
+7. ❌ **Framework-routing** — teaching which MAOS tool to use is `maos-concierge`'s job, not this.
+
+## Quality tests (6 self-validity)
+
+1. **Self-application** — this conductor was itself designed by gathering the existing landscape (a recon),
+   prioritizing the one genuine gap over the redundant, and presenting a single routed recommendation. ✅
+2. **Non-contradiction** — composes `work-compass`/`pulse`/`morning-briefing` without overriding any;
+   distinct from `maos-concierge` (framework), `reactivate` (agent-facing twin), `ops-strategist` (the
+   optional brain it routes to). ✅
+3. **Survival** — applied to itself it advocates route-don't-reimplement + read-only; it does exactly that. ✅
+4. **Bounded-responsibility** — quick default · route-only core · read-only · on-demand · qualitative sunset. ✅
+5. **Explicit-exception** — operator override (Invariant 1) · the not-use routing list · optional-ops-strategist. ✅
+6. **Utility-sunset** — below. ✅
+
+## Sunset (qualitative, not counter-based)
+
+Deprecate when ANY: the host ships a native operator work-focus dashboard that subsumes this · `ops-strategist`
+is promoted community-resident AND grows a front-door making this redundant · the concierge/conductor family
+absorbs it into a unified entry · operator retraction · ≥3 false-fires (fired on a non-work-focus intent).
+
+## Refs
+
+- Composed (never reimplemented): `skills/work-compass` (GATHER) · `skills/pulse` (Eisenhower core) ·
+  `skills/morning-briefing` (SitRep contract).
+- Optional (user-scope, probed-not-required): `ops-strategist` (the 4-lens TPM+CoS+SRE+Agentic brain).
+- Siblings (distinct): `skills/maos-concierge` (framework-facing) · `skills/reactivate` (Entelecheia —
+  agent-facing twin) · `skills/session-reentry` (Anamnesis) · `skills/directive-braindump-triage`.
+- Governance: the host's end-of-action briefing protocol §7 (PRESENT format) · Cowork-Process-Topology §9
+  (the 7 CPT domains work-compass renders) · loose-end-triage-queue / Taxis (the no-silent-drop discipline
+  behind PHASE-5 loose-ends) · layer-precedence-policy (the Layer-purity of Invariant 3).
+- Named by `skills/anima` per the host's naming authority; recorded in `bin/artifact-registry`.
+- Grounding: Xenophon, *Oeconomicus* (the oikonomos as household steward); Greek *οἰκονόμος* (LSJ).


### PR DESCRIPTION
## Summary

Adds **`chief-of-staff`** (soul-name **Oikonomos**) — the operator-facing work-focus conductor, the **human twin** of the agent-facing `reactivate`/**Entelecheia** (open PR #280). Where Entelecheia orients a fresh amnesic *agent* at cold-wake, Oikonomos keeps the *operator* on focus across live work: ONE front-door answering *"what should I focus on now? who asked me for what, by when? any loose ends?"*

**Route-never-reimplement** 5-phase pipeline:
- **GATHER** → delegates `work-compass` (ONE N-Tree of all scattered work, 7 CPT domains)
- **PRIORITIZE** → delegates `pulse` (Eisenhower 2×2, maos-resident core); `ops-strategist` 4-lens **optional** at `--depth full` **if present** (Layer-pure — never a hard dep)
- **SURFACE** → *newly-authored* people-ask view (who · when · by-when) as a **read projection over EXISTING tracker fields** (Jira `reporter`/`duedate`, GitHub author/milestone) — **NOT a new store**; + `tag`/`categorize` verbs
- **BRIEF** → `morning-briefing` 7-section SitRep contract
- **PRESENT** → one operator briefing (▶ next-action · Eisenhower quadrants · ⏰ who-asked/by-when · 🧹 loose-ends), read-only

Adds ONLY the genuinely-absent pieces (people-ask projection, `tag`/`categorize`, the unified front-door). Reimplements no aggregation or Eisenhower logic.

### Why (RECON-grounded)
A `/deep-research` scoped "two focus tools" (agent-facing + operator-facing). RECON (Q2.1 PR-State Inventory Gate) found the **agent-facing** one already built as `reactivate`/Entelecheia (PR #280 — untouched here). The **operator-facing** front-door was the genuine gap: `work-compass` (eyes), `pulse`/`ops-strategist` (brains), `morning-briefing` (cadence) all exist, but nothing unified them into an operator "keep-me-on-track" surface, and `maos-concierge` is explicitly framework-facing.

## Files
- `skills/chief-of-staff/SKILL.md` (v0.1.0) — the conductor
- `commands/chief-of-staff.md` — thin `/chief-of-staff` wrapper
- `CHANGELOG.md` — `[Unreleased]` entry (no `plugin.json` bump — avoids collision with PR #280's 1.22.0)

## Test plan
- [x] `bash tests/validate-plugin.sh` → **0 errors** (skill + command validate; the 1 warning is the pre-existing `COWORK-AUTONOMY-POLICY.md`)
- [x] gitleaks pre-commit → clean
- [x] DRY-proof scan → **0** reimplemented aggregation/prioritizer logic (23 delegate/route refs; phases 1/2/4 delegate, only 3/5 newly-authored)
- [x] Anima artifact-registry: slug `chief-of-staff` **CLEAR** (no collision) + name recorded
- [ ] Dogfood ≥2 real cycles before promotion (post-merge; `dogfooding-mandate`)

## Risk + rollback
Low. Additive skill + command + changelog only — no edits to existing tools, no hooks, no `settings.json`, no runtime. Read-only by default. Rollback = revert this PR (self-contained).

## Out of scope (deferred)
- **Phase 2** — proactive/scheduled firing (extend a hook + `/schedule`; touches `settings.json` → operator-confirmed `[C13]`)
- **Phase 3** — wirings: Google Calendar ingest (due-dates → signals), a work-item notify channel, a full trajectory drift-judge
- PR #280 (`reactivate`/Entelecheia) — a peer session's WIP; **not touched**

## Refs
- Sibling: PR #280 `feat/reactivate-conductor` (Entelecheia — agent-facing twin)
- Composes: `work-compass` · `pulse` · `morning-briefing` · (optional user-scope) `ops-strategist`
- Distinct from: `maos-concierge` (framework-facing)
- Named by `skills/anima` per the naming authority; recorded in `bin/artifact-registry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
