### PR TITLE
feat(skills): research-dossier — provenance-gated research→dossier IR (#287)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_comment": "MAOS plugin manifest. Edit version on release; see CHANGELOG.md. Namespacing + vendor-reserved details below.",
   "name": "maos",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ __pycache__/
 *_logs.txt
 step*_logs.txt
 *_deploy_logs.txt
+
+# research-dossier render output (build artifact, never committed)
+out/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `research-dossier`: finished research → decision-ready visual dossier, behind two deterministic gates (#287)
+
+The missing spine between researchers and the ~110 `design-templates/` + ~150 `design-systems/`
+already installed. Research emits prose; every renderer wants structured input; nothing converted
+one to the other — so each dashboard was hand-rolled, with no provenance and no reuse.
+
+The lever is the **IR**, not the HTML: once research becomes JSON with per-claim provenance, the
+existing renderers are reachable for free. One contract unlocks N consumers.
+
+- **`skills/research-dossier/SKILL.md`** (v0.1.0) — thin orchestrator routing
+  `corpus → IR → (scorecard) → render`. Never renders directly.
+- **`templates/ir.schema.json`** — the contract. `claims[]` carry `source` + `as_of` + `confidence`;
+  charts, scorecard cells and recommendations all cite claims **by id**, so a number in a chart that
+  appears in no claim is unsourced by construction. `not_checked[]` is **required and non-empty** —
+  a dossier that states its own blind spots is the one worth trusting.
+- **`bin/research-dossier-render.mjs`** — fan-out (html · md · json; pdf/pptx/xlsx as hand-off
+  manifests) behind **two f=0 oracles**, both of which fail the build:
+  - **provenance** — unsourced claim · dangling `source_claims` · recommendation with no owner/eta ·
+    empty `not_checked[]` · **undeclared truncation on a magnitude axis**. That last check is what
+    carries the text-level faithfulness discipline into the *visual* layer: a bar chart starting at
+    60 distorts a ratio whether or not anyone meant it to. Declared truncation passes, and the
+    rationale is then printed on the face of the chart.
+  - **palette** — delegates to the bundled `dataviz` skill's own `validate_palette.js` in **both**
+    light and dark (CVD ΔE OKLab per protan/deutan/tritan, lightness band, chroma floor,
+    normal-vision floor, surface contrast). Colour is cited, never reimplemented. The validator
+    lives in a version-and-hash-keyed temp dir that moves on every CLI upgrade → discovered at
+    runtime, degrading to a **loud WARN** when absent (`--strict` makes it a failure; a silent
+    green would be worse than no gate).
+- **`references/scorecard.md`** — the comparison primitive: N options × M criteria with evidence
+  **per cell**. Sparse is honest, complete is often fabricated; weights are declared or they are
+  smuggled; the verdict names its runner-up and why it lost.
+- **`references/audience-map.md`** — closes the long-standing gap where `--audience` stopped at
+  lens selection and never reached the design system. Maps audience → design system → the eight
+  parameters `dataviz` consumes. Audience changes **presentation only** — never the claims, the
+  scorecard, or `not_checked[]`.
+- **`templates/dossier.html`** — fallback for when the `od` daemon is absent. Single file, opens
+  over `file://`, zero network, inline SVG (no library to bundle, no canvas to hide from a screen
+  reader). Every chart: `role="img"` + a value-describing `aria-label` + a real `<table>`.
+  Server-rendered, so **JS off still shows the whole dossier**; JS only reveals the theme toggle.
+  Dark mode is *selected*, not flipped.
+- **`commands/research-dossier.md`** — `/maos:research-dossier` surface.
+- **`examples/`** — 1 working fixture (dogfood: the chart-library comparison that chose the
+  template's own renderer) + **5 negative fixtures**, each of which must fail.
+
+Verified by execution: 6/6 fixtures hit their expected exit codes, 18/18 output checks pass,
+Layer Purity clean, `validate-plugin.sh` 0 errors.
+
+Two defects were found and root-fixed *while verifying* — both the same family, a test passing for
+the wrong reason. The body was initially client-rendered (JS off → blank page). And substitution
+used single-match `.replace()` while the template's own header comment named the placeholders, so
+the first match was the *documentation* and the live slot never filled — output that looked
+plausible while carrying no dossier, which the first verification scored as 12,613 chars of content
+(real figure: 4,657). Fixed globally, and the renderer now **asserts no slot survives**.
+
+Composes, never duplicates: zero new design systems, zero new per-format renderers, chart form and
+colour delegated to the bundled `dataviz` skill.
+
 ### Added — `chief-of-staff` (Oikonomos): the operator work-focus conductor — human twin of `reactivate`/Entelecheia
 
 The operator-facing counterpart of the agent-facing `reactivate` conductor: **Entelecheia** orients a fresh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,14 @@ existing renderers are reachable for free. One contract unlocks N consumers.
 - **`examples/`** — 1 working fixture (dogfood: the chart-library comparison that chose the
   template's own renderer) + **5 negative fixtures**, each of which must fail.
 
-- **`bin/tests/research-dossier.test.sh`** — 55 assertions, wired into `validate-plugin.sh`. Every
+- **`bin/tests/research-dossier.test.sh`** — 68 assertions, wired into `validate-plugin.sh`. Every
   negative fixture is asserted on its **specific failure code**, not merely on exit 1: a fixture
   failing for an unintended reason would satisfy a naive check while proving nothing about the check
   it exists to exercise. Exit codes captured directly — a pipe reports its *last* command's status,
   so `render | grep` would make a failing build read green. Mutation-tested: emptying
   `MAGNITUDE_FORMS` turns 2 assertions red, so the suite is known capable of failing.
 
-Verified by execution: 6/6 fixtures hit their expected exit codes, 55/55 tests pass, Layer Purity
+Verified by execution: 6/6 fixtures hit their expected exit codes, 68/68 tests pass, Layer Purity
 clean, `validate-plugin.sh` 0 errors, and the full render succeeds under a stripped environment
 (`env -i PATH=/usr/bin:/bin`) with every offline/a11y/print invariant intact.
 
@@ -82,6 +82,35 @@ used single-match `.replace()` while the template's own header comment named the
 the first match was the *documentation* and the live slot never filled — output that looked
 plausible while carrying no dossier, which the first verification scored as 12,613 chars of content
 (real figure: 4,657). Fixed globally, and the renderer now **asserts no slot survives**.
+
+**Red-teamed, and it broke.** An independent adversary (≠ author) was tasked with passing the
+provenance gate while producing a misleading dossier, and succeeded — a board-grade artifact that
+inverted a $1.18M-vs-$0.34M cost comparison, hid a 6-hour outage and a lapsed attestation, and drew
+a 19x-reversed chart, at exit 0 with zero failures. The diagnosis was exact: the gate verified that
+citations **resolve**, never that they **agree**. Referential integrity was airtight — 19/19
+structural attacks caught — while every *semantic* relationship went unchecked. The IR already
+carried everything needed (`metric.value`, `direction`, `weight`, per-cell `source_claims`), so the
+data model was right and the checks were simply never written.
+
+Nine now close it, each with a test and each mutation-verified: a chart point contradicting the
+claim it cites; a `display` string overriding its own `value` (one field, no arithmetic, total
+inversion); stacked parts missing their cited total; a verdict that is not the argmax of its
+declared weights; a blank scorecard cell whose evidence exists but went unused; `not_checked[]`
+filled with boilerplate or marked entirely inconsequential; evidence years staler than the dossier;
+and an inflated `y_max`, since truncation is only one of two ways to lie with an axis.
+
+The sharpest structural finding: **`ch.form` was read by the gate and ignored by the renderer**,
+which draws every chart as proportional bars — so `form: "line"` bypassed the truncation check while
+still rendering truncated bars. `MAGNITUDE_FORMS` was guarding a rendering that did not exist. The
+check now gates on what is *drawn*, not what is *declared*.
+
+Two limits are **surfaced rather than hidden**: a weighting can decide an outcome on its own (when
+one criterion outweighs all others combined the build warns, because arithmetic cannot refute a
+rigged weight — only disclosure can), and summary-vs-claims plus recommendation-vs-its-own-citations
+remain semantic judgements outside `f=0` reach. `SKILL.md` now says so. The rendered footer no
+longer claims "gates passed" — that read as a certificate over the *conclusion*, and was
+load-bearing in the adversary's deception; it now states exactly what was verified and closes with
+"a check of the evidence, not an endorsement of the conclusion".
 
 Composes, never duplicates: zero new design systems, zero new per-format renderers, chart form and
 colour delegated to the bundled `dataviz` skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,8 +52,29 @@ existing renderers are reachable for free. One contract unlocks N consumers.
 - **`examples/`** — 1 working fixture (dogfood: the chart-library comparison that chose the
   template's own renderer) + **5 negative fixtures**, each of which must fail.
 
-Verified by execution: 6/6 fixtures hit their expected exit codes, 18/18 output checks pass,
-Layer Purity clean, `validate-plugin.sh` 0 errors.
+- **`bin/tests/research-dossier.test.sh`** — 55 assertions, wired into `validate-plugin.sh`. Every
+  negative fixture is asserted on its **specific failure code**, not merely on exit 1: a fixture
+  failing for an unintended reason would satisfy a naive check while proving nothing about the check
+  it exists to exercise. Exit codes captured directly — a pipe reports its *last* command's status,
+  so `render | grep` would make a failing build read green. Mutation-tested: emptying
+  `MAGNITUDE_FORMS` turns 2 assertions red, so the suite is known capable of failing.
+
+Verified by execution: 6/6 fixtures hit their expected exit codes, 55/55 tests pass, Layer Purity
+clean, `validate-plugin.sh` 0 errors, and the full render succeeds under a stripped environment
+(`env -i PATH=/usr/bin:/bin`) with every offline/a11y/print invariant intact.
+
+**Density now reaches the render.** `--audience` previously stopped at the prose — `ir.audience` was
+read only to print it in the header, so gap #5 was half-closed and `audience-map.md` described
+effects the renderer did not implement. A documented-but-inert parameter is exactly the theater
+these gates exist to prevent. Now: charts beyond the audience cap are omitted **with the omission
+disclosed on the page** (an omission the reader cannot see is an edit, not a summary), and the
+evidence table starts expanded for `engineer`, collapsed elsewhere — collapsed but never
+script-gated, since `<details>` is native and works with JS off. `stakes: "high"` re-expands
+evidence at every audience, so the reader with the least context does not receive the
+least-qualified version of the truth. Audience stays presentation-only: a test asserts `claims`,
+scorecard `cells` and `not_checked[]` are byte-identical across an exec and an engineer render. The
+one remaining documented effect (demote a <4-point chart to a stat tile) is listed in
+`audience-map.md` as a **gap**, not described as behaviour.
 
 Two defects were found and root-fixed *while verifying* — both the same family, a test passing for
 the wrong reason. The body was initially client-rendered (JS off → blank page). And substitution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,14 +52,19 @@ existing renderers are reachable for free. One contract unlocks N consumers.
 - **`examples/`** — 1 working fixture (dogfood: the chart-library comparison that chose the
   template's own renderer) + **5 negative fixtures**, each of which must fail.
 
-- **`bin/tests/research-dossier.test.sh`** — 68 assertions, wired into `validate-plugin.sh`. Every
+- **`bin/tests/research-dossier.test.sh`** — 89 assertions, wired into `validate-plugin.sh`. Every
   negative fixture is asserted on its **specific failure code**, not merely on exit 1: a fixture
   failing for an unintended reason would satisfy a naive check while proving nothing about the check
   it exists to exercise. Exit codes captured directly — a pipe reports its *last* command's status,
-  so `render | grep` would make a failing build read green. Mutation-tested: emptying
-  `MAGNITUDE_FORMS` turns 2 assertions red, so the suite is known capable of failing.
+  so `render | grep` would make a failing build read green. **Mutation-tested**: reverting a guard
+  turns the assertion covering it red — the truncation baseline, the `javascript:`/palette
+  allowlists, per-bucket stacked composition, the emitter signature and both crash guards were each
+  neutered and the corresponding assertions observed to fail. One security assertion was rewritten
+  after mutation testing showed it passed with its guard removed: the fixture used a palette key the
+  renderer never reads, so the payload only reached the inert JSON island. A security test that
+  cannot fail is worse than none — it certifies a hole it never touched.
 
-Verified by execution: 6/6 fixtures hit their expected exit codes, 68/68 tests pass, Layer Purity
+Verified by execution: 6/6 fixtures hit their expected exit codes, 89/89 tests pass, Layer Purity
 clean, `validate-plugin.sh` 0 errors, and the full render succeeds under a stripped environment
 (`env -i PATH=/usr/bin:/bin`) with every offline/a11y/print invariant intact.
 

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -444,8 +444,29 @@ function renderMarkdown(ir) {
  *  in the output reveals the theme toggle; with JS off the dossier is complete.
  *  That is affordable because theming is pure CSS — the validated palette lands as
  *  --series-N under both scopes and the SVG marks reference them by var(). */
+/** audience → density. See references/audience-map.md.
+ *  Density is a real parameter, not a mood: it changes how many charts survive
+ *  into the render and whether the evidence table starts expanded. It NEVER
+ *  changes the claims, the scorecard cells, or not_checked[] — an exec dossier
+ *  and an engineer dossier carry the same evidence and pass the same gates.
+ *  stakes:"high" overrides density downward everywhere (gaps stay expanded). */
+const DENSITY = {
+  exec:     { maxCharts: 3, tablesOpen: false },
+  client:   { maxCharts: 3, tablesOpen: false },
+  public:   { maxCharts: 2, tablesOpen: false },
+  team:     { maxCharts: 5, tablesOpen: false },
+  engineer: { maxCharts: Infinity, tablesOpen: true }
+};
+function densityOf(ir) {
+  const d = DENSITY[ir.audience] || DENSITY.team;
+  // High stakes expands evidence regardless of audience: the reader with the
+  // least context must not get the least-qualified version of the truth.
+  return ir.stakes === 'high' ? { ...d, tablesOpen: true } : d;
+}
+
 function renderHtmlBody(ir) {
   const H = [];
+  const den = densityOf(ir);
   const claimIds = new Set((ir.claims || []).map(c => c.id));
   const entityLabel = id => (ir.entities || []).find(e => e.id === id)?.label ?? id;
   const entityIdx = id => {
@@ -496,8 +517,16 @@ function renderHtmlBody(ir) {
 
   // charts — inline SVG + mandatory data table
   if ((ir.charts || []).length) {
+    // Density caps how many charts survive. A dropped chart is DISCLOSED, never
+    // silently swallowed: an omission the reader cannot see is an edit, not a
+    // summary. The charts' underlying claims stay in the evidence table either way.
+    const shown = ir.charts.slice(0, den.maxCharts);
+    const dropped = ir.charts.length - shown.length;
     H.push('<section><h2>Charts</h2>');
-    for (const ch of ir.charts) {
+    if (dropped > 0) {
+      H.push(`<p class="note">${dropped} further chart${dropped === 1 ? '' : 's'} omitted at "${esc(ir.audience)}" density; the underlying claims remain in the evidence table below.</p>`);
+    }
+    for (const ch of shown) {
       const pts = [];
       for (const s of ch.series || [])
         for (const p of s.data || []) pts.push({ ...p, entity: s.entity, sLabel: s.label });
@@ -543,7 +572,7 @@ function renderHtmlBody(ir) {
       // A declared truncation is stated in the OUTPUT, not just in the IR.
       if (ax.axis_truncated === true)
         H.push(`<p class="axis-note">⚠ Axis truncated at ${esc(ax.y_min)} — ${esc(ax.truncation_rationale || 'rationale not recorded')}. Bar lengths are not proportional to values.</p>`);
-      H.push('<details class="tableview" open><summary>Data table</summary><table>');
+      H.push(`<details class="tableview"${den.tablesOpen ? ' open' : ''}><summary>Data table</summary><table>`);
       H.push(`<thead><tr><th scope="col">${esc(ax.x_label || 'Item')}</th><th scope="col" class="num">${esc(ax.y_label || 'Value')}</th></tr></thead><tbody>${rows}</tbody>`);
       H.push('</table></details></figure></div>');
     }

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -369,7 +369,10 @@ function gateProvenance(ir) {
             if (typeof c.value === 'boolean') return c.value ? 1 : 0;
             return null;
           });
-          if (vals.some(x => x === null)) continue;   // sparse row: not comparable
+          // `[].some()` is vacuously false, so a criterion with NO options at all
+          // would slip past the sparse-row guard and count as "comparable" while
+          // contributing nothing — zero options compared is not a comparison.
+          if (!vals.length || vals.some(x => x === null)) continue;   // sparse row: not comparable
           const lo = Math.min(...vals), hi = Math.max(...vals);
           if (hi === lo) continue;
           comparable++;
@@ -381,7 +384,12 @@ function gateProvenance(ir) {
         }
         // Only judge when at least two criteria were fully scored — a verdict
         // resting on one comparable row is a judgement call, not arithmetic.
-        if (comparable >= 2) {
+        // `score` can still be empty here (cells citing options the scorecard no
+        // longer declares), and an unhandled reduce would replace the verdict with
+        // a stack trace — strictly worse than a gate failure, since a crash tells
+        // the author nothing about which invariant broke. The dangling-option
+        // failures above already report the real defect; guard and let them speak.
+        if (comparable >= 2 && Object.keys(score).length) {
           const best = Object.keys(score).reduce((a, b) => (score[b] > score[a] ? b : a));
           if (score[best] - (score[v.winner] ?? -Infinity) > 1e-9 && !v.override_rationale)
             FAIL('VERDICT_UNSUPPORTED',

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -85,10 +85,13 @@ const INFO = m => report.info.push(m);
 // ═══════════════════════════════════════════════════════════════════════════
 const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
 const CONFIDENCE = new Set(['high', 'medium', 'low']);
-/** Forms where the y-axis encodes MAGNITUDE — the family where a truncated
- *  baseline lies about proportion. A line chart of a bounded index may legitimately
- *  start above zero; a bar chart may not. */
-const MAGNITUDE_FORMS = new Set(['bar', 'column', 'stacked-bar', 'area', 'diverging-bar']);
+/* A MAGNITUDE_FORMS allow-list used to scope the truncation check to bar-like
+ * charts. It is deliberately GONE: the renderer draws every chart as proportional
+ * bars regardless of ch.form, so keying the check to a declared form let
+ * `form:"line"` bypass it while still rendering truncated bars — the gate was
+ * guarding a rendering that did not exist. The check now keys off what is DRAWN.
+ * Recorded rather than deleted silently, so the next reader does not reintroduce
+ * the allow-list as an apparent improvement. */
 
 function gateProvenance(ir) {
   // -- structural minimums the schema also states, re-checked here because the
@@ -332,6 +335,15 @@ function gateProvenance(ir) {
       for (const o of missing) {
         const covered = (ir.claims || []).some(c => {
           if (!c || c.entity !== o) return false;
+          // The unused claim must plausibly be about THIS criterion. Matching any
+          // unused claim about the option made an unrelated note (a licence, a
+          // release date) fail an unrelated blank cell — and a gate that fires on
+          // honest sparsity teaches authors to fabricate cells to silence it,
+          // which is the exact behaviour this check exists to prevent.
+          const topic = `${c.metric?.name || ''} ${c.text || ''}`.toLowerCase();
+          const label = `${cr.id} ${cr.label || ''}`.toLowerCase().trim();
+          const relevant = label.split(/[\s_-]+/).filter(w => w.length > 2).some(w => topic.includes(w));
+          if (!relevant) return false;
           const inCell = (sc.cells || []).some(x => (x.source_claims || []).includes(c.id));
           return !inCell;
         });
@@ -578,8 +590,21 @@ const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': 
 // is to be opened in a browser and passed around, so a citation URL is attack
 // surface, not decoration. Allowlist the schemes a citation could legitimately
 // use rather than blocklisting the ones we happen to remember.
-const SAFE_URL = /^(?:https?:|mailto:|\/|\.{1,2}\/|#)/i;
-const safeHref = u => (SAFE_URL.test(String(u ?? '').trim()) ? String(u).trim() : null);
+// Protocol-relative `//host/x` is excluded deliberately: this artifact is opened
+// over file://, where it resolves against the local filesystem rather than a host,
+// so it is never the right way to write a citation and is a needless ambiguity.
+const SAFE_URL = /^(?:https?:\/\/|mailto:|[^/]|\/(?!\/)|#)/i;
+const SAFE_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
+const safeHref = u => {
+  const s = String(u ?? '').trim();
+  if (!s) return null;
+  // Any explicit scheme must be one we allow; anything schemeless is a relative
+  // reference, which cannot execute. Allowlist the schemes rather than blocklist
+  // the dangerous ones — `javascript:` is the famous case, but `vbscript:`,
+  // `data:` and whatever a future browser adds all fail closed this way.
+  if (SAFE_SCHEME.test(s)) return /^(?:https?:\/\/|mailto:)/i.test(s) ? s : null;
+  return s.startsWith('//') ? null : s;
+};
 
 // Palette values are interpolated into a <style> block as `--series-N: ${hex};`.
 // The palette gate would reject a malformed colour, but it degrades to a WARN when
@@ -961,6 +986,15 @@ Exit: 0 ok · 1 gate failure · 2 usage/IO`);
     return EXIT_OK;
   }
 
+  // Failures registered DURING rendering (after the gate summary was already
+  // printed) still have to reach the exit code and the operator's eyes.
+  const renderFailure = () => {
+    for (const f of report.fail) console.log(`    ✗ ${f.code}  ${f.msg}`);
+    console.log(`  → RENDER FAILED — ${report.fail.length} failure(s); the artifact was NOT written.`);
+    console.log('');
+    return EXIT_GATE;
+  };
+
   mkdirSync(a.out, { recursive: true });
   const written = [];
   for (const fmt of a.formats) {
@@ -974,6 +1008,12 @@ Exit: 0 ok · 1 gate failure · 2 usage/IO`);
       } else if (fmt === 'html') {
         const html = renderHtml(ir);
         if (html) { const p = join(a.out, 'dossier.html'); writeFileSync(p, html); written.push(p); }
+        // renderHtml() returns null after registering a FAIL (a missing template, an
+        // unfilled slot). Those failures land AFTER the gate summary was printed, so
+        // without this the run reports GATES PASS, writes nothing, and exits 0 — a
+        // build claiming success while producing no artifact, which is precisely the
+        // silent-plausibility failure TEMPLATE_SLOT_UNFILLED exists to prevent.
+        else return renderFailure();
       } else if (['pdf', 'pptx', 'xlsx'].includes(fmt)) {
         // Handed off, not reimplemented: make-pdf / document-skills own these.
         const p = join(a.out, `handoff.${fmt}.json`);

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -794,7 +794,15 @@ function renderHtmlBody(ir) {
   H.push('</tbody></table></div></section>');
 
   H.push(`<footer class="foot">Question: ${esc(ir.question)}<br>`
-    + 'Rendered by research-dossier — provenance and palette gates passed before this file was written.</footer>');
+    // Say what was actually verified. "Gates passed" reads as a warrant for the
+    // ARGUMENT; the gates check the evidential chain and the numbers' consistency,
+    // not whether the conclusion follows. A certificate that outruns its check
+    // transfers unearned trust — worse than no certificate.
+    + 'Rendered by research-dossier. Before this file was written, every claim was '
+    + 'checked for a source and a date, every citation for existence and agreement '
+    + 'with the value it cites, every magnitude axis for undeclared distortion, and '
+    + 'the palette for colour-vision separation in both themes. That is a check of '
+    + 'the evidence, not an endorsement of the conclusion.</footer>');
 
   return H.join('\n');
 }

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -111,6 +111,16 @@ function gateProvenance(ir) {
     if (!c.as_of) FAIL('CLAIM_NO_AS_OF', `${at}: missing as_of`);
     else if (!ISO_DATE.test(c.as_of)) FAIL('CLAIM_BAD_AS_OF', `${at}: as_of must be YYYY-MM-DD, got "${c.as_of}"`);
     else if (ir.as_of && c.as_of > ir.as_of) FAIL('CLAIM_FUTURE', `${at}: as_of ${c.as_of} is newer than the dossier's as_of ${ir.as_of}`);
+    // Only FUTURE dates failed, so evidence could be arbitrarily old and still read
+    // as current — a dossier dated today resting entirely on years-old claims.
+    else if (ir.as_of && ISO_DATE.test(ir.as_of)) {
+      const days = (Date.parse(ir.as_of) - Date.parse(c.as_of)) / 86400000;
+      if (days > 365) {
+        const msg = `${at}: as_of ${c.as_of} is ${Math.floor(days / 365)}y older than the dossier (${ir.as_of}) — stale evidence presented as current`;
+        if (ir.stakes === 'high') FAIL('CLAIM_STALE', msg);
+        else WARN('CLAIM_STALE', msg);
+      }
+    }
 
     if (!c.confidence) FAIL('CLAIM_NO_CONFIDENCE', `${at}: missing confidence`);
     else if (!CONFIDENCE.has(c.confidence)) FAIL('CLAIM_BAD_CONFIDENCE', `${at}: confidence must be high|medium|low, got "${c.confidence}"`);
@@ -166,22 +176,44 @@ function gateProvenance(ir) {
       if (!Array.isArray(s.data) || s.data.length === 0) FAIL('SERIES_NO_DATA', `${at}.series[${j}]: data[] is empty`);
       if (s.entity && Array.isArray(ir.entities) && !ir.entities.some(e => e.id === s.entity))
         FAIL('SERIES_DANGLING_ENTITY', `${at}.series[${j}]: entity "${s.entity}" not in entities[]`);
-      for (const [k, p] of (s.data || []).entries())
-        if (p && p.claim && !ids.has(p.claim))
+      for (const [k, p] of (s.data || []).entries()) {
+        if (!p || !p.claim) continue;
+        if (!ids.has(p.claim)) {
           FAIL('POINT_DANGLING_CLAIM', `${at}.series[${j}].data[${k}]: claim "${p.claim}" is not a claim id`);
+          continue;
+        }
+        // A resolving citation is not a true one. Until this check existed, a point
+        // could cite a claim saying "208 KB" and plot 41 — cited, resolving, rendered,
+        // and false. metric.value exists precisely so a chart can cite instead of
+        // restate; comparing them is what makes the citation load-bearing.
+        const src = (ir.claims || []).find(c => c && c.id === p.claim);
+        const mv = src && src.metric ? src.metric.value : undefined;
+        if (typeof mv === 'number' && typeof p.y === 'number' && p.y !== mv) {
+          const t = ch.transform || {};
+          const scaled = typeof t.scale === 'number' ? mv * t.scale : null;
+          const explained = scaled !== null && Math.abs(p.y - scaled) <= Math.abs(scaled) * 1e-9;
+          if (!explained)
+            FAIL('CHART_POINT_VALUE_MISMATCH',
+              `${at}.series[${j}].data[${k}]: plots y=${p.y} while its cited claim "${p.claim}" states ${mv}${src.metric.unit ? ' ' + src.metric.unit : ''} — a chart may cite a claim or contradict it, not both (declare chart.transform.scale if the difference is a unit conversion)`);
+        }
+      }
     }
 
     // THE magnitude-distortion check. A bar chart starting at 90 turns a 2%
     // difference into a visual landslide; declaring it is the price of doing it.
     const ax = ch.axis || {};
-    if (MAGNITUDE_FORMS.has(ch.form)) {
-      const ys = series.flatMap(s => (s.data || []).map(p => p && p.y)).filter(v => typeof v === 'number');
+    const ys = series.flatMap(s => (s.data || []).map(p => p && p.y)).filter(v => typeof v === 'number');
+    // Gate on what is DRAWN, not what is DECLARED. The renderer draws every chart
+    // as proportional bars regardless of ch.form, so keying this check to a
+    // form allow-list let `form:"line"` bypass it while still rendering truncated
+    // bars. Declaring a form the renderer does not honour is not a defence.
+    {
       const dataMin = ys.length ? Math.min(...ys) : null;
       const naturalBaseline = dataMin !== null && dataMin < 0 ? dataMin : 0;
       const truncates = typeof ax.y_min === 'number' && ax.y_min > naturalBaseline;
       if (truncates && ax.axis_truncated !== true)
         FAIL('UNDECLARED_TRUNCATION',
-          `${at}: y_min=${ax.y_min} truncates a "${ch.form}" magnitude axis above its natural baseline (${naturalBaseline}) without axis.axis_truncated:true — this is magnitude distortion`);
+          `${at}: y_min=${ax.y_min} truncates a magnitude axis above its natural baseline (${naturalBaseline}) without axis.axis_truncated:true — this is magnitude distortion (declared form "${ch.form}" does not exempt it; the renderer draws proportional marks)`);
       if (ax.axis_truncated === true && !truncates)
         WARN('TRUNCATION_FLAG_UNUSED', `${at}: axis_truncated:true but y_min does not truncate — flag is misleading`);
     }
@@ -189,6 +221,31 @@ function gateProvenance(ir) {
       FAIL('TRUNCATION_NO_RATIONALE', `${at}: axis_truncated:true requires axis.truncation_rationale`);
     if (typeof ax.y_min === 'number' && typeof ax.y_max === 'number' && ax.y_min >= ax.y_max)
       FAIL('AXIS_INVERTED', `${at}: y_min (${ax.y_min}) >= y_max (${ax.y_max})`);
+    // Truncation is only ONE way to lie with an axis. Inflating y_max compresses
+    // every mark toward zero, so 4% and 96% render as two identical stubs — a
+    // difference-hiding distortion the truncation check never sees.
+    if (typeof ax.y_max === 'number' && ys.length) {
+      const dataMax = Math.max(...ys);
+      if (dataMax > 0 && ax.y_max > dataMax * 1.5 && ax.axis_truncated !== true)
+        FAIL('UNDECLARED_COMPRESSION',
+          `${at}: y_max=${ax.y_max} is ${(ax.y_max / dataMax).toFixed(1)}x the largest plotted value (${dataMax}), compressing every mark toward the baseline — declare it via axis.axis_truncated + truncation_rationale or use a fitted maximum`);
+    }
+
+    // A stack asserts "these parts compose this whole". If the chart cites a claim
+    // carrying a total and the parts do not reach it, the chart silently drops the
+    // remainder — every part can match its own claim while the composition lies.
+    if (ch.form === 'stacked-bar' || ch.form === 'stacked-area') {
+      const plotted = ys.reduce((a, b) => a + b, 0);
+      const cited = (ch.source_claims || [])
+        .map(id => (ir.claims || []).find(c => c && c.id === id))
+        .filter(c => c && c.metric && typeof c.metric.value === 'number' && /total|sum|overall/i.test(`${c.metric.name} ${c.id} ${c.text}`));
+      for (const t of cited) {
+        const tv = t.metric.value;
+        if (tv > 0 && Math.abs(plotted - tv) > tv * 0.05)
+          FAIL('STACKED_PARTS_MISMATCH',
+            `${at}: stacked parts sum to ${plotted} but cited claim "${t.id}" states a total of ${tv} — the stack presents itself as the whole while omitting ${(100 * (1 - plotted / tv)).toFixed(0)}% of it`);
+      }
+    }
 
     if (ch.emphasis && Array.isArray(ir.entities) && !ir.entities.some(e => e.id === ch.emphasis))
       FAIL('CHART_DANGLING_EMPHASIS', `${at}: emphasis "${ch.emphasis}" not in entities[]`);
@@ -220,9 +277,71 @@ function gateProvenance(ir) {
       if (!cell.confidence) FAIL('CELL_NO_CONFIDENCE', `${at}: missing confidence`);
       else if (!CONFIDENCE.has(cell.confidence)) FAIL('CELL_BAD_CONFIDENCE', `${at}: confidence must be high|medium|low`);
       checkRefs(cell.source_claims, at);
+      // `display` is emitted verbatim and overrides `value`, so a cell carrying
+      // value:1180000 could print "$0.18M" — the audit trail stays correct in the
+      // JSON while the human artifact states the opposite. One field, no
+      // arithmetic, total inversion. The renderer trusts display; the gate must not.
+      if (typeof cell.value === 'number' && typeof cell.display === 'string') {
+        const m = cell.display.replace(/[\s,$%]/g, '').match(/-?\d+(?:\.\d+)?\s*([KMB])?/i);
+        if (m) {
+          const mult = { k: 1e3, m: 1e6, b: 1e9 }[(m[1] || '').toLowerCase()] || 1;
+          const shown = parseFloat(m[0]) * mult;
+          const av = Math.abs(cell.value);
+          // Accept unit-consistent restatements (1180000 → "1.18M", 0.42 → "42%")
+          // and rounding; reject a magnitude that contradicts the recorded value.
+          const ok = [1, 1e-3, 1e-6, 1e-9, 1e3, 1e6, 1e9, 100, 0.01]
+            .some(s => av === 0 ? shown === 0 : Math.abs(Math.abs(shown) - av * s) <= av * s * 0.01 + 1e-9);
+          if (!ok)
+            FAIL('CELL_DISPLAY_DIVERGES',
+              `${at}: display "${cell.display}" reads as ${shown} but the recorded value is ${cell.value} — the rendered cell would contradict its own audit trail`);
+        }
+      }
       const key = `${cell.option}::${cell.criterion}`;
       if (seen.has(key)) FAIL('CELL_DUPLICATE', `${at}: duplicate cell for (${cell.option}, ${cell.criterion})`);
       seen.add(key);
+    }
+
+    // Selective omission is the scorecard's sharpest weapon: a sparse grid is
+    // honest ONLY when the evidence is genuinely absent. If a claim exists whose
+    // entity is the missing option, the cell was not unmeasured — it was dropped.
+    for (const cr of sc.criteria || []) {
+      const missing = (sc.options || []).filter(o => !seen.has(`${o}::${cr.id}`));
+      if (missing.length === 0 || missing.length === (sc.options || []).length) continue;
+      for (const o of missing) {
+        const covered = (ir.claims || []).some(c => {
+          if (!c || c.entity !== o) return false;
+          const inCell = (sc.cells || []).some(x => (x.source_claims || []).includes(c.id));
+          return !inCell;
+        });
+        if (covered)
+          FAIL('SCORECARD_ASYMMETRIC_COVERAGE',
+            `scorecard: (${o}, ${cr.id}) is blank while claims about "${o}" sit unused in the evidence — a blank cell must mean unmeasured, not omitted; cite it or state why it does not apply`);
+      }
+    }
+    // Weighting after seeing the numbers is how a verdict is smuggled. A dominant
+    // weight on a criterion only ONE option was scored against decides the outcome
+    // by construction rather than by evidence.
+    {
+      const ws = (sc.criteria || []).filter(c => typeof c.weight === 'number').map(c => c.weight);
+      if (ws.length > 1) {
+        const mx = Math.max(...ws), mn = Math.min(...ws.filter(w => w > 0));
+        if (mx / mn >= 3) {
+          const rest = ws.reduce((a, b) => a + b, 0) - mx;
+          for (const cr of sc.criteria || []) {
+            if (cr.weight !== mx) continue;
+            const scored = (sc.options || []).filter(o => seen.has(`${o}::${cr.id}`)).length;
+            if (scored === 1 && (sc.options || []).length > 1)
+              WARN('SCORECARD_WEIGHT_CONCENTRATION',
+                `scorecard: criterion "${cr.id}" carries the dominant weight (${mx}, ${(mx / mn).toFixed(1)}x the lowest) but only ${scored} of ${sc.options.length} options were scored on it — the weighting, not the evidence, is deciding`);
+            // A single criterion outweighing all others COMBINED cannot be
+            // outvoted by any amount of contrary evidence: the grid's remaining
+            // rows are decorative, whatever they say.
+            else if (rest > 0 && mx > rest)
+              WARN('SCORECARD_WEIGHT_DOMINANT',
+                `scorecard: criterion "${cr.id}" (weight ${mx}) outweighs every other criterion combined (${rest}) — no evidence in the remaining rows can change the outcome; confirm the weights were set before the cells were filled`);
+          }
+        }
+      }
     }
 
     const v = sc.verdict;
@@ -233,6 +352,42 @@ function gateProvenance(ir) {
       // A verdict that names no loser is an endorsement, not a decision.
       if (v.winner && !v.runner_up && optIds.size > 1)
         WARN('VERDICT_NO_RUNNER_UP', 'scorecard.verdict names a winner but no runner_up — the rejected alternative is the field that ages best');
+
+      // The grid is arithmetic; the verdict is a claim ABOUT that arithmetic. If
+      // the declared winner is not the argmax of its own weighted cells, the
+      // scorecard is decoration for a decision made elsewhere. Everything needed
+      // to check this — weight, direction, per-cell values — is already in the IR.
+      if (v.winner && (sc.cells || []).length) {
+        const score = {};
+        let comparable = 0;
+        for (const cr of sc.criteria || []) {
+          const w = typeof cr.weight === 'number' ? cr.weight : 1;
+          const vals = (sc.options || []).map(o => {
+            const c = (sc.cells || []).find(x => x.option === o && x.criterion === cr.id);
+            if (!c) return null;
+            if (typeof c.value === 'number') return c.value;
+            if (typeof c.value === 'boolean') return c.value ? 1 : 0;
+            return null;
+          });
+          if (vals.some(x => x === null)) continue;   // sparse row: not comparable
+          const lo = Math.min(...vals), hi = Math.max(...vals);
+          if (hi === lo) continue;
+          comparable++;
+          (sc.options || []).forEach((o, i) => {
+            // Normalise to 0..1 "better", honouring the criterion's own direction.
+            const n = (vals[i] - lo) / (hi - lo);
+            score[o] = (score[o] || 0) + w * (cr.direction === 'lower-better' ? 1 - n : n);
+          });
+        }
+        // Only judge when at least two criteria were fully scored — a verdict
+        // resting on one comparable row is a judgement call, not arithmetic.
+        if (comparable >= 2) {
+          const best = Object.keys(score).reduce((a, b) => (score[b] > score[a] ? b : a));
+          if (score[best] - (score[v.winner] ?? -Infinity) > 1e-9 && !v.override_rationale)
+            FAIL('VERDICT_UNSUPPORTED',
+              `scorecard.verdict: winner "${v.winner}" scores ${(score[v.winner] ?? 0).toFixed(2)} against "${best}" at ${score[best].toFixed(2)} on the declared weights and directions — the grid does not support the verdict; either the weights are wrong or the decision is being made outside the evidence (set verdict.override_rationale to declare a judgement that overrides the arithmetic)`);
+        }
+      }
     }
   }
 
@@ -243,7 +398,20 @@ function gateProvenance(ir) {
   for (const [i, n] of nc.entries()) {
     if (!n.text) FAIL('NOT_CHECKED_NO_TEXT', `not_checked[${i}]: missing text`);
     if (!n.reason) FAIL('NOT_CHECKED_NO_REASON', `not_checked[${i}]: missing reason`);
+    // The gate rejects an EMPTY array as a claim of omniscience — so the evasion
+    // is to write that claim out longhand ("everything material was checked") or
+    // to fill the field with a placeholder. A blind spot must be NAMED to count.
+    const t = String(n.text || '').trim();
+    if (t && (t.length < 25 || /^(all|everything|nothing|none|n\/?a|[-.·]+)\b/i.test(t)))
+      FAIL('NOT_CHECKED_VACUOUS',
+        `not_checked[${i}]: "${t}" names no specific blind spot — this field is load-bearing precisely because it is the part a reader cannot verify; state what was actually left unexamined`);
   }
+  // At least one acknowledged gap must be capable of affecting the conclusion.
+  // An all-"none" list satisfies the letter of the check while asserting that
+  // nothing unexamined could possibly matter — omniscience by another route.
+  if (nc.length && nc.every(n => !n.impact || n.impact === 'none'))
+    FAIL('NOT_CHECKED_ALL_INCONSEQUENTIAL',
+      'not_checked[]: every entry is marked impact:"none" — a review whose blind spots provably cannot matter is a review that has not found its blind spots');
 
   // -- stakes=high tightens the bar.
   if (ir.stakes === 'high') {

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -1,0 +1,736 @@
+#!/usr/bin/env node
+/**
+ * MAOS — research-dossier · renderer + the two deterministic gates
+ *
+ * Function: consume an IR (skills/research-dossier/templates/ir.schema.json) and
+ *   fan it out to html / md / json (+ hand-off manifests for pdf / pptx / xlsx),
+ *   but ONLY after both f=0 gates pass. The gates are the point; the rendering is
+ *   the easy half.
+ *
+ *   GATE 1 — provenance.  Fails the build when the dossier's evidential chain is
+ *     broken: a claim missing source/as_of/confidence, a chart or recommendation
+ *     citing a claim id that does not exist, a truncated magnitude axis that was
+ *     not declared, or an empty not_checked[]. This is what carries the text-level
+ *     faithfulness discipline into the VISUAL layer — a truncated axis distorts a
+ *     magnitude whether or not anyone intended it to.
+ *
+ *   GATE 2 — palette.  Shells out to the bundled `dataviz` skill's own
+ *     validate_palette.js (CVD ΔE OKLab per protan/deutan/tritan, lightness band,
+ *     chroma floor, normal-vision floor, surface contrast) in BOTH light and dark.
+ *     Not reimplemented here: dataviz owns color, we cite it. The validator path is
+ *     DISCOVERED AT RUNTIME because it lives in a version-and-hash-keyed temp dir
+ *     that moves on every CLI upgrade; when it cannot be found the gate degrades to
+ *     a VISIBLE WARN rather than a silent pass (a security-by-absence failure would
+ *     be worse than no gate at all, because it would look green).
+ *
+ * Why deterministic: both gates are f=0 oracles — same input, same verdict, no model
+ *   judgement anywhere in the path. A gate a model can talk itself past is theater.
+ *
+ * Fail-safe: unknown/unreadable => FAIL (never render blind). Exception: gate 2's
+ *   MISSING VALIDATOR, which is an environment fact rather than a palette defect, and
+ *   which is therefore a loud WARN — see DATAVIZ_VALIDATOR to force-fail in CI.
+ *
+ * Portability: Node >= 18, ZERO dependencies (no package.json at repo root; that is
+ *   deliberate). No organization-specific content — Layer-Purity clean.
+ *
+ * Usage:
+ *   research-dossier-render.mjs --ir <path> [--formats html,md,json] [--out <dir>]
+ *                               [--gates-only] [--strict] [--quiet]
+ * Env:
+ *   DATAVIZ_VALIDATOR   explicit path to validate_palette.js; set to a nonexistent
+ *                       path to exercise the degradation branch.
+ * Exit: 0 ok · 1 gate failure · 2 usage/IO error
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = resolve(HERE, '..', 'skills', 'research-dossier');
+
+const EXIT_OK = 0, EXIT_GATE = 1, EXIT_USAGE = 2;
+
+// ── tiny arg parser (zero-dep) ──────────────────────────────────────────────
+function parseArgs(argv) {
+  const a = { formats: ['html', 'md', 'json'], out: 'out', gatesOnly: false, strict: false, quiet: false };
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
+    if (t === '--ir') a.ir = argv[++i];
+    else if (t === '--formats') a.formats = String(argv[++i]).split(',').map(s => s.trim()).filter(Boolean);
+    else if (t === '--out') a.out = argv[++i];
+    else if (t === '--gates-only') a.gatesOnly = true;
+    else if (t === '--strict') a.strict = true;
+    else if (t === '--quiet') a.quiet = true;
+    else if (t === '--help' || t === '-h') a.help = true;
+    else if (t.startsWith('--')) { a.unknown = t; }
+  }
+  return a;
+}
+
+// ── report accumulator ──────────────────────────────────────────────────────
+const report = { fail: [], warn: [], info: [] };
+const FAIL = (code, msg) => report.fail.push({ code, msg });
+const WARN = (code, msg) => report.warn.push({ code, msg });
+const INFO = m => report.info.push(m);
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GATE 1 — provenance
+// ═══════════════════════════════════════════════════════════════════════════
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+const CONFIDENCE = new Set(['high', 'medium', 'low']);
+/** Forms where the y-axis encodes MAGNITUDE — the family where a truncated
+ *  baseline lies about proportion. A line chart of a bounded index may legitimately
+ *  start above zero; a bar chart may not. */
+const MAGNITUDE_FORMS = new Set(['bar', 'column', 'stacked-bar', 'area', 'diverging-bar']);
+
+function gateProvenance(ir) {
+  // -- structural minimums the schema also states, re-checked here because the
+  //    renderer must never assume an upstream validator ran.
+  for (const f of ['question', 'as_of', 'audience', 'claims', 'not_checked', 'methodology']) {
+    if (ir[f] === undefined || ir[f] === null) FAIL('IR_MISSING_FIELD', `required top-level field missing: ${f}`);
+  }
+  if (ir.as_of && !ISO_DATE.test(ir.as_of)) FAIL('IR_BAD_DATE', `as_of must be YYYY-MM-DD, got: ${ir.as_of}`);
+
+  // -- claims: the five-field contract. Everything downstream rests on this.
+  const claims = Array.isArray(ir.claims) ? ir.claims : [];
+  if (claims.length === 0) FAIL('NO_CLAIMS', 'claims[] is empty — a dossier with no evidence is prose');
+
+  const ids = new Map();
+  const confidences = [];
+  for (const [i, c] of claims.entries()) {
+    const at = `claims[${i}]${c && c.id ? ` (${c.id})` : ''}`;
+    if (!c || typeof c !== 'object') { FAIL('CLAIM_SHAPE', `${at}: not an object`); continue; }
+    if (!c.id) FAIL('CLAIM_NO_ID', `${at}: missing id`);
+    else if (ids.has(c.id)) FAIL('CLAIM_DUP_ID', `${at}: duplicate id "${c.id}" (first at claims[${ids.get(c.id)}])`);
+    else ids.set(c.id, i);
+
+    if (!c.text) FAIL('CLAIM_NO_TEXT', `${at}: missing text`);
+    if (!c.source || !c.source.label) FAIL('CLAIM_NO_SOURCE', `${at}: missing source.label — an unsourced claim cannot be rendered as evidence`);
+    if (!c.as_of) FAIL('CLAIM_NO_AS_OF', `${at}: missing as_of`);
+    else if (!ISO_DATE.test(c.as_of)) FAIL('CLAIM_BAD_AS_OF', `${at}: as_of must be YYYY-MM-DD, got "${c.as_of}"`);
+    else if (ir.as_of && c.as_of > ir.as_of) FAIL('CLAIM_FUTURE', `${at}: as_of ${c.as_of} is newer than the dossier's as_of ${ir.as_of}`);
+
+    if (!c.confidence) FAIL('CLAIM_NO_CONFIDENCE', `${at}: missing confidence`);
+    else if (!CONFIDENCE.has(c.confidence)) FAIL('CLAIM_BAD_CONFIDENCE', `${at}: confidence must be high|medium|low, got "${c.confidence}"`);
+    else confidences.push(c.confidence);
+
+    if (c.entity && Array.isArray(ir.entities) && !ir.entities.some(e => e.id === c.entity))
+      FAIL('CLAIM_DANGLING_ENTITY', `${at}: entity "${c.entity}" not in entities[]`);
+  }
+
+  // A real comparison has softer and harder cells. Uniform high confidence across a
+  // non-trivial corpus is the signature of a field filled in rather than assessed.
+  if (confidences.length >= 5 && confidences.every(c => c === 'high'))
+    WARN('UNIFORM_CONFIDENCE', `all ${confidences.length} claims are confidence:high — plausible only if every one was equally verified`);
+
+  // -- referential integrity: every source_claims[] resolves.
+  //    A dangling ref is worse than no ref: it LOOKS sourced.
+  const checkRefs = (refs, where) => {
+    if (!Array.isArray(refs) || refs.length === 0) {
+      FAIL('NO_SOURCE_CLAIMS', `${where}: source_claims is required and must be non-empty`);
+      return;
+    }
+    for (const r of refs) if (!ids.has(r)) FAIL('DANGLING_CLAIM_REF', `${where}: source_claims references "${r}", which is not a claim id`);
+  };
+
+  for (const key of ['insights', 'gaps', 'risks', 'opportunities']) {
+    for (const [i, d] of (ir[key] || []).entries()) {
+      if (!d.text) FAIL('DERIVED_NO_TEXT', `${key}[${i}]: missing text`);
+      checkRefs(d.source_claims, `${key}[${i}]`);
+    }
+  }
+
+  for (const [i, r] of (ir.recommendations || []).entries()) {
+    const at = `recommendations[${i}]`;
+    if (!r.text) FAIL('REC_NO_TEXT', `${at}: missing text`);
+    // owner+eta are the line between a decision and a wish.
+    if (!r.owner) FAIL('REC_NO_OWNER', `${at}: missing owner — a recommendation nobody owns is a wish`);
+    if (!r.eta) FAIL('REC_NO_ETA', `${at}: missing eta — a recommendation with no date is a wish`);
+    checkRefs(r.source_claims, at);
+  }
+
+  // -- charts: source_claims + the axis-truncation cross-check.
+  for (const [i, ch] of (ir.charts || []).entries()) {
+    const at = `charts[${i}]${ch && ch.id ? ` (${ch.id})` : ''}`;
+    if (!ch || typeof ch !== 'object') { FAIL('CHART_SHAPE', `${at}: not an object`); continue; }
+    if (!ch.form) FAIL('CHART_NO_FORM', `${at}: missing form`);
+    if (!ch.title) FAIL('CHART_NO_TITLE', `${at}: missing title`);
+    checkRefs(ch.source_claims, at);
+
+    const series = Array.isArray(ch.series) ? ch.series : [];
+    if (series.length === 0) FAIL('CHART_NO_SERIES', `${at}: series[] is empty`);
+    for (const [j, s] of series.entries()) {
+      if (!s.label) FAIL('SERIES_NO_LABEL', `${at}.series[${j}]: missing label`);
+      if (!Array.isArray(s.data) || s.data.length === 0) FAIL('SERIES_NO_DATA', `${at}.series[${j}]: data[] is empty`);
+      if (s.entity && Array.isArray(ir.entities) && !ir.entities.some(e => e.id === s.entity))
+        FAIL('SERIES_DANGLING_ENTITY', `${at}.series[${j}]: entity "${s.entity}" not in entities[]`);
+      for (const [k, p] of (s.data || []).entries())
+        if (p && p.claim && !ids.has(p.claim))
+          FAIL('POINT_DANGLING_CLAIM', `${at}.series[${j}].data[${k}]: claim "${p.claim}" is not a claim id`);
+    }
+
+    // THE magnitude-distortion check. A bar chart starting at 90 turns a 2%
+    // difference into a visual landslide; declaring it is the price of doing it.
+    const ax = ch.axis || {};
+    if (MAGNITUDE_FORMS.has(ch.form)) {
+      const ys = series.flatMap(s => (s.data || []).map(p => p && p.y)).filter(v => typeof v === 'number');
+      const dataMin = ys.length ? Math.min(...ys) : null;
+      const naturalBaseline = dataMin !== null && dataMin < 0 ? dataMin : 0;
+      const truncates = typeof ax.y_min === 'number' && ax.y_min > naturalBaseline;
+      if (truncates && ax.axis_truncated !== true)
+        FAIL('UNDECLARED_TRUNCATION',
+          `${at}: y_min=${ax.y_min} truncates a "${ch.form}" magnitude axis above its natural baseline (${naturalBaseline}) without axis.axis_truncated:true — this is magnitude distortion`);
+      if (ax.axis_truncated === true && !truncates)
+        WARN('TRUNCATION_FLAG_UNUSED', `${at}: axis_truncated:true but y_min does not truncate — flag is misleading`);
+    }
+    if (ax.axis_truncated === true && !ax.truncation_rationale)
+      FAIL('TRUNCATION_NO_RATIONALE', `${at}: axis_truncated:true requires axis.truncation_rationale`);
+    if (typeof ax.y_min === 'number' && typeof ax.y_max === 'number' && ax.y_min >= ax.y_max)
+      FAIL('AXIS_INVERTED', `${at}: y_min (${ax.y_min}) >= y_max (${ax.y_max})`);
+
+    if (ch.emphasis && Array.isArray(ir.entities) && !ir.entities.some(e => e.id === ch.emphasis))
+      FAIL('CHART_DANGLING_EMPHASIS', `${at}: emphasis "${ch.emphasis}" not in entities[]`);
+  }
+
+  // -- scorecard
+  if (ir.scorecard) {
+    const sc = ir.scorecard;
+    const optIds = new Set(sc.options || []);
+    const critIds = new Set((sc.criteria || []).map(c => c.id));
+    if (optIds.size < 2) FAIL('SCORECARD_THIN', 'scorecard.options needs >= 2 — a scorecard of one is a profile');
+    if (critIds.size < 1) FAIL('SCORECARD_NO_CRITERIA', 'scorecard.criteria[] is empty');
+
+    for (const o of sc.options || [])
+      if (Array.isArray(ir.entities) && !ir.entities.some(e => e.id === o))
+        FAIL('SCORECARD_DANGLING_OPTION', `scorecard.options: "${o}" not in entities[]`);
+
+    for (const [i, c] of (sc.criteria || []).entries()) {
+      if (typeof c.weight === 'number' && !(c.weight >= 0))
+        FAIL('SCORECARD_BAD_WEIGHT', `scorecard.criteria[${i}] (${c.id}): weight must be >= 0`);
+    }
+
+    const seen = new Set();
+    for (const [i, cell] of (sc.cells || []).entries()) {
+      const at = `scorecard.cells[${i}]`;
+      if (!optIds.has(cell.option)) FAIL('CELL_DANGLING_OPTION', `${at}: option "${cell.option}" not in scorecard.options`);
+      if (!critIds.has(cell.criterion)) FAIL('CELL_DANGLING_CRITERION', `${at}: criterion "${cell.criterion}" not in scorecard.criteria`);
+      if (cell.value === undefined || cell.value === null) FAIL('CELL_NO_VALUE', `${at}: missing value`);
+      if (!cell.confidence) FAIL('CELL_NO_CONFIDENCE', `${at}: missing confidence`);
+      else if (!CONFIDENCE.has(cell.confidence)) FAIL('CELL_BAD_CONFIDENCE', `${at}: confidence must be high|medium|low`);
+      checkRefs(cell.source_claims, at);
+      const key = `${cell.option}::${cell.criterion}`;
+      if (seen.has(key)) FAIL('CELL_DUPLICATE', `${at}: duplicate cell for (${cell.option}, ${cell.criterion})`);
+      seen.add(key);
+    }
+
+    const v = sc.verdict;
+    if (v) {
+      if (v.winner && !optIds.has(v.winner)) FAIL('VERDICT_DANGLING_WINNER', `scorecard.verdict.winner "${v.winner}" is not an option`);
+      if (v.runner_up && !optIds.has(v.runner_up)) FAIL('VERDICT_DANGLING_RUNNER_UP', `scorecard.verdict.runner_up "${v.runner_up}" is not an option`);
+      if (v.winner && !v.rationale) FAIL('VERDICT_NO_RATIONALE', 'scorecard.verdict declares a winner with no rationale');
+      // A verdict that names no loser is an endorsement, not a decision.
+      if (v.winner && !v.runner_up && optIds.size > 1)
+        WARN('VERDICT_NO_RUNNER_UP', 'scorecard.verdict names a winner but no runner_up — the rejected alternative is the field that ages best');
+    }
+  }
+
+  // -- not_checked: required, non-empty, each with a reason.
+  const nc = Array.isArray(ir.not_checked) ? ir.not_checked : [];
+  if (nc.length === 0)
+    FAIL('EMPTY_NOT_CHECKED', 'not_checked[] is empty — that is a claim of omniscience; if nothing was left unexamined, say so with a reason');
+  for (const [i, n] of nc.entries()) {
+    if (!n.text) FAIL('NOT_CHECKED_NO_TEXT', `not_checked[${i}]: missing text`);
+    if (!n.reason) FAIL('NOT_CHECKED_NO_REASON', `not_checked[${i}]: missing reason`);
+  }
+
+  // -- stakes=high tightens the bar.
+  if (ir.stakes === 'high') {
+    for (const c of claims)
+      if (c.confidence === 'low' && !nc.some(n => (n.text || '').includes(c.id)))
+        WARN('HIGH_STAKES_LOW_CONFIDENCE', `stakes=high but claim "${c.id}" is confidence:low and not surfaced in not_checked[]`);
+    if (nc.some(n => n.impact === 'high'))
+      WARN('HIGH_STAKES_HIGH_IMPACT_GAP', 'stakes=high with a not_checked[] entry of impact:high — the dossier is admitting its conclusion may not hold');
+  }
+
+  // -- summary numerals that appear in no claim (advisory: numbers are the part a
+  //    reader will quote, so an unsourced one in the summary is the costliest kind).
+  if (typeof ir.summary === 'string') {
+    const claimText = claims.map(c => `${c.text} ${c.metric ? c.metric.value : ''}`).join(' ');
+    const orphans = [...new Set((ir.summary.match(/\b\d[\d.,]*\b/g) || []))]
+      .filter(n => n.length > 1 && !claimText.includes(n));
+    if (orphans.length) WARN('SUMMARY_ORPHAN_NUMERAL', `summary contains numerals absent from every claim: ${orphans.join(', ')}`);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// GATE 2 — palette (delegates to the bundled dataviz validator)
+// ═══════════════════════════════════════════════════════════════════════════
+
+/** The bundled skill materializes under a version+hash keyed temp dir that changes
+ *  on every CLI upgrade, so the path is discovered rather than pinned. Newest mtime
+ *  wins when several versions coexist. */
+function discoverValidator() {
+  const explicit = process.env.DATAVIZ_VALIDATOR;
+  if (explicit) return existsSync(explicit) ? explicit : null;
+
+  const roots = [
+    process.env.TMPDIR ? join(process.env.TMPDIR, '..') : null,
+    '/private/tmp', '/tmp',
+  ].filter(Boolean);
+
+  const found = [];
+  for (const root of roots) {
+    let entries = [];
+    try { entries = readdirSync(root); } catch { continue; }
+    for (const e of entries) {
+      if (!e.startsWith('claude-')) continue;
+      const base = join(root, e, 'bundled-skills');
+      let versions = [];
+      try { versions = readdirSync(base); } catch { continue; }
+      for (const v of versions) {
+        let hashes = [];
+        try { hashes = readdirSync(join(base, v)); } catch { continue; }
+        for (const h of hashes) {
+          const p = join(base, v, h, 'dataviz', 'scripts', 'validate_palette.js');
+          try { if (statSync(p).isFile()) found.push({ p, m: statSync(p).mtimeMs }); } catch { /* not this one */ }
+        }
+      }
+    }
+  }
+  if (!found.length) return null;
+  found.sort((a, b) => b.m - a.m);
+  return found[0].p;
+}
+
+const DEFAULT_LIGHT = ['#2a78d6', '#eb6834', '#1baf7a'];
+const DEFAULT_DARK  = ['#3987e5', '#d95926', '#199e70'];
+const SURFACE_LIGHT = '#fcfcfb';
+const SURFACE_DARK  = '#1a1a19';
+
+function resolvePalette(ir) {
+  const t = (ir.theme && ir.theme.palette) || {};
+  return {
+    light: t.categorical_light && t.categorical_light.length ? t.categorical_light : DEFAULT_LIGHT,
+    dark:  t.categorical_dark  && t.categorical_dark.length  ? t.categorical_dark  : DEFAULT_DARK,
+    surfaceLight: t.surface_light || SURFACE_LIGHT,
+    surfaceDark:  t.surface_dark  || SURFACE_DARK,
+  };
+}
+
+function gatePalette(ir, opts) {
+  const pal = resolvePalette(ir);
+  const validator = discoverValidator();
+
+  if (!validator) {
+    const msg = 'dataviz validate_palette.js not found — the palette was NOT colorblind-validated. '
+      + 'Set DATAVIZ_VALIDATOR to an explicit path, or run inside a Claude Code session where the bundled skill is materialized.';
+    if (opts.strict) FAIL('PALETTE_VALIDATOR_MISSING', `${msg} (--strict: treated as failure)`);
+    else WARN('PALETTE_VALIDATOR_MISSING', msg);
+    return { validator: null, runs: [] };
+  }
+  INFO(`palette validator: ${validator}`);
+
+  const runs = [];
+  for (const [mode, colors, surface] of [
+    ['light', pal.light, pal.surfaceLight],
+    ['dark',  pal.dark,  pal.surfaceDark],
+  ]) {
+    // A duplicate hex is a degenerate ΔE 0 the validator would flag anyway, but the
+    // message is clearer here.
+    const dupes = colors.filter((c, i) => colors.indexOf(c) !== i);
+    if (dupes.length) FAIL('PALETTE_DUPLICATE', `${mode}: duplicate colors in palette: ${[...new Set(dupes)].join(', ')}`);
+
+    let out = '', code = 0;
+    try {
+      // execFileSync (not exec) — no shell, so a hex string can never be a command.
+      out = execFileSync(process.execPath, [validator, colors.join(','), '--mode', mode, '--surface', surface],
+        { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: 20000 });
+    } catch (e) {
+      // Non-zero exit IS the FAIL verdict; capture output rather than treating it as a crash.
+      code = typeof e.status === 'number' ? e.status : -1;
+      out = `${e.stdout || ''}${e.stderr || ''}`;
+      if (code === -1) {
+        FAIL('PALETTE_VALIDATOR_ERROR', `${mode}: validator could not be executed: ${e.message}`);
+        runs.push({ mode, code, out });
+        continue;
+      }
+    }
+    runs.push({ mode, code, out: out.trim() });
+    if (code !== 0) {
+      const lines = out.split('\n').filter(l => l.includes('[FAIL]')).map(l => l.trim());
+      FAIL('PALETTE_FAIL', `${mode} mode failed dataviz validation:\n      ${lines.join('\n      ') || out.trim()}`);
+    } else {
+      for (const l of out.split('\n').filter(l => l.includes('[WARN]')))
+        WARN('PALETTE_WARN', `${mode}: ${l.trim()}`);
+    }
+  }
+  return { validator, runs };
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// renderers
+// ═══════════════════════════════════════════════════════════════════════════
+const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+
+function renderMarkdown(ir) {
+  const L = [];
+  const claimById = new Map((ir.claims || []).map(c => [c.id, c]));
+  const cite = refs => (refs || []).map(r => `[^${r}]`).join('');
+
+  L.push(`# ${ir.title || ir.question}`, '');
+  L.push(`> **Question** ${ir.question}  `);
+  L.push(`> **As of** ${ir.as_of} · **Audience** ${ir.audience}${ir.stakes ? ` · **Stakes** ${ir.stakes}` : ''}`, '');
+  if (ir.summary) L.push('## Summary', '', ir.summary, '');
+
+  if (ir.scorecard) {
+    const sc = ir.scorecard;
+    const label = id => (ir.entities || []).find(e => e.id === id)?.label || id;
+    const cellOf = (o, c) => (sc.cells || []).find(x => x.option === o && x.criterion === c);
+    L.push('## Comparison', '');
+    L.push(`| Criterion | ${sc.options.map(label).join(' | ')} |`);
+    L.push(`|---|${sc.options.map(() => '---').join('|')}|`);
+    for (const cr of sc.criteria) {
+      const w = typeof cr.weight === 'number' ? ` _(w${cr.weight})_` : '';
+      const row = sc.options.map(o => {
+        const cell = cellOf(o, cr.id);
+        if (!cell) return '— _not measured_';
+        return `${esc(cell.display ?? cell.value)} <sub>${cell.confidence}</sub>${cite(cell.source_claims)}`;
+      });
+      L.push(`| **${cr.label}**${w} | ${row.join(' | ')} |`);
+    }
+    L.push('');
+    if (sc.verdict?.winner) {
+      L.push(`**Verdict — ${label(sc.verdict.winner)}.** ${sc.verdict.rationale || ''}`, '');
+      if (sc.verdict.runner_up) L.push(`_Runner-up ${label(sc.verdict.runner_up)}: ${sc.verdict.rejected_because || 'no reason recorded'}_`, '');
+    }
+  }
+
+  const section = (title, arr, fmt) => {
+    if (!arr?.length) return;
+    L.push(`## ${title}`, '');
+    for (const it of arr) L.push(`- ${fmt(it)}`);
+    L.push('');
+  };
+  section('Insights', ir.insights, i => `${i.text}${cite(i.source_claims)}`);
+  section('Risks', ir.risks, r => `${r.severity ? `**[${r.severity}]** ` : ''}${r.text}${cite(r.source_claims)}${r.mitigation ? ` — _mitigation:_ ${r.mitigation}` : ''}`);
+  section('Opportunities', ir.opportunities, o => `${o.text}${cite(o.source_claims)}`);
+  section('Gaps', ir.gaps, g => `${g.text}${cite(g.source_claims)}`);
+  section('Recommendations', ir.recommendations, r => `${r.priority ? `**${r.priority}** ` : ''}${r.text} — **${r.owner}**, ${r.eta}${cite(r.source_claims)}`);
+
+  L.push('## Not checked', '');
+  for (const n of ir.not_checked) L.push(`- ${n.text} — _${n.reason}_${n.impact ? ` (impact: ${n.impact})` : ''}`);
+  L.push('');
+
+  L.push('## Methodology', '', ir.methodology.approach, '');
+  if (ir.methodology.sources_consulted != null) L.push(`- Sources consulted: ${ir.methodology.sources_consulted}`);
+  if (ir.methodology.window) L.push(`- Window: ${ir.methodology.window.from || '?'} → ${ir.methodology.window.to || '?'}`);
+  for (const l of ir.methodology.limitations || []) L.push(`- Limitation: ${l}`);
+  L.push('');
+
+  L.push('## Evidence', '');
+  for (const c of claimById.values()) {
+    const src = c.source.url ? `[${c.source.label}](${c.source.url})` : c.source.label;
+    L.push(`[^${c.id}]: ${c.text} — ${src}, ${c.as_of}, confidence ${c.confidence}${c.contested ? ' ⚠︎ contested' : ''}`);
+  }
+  L.push('');
+  return L.join('\n');
+}
+
+/** Server-side HTML body.
+ *  Everything renders here, not in the browser: a decision artifact that needs a
+ *  script to display its own evidence is not archival. The only client-side script
+ *  in the output reveals the theme toggle; with JS off the dossier is complete.
+ *  That is affordable because theming is pure CSS — the validated palette lands as
+ *  --series-N under both scopes and the SVG marks reference them by var(). */
+function renderHtmlBody(ir) {
+  const H = [];
+  const claimIds = new Set((ir.claims || []).map(c => c.id));
+  const entityLabel = id => (ir.entities || []).find(e => e.id === id)?.label ?? id;
+  const entityIdx = id => {
+    const i = (ir.entities || []).findIndex(e => e.id === id);
+    return i < 0 ? 0 : i;
+  };
+  const cites = refs => (refs || [])
+    .map(r => `<a class="cite" href="#claim-${esc(r)}"${claimIds.has(r) ? '' : ' data-dangling="1"'}>[${esc(r)}]</a>`)
+    .join('');
+  const conf = c => (c ? `<span class="conf">${esc(c)}</span>` : '');
+  const STATUS_ICON = { good: '●', warning: '▲', serious: '◆', critical: '■' };
+
+  // header
+  H.push('<header class="head"><div>');
+  H.push(`<h1>${esc(ir.title || ir.question)}</h1>`);
+  H.push(`<div class="meta"><b>As of ${esc(ir.as_of)}</b> · audience ${esc(ir.audience)}${ir.stakes ? ` · stakes ${esc(ir.stakes)}` : ''}</div>`);
+  H.push('</div>');
+  H.push('<button class="theme" type="button" id="theme-toggle" aria-pressed="false" aria-label="Toggle colour theme">◑ theme</button>');
+  H.push('</header>');
+
+  if (ir.summary) H.push(`<section><h2>Summary</h2><div class="card"><p class="lede">${esc(ir.summary)}</p></div></section>`);
+
+  // scorecard
+  if (ir.scorecard) {
+    const sc = ir.scorecard;
+    const cellOf = (o, c) => (sc.cells || []).find(x => x.option === o && x.criterion === c);
+    H.push('<section><h2>Comparison</h2><div class="card"><table>');
+    H.push('<caption>Evidence per cell. A blank cell was not measured — it is not a zero.</caption>');
+    H.push(`<thead><tr><th scope="col">Criterion</th>${sc.options.map(o => `<th scope="col">${esc(entityLabel(o))}</th>`).join('')}</tr></thead><tbody>`);
+    for (const cr of sc.criteria || []) {
+      const w = typeof cr.weight === 'number' ? `<span class="conf">w${cr.weight}</span>` : '';
+      const cells = sc.options.map(o => {
+        const c = cellOf(o, cr.id);
+        return c
+          ? `<td>${esc(c.display ?? c.value)}${conf(c.confidence)}${cites(c.source_claims)}</td>`
+          : '<td><span class="nomeasure">— not measured</span></td>';
+      }).join('');
+      H.push(`<tr><th scope="row">${esc(cr.label)}${w}</th>${cells}</tr>`);
+    }
+    H.push('</tbody></table>');
+    const v = sc.verdict;
+    if (v?.winner) {
+      H.push(`<p style="margin:16px 0 0"><b>Verdict — ${esc(entityLabel(v.winner))}.</b> ${esc(v.rationale || '')}</p>`);
+      if (v.runner_up) H.push(`<p class="meta" style="margin:8px 0 0">Runner-up ${esc(entityLabel(v.runner_up))}: ${esc(v.rejected_because || 'no reason recorded')}</p>`);
+    }
+    H.push('</div></section>');
+  }
+
+  // charts — inline SVG + mandatory data table
+  if ((ir.charts || []).length) {
+    H.push('<section><h2>Charts</h2>');
+    for (const ch of ir.charts) {
+      const pts = [];
+      for (const s of ch.series || [])
+        for (const p of s.data || []) pts.push({ ...p, entity: s.entity, sLabel: s.label });
+
+      const ax = ch.axis || {};
+      const nums = pts.map(p => (typeof p.y === 'number' ? p.y : 0));
+      const lo = typeof ax.y_min === 'number' ? ax.y_min : 0;
+      const hi = typeof ax.y_max === 'number' ? ax.y_max : Math.max(...nums, 1);
+      const span = (hi - lo) || 1;
+      const rowH = 34, padL = 168, padR = 78, W = 860, padT = 6;
+      const height = padT + pts.length * rowH + 6;
+
+      const desc = `${ch.title}${ch.subtitle ? ` — ${ch.subtitle}` : ''}. `
+        + pts.map(p => `${p.x}: ${p.y == null ? 'no data' : p.y}`).join('; ')
+        + '. Equivalent data table follows.';
+
+      const marks = pts.map((p, i) => {
+        const y = padT + i * rowH;
+        const frac = p.y == null ? 0 : Math.max(0, Math.min(1, (p.y - lo) / span));
+        const barW = p.y == null ? 0 : Math.max(2, frac * (W - padL - padR));
+        // Colour follows the ENTITY (dataviz non-negotiable), via a CSS var so the
+        // theme toggle recolours with no redraw.
+        const emphasised = ch.emphasis && p.entity === ch.emphasis;
+        const fill = (ch.emphasis && !emphasised) ? 'var(--muted)' : `var(--series-${(p.entity != null ? entityIdx(p.entity) : i) + 1}, var(--series-1))`;
+        const label = `<text x="${padL - 12}" y="${y + 20}" text-anchor="end" class="bar-label">${esc(p.x)}</text>`;
+        if (p.y == null) return `${label}<text x="${padL}" y="${y + 20}" class="bar-label">no data</text>`;
+        return `${label}<rect x="${padL}" y="${y + 5}" width="${barW.toFixed(1)}" height="${rowH - 12}" rx="4" fill="${fill}"/>`
+          + `<text x="${(padL + barW + 10).toFixed(1)}" y="${y + 20}" class="bar-value">${esc(p.y)}</text>`;
+      }).join('');
+
+      const rows = pts.map(p =>
+        `<tr><th scope="row">${esc(p.x)}</th><td class="num">${p.y == null ? 'no data' : esc(p.y)}${p.claim ? cites([p.claim]) : ''}</td></tr>`
+      ).join('');
+
+      H.push('<div class="card">');
+      H.push(`<p class="chart-title">${esc(ch.title)}${cites(ch.source_claims)}</p>`);
+      H.push('<figure class="chart">');
+      if (ch.subtitle) H.push(`<figcaption>${esc(ch.subtitle)}</figcaption>`);
+      H.push(`<svg viewBox="0 0 ${W} ${height}" width="100%" height="${height}" role="img" aria-label="${esc(desc)}">`);
+      H.push(marks);
+      H.push(`<line x1="${padL}" y1="${padT}" x2="${padL}" y2="${height - 6}" stroke="var(--baseline)" stroke-width="1"/>`);
+      H.push('</svg>');
+      // A declared truncation is stated in the OUTPUT, not just in the IR.
+      if (ax.axis_truncated === true)
+        H.push(`<p class="axis-note">⚠ Axis truncated at ${esc(ax.y_min)} — ${esc(ax.truncation_rationale || 'rationale not recorded')}. Bar lengths are not proportional to values.</p>`);
+      H.push('<details class="tableview" open><summary>Data table</summary><table>');
+      H.push(`<thead><tr><th scope="col">${esc(ax.x_label || 'Item')}</th><th scope="col" class="num">${esc(ax.y_label || 'Value')}</th></tr></thead><tbody>${rows}</tbody>`);
+      H.push('</table></details></figure></div>');
+    }
+    H.push('</section>');
+  }
+
+  const listSection = (title, arr, fmt, cls) => {
+    if (!arr?.length) return;
+    H.push(`<section><h2>${esc(title)}</h2><div class="card${cls ? ` ${cls}` : ''}"><ul class="items">`);
+    for (const it of arr) H.push(`<li>${fmt(it)}</li>`);
+    H.push('</ul></div></section>');
+  };
+
+  listSection('Insights', ir.insights, i => `${esc(i.text)}${cites(i.source_claims)}`);
+  listSection('Risks', ir.risks, r =>
+    `${r.severity ? `<span class="tag st-${esc(r.severity)}">${STATUS_ICON[r.severity] || '•'} ${esc(r.severity)}</span>` : ''}`
+    + `${esc(r.text)}${cites(r.source_claims)}`
+    + `${r.mitigation ? `<div class="meta" style="margin-top:5px">Mitigation: ${esc(r.mitigation)}</div>` : ''}`);
+  listSection('Opportunities', ir.opportunities, o => `${esc(o.text)}${cites(o.source_claims)}`);
+  listSection('Gaps', ir.gaps, g => `${esc(g.text)}${cites(g.source_claims)}`);
+  listSection('Recommendations', ir.recommendations, r =>
+    `${r.priority ? `<span class="tag">${esc(r.priority)}</span>` : ''}${esc(r.text)}${cites(r.source_claims)}`
+    + `<div class="meta" style="margin-top:5px">Owner: ${esc(r.owner)} · ETA: ${esc(r.eta)}${r.effort ? ` · Effort: ${esc(r.effort)}` : ''}</div>`);
+
+  listSection('Not checked', ir.not_checked, n =>
+    `${esc(n.text)}<div class="meta" style="margin-top:5px">${esc(n.reason)}${n.impact ? ` · potential impact on the conclusion: ${esc(n.impact)}` : ''}</div>`,
+    'notchecked');
+
+  if (ir.methodology) {
+    H.push('<section><h2>Methodology</h2><div class="card">');
+    H.push(`<p style="margin:0">${esc(ir.methodology.approach)}</p>`);
+    const bits = [];
+    if (ir.methodology.sources_consulted != null) bits.push(`Sources consulted: ${ir.methodology.sources_consulted}`);
+    if (ir.methodology.window) bits.push(`Window: ${ir.methodology.window.from || '?'} → ${ir.methodology.window.to || '?'}`);
+    for (const l of ir.methodology.limitations || []) bits.push(`Limitation: ${l}`);
+    if (bits.length) H.push(`<ul class="items" style="margin-top:10px">${bits.map(b => `<li>${esc(b)}</li>`).join('')}</ul>`);
+    H.push('</div></section>');
+  }
+
+  // evidence — every citation lands here
+  H.push('<section><h2>Evidence</h2><div class="card"><table>');
+  H.push('<thead><tr><th scope="col">id</th><th scope="col">Claim</th><th scope="col">Source</th><th scope="col">As of</th><th scope="col">Confidence</th></tr></thead><tbody>');
+  for (const c of ir.claims || []) {
+    const src = c.source?.url
+      ? `<a href="${esc(c.source.url)}" rel="noopener noreferrer">${esc(c.source.label)}</a>`
+      : esc(c.source?.label || '—');
+    H.push(`<tr id="claim-${esc(c.id)}"><th scope="row"><code class="cid">${esc(c.id)}</code></th>`
+      + `<td>${esc(c.text)}${c.contested ? '<span class="tag st-warning" style="margin-left:8px">▲ contested</span>' : ''}</td>`
+      + `<td>${src}</td><td style="white-space:nowrap">${esc(c.as_of)}</td><td style="white-space:nowrap">${esc(c.confidence)}</td></tr>`);
+  }
+  H.push('</tbody></table></div></section>');
+
+  H.push(`<footer class="foot">Question: ${esc(ir.question)}<br>`
+    + 'Rendered by research-dossier — provenance and palette gates passed before this file was written.</footer>');
+
+  return H.join('\n');
+}
+
+function renderHtml(ir) {
+  const tplPath = join(SKILL_DIR, 'templates', 'dossier.html');
+  if (!existsSync(tplPath)) {
+    WARN('TEMPLATE_MISSING', `fallback template not found at ${tplPath} — html skipped`);
+    return null;
+  }
+  const tpl = readFileSync(tplPath, 'utf8');
+  const pal = resolvePalette(ir);
+  const vars = list => list.map((hex, i) => `--series-${i + 1}: ${hex};`).join(' ');
+
+  // Every substitution is GLOBAL. A single-match .replace() here was a real bug:
+  // the template's own header comment named the placeholders, so the first match
+  // was the documentation and the live slot went unfilled — producing a page that
+  // looked plausible while carrying no dossier at all. Global replace plus the
+  // assertion below makes that failure mode structurally impossible rather than
+  // merely fixed once.
+  const html = tpl
+    .replace(/\/\*__PALETTE_VARS_LIGHT__\*\//g, vars(pal.light))
+    .replace(/\/\*__PALETTE_VARS_DARK__\*\//g, vars(pal.dark))
+    .replace(/__LANG__/g, 'en')
+    .replace(/__TITLE__/g, esc(ir.title || ir.question))
+    .replace(/<!--__BODY__-->/g, renderHtmlBody(ir))
+    // A literal </script> inside the JSON island would close the tag early.
+    .replace(/<!--__IR_JSON__-->/g, JSON.stringify(ir).replace(/</g, '\\u003c'));
+
+  const survivors = [...new Set(html.match(/__[A-Z_]+__/g) || [])];
+  if (survivors.length) {
+    FAIL('TEMPLATE_SLOT_UNFILLED',
+      `template placeholders survived substitution: ${survivors.join(', ')} — the output would look plausible while carrying no data`);
+    return null;
+  }
+  return html;
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// main
+// ═══════════════════════════════════════════════════════════════════════════
+function main() {
+  const a = parseArgs(process.argv.slice(2));
+
+  if (a.help || !a.ir) {
+    console.log(`research-dossier-render — IR to multi-format, behind two f=0 gates
+
+  --ir <path>          IR JSON (required)
+  --formats <list>     html,md,json          [default: html,md,json]
+  --out <dir>          output directory      [default: out]
+  --gates-only         run both gates, render nothing
+  --strict             a missing dataviz validator FAILS instead of warning
+  --quiet              suppress the report on success
+
+Env: DATAVIZ_VALIDATOR   explicit validator path (nonexistent => exercises degradation)
+Exit: 0 ok · 1 gate failure · 2 usage/IO`);
+    return a.help ? EXIT_OK : EXIT_USAGE;
+  }
+  if (a.unknown) { console.error(`unknown flag: ${a.unknown}`); return EXIT_USAGE; }
+
+  let ir;
+  try {
+    ir = JSON.parse(readFileSync(a.ir, 'utf8'));
+  } catch (e) {
+    console.error(`✗ cannot read IR: ${e.message}`);
+    return EXIT_USAGE;
+  }
+
+  gateProvenance(ir);
+  const paletteInfo = gatePalette(ir, a);
+
+  const failed = report.fail.length > 0;
+  const show = failed || !a.quiet;
+
+  if (show) {
+    console.log('');
+    console.log(`research-dossier · gates  (${a.ir})`);
+    for (const i of report.info) console.log(`  ·  ${i}`);
+    console.log(`  ${failed ? '[FAIL]' : '[PASS]'} Gate 1 — provenance      ${report.fail.filter(f => !f.code.startsWith('PALETTE')).length} failure(s)`);
+    console.log(`  ${report.fail.some(f => f.code.startsWith('PALETTE')) ? '[FAIL]' : (report.warn.some(w => w.code.startsWith('PALETTE')) ? '[WARN]' : '[PASS]')} Gate 2 — palette (dataviz)  ${paletteInfo.validator ? 'validated light + dark' : 'NOT VALIDATED'}`);
+    for (const f of report.fail) console.log(`    ✗ ${f.code}  ${f.msg}`);
+    for (const w of report.warn) console.log(`    ⚠ ${w.code}  ${w.msg}`);
+    console.log('');
+  }
+
+  if (failed) {
+    console.log(`  → BUILD FAILED — ${report.fail.length} gate failure(s); nothing rendered.`);
+    console.log('');
+    return EXIT_GATE;
+  }
+  if (a.gatesOnly) {
+    if (show) console.log('  → GATES PASS (--gates-only; nothing rendered)\n');
+    return EXIT_OK;
+  }
+
+  mkdirSync(a.out, { recursive: true });
+  const written = [];
+  for (const fmt of a.formats) {
+    try {
+      if (fmt === 'json') {
+        const p = join(a.out, 'dossier.json');
+        writeFileSync(p, JSON.stringify(ir, null, 2)); written.push(p);
+      } else if (fmt === 'md') {
+        const p = join(a.out, 'dossier.md');
+        writeFileSync(p, renderMarkdown(ir)); written.push(p);
+      } else if (fmt === 'html') {
+        const html = renderHtml(ir);
+        if (html) { const p = join(a.out, 'dossier.html'); writeFileSync(p, html); written.push(p); }
+      } else if (['pdf', 'pptx', 'xlsx'].includes(fmt)) {
+        // Handed off, not reimplemented: make-pdf / document-skills own these.
+        const p = join(a.out, `handoff.${fmt}.json`);
+        writeFileSync(p, JSON.stringify({
+          format: fmt, ir_path: resolve(a.ir),
+          via: { pdf: 'make-pdf (or print-CSS from dossier.html)', pptx: 'document-skills:pptx (fallback marp-cli)', xlsx: 'document-skills:xlsx (fallback csv)' }[fmt],
+          note: 'gates already passed; this manifest is the handoff contract',
+        }, null, 2));
+        written.push(p);
+      } else {
+        WARN('UNKNOWN_FORMAT', `unknown format "${fmt}" — skipped`);
+      }
+    } catch (e) {
+      console.error(`✗ render ${fmt}: ${e.message}`);
+      return EXIT_USAGE;
+    }
+  }
+
+  if (show) {
+    console.log('  → GATES PASS');
+    for (const w of report.warn) console.log(`    ⚠ ${w.code}`);
+    for (const p of written) console.log(`    wrote ${p}`);
+    console.log('');
+  }
+  return EXIT_OK;
+}
+
+process.exit(main());

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -51,6 +51,11 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const SKILL_DIR = resolve(HERE, '..', 'skills', 'research-dossier');
 
 const EXIT_OK = 0, EXIT_GATE = 1, EXIT_USAGE = 2;
+// Stable emitter identity stamped into every rendered artifact. Version-bearing so
+// a dossier in the wild can be traced to the gate revision that cleared it — the
+// checks tightened materially once already, and an artifact that predates that
+// hardening should not be indistinguishable from one that followed it.
+const RENDERER_ID = 'research-dossier v0.1.0';
 
 // ── tiny arg parser (zero-dep) ──────────────────────────────────────────────
 function parseArgs(argv) {
@@ -235,15 +240,32 @@ function gateProvenance(ir) {
     // carrying a total and the parts do not reach it, the chart silently drops the
     // remainder — every part can match its own claim while the composition lies.
     if (ch.form === 'stacked-bar' || ch.form === 'stacked-area') {
-      const plotted = ys.reduce((a, b) => a + b, 0);
+      // A stack composes PER BUCKET: in a two-quarter chart, each quarter's parts
+      // form that quarter's whole. Summing every point flat would compare two
+      // quarters against a one-quarter total and fail a perfectly valid chart —
+      // a false positive on the gate is not a harmless excess of caution, it
+      // teaches authors that the gate is noise and trains them to route around it.
+      const buckets = new Map();
+      for (const s of ch.series || [])
+        for (const p of s.data || [])
+          if (typeof p.y === 'number') {
+            const k = p.x !== undefined ? JSON.stringify(p.x) : '__single__';
+            buckets.set(k, (buckets.get(k) || 0) + p.y);
+          }
       const cited = (ch.source_claims || [])
         .map(id => (ir.claims || []).find(c => c && c.id === id))
         .filter(c => c && c.metric && typeof c.metric.value === 'number' && /total|sum|overall/i.test(`${c.metric.name} ${c.id} ${c.text}`));
       for (const t of cited) {
         const tv = t.metric.value;
-        if (tv > 0 && Math.abs(plotted - tv) > tv * 0.05)
+        if (!(tv > 0)) continue;
+        // A cited total matching ANY bucket is the total OF that bucket, and the
+        // stack is honest. Only when no bucket reaches it is the whole overstated.
+        const sums = [...buckets.values()];
+        if (!sums.length) continue;
+        const nearest = sums.reduce((a, b) => (Math.abs(b - tv) < Math.abs(a - tv) ? b : a));
+        if (Math.abs(nearest - tv) > tv * 0.05)
           FAIL('STACKED_PARTS_MISMATCH',
-            `${at}: stacked parts sum to ${plotted} but cited claim "${t.id}" states a total of ${tv} — the stack presents itself as the whole while omitting ${(100 * (1 - plotted / tv)).toFixed(0)}% of it`);
+            `${at}: no stacked bucket reaches the total cited by claim "${t.id}" (${tv}); the closest composes to ${nearest}, omitting ${(100 * (1 - nearest / tv)).toFixed(0)}% — a stack presents itself as the whole`);
       }
     }
 
@@ -550,6 +572,24 @@ function gatePalette(ir, opts) {
 // ═══════════════════════════════════════════════════════════════════════════
 const esc = s => String(s ?? '').replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
 
+// esc() stops an attribute from being broken out of; it does not stop a URL from
+// being dangerous *within* a well-formed attribute. `javascript:alert(1)` survives
+// escaping intact and becomes a clickable link — and this artifact's whole purpose
+// is to be opened in a browser and passed around, so a citation URL is attack
+// surface, not decoration. Allowlist the schemes a citation could legitimately
+// use rather than blocklisting the ones we happen to remember.
+const SAFE_URL = /^(?:https?:|mailto:|\/|\.{1,2}\/|#)/i;
+const safeHref = u => (SAFE_URL.test(String(u ?? '').trim()) ? String(u).trim() : null);
+
+// Palette values are interpolated into a <style> block as `--series-N: ${hex};`.
+// The palette gate would reject a malformed colour, but it degrades to a WARN when
+// the bundled dataviz validator is absent (a supported path) — so on that path an
+// unvalidated string reaches the stylesheet and `#fff;} body{display:none} .x{a:b`
+// closes the declaration and injects rules. A colour token is a closed grammar;
+// anything outside it is not a colour, whatever the validator was able to say.
+const SAFE_COLOR = /^(?:#[0-9a-f]{3,8}|(?:rgb|hsl|oklch|oklab|lab|lch)a?\([0-9a-z%.,\s/+-]*\)|[a-z]+)$/i;
+const safeColor = (c, fallback) => (SAFE_COLOR.test(String(c ?? '').trim()) ? String(c).trim() : fallback);
+
 function renderMarkdown(ir) {
   const L = [];
   const claimById = new Map((ir.claims || []).map(c => [c.id, c]));
@@ -792,8 +832,14 @@ function renderHtmlBody(ir) {
   H.push('<section><h2>Evidence</h2><div class="card"><table>');
   H.push('<thead><tr><th scope="col">id</th><th scope="col">Claim</th><th scope="col">Source</th><th scope="col">As of</th><th scope="col">Confidence</th></tr></thead><tbody>');
   for (const c of ir.claims || []) {
+    // A rejected scheme still shows the URL as text — the provenance stays visible
+    // and auditable; only its clickability is withdrawn. Silently dropping it would
+    // hide evidence, which is the opposite of what this table is for.
+    const href = safeHref(c.source?.url);
     const src = c.source?.url
-      ? `<a href="${esc(c.source.url)}" rel="noopener noreferrer">${esc(c.source.label)}</a>`
+      ? (href
+        ? `<a href="${esc(href)}" rel="noopener noreferrer">${esc(c.source.label)}</a>`
+        : `${esc(c.source.label)} <span class="tag st-warning" title="Link not rendered: unsupported URL scheme">⚠ ${esc(c.source.url)}</span>`)
       : esc(c.source?.label || '—');
     H.push(`<tr id="claim-${esc(c.id)}"><th scope="row"><code class="cid">${esc(c.id)}</code></th>`
       + `<td>${esc(c.text)}${c.contested ? '<span class="tag st-warning" style="margin-left:8px">▲ contested</span>' : ''}</td>`
@@ -810,7 +856,14 @@ function renderHtmlBody(ir) {
     + 'checked for a source and a date, every citation for existence and agreement '
     + 'with the value it cites, every magnitude axis for undeclared distortion, and '
     + 'the palette for colour-vision separation in both themes. That is a check of '
-    + 'the evidence, not an endorsement of the conclusion.</footer>');
+    + 'the evidence, not an endorsement of the conclusion.<br>'
+    // Who emitted this, and as of when. `as_of` is the IR's own dated horizon —
+    // deterministic, so re-rendering the same IR yields a byte-identical file. A
+    // wall-clock stamp would make every render differ from the last and turn a
+    // diff into noise; the question "how current is this?" is answered by the
+    // evidence's date, not by when someone happened to press the button.
+    + `<span class="prov">${esc(RENDERER_ID)} · evidence as of ${esc(ir.as_of || 'undated')}`
+    + `${ir.audience ? ` · ${esc(ir.audience)} density` : ''}</span></footer>`);
 
   return H.join('\n');
 }
@@ -823,7 +876,9 @@ function renderHtml(ir) {
   }
   const tpl = readFileSync(tplPath, 'utf8');
   const pal = resolvePalette(ir);
-  const vars = list => list.map((hex, i) => `--series-${i + 1}: ${hex};`).join(' ');
+  // currentColor is an inert fallback: a rejected token renders as the surrounding
+  // ink rather than breaking the stylesheet or silently disappearing.
+  const vars = list => list.map((hex, i) => `--series-${i + 1}: ${safeColor(hex, 'currentColor')};`).join(' ');
 
   // Every substitution is GLOBAL. A single-match .replace() here was a real bug:
   // the template's own header comment named the placeholders, so the first match

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -39,7 +39,11 @@ if ! command -v node >/dev/null 2>&1; then
   printf '  SKIP: node not available\n\n0 passed, 0 failed\n'; exit 0
 fi
 
-TMP="$(mktemp -d 2>/dev/null || echo /tmp/rdt.$$)"; mkdir -p "$TMP"
+# No predictable fallback path: `/tmp/rdt.$$` is guessable, so on a shared host a
+# pre-created symlink there would redirect every write in this suite. If mktemp
+# cannot give us a private directory, stop — a test run is not worth that risk.
+TMP="$(mktemp -d 2>/dev/null)" || { printf '  ✗ cannot create a private temp dir\n'; exit 1; }
+[ -d "$TMP" ] || { printf '  ✗ mktemp returned no directory\n'; exit 1; }
 cleanup() { rm -rf "$TMP" 2>/dev/null || true; }
 trap cleanup EXIT
 
@@ -84,12 +88,23 @@ case "$OUT" in *REC_NO_OWNER*) ok 'wish-not-decision → REC_NO_OWNER' ;; *) no 
 case "$OUT" in *REC_NO_ETA*)   ok 'wish-not-decision → REC_NO_ETA' ;;   *) no 'wish-not-decision → REC_NO_ETA' "$OUT" ;; esac
 
 # ── gate 2: colour is computable, so it is computed ───────────────────────────
-gates ir-bad-palette.json
-eq '1' "$RC" 'ir-bad-palette fails (exit 1)'
-case "$OUT" in *PALETTE_FAIL*) ok 'bad-palette → PALETTE_FAIL' ;; *) no 'bad-palette → PALETTE_FAIL' "$OUT" ;; esac
-# Both modes are validated: dark is SELECTED, not flipped, so it can fail alone.
-case "$OUT" in *light*) ok 'palette gate validates light mode' ;; *) no 'palette gate validates light mode' "$OUT" ;; esac
-case "$OUT" in *dark*)  ok 'palette gate validates dark mode'  ;; *) no 'palette gate validates dark mode'  "$OUT" ;; esac
+# Gate 2 needs the bundled dataviz validator, which lives in a version-and-hash
+# keyed temp dir that only exists inside a Claude Code session. Its absence is a
+# SUPPORTED condition everywhere else in this suite (loud WARN, --strict to fail),
+# so asserting PALETTE_FAIL unconditionally would red the build on exactly the
+# hosts the degradation path was written for. Skip loudly rather than lie either way.
+gates ir-valid.json
+case "$OUT" in
+  *PALETTE_VALIDATOR_MISSING*)
+    ok 'SKIP bad-palette assertions (bundled dataviz validator not present on this host)' ;;
+  *)
+    gates ir-bad-palette.json
+    eq '1' "$RC" 'ir-bad-palette fails (exit 1)'
+    case "$OUT" in *PALETTE_FAIL*) ok 'bad-palette → PALETTE_FAIL' ;; *) no 'bad-palette → PALETTE_FAIL' "$OUT" ;; esac
+    # Both modes are validated: dark is SELECTED, not flipped, so it can fail alone.
+    case "$OUT" in *light*) ok 'palette gate validates light mode' ;; *) no 'palette gate validates light mode' "$OUT" ;; esac
+    case "$OUT" in *dark*)  ok 'palette gate validates dark mode'  ;; *) no 'palette gate validates dark mode'  "$OUT" ;; esac ;;
+esac
 
 # ── degradation: the bundled validator lives in a version-and-hash-keyed temp
 # dir that MOVES on every CLI upgrade. Absent → loud WARN, never a silent pass.
@@ -331,6 +346,60 @@ PY
   fi
 else
   ok 'SKIP density tests (python3 unavailable)'
+fi
+
+# ── asymmetric coverage is TOPICAL, not any-claim-about-the-option ────────────
+# A gate that fires on honest sparsity teaches authors to fabricate cells to
+# silence it — the exact behaviour this check exists to prevent. So an unused
+# LICENCE note must not fail a blank TELEMETRY cell, while an unused telemetry
+# claim still must.
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$EX/ir-valid.json" "$TMP/ir-cov-ok.json" "$TMP/ir-cov-bad.json" <<'PY' 2>/dev/null
+import json,sys
+ir=json.load(open(sys.argv[1])); sc=ir['scorecard']; opts=sc['options']
+sc['criteria'].append({"id":"telemetry","label":"Telemetry footprint","weight":1,"direction":"lower-better"})
+have={(c['option'],c['criterion']) for c in sc['cells']}
+for o in opts:
+    for cr in [c['id'] for c in sc['criteria']]:
+        if (o,cr) not in have and cr!='telemetry':
+            sc['cells'].append({"option":o,"criterion":cr,"value":1,"confidence":"medium","source_claims":[]})
+for o in opts[1:]:
+    sc['cells'].append({"option":o,"criterion":"telemetry","value":0,"confidence":"low","source_claims":[]})
+ir['claims'].append({"id":"c-licence","text":f"{opts[0]} is MIT licensed.","entity":opts[0],
+  "source":{"label":"repo"},"as_of":"2026-07-01","confidence":"high"})
+json.dump(ir,open(sys.argv[2],'w'))
+ir['claims'].append({"id":"c-tel","text":f"{opts[0]} sends telemetry on load.","entity":opts[0],
+  "source":{"label":"audit"},"as_of":"2026-07-01","confidence":"high",
+  "metric":{"name":"telemetry","value":1,"unit":"flag"}})
+json.dump(ir,open(sys.argv[3],'w'))
+PY
+  if [ -s "$TMP/ir-cov-ok.json" ]; then
+    case "$(node "$REND" --ir "$TMP/ir-cov-ok.json" --gates-only 2>&1)" in
+      *SCORECARD_ASYMMETRIC_COVERAGE*) no 'an unrelated unused claim does NOT fail a blank cell' 'fired on honest sparsity' ;;
+      *) ok 'an unrelated unused claim does NOT fail a blank cell' ;;
+    esac
+    case "$(node "$REND" --ir "$TMP/ir-cov-bad.json" --gates-only 2>&1)" in
+      *SCORECARD_ASYMMETRIC_COVERAGE*) ok 'a TOPICALLY relevant unused claim still fails the blank cell' ;;
+      *) no 'a TOPICALLY relevant unused claim still fails the blank cell' 'selective omission slipped through' ;;
+    esac
+  fi
+fi
+
+# ── a render-time failure must reach the EXIT CODE ────────────────────────────
+# renderHtml() returns null after registering a FAIL, and that happens AFTER the
+# gate summary prints. Without propagation the run says GATES PASS, writes no
+# file, and exits 0 — a build claiming success while producing nothing, which is
+# the silent-plausibility failure TEMPLATE_SLOT_UNFILLED exists to prevent.
+TPL="$ROOT/../skills/research-dossier/templates/dossier.html"
+if [ -f "$TPL" ]; then
+  cp "$TPL" "$TMP/tpl.bak"
+  printf '\n<!-- __GHOST_SLOT__ -->\n' >> "$TPL"
+  node "$REND" --ir "$EX/ir-valid.json" --formats html --out "$TMP/slot" >"$TMP/slot.log" 2>&1; RC=$?
+  cp "$TMP/tpl.bak" "$TPL"
+  eq '1' "$RC" 'an unfilled template slot FAILS the build (never a silent exit 0)'
+  [ -f "$TMP/slot/dossier.html" ] && no 'no artifact is written when a slot survives' 'file written' \
+                                  || ok 'no artifact is written when a slot survives'
+  case "$(cat "$TMP/slot.log")" in *TEMPLATE_SLOT_UNFILLED*) ok '→ TEMPLATE_SLOT_UNFILLED is reported, not swallowed' ;; *) no '→ TEMPLATE_SLOT_UNFILLED is reported, not swallowed' 'never surfaced' ;; esac
 fi
 
 # ── stacked composition is PER BUCKET (2026-07-29 review) ─────────────────────

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -237,6 +237,27 @@ PY
   node "$REND" --ir "$TMP/ir-stale.json" --gates-only >/dev/null 2>&1
   eq '1' "$?" 'years-stale evidence FAILS at stakes:high'
   case "$(gt ir-stale.json)" in *CLAIM_STALE*) ok '→ CLAIM_STALE' ;; *) no '→ CLAIM_STALE' 'not raised' ;; esac
+
+  # A malformed IR must produce a GATE VERDICT, never a stack trace. A crash is
+  # strictly worse than a failure: it tells the author nothing about which
+  # invariant broke, and an exit code from an uncaught throw is indistinguishable
+  # from a legitimate rejection. Empty options + retained cells slipped past the
+  # sparse-row guard (`[].some()` is vacuously false) into an empty-object reduce.
+  python3 - "$EX/ir-valid.json" "$TMP/ir-nooptions.json" <<'PY' 2>/dev/null
+import json,sys
+ir=json.load(open(sys.argv[1]))
+(ir.get('scorecard') or {})['options']=[]        # cells deliberately RETAINED
+json.dump(ir,open(sys.argv[2],'w'))
+PY
+  if [ -s "$TMP/ir-nooptions.json" ]; then
+    OUT="$(node "$REND" --ir "$TMP/ir-nooptions.json" --gates-only 2>&1)"; RC=$?
+    eq '1' "$RC" 'options:[] with cells retained fails the GATE (exit 1, not a crash)'
+    case "$OUT" in
+      *TypeError*|*RangeError*|*"at gateProvenance"*) no 'malformed IR never throws — a crash is not a verdict' "$OUT" ;;
+      *) ok 'malformed IR never throws — a crash is not a verdict' ;;
+    esac
+    case "$OUT" in *BUILD\ FAILED*) ok 'crash-path still reports a readable gate verdict' ;; *) no 'crash-path still reports a readable gate verdict' "$OUT" ;; esac
+  fi
 else
   ok 'SKIP red-team hardening tests (python3 unavailable)'
 fi

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -169,6 +169,67 @@ else
   ok 'SKIP declared-truncation (python3 unavailable)'
 fi
 
+# ── density: audience reaches the RENDER, not just the prose ──────────────────
+# Gap #5. Density changes presentation only — never claims, cells, or not_checked[].
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$EX/ir-valid.json" "$TMP" <<'PY' 2>/dev/null
+import json,copy,sys,os
+ir=json.load(open(sys.argv[1])); t=sys.argv[2]
+for aud in ('exec','engineer'):
+    v=copy.deepcopy(ir); v['audience']=aud
+    json.dump(v,open(os.path.join(t,f'ir-{aud}.json'),'w'))
+v=copy.deepcopy(ir); v['audience']='exec'; v['stakes']='high'
+json.dump(v,open(os.path.join(t,'ir-exec-high.json'),'w'))
+# 4 charts: over the public cap (2), under the engineer cap (Infinity)
+v=copy.deepcopy(ir); base=v['charts'][0]; v['charts']=[]
+for i in range(4):
+    c=copy.deepcopy(base); c['id']=f"{base['id']}-{i}"; v['charts'].append(c)
+v['audience']='public'; json.dump(v,open(os.path.join(t,'ir-many-public.json'),'w'))
+v['audience']='engineer'; json.dump(v,open(os.path.join(t,'ir-many-eng.json'),'w'))
+PY
+
+  rd() { node "$REND" --ir "$TMP/$1" --formats html --out "$TMP/den-$2" >/dev/null 2>&1; }
+  # grep -c prints 0 AND exits 1 on no-match, so a `|| echo 0` would emit TWO
+  # lines and every numeric compare downstream would silently fail. Take head -1.
+  cnt() { grep -c "$2" "$TMP/den-$1/dossier.html" 2>/dev/null | head -1; }
+
+  rd ir-exec.json exec
+  eq '0' "$(cnt exec 'details class="tableview" open')" 'exec density collapses the evidence table'
+  rd ir-engineer.json eng
+  [ "$(cnt eng 'details class="tableview" open')" -ge 1 ] \
+    && ok 'engineer density expands the evidence table' \
+    || no 'engineer density expands the evidence table' 'not open'
+  # High stakes re-expands regardless of audience: the reader with the least
+  # context must not receive the least-qualified version of the truth.
+  rd ir-exec-high.json exechigh
+  [ "$(cnt exechigh 'details class="tableview" open')" -ge 1 ] \
+    && ok 'stakes:high re-expands evidence even at exec density' \
+    || no 'stakes:high re-expands evidence even at exec density' 'stayed collapsed'
+
+  rd ir-many-public.json manypub
+  eq '2' "$(cnt manypub '<svg')" 'public density caps charts at 2'
+  # A dropped chart is disclosed — an omission the reader cannot see is an edit.
+  [ "$(cnt manypub 'omitted at')" -ge 1 ] \
+    && ok 'omitted charts are DISCLOSED, not silently swallowed' \
+    || no 'omitted charts are DISCLOSED, not silently swallowed' 'no notice'
+  rd ir-many-eng.json manyeng
+  eq '4' "$(cnt manyeng '<svg')" 'engineer density renders all 4 charts'
+  eq '0' "$(cnt manyeng 'omitted at')" 'no omission notice when nothing is omitted'
+
+  # Density is PRESENTATION. The evidence must be byte-identical across audiences.
+  node "$REND" --ir "$TMP/ir-exec.json"     --formats json --out "$TMP/j-exec" >/dev/null 2>&1
+  node "$REND" --ir "$TMP/ir-engineer.json" --formats json --out "$TMP/j-eng"  >/dev/null 2>&1
+  a="$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));print(json.dumps([d.get('claims'),d.get('not_checked'),(d.get('scorecard') or {}).get('cells')],sort_keys=True))" "$TMP/j-exec/dossier.json" 2>/dev/null)"
+  b="$(python3 -c "import json,sys;d=json.load(open(sys.argv[1]));print(json.dumps([d.get('claims'),d.get('not_checked'),(d.get('scorecard') or {}).get('cells')],sort_keys=True))" "$TMP/j-eng/dossier.json" 2>/dev/null)"
+  if [ -n "$a" ] && [ "$a" = "$b" ]; then
+    ok 'audience changes presentation ONLY — claims/cells/not_checked identical'
+  else
+    no 'audience changes presentation ONLY — claims/cells/not_checked identical' 'evidence differs across audiences'
+  fi
+else
+  ok 'SKIP density tests (python3 unavailable)'
+fi
+
 # ── CLI contract: 2 is usage/IO, distinct from 1 (gate failure) ───────────────
 node "$REND" --ir /nonexistent/nope.json --gates-only >/dev/null 2>&1
 eq '2' "$?" 'missing IR file exits 2 (usage/IO, not a gate failure)'

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# Tests for bin/research-dossier-render.mjs — the renderer and its two f=0 gates.
+#
+# The point of this file: a gate is only real if it is proven in BOTH directions.
+# Every negative fixture is therefore asserted on its SPECIFIC failure code, not
+# merely on "exit 1" — a fixture that failed for an unintended reason would pass a
+# naive check while proving nothing about the check it was written to exercise.
+#
+# Exit codes are captured DIRECTLY, never through a pipe: a pipe reports the exit
+# of its LAST command, so `node render.mjs | grep x` silently reports grep's status
+# and a failing build reads as green.
+#
+# Bash 3.2-safe, self-contained, network-free.
+# Run: bash bin/tests/research-dossier.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ROOT="$DIR/.."
+REND="$ROOT/research-dossier-render.mjs"
+EX="$ROOT/../skills/research-dossier/examples"
+
+pass=0 ; fail=0
+ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  \xe2\x9c\x97 %s\n      got: [%s]\n' "$1" "$2"; }
+eq() { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
+
+printf 'research-dossier.test.sh\n'
+
+if ! command -v node >/dev/null 2>&1; then
+  printf '  SKIP: node not available\n\n0 passed, 0 failed\n'; exit 0
+fi
+
+TMP="$(mktemp -d 2>/dev/null || echo /tmp/rdt.$$)"; mkdir -p "$TMP"
+cleanup() { rm -rf "$TMP" 2>/dev/null || true; }
+trap cleanup EXIT
+
+# gates <fixture> [extra-args...] → sets RC and OUT (exit code captured directly)
+gates() {
+  local f="$1"; shift
+  OUT="$(node "$REND" --ir "$EX/$f" --gates-only "$@" 2>&1)"; RC=$?
+}
+
+# ── fixtures exist ────────────────────────────────────────────────────────────
+for f in valid missing-source truncated-axis dangling-refs bad-palette wish-not-decision; do
+  [ -f "$EX/ir-$f.json" ] && ok "fixture ir-$f.json present" || no "fixture ir-$f.json present" "missing"
+done
+
+# ── the positive: the valid IR must actually pass ─────────────────────────────
+# A gate that rejects everything is not a gate, it is a wall.
+gates ir-valid.json
+eq '0' "$RC" 'ir-valid passes both gates (exit 0)'
+
+# ── the negatives: each must fail, and fail for ITS OWN reason ────────────────
+gates ir-missing-source.json
+eq '1' "$RC" 'ir-missing-source fails (exit 1)'
+case "$OUT" in *CLAIM_NO_SOURCE*)     ok 'missing-source → CLAIM_NO_SOURCE' ;;     *) no 'missing-source → CLAIM_NO_SOURCE' "$OUT" ;; esac
+case "$OUT" in *CLAIM_NO_CONFIDENCE*) ok 'missing-source → CLAIM_NO_CONFIDENCE' ;; *) no 'missing-source → CLAIM_NO_CONFIDENCE' "$OUT" ;; esac
+case "$OUT" in *CLAIM_NO_AS_OF*)      ok 'missing-source → CLAIM_NO_AS_OF' ;;      *) no 'missing-source → CLAIM_NO_AS_OF' "$OUT" ;; esac
+
+# The load-bearing one: this is what carries the text-level faithfulness
+# discipline into the visual layer. A bar chart starting at 60 exaggerates a small
+# difference into a landslide whether or not anyone intended it.
+gates ir-truncated-axis.json
+eq '1' "$RC" 'ir-truncated-axis fails (exit 1)'
+case "$OUT" in *UNDECLARED_TRUNCATION*) ok 'truncated-axis → UNDECLARED_TRUNCATION' ;; *) no 'truncated-axis → UNDECLARED_TRUNCATION' "$OUT" ;; esac
+
+gates ir-dangling-refs.json
+eq '1' "$RC" 'ir-dangling-refs fails (exit 1)'
+case "$OUT" in *DANGLING_CLAIM_REF*) ok 'dangling-refs → DANGLING_CLAIM_REF' ;; *) no 'dangling-refs → DANGLING_CLAIM_REF' "$OUT" ;; esac
+case "$OUT" in *EMPTY_NOT_CHECKED*)  ok 'dangling-refs → EMPTY_NOT_CHECKED' ;;  *) no 'dangling-refs → EMPTY_NOT_CHECKED' "$OUT" ;; esac
+
+gates ir-wish-not-decision.json
+eq '1' "$RC" 'ir-wish-not-decision fails (exit 1)'
+case "$OUT" in *REC_NO_OWNER*) ok 'wish-not-decision → REC_NO_OWNER' ;; *) no 'wish-not-decision → REC_NO_OWNER' "$OUT" ;; esac
+case "$OUT" in *REC_NO_ETA*)   ok 'wish-not-decision → REC_NO_ETA' ;;   *) no 'wish-not-decision → REC_NO_ETA' "$OUT" ;; esac
+
+# ── gate 2: colour is computable, so it is computed ───────────────────────────
+gates ir-bad-palette.json
+eq '1' "$RC" 'ir-bad-palette fails (exit 1)'
+case "$OUT" in *PALETTE_FAIL*) ok 'bad-palette → PALETTE_FAIL' ;; *) no 'bad-palette → PALETTE_FAIL' "$OUT" ;; esac
+# Both modes are validated: dark is SELECTED, not flipped, so it can fail alone.
+case "$OUT" in *light*) ok 'palette gate validates light mode' ;; *) no 'palette gate validates light mode' "$OUT" ;; esac
+case "$OUT" in *dark*)  ok 'palette gate validates dark mode'  ;; *) no 'palette gate validates dark mode'  "$OUT" ;; esac
+
+# ── degradation: the bundled validator lives in a version-and-hash-keyed temp
+# dir that MOVES on every CLI upgrade. Absent → loud WARN, never a silent pass.
+OUT="$(DATAVIZ_VALIDATOR=/nonexistent node "$REND" --ir "$EX/ir-valid.json" --gates-only 2>&1)"; RC=$?
+eq '0' "$RC" 'missing validator degrades to WARN (still exit 0)'
+case "$OUT" in *WARN*) ok 'missing validator emits a visible WARN' ;; *) no 'missing validator emits a visible WARN' "$OUT" ;; esac
+
+# ...and --strict turns that warning into a failure, so CI cannot drift green.
+OUT="$(DATAVIZ_VALIDATOR=/nonexistent node "$REND" --ir "$EX/ir-valid.json" --gates-only --strict 2>&1)"; RC=$?
+eq '1' "$RC" '--strict makes a missing validator a FAILURE'
+case "$OUT" in *PALETTE_VALIDATOR_MISSING*) ok '--strict → PALETTE_VALIDATOR_MISSING' ;; *) no '--strict → PALETTE_VALIDATOR_MISSING' "$OUT" ;; esac
+
+# ── gates run BEFORE anything is written ──────────────────────────────────────
+# A failed dossier must produce NO output at all, rather than a plausible-looking
+# one. Half a dossier is more dangerous than none: it looks finished.
+OUTDIR="$TMP/nowrite"
+node "$REND" --ir "$EX/ir-missing-source.json" --formats html,md,json --out "$OUTDIR" >/dev/null 2>&1; RC=$?
+eq '1' "$RC" 'failing IR exits 1 on a full render'
+if [ ! -d "$OUTDIR" ] || [ -z "$(ls -A "$OUTDIR" 2>/dev/null)" ]; then
+  ok 'failing IR wrote NOTHING (gates precede all writes)'
+else
+  no 'failing IR wrote NOTHING (gates precede all writes)' "$(ls -A "$OUTDIR" 2>/dev/null | tr '\n' ' ')"
+fi
+
+# ── fan-out: one IR → three formats ───────────────────────────────────────────
+OUTDIR="$TMP/out"
+node "$REND" --ir "$EX/ir-valid.json" --formats html,md,json --out "$OUTDIR" >/dev/null 2>&1; RC=$?
+eq '0' "$RC" 'valid IR renders (exit 0)'
+for f in dossier.html dossier.md dossier.json; do
+  [ -s "$OUTDIR/$f" ] && ok "emits $f (non-empty)" || no "emits $f (non-empty)" "missing or empty"
+done
+
+HTML="$OUTDIR/dossier.html"
+if [ -s "$HTML" ]; then
+  # ── offline: opens over file://, no network ────────────────────────────────
+  # The invariant is no remote SUBRESOURCE — source citation URLs are provenance
+  # and MUST stay. Grepping for "https" would flag the evidence as the defect.
+  n=$(grep -cE '<(script|link|img)[^>]+(src|href)="https?://' "$HTML" 2>/dev/null || true)
+  eq '0' "${n:-0}" 'zero remote subresources (script/link/img) — opens offline'
+
+  # ── JS off → the dossier still renders completely ──────────────────────────
+  # An archival decision artifact that needs a script to show its evidence is not
+  # archival. The body is server-side; JS only reveals the theme toggle.
+  n=$(grep -c '<table' "$HTML" 2>/dev/null || true)
+  [ "${n:-0}" -ge 1 ] && ok "evidence tables are server-rendered (${n} <table>)" \
+                      || no 'evidence tables are server-rendered' "found ${n:-0}"
+  n=$(grep -c '__[A-Z_]*__' "$HTML" 2>/dev/null || true)
+  eq '0' "${n:-0}" 'no unfilled template placeholders survived substitution'
+
+  # ── accessibility + print (per dataviz: the table IS the accessible rendering)
+  n=$(grep -c 'role="img"' "$HTML" 2>/dev/null || true)
+  [ "${n:-0}" -ge 1 ] && ok "charts carry role=\"img\" (${n})" || no 'charts carry role="img"' "found ${n:-0}"
+  n=$(grep -c 'aria-label' "$HTML" 2>/dev/null || true)
+  [ "${n:-0}" -ge 1 ] && ok "charts carry aria-label (${n})" || no 'charts carry aria-label' "found ${n:-0}"
+  for pat in '@media print' 'prefers-reduced-motion' 'prefers-color-scheme'; do
+    grep -q "$pat" "$HTML" 2>/dev/null && ok "honors $pat" || no "honors $pat" 'absent'
+  done
+
+  # ── the blind spots are what make the rest credible ────────────────────────
+  grep -qi 'not checked\|not_checked' "$HTML" 2>/dev/null \
+    && ok 'not_checked[] is surfaced in the output' || no 'not_checked[] is surfaced in the output' 'absent'
+fi
+
+# ── declared truncation: passes, AND the rationale is printed on the chart ────
+# The declaration is a cost, not a bypass — it survives into what the reader sees.
+python3 - "$EX/ir-valid.json" "$TMP/ir-declared.json" <<'PY' 2>/dev/null
+import json,sys
+ir=json.load(open(sys.argv[1]))
+ch=(ir.get('charts') or [])
+if ch:
+    ax=ch[0].setdefault('axis',{})
+    ax['y_min']=60; ax['axis_truncated']=True
+    ax['truncation_rationale']='Baseline is 60 KB; below that no library is viable.'
+json.dump(ir,open(sys.argv[2],'w'))
+PY
+if [ -s "$TMP/ir-declared.json" ]; then
+  node "$REND" --ir "$TMP/ir-declared.json" --gates-only >/dev/null 2>&1; RC=$?
+  eq '0' "$RC" 'DECLARED truncation passes the gate'
+  node "$REND" --ir "$TMP/ir-declared.json" --formats html --out "$TMP/decl" >/dev/null 2>&1
+  if [ -s "$TMP/decl/dossier.html" ]; then
+    grep -qi 'truncat' "$TMP/decl/dossier.html" \
+      && ok 'declared truncation is disclosed in the rendered chart' \
+      || no 'declared truncation is disclosed in the rendered chart' 'no notice in output'
+  fi
+else
+  ok 'SKIP declared-truncation (python3 unavailable)'
+fi
+
+# ── CLI contract: 2 is usage/IO, distinct from 1 (gate failure) ───────────────
+node "$REND" --ir /nonexistent/nope.json --gates-only >/dev/null 2>&1
+eq '2' "$?" 'missing IR file exits 2 (usage/IO, not a gate failure)'
+node "$REND" >/dev/null 2>&1
+eq '2' "$?" 'no --ir exits 2 (usage)'
+node "$REND" --help >/dev/null 2>&1
+eq '0' "$?" '--help exits 0'
+
+printf '\n%d passed, %d failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -169,6 +169,78 @@ else
   ok 'SKIP declared-truncation (python3 unavailable)'
 fi
 
+# ── red-team hardening: the semantic checks (2026-07-29) ──────────────────────
+# An independent adversary produced a board-grade dossier that inverted a
+# $1.18M-vs-$0.34M comparison at exit 0. Referential integrity held throughout —
+# every pointer resolved. What was missing was any check that a citation AGREED
+# with what it cited. Each assertion below pins one of those bypasses shut.
+if command -v python3 >/dev/null 2>&1; then
+  mk() { python3 - "$EX/ir-valid.json" "$TMP/$1" "$2" <<'PY' 2>/dev/null
+import json,sys
+ir=json.load(open(sys.argv[1])); out=sys.argv[2]; which=sys.argv[3]
+sc=ir.get('scorecard') or {}
+if which=='point-mismatch':          # chart plots a number its cited claim contradicts
+    ir['charts'][0]['series'][0]['data'][0]['y']=41
+elif which=='display-lie':           # display overrides value with an inverted magnitude
+    for c in sc.get('cells',[]):
+        if c.get('criterion')=='size' and isinstance(c.get('value'),(int,float)):
+            c['display']='18 KB'; break
+elif which=='form-dodge':            # non-magnitude form + truncated axis
+    ir['charts'][0]['form']='line'; ir['charts'][0]['axis']['y_min']=60
+elif which=='compression':           # inflated y_max flattens every mark
+    ir['charts'][0]['axis']['y_max']=100000
+elif which=='vacuous-nc':
+    ir['not_checked']=[{'text':'Everything material was checked.','reason':'Comprehensive review.','impact':'none'}]
+elif which=='all-none-nc':
+    for n in ir['not_checked']: n['impact']='none'
+elif which=='stale':                 # every claim years older than the dossier
+    ir['stakes']='high'
+    for c in ir['claims']: c['as_of']='2019-01-01'
+json.dump(ir,open(out,'w'))
+PY
+  }
+  gt() { node "$REND" --ir "$TMP/$1" --gates-only 2>&1; }
+
+  mk ir-point.json point-mismatch
+  node "$REND" --ir "$TMP/ir-point.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'chart data contradicting its cited claim FAILS'
+  case "$(gt ir-point.json)" in *CHART_POINT_VALUE_MISMATCH*) ok '→ CHART_POINT_VALUE_MISMATCH' ;; *) no '→ CHART_POINT_VALUE_MISMATCH' 'not raised' ;; esac
+
+  mk ir-display.json display-lie
+  node "$REND" --ir "$TMP/ir-display.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'cell display contradicting its own value FAILS'
+  case "$(gt ir-display.json)" in *CELL_DISPLAY_DIVERGES*) ok '→ CELL_DISPLAY_DIVERGES' ;; *) no '→ CELL_DISPLAY_DIVERGES' 'not raised' ;; esac
+
+  # The renderer draws every chart as proportional bars, so a declared form that
+  # the renderer ignores must not exempt a chart from the truncation check.
+  mk ir-form.json form-dodge
+  node "$REND" --ir "$TMP/ir-form.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'truncation is caught regardless of declared form'
+  case "$(gt ir-form.json)" in *UNDECLARED_TRUNCATION*) ok '→ UNDECLARED_TRUNCATION on a non-bar form' ;; *) no '→ UNDECLARED_TRUNCATION on a non-bar form' 'not raised' ;; esac
+
+  mk ir-compress.json compression
+  node "$REND" --ir "$TMP/ir-compress.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'inflated y_max (difference-hiding) FAILS'
+  case "$(gt ir-compress.json)" in *UNDECLARED_COMPRESSION*) ok '→ UNDECLARED_COMPRESSION' ;; *) no '→ UNDECLARED_COMPRESSION' 'not raised' ;; esac
+
+  # The empty-array check was evaded by writing the omniscience claim longhand.
+  mk ir-vacuous.json vacuous-nc
+  node "$REND" --ir "$TMP/ir-vacuous.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'boilerplate not_checked[] FAILS'
+  case "$(gt ir-vacuous.json)" in *NOT_CHECKED_VACUOUS*|*NOT_CHECKED_ALL_INCONSEQUENTIAL*) ok '→ NOT_CHECKED_VACUOUS / ALL_INCONSEQUENTIAL' ;; *) no '→ NOT_CHECKED_VACUOUS / ALL_INCONSEQUENTIAL' 'not raised' ;; esac
+
+  mk ir-allnone.json all-none-nc
+  node "$REND" --ir "$TMP/ir-allnone.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'every blind spot marked impact:none FAILS'
+
+  mk ir-stale.json stale
+  node "$REND" --ir "$TMP/ir-stale.json" --gates-only >/dev/null 2>&1
+  eq '1' "$?" 'years-stale evidence FAILS at stakes:high'
+  case "$(gt ir-stale.json)" in *CLAIM_STALE*) ok '→ CLAIM_STALE' ;; *) no '→ CLAIM_STALE' 'not raised' ;; esac
+else
+  ok 'SKIP red-team hardening tests (python3 unavailable)'
+fi
+
 # ── density: audience reaches the RENDER, not just the prose ──────────────────
 # Gap #5. Density changes presentation only — never claims, cells, or not_checked[].
 if command -v python3 >/dev/null 2>&1; then

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -10,7 +10,16 @@
 # of its LAST command, so `node render.mjs | grep x` silently reports grep's status
 # and a failing build reads as green.
 #
-# Bash 3.2-safe, self-contained, network-free.
+# Spec:        skills/research-dossier/SKILL.md (§Verify) — the gates under test.
+# Requires:    bash 3.2+, node >= 18. python3 is OPTIONAL: the blocks that need it
+#              build IR mutations on the fly and self-skip with a logged SKIP when it
+#              is absent, so the suite still runs (narrower) on a minimal host.
+# Idempotent:  yes — all writes go to a mktemp dir removed on EXIT; nothing outside
+#              it is touched, so repeated runs on the same tree are identical.
+# Network:     none. Offline by construction.
+# Portability: POSIX-spelled utilities (`head -n 1`, not `head -1`); no GNU-only flags.
+# Layer:       no organization-specific content — Layer-Purity clean.
+#
 # Run: bash bin/tests/research-dossier.test.sh
 set -uo pipefail
 
@@ -283,8 +292,9 @@ PY
 
   rd() { node "$REND" --ir "$TMP/$1" --formats html --out "$TMP/den-$2" >/dev/null 2>&1; }
   # grep -c prints 0 AND exits 1 on no-match, so a `|| echo 0` would emit TWO
-  # lines and every numeric compare downstream would silently fail. Take head -1.
-  cnt() { grep -c "$2" "$TMP/den-$1/dossier.html" 2>/dev/null | head -1; }
+  # lines and every numeric compare downstream would silently fail. Take head -n 1
+  # (the POSIX spelling; `head -1` is an obsolescent form).
+  cnt() { grep -c "$2" "$TMP/den-$1/dossier.html" 2>/dev/null | head -n 1; }
 
   rd ir-exec.json exec
   eq '0' "$(cnt exec 'details class="tableview" open')" 'exec density collapses the evidence table'
@@ -321,6 +331,118 @@ PY
   fi
 else
   ok 'SKIP density tests (python3 unavailable)'
+fi
+
+# ── stacked composition is PER BUCKET (2026-07-29 review) ─────────────────────
+# A stack composes per x-bucket: two quarters against a one-quarter total is not a
+# discrepancy. Both directions matter — a false positive here would train authors
+# to treat the gate as noise, which is how a gate stops being a gate.
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$EX/ir-valid.json" "$TMP/ir-stack-ok.json" "$TMP/ir-stack-bad.json" <<'PY' 2>/dev/null
+import json,sys
+base=json.load(open(sys.argv[1]))
+def build(dst, per_bucket, buckets, total):
+    ir=json.loads(json.dumps(base))
+    ir['claims']=[c for c in ir['claims'] if c['id']!='c-stack-total'] + [{
+        "id":"c-stack-total","text":f"Total spend was {total}.","source":{"label":"finance"},
+        "as_of":"2026-07-01","confidence":"high",
+        "metric":{"name":"total spend","value":total,"unit":"USD"}}]
+    ir['charts']=[{"id":"ch-stack","form":"stacked-bar","title":"Spend composition",
+        "source_claims":["c-stack-total"],
+        "series":[{"label":f"part{p}","data":[{"x":f"Q{b+1}","y":per_bucket/2} for b in range(buckets)]}
+                  for p in range(2)]}]
+    json.dump(ir,open(dst,'w'))
+# honest: 2 buckets, each composing to the cited 1-bucket total
+build(sys.argv[2], 1000, 2, 1000)
+# dishonest: no bucket reaches the cited total
+build(sys.argv[3],  100, 2, 1000)
+PY
+  if [ -s "$TMP/ir-stack-ok.json" ]; then
+    OUT="$(node "$REND" --ir "$TMP/ir-stack-ok.json" --gates-only 2>&1)"
+    case "$OUT" in
+      *STACKED_PARTS_MISMATCH*) no 'multi-bucket stack is NOT a false positive' "$OUT" ;;
+      *) ok 'multi-bucket stack is NOT a false positive (per-bucket, not flat sum)' ;;
+    esac
+    node "$REND" --ir "$TMP/ir-stack-bad.json" --gates-only >/dev/null 2>&1
+    eq '1' "$?" 'a stack where NO bucket reaches its cited total still FAILS'
+    case "$(node "$REND" --ir "$TMP/ir-stack-bad.json" --gates-only 2>&1)" in
+      *STACKED_PARTS_MISMATCH*) ok '→ STACKED_PARTS_MISMATCH (real omission still caught)' ;;
+      *) no '→ STACKED_PARTS_MISMATCH (real omission still caught)' 'not raised' ;;
+    esac
+  fi
+fi
+
+# ── every artifact carries its emitter + evidence horizon ─────────────────────
+# CLAUDE.md MUST: "Sign documents with agent ID and timestamp". Dated from the IR's
+# own as_of, NOT wall-clock: re-rendering an unchanged IR must be byte-identical, or
+# every diff becomes noise and the signature stops being auditable.
+if [ -s "$HTML" ]; then
+  grep -q 'research-dossier v' "$HTML" && ok 'rendered dossier is signed with the emitter id' \
+                                       || no 'rendered dossier is signed with the emitter id' 'absent'
+  grep -q 'evidence as of' "$HTML" && ok 'rendered dossier states its evidence horizon' \
+                                   || no 'rendered dossier states its evidence horizon' 'absent'
+  node "$REND" --ir "$EX/ir-valid.json" --formats html --out "$TMP/idem" >/dev/null 2>&1
+  if cmp -s "$HTML" "$TMP/idem/dossier.html"; then ok 'render is idempotent (no wall-clock in the artifact)'
+  else no 'render is idempotent (no wall-clock in the artifact)' 'byte-differs across runs'; fi
+fi
+
+# ── the rendered HTML is untrusted-input-safe (2026-07-29 review) ─────────────
+# This artifact exists to be opened in a browser and passed around, so an IR field
+# is attack surface, not decoration. Both holes below were live and demonstrated
+# before the fix; each assertion checks the EXPLOIT is dead AND the legitimate
+# behaviour it rode on still works — a "safe" renderer that drops the evidence or
+# the colour would pass a naive check while breaking the dossier.
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$EX/ir-valid.json" "$TMP/ir-xss.json" "$TMP/ir-cssinj.json" <<'PY' 2>/dev/null
+import json,sys
+base=json.load(open(sys.argv[1]))
+a=json.loads(json.dumps(base))
+a['claims'][0]['source']['url']='javascript:alert(document.domain)'
+json.dump(a,open(sys.argv[2],'w'))
+b=json.loads(json.dumps(base))
+# The key must be the one resolvePalette() actually reads. An earlier draft of this
+# fixture used theme.palette=[...] — the payload then only ever appeared inside the
+# inert JSON island, so the assertion passed with the guard REMOVED. A security test
+# that cannot fail is worse than none: it certifies a hole it never touched.
+t=b.setdefault('theme',{}).setdefault('palette',{})
+t['categorical_light']=['#1f77b4;} body{display:none} .x{color:red','#ff7f0e']
+t['categorical_dark'] =['#1f77b4;} body{display:none} .y{color:red','#ff7f0e']
+json.dump(b,open(sys.argv[3],'w'))
+PY
+  if [ -s "$TMP/ir-xss.json" ]; then
+    node "$REND" --ir "$TMP/ir-xss.json" --formats html --out "$TMP/sec-xss" >/dev/null 2>&1
+    X="$TMP/sec-xss/dossier.html"
+    n=$(grep -c 'href="javascript:' "$X" 2>/dev/null || true)
+    eq '0' "${n:-0}" 'a javascript: source URL never becomes a clickable href'
+    # Withdrawing clickability must not withdraw the PROVENANCE — hiding the URL
+    # would trade an XSS for an evidence gap, which is the worse defect here.
+    n=$(grep -c 'javascript:alert' "$X" 2>/dev/null || true)
+    [ "${n:-0}" -ge 1 ] && ok 'the rejected URL is still shown as text (evidence preserved)' \
+                        || no 'the rejected URL is still shown as text (evidence preserved)' 'URL vanished'
+    n=$(grep -cE 'href="https?://' "$X" 2>/dev/null || true)
+    [ "${n:-0}" -ge 1 ] && ok 'legitimate http(s) citations remain clickable' \
+                        || no 'legitimate http(s) citations remain clickable' 'allowlist too strict'
+  fi
+  if [ -s "$TMP/ir-cssinj.json" ]; then
+    # WITHOUT the bundled validator: the supported degrade-to-WARN path is exactly
+    # where an unvalidated palette token would reach the stylesheet.
+    DATAVIZ_VALIDATOR=/nonexistent node "$REND" --ir "$TMP/ir-cssinj.json" --formats html --out "$TMP/sec-css" >/dev/null 2>&1
+    C="$TMP/sec-css/dossier.html"
+    n=$(grep -cE -- '--series-[0-9]+:[^;]*[{}]' "$C" 2>/dev/null || true)
+    eq '0' "${n:-0}" 'a palette token cannot close its declaration and inject CSS rules'
+    # ...and the payload must not reach the stylesheet by ANY route. Checking only
+    # the declaration shape would miss a token that escaped the <style> block whole.
+    n=$(sed -n '/<style/,/<\/style>/p' "$C" 2>/dev/null | grep -c 'display:none' || true)
+    eq '0' "${n:-0}" 'the injected rule never lands inside <style> (inert JSON island is fine)'
+    # A rejected token must be neutralised, not silently dropped: the inert fallback
+    # is what keeps the chart legible instead of colourless.
+    n=$(grep -c -- '--series-1: currentColor;' "$C" 2>/dev/null || true)
+    [ "${n:-0}" -ge 1 ] && ok 'a rejected palette token degrades to an inert fallback' \
+                        || no 'a rejected palette token degrades to an inert fallback' 'no fallback emitted'
+    n=$(grep -cE -- '--series-2: *#[0-9a-fA-F]{3,8};' "$C" 2>/dev/null || true)
+    [ "${n:-0}" -ge 1 ] && ok 'valid palette hexes alongside it still reach the stylesheet' \
+                        || no 'valid palette hexes alongside it still reach the stylesheet' 'colour lost'
+  fi
 fi
 
 # ── CLI contract: 2 is usage/IO, distinct from 1 (gate failure) ───────────────

--- a/commands/research-dossier.md
+++ b/commands/research-dossier.md
@@ -1,0 +1,72 @@
+---
+name: research-dossier
+description: Turn finished research into a decision-ready visual dossier (html/md/json + pdf/pptx/xlsx hand-offs), routed through an IR with per-claim provenance and gated by two deterministic oracles — a provenance gate and the bundled dataviz palette validator. Does NOT perform the research.
+argument-hint: "[--corpus <path> | --ir <path>] [--audience exec|engineer|team|client|public] [--formats html,md,json,pdf,pptx,xlsx] [--stakes low|high] [--out <dir>] [--strict]"
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Skill
+---
+
+# /maos:research-dossier
+
+Thin wrapper that invokes `skills/research-dossier/SKILL.md`. The skill holds all
+logic (the IR contract, the extraction discipline, the two gates, the audience map,
+the anti-patterns). **This file is the command surface only.**
+
+> **Invocation**: canonical form is `/maos:research-dossier` (`plugin.json` sets
+> `command_namespace.prefix_required=true`). Bare `/research-dossier` also resolves via
+> `permit_unprefixed_if_no_collision`, but prefer the prefixed form in docs and scripts.
+
+## Usage
+
+```
+/maos:research-dossier --corpus ~/.claude/plans/tool-comparison.md
+/maos:research-dossier --corpus <path> --audience exec --formats html,pdf
+/maos:research-dossier --ir out/dossier.json --audience engineer     # re-render, skip extraction
+/maos:research-dossier --corpus <path> --stakes high                 # tighter gate, gaps expanded
+```
+
+## What it does
+
+`corpus → IR → (scorecard, if a comparison) → render`. The intermediate representation
+is the deliverable, not the HTML: once research carries per-claim provenance, the
+~110 templates and ~150 design systems already installed become reachable.
+
+Two **deterministic** gates run before anything is written — a failed dossier
+produces no output at all, rather than a plausible-looking one:
+
+1. **Provenance** — every claim sourced and dated, every chart citing claims that
+   exist, every recommendation owning an owner and an eta, `not_checked[]` non-empty,
+   and no magnitude axis truncated without declaring it. That last check is what
+   carries the faithfulness discipline into the visual layer.
+2. **Palette** — the bundled `dataviz` skill's own `validate_palette.js` in both
+   light and dark: CVD ΔE OKLab per protan/deutan/tritan, lightness band, chroma
+   floor, normal-vision floor, surface contrast.
+
+## Composes, never duplicates
+
+Chart form and colour → the bundled **`dataviz`** skill. Templates → **`open-design`**.
+pdf → **`make-pdf`**. pptx/xlsx → **`document-skills`**. Prose → **`content-recast`**.
+The research itself → `/deep-research`, `last30days`, `exa`.
+
+New here: the IR contract, the scorecard primitive, the two gates, the audience map.
+
+## Degradation
+
+No `od` daemon → built-in fallback template. No bundled validator (its path moves on
+every CLI upgrade) → runtime discovery, then a **loud WARN**, never a silent pass;
+`--strict` makes it a failure. JS off → the dossier still renders completely.
+
+## Direct renderer
+
+```bash
+node bin/research-dossier-render.mjs --ir <path> --formats html,md,json --out out
+# exit 0 rendered · 1 gate failed (nothing written) · 2 usage/IO
+```
+
+Capture the exit code directly — a pipe reports the *last* command's status, so
+`cmd | grep` makes a failing build read as green.
+
+## Related
+
+`skills/research-dossier/SKILL.md` (logic) · the bundled `dataviz` skill (form + colour
+authority) · `skills/content-recast/SKILL.md` · `skills/decompose-abstract-to-measurable/SKILL.md`
+(sibling discipline: abstract criterion → measurable leaves).

--- a/commands/research-dossier.md
+++ b/commands/research-dossier.md
@@ -17,7 +17,7 @@ the anti-patterns). **This file is the command surface only.**
 
 ## Usage
 
-```
+```text
 /maos:research-dossier --corpus ~/.claude/plans/tool-comparison.md
 /maos:research-dossier --corpus <path> --audience exec --formats html,pdf
 /maos:research-dossier --ir out/dossier.json --audience engineer     # re-render, skip extraction

--- a/skills/research-dossier/SKILL.md
+++ b/skills/research-dossier/SKILL.md
@@ -47,6 +47,30 @@ over the resolved palette in **both** light and dark: lightness band, chroma flo
 CVD separation (ΔE OKLab per protan/deutan/tritan), normal-vision floor, surface
 contrast. Colour is not reimplemented here — `dataviz` owns it, we cite it.
 
+### What the gates check — and what they do not
+
+An independent red-team broke the first version of gate 1, so this section is
+written from evidence rather than intent. Its finding: the gate verified that
+citations **resolve** and never that they **agree**. Both are now checked — a chart
+point contradicting the claim it cites, a `display` string contradicting its own
+`value`, stacked parts that miss their cited total, a verdict that is not the argmax
+of its declared weights, a blank scorecard cell whose evidence exists but went
+unused, evidence years staler than the dossier: all fail the build.
+
+Two things remain **outside** deterministic reach, and are stated here rather than
+implied away:
+
+- **Summary vs. claims.** Prose can contradict the evidence beneath it. A numeral in
+  the summary that appears in no claim raises a warning; a purely qualitative
+  inversion ("the pilot succeeded") does not.
+- **A recommendation citing the claims that refute it.** Citations are checked for
+  existence and agreement-on-value, not for whether they *support* the sentence.
+
+Both are semantic judgements. Do not read a green build as a claim that the argument
+is sound — only that its numbers are consistent with its evidence. A weighting can
+also decide an outcome on its own; when one criterion outweighs all others combined
+the build warns, because arithmetic cannot refute a rigged weight, only disclosure can.
+
 ## Use it / don't
 
 **Use when** research is finished and needs to become decidable: a tool comparison,

--- a/skills/research-dossier/SKILL.md
+++ b/skills/research-dossier/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: research-dossier
+version: "0.1.0"
+description: |
+  Turn finished research into a decision-ready visual dossier — html, md, json, and
+  hand-offs to pdf/pptx/xlsx — routed through an intermediate representation that
+  carries per-claim provenance, and gated by two deterministic oracles that fail the
+  build: a provenance gate (every claim sourced, every chart citing its claims, no
+  undeclared axis truncation, no empty not_checked) and a palette gate (the bundled
+  dataviz validator, colorblind separation in both light and dark).
+  Use when research already exists — a comparison, a market scan, a satisfaction or
+  performance study — and it needs to become something a person can decide from.
+  Does NOT perform the research.
+  Triggers: "build a dashboard from this research", "turn this comparison into a
+  report", "dossier from these findings", "compare x y z and visualize", "executive
+  summary with charts", "decision-ready report".
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash, Skill
+---
+
+# research-dossier
+
+Research emits prose. Renderers want data. Nothing bridged the two, so every
+dashboard was hand-rolled — no provenance, and no reuse of the ~110 templates and
+~150 design systems already installed.
+
+This skill is that bridge, and it is deliberately thin. The lever is not the HTML;
+it is the **IR**. Once research becomes JSON with provenance attached to each claim,
+the existing renderers are reachable for free. Everything here composes; nothing here
+duplicates.
+
+## What makes this different from a report generator
+
+Two **deterministic** gates can fail the build. Neither is a model judgement — same
+input, same verdict, every time. A gate a model can talk its way past is decoration.
+
+**Gate 1 — provenance.** Fails when the evidential chain is broken: a claim missing
+`source` / `as_of` / `confidence`; a chart or recommendation citing a claim id that
+does not exist; a recommendation with no owner or no eta; an empty `not_checked[]`;
+or a **magnitude axis truncated without declaring it**. That last check is the point
+of the whole gate — it carries the text-level faithfulness discipline into the
+*visual* layer. A bar chart starting at 60 exaggerates a small difference into a
+landslide whether or not anyone intended it. Declaring the truncation passes, and
+the rationale is then printed on the face of the chart.
+
+**Gate 2 — palette.** Runs the bundled `dataviz` skill's own `validate_palette.js`
+over the resolved palette in **both** light and dark: lightness band, chroma floor,
+CVD separation (ΔE OKLab per protan/deutan/tritan), normal-vision floor, surface
+contrast. Colour is not reimplemented here — `dataviz` owns it, we cite it.
+
+## Use it / don't
+
+**Use when** research is finished and needs to become decidable: a tool comparison,
+a market scan, a satisfaction survey, a performance review, a post-mortem.
+
+**Don't use** to *do* the research (`/deep-research`, `last30days`, `exa` do that),
+for a single chart with no argument around it (`dataviz` directly), or for prose
+reformatting with no evidential claims (`content-recast`).
+
+## Flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--corpus <path>` | — | the finished research to read |
+| `--ir <path>` | — | skip extraction, render an existing IR |
+| `--audience` | `team` | `exec` · `engineer` · `team` · `client` · `public` |
+| `--formats` | `html,md,json` | + `pdf` · `pptx` · `xlsx` (hand-off manifests) |
+| `--design-system` | `auto` | `auto` resolves from audience |
+| `--stakes` | `low` | `high` tightens the gate and expands gaps |
+| `--out` | `out` | output directory |
+| `--strict` | off | a missing dataviz validator FAILS instead of warning |
+
+## The pipeline
+
+### 1 — Extract the IR (probabilistic; this is the judgement work)
+
+Read the corpus and write an IR against `templates/ir.schema.json`. The schema is the
+contract; read it before writing one.
+
+The part that takes discipline is **claims[]**. Each needs `id`, `text`, `source`,
+`as_of`, `confidence` — and everything downstream cites those ids. A number that
+appears in a chart but in no claim is unsourced by construction, which is exactly
+what gate 1 catches.
+
+Rules worth internalising while extracting:
+
+- **`not_checked[]` is required and non-empty.** Not a formality — the blind spots
+  are what make the rest credible. If the scope genuinely was exhaustive, say so
+  with a reason. An empty array is a claim of omniscience and the gate rejects it.
+- **Confidence is per claim**, three bands. Uniform `high` across a large corpus
+  earns a warning, because a real body of evidence has softer and harder parts.
+- **A recommendation needs an owner and an eta.** Without both it is a wish, and this
+  format refuses to render wishes as decisions.
+- **Don't fill the scorecard grid by inference.** A missing cell renders as an
+  explicit gap, which is honest; a cell invented to complete the matrix renders as
+  evidence, which is not. → `references/scorecard.md`
+- **Contested claims stay marked.** Averaging disagreeing sources into one number is
+  a lie of omission.
+
+### 2 — Choose the form (delegate to `dataviz`)
+
+**Invoke the `dataviz` skill.** Do not reinvent its guidance here — it is the
+authority on form and colour, and it ships with this CLI.
+
+The two things it will tell you that are easiest to get wrong: sometimes the right
+form is **not a chart** (three numbers are a KPI row, not a bar chart), and colour
+comes **last**, after form, marks, and interaction. Its non-negotiables apply in
+full — never a dual axis; colour follows the entity and never its rank; categorical
+hues in fixed order, never cycled; a ninth series folds into "Other" rather than
+generating a ninth hue.
+
+### 3 — Resolve the theme
+
+`--audience` selects a design system and a density; the design system supplies the
+eight parameters `dataviz` consumes. → `references/audience-map.md`
+
+Audience changes **presentation only**. It never changes the claims, the scorecard,
+or `not_checked[]`. An exec dossier and an engineer dossier from one IR contain the
+same evidence and pass the same gates.
+
+### 4 — Render (deterministic; the gates run here)
+
+```bash
+node bin/research-dossier-render.mjs --ir <path> --formats html,md,json --out out
+```
+
+Exit `0` renders, `1` means a gate failed and nothing was written, `2` is usage or
+I/O. Both gates run before any file is created — a failed dossier produces no
+output at all, rather than a plausible-looking one.
+
+`pdf`, `pptx`, and `xlsx` emit **hand-off manifests** rather than files: those
+formats belong to `make-pdf` and `document-skills`, and reimplementing them here
+would be exactly the duplication this skill exists to avoid.
+
+## Composition — what this delegates
+
+| Concern | Owner |
+|---|---|
+| chart form, colour, marks, palette validation | the bundled **`dataviz`** skill |
+| html templates + design systems | **`open-design`** (~110 / ~150) |
+| pdf | **`make-pdf`**, or print-CSS from the rendered html |
+| pptx / xlsx | **`document-skills`** (fallbacks: `marp-cli`, csv) |
+| prose recasting | **`content-recast`** |
+| the research itself | `/deep-research`, `last30days`, `exa` |
+
+What is genuinely new here is only the IR contract, the scorecard primitive, the two
+gates, and the audience map. Everything else is routing.
+
+## Degradation
+
+Each of these is a tested path, not an aspiration:
+
+- **No `od` daemon** → the built-in `templates/dossier.html` fallback.
+- **No bundled `dataviz` validator** (it lives in a version-and-hash-keyed temp dir
+  that moves on every CLI upgrade) → the path is discovered at runtime; when absent
+  the gate degrades to a **loud WARN**, never a silent pass. `--strict` makes it a
+  failure for CI. `DATAVIZ_VALIDATOR` overrides the path.
+- **JavaScript off** → the dossier still renders completely. The body is written
+  server-side; JS only reveals the theme toggle. An archival decision artifact that
+  needs a script to show its evidence is not archival.
+
+## The output
+
+Single file, opens over `file://`, no network. Inline SVG charts — nothing to bundle
+and no canvas to hide from a screen reader. Every chart carries `role="img"`, an
+`aria-label` describing the actual values, and a real `<table>` of the same numbers
+(per `dataviz`, that table *is* the accessible rendering, not a courtesy). Dark mode
+is selected rather than flipped: its own validated steps under both the OS query and
+the `data-theme` toggle, toggle winning either way. `@media print` and
+`prefers-reduced-motion` present. Citations are anchors into the evidence table.
+
+## Verify
+
+```bash
+node bin/research-dossier-render.mjs --ir skills/research-dossier/examples/ir-valid.json --gates-only   # 0
+for f in missing-source truncated-axis dangling-refs bad-palette wish-not-decision; do
+  node bin/research-dossier-render.mjs --ir "skills/research-dossier/examples/ir-$f.json" --gates-only >/dev/null 2>&1
+  echo "$f -> $?"   # each must be 1
+done
+DATAVIZ_VALIDATOR=/nonexistent node bin/research-dossier-render.mjs --ir skills/research-dossier/examples/ir-valid.json --gates-only 2>&1 | grep WARN
+```
+
+Capture exit codes directly. A pipe returns the exit of the *last* command in it, so
+`cmd | grep` silently reports the grep's status and a failing build reads as green.
+
+## Anti-patterns
+
+- **Rendering before gating.** The gates exist to stop output, not to annotate it.
+- **Filling `not_checked[]` with boilerplate** to satisfy the gate. It is load-bearing.
+- **Truncating an axis and declaring it reflexively.** The declaration is a cost, not
+  a bypass — if there is no real rationale, don't truncate.
+- **Copying `dataviz` guidance into this skill.** Cite it; it ships with the CLI and
+  it will be updated without us.
+- **Adding a format renderer** instead of a hand-off manifest.
+- **Softening a dossier for an executive audience** by dropping gaps or contested
+  markers. Audience changes density, never evidence.
+- **Inventing scorecard cells** so the grid looks complete.
+
+## Files
+
+| Path | What |
+|---|---|
+| `templates/ir.schema.json` | the IR contract |
+| `templates/dossier.html` | fallback template (server-rendered shell) |
+| `references/scorecard.md` | the comparison primitive's discipline |
+| `references/audience-map.md` | audience → design system → the 8 dataviz parameters |
+| `examples/ir-valid.json` | working fixture (dogfood: the chart-library comparison) |
+| `examples/ir-*.json` (5) | negative fixtures — each must fail the gate |
+| `bin/research-dossier-render.mjs` | renderer + both gates |

--- a/skills/research-dossier/SKILL.md
+++ b/skills/research-dossier/SKILL.md
@@ -93,6 +93,19 @@ reformatting with no evidential claims (`content-recast`).
 | `--out` | `out` | output directory |
 | `--strict` | off | a missing dataviz validator FAILS instead of warning |
 
+## Requirements
+
+| Need | Why | If absent |
+|---|---|---|
+| **Node ≥ 18** | the renderer and both gates | hard requirement — nothing runs |
+| **`dataviz`** (bundled) | gate 2's `validate_palette.js` | loud WARN; `--strict` makes it fail |
+| **`od` daemon** (optional) | `open-design` templates | falls back to `templates/dossier.html` |
+| **`python3`** (optional) | test-suite IR mutations only | those blocks self-skip |
+
+Zero npm dependencies, by design: a decision artifact whose renderer needs a
+lockfile ages badly. The only third-party code involved is `dataviz`'s validator,
+which ships with the CLI and is invoked, never vendored.
+
 ## The pipeline
 
 ### 1 — Extract the IR (probabilistic; this is the judgement work)

--- a/skills/research-dossier/examples/DOGFOOD.md
+++ b/skills/research-dossier/examples/DOGFOOD.md
@@ -1,0 +1,57 @@
+# Dogfood — the fixture is real research, not a synthetic sample
+
+`ir-valid.json` is not invented demo data. It is the chart-library comparison this
+skill's own recon produced while deciding what the fallback template should embed
+— dist bytes read off each library's distributed build, accessibility read off each
+vendor's published documentation, on 2026-07-29.
+
+That matters for one reason: **a fixture written to make the gates pass proves
+nothing.** This one was written to answer a real question, and the gates were built
+afterward. If the two ever disagree, the research is right and the gate is wrong.
+
+## The test the dogfood has to survive
+
+> Run the artifact over the corpus and check that the resulting dossier reproduces
+> the same decision the recon reached.
+
+It does. Verified 2026-07-29:
+
+| Check | Result |
+|---|---|
+| Decision preserved | Chart.js — the recon's pick, unchanged |
+| Runner-up named + why it lost | Apache ECharts, "~5x the bytes for a benefit the table view already delivers" |
+| Every chart datapoint traceable to a claim id | 0 untraceable |
+| Magnitude axis honest | `y_min: 0`, not truncated |
+| Missing scorecard cells | render `— not measured`, never as a zero |
+| Renders with JavaScript off | verdict, scorecard, chart values, data table, evidence, `not_checked[]` all present |
+| Remote subresources | 0 (source citation URLs remain — those are provenance, not dependencies) |
+
+Reproduce:
+
+```bash
+node bin/research-dossier-render.mjs --ir skills/research-dossier/examples/ir-valid.json \
+  --formats html,md,json --out out
+echo $?    # 0 — capture directly; a pipe would report the pipe's last command
+```
+
+## What the dogfood found
+
+Two things worth recording, because a dogfood that finds nothing usually means
+nobody looked.
+
+1. **Claim text containing a literal `<table>` renders as a raw tag in the markdown
+   output.** The HTML path escapes it correctly (`&lt;table&gt;`, verified — and
+   verified *not* double-escaped), so this is a fidelity nit on one output format,
+   not an injection surface. Left unfixed deliberately: markdown is not an execution
+   sink, and blanket-escaping prose would mangle legitimate text for a cosmetic gain.
+
+2. **The scorecard is deliberately sparse.** Four of nine cells are unmeasured, and
+   the grid says so. Filling them would have made the comparison *look* more
+   complete and *be* less true — which is the exact failure `references/scorecard.md`
+   exists to prevent.
+
+## What this fixture is NOT
+
+It is three libraries, not an exhaustive survey, and the decision is cheap to
+reverse. Its own `not_checked[]` says so. It is a working example of the discipline,
+not a claim about the charting ecosystem.

--- a/skills/research-dossier/examples/ir-bad-palette.json
+++ b/skills/research-dossier/examples/ir-bad-palette.json
@@ -1,0 +1,358 @@
+{
+  "schema_version": "1.0.0",
+  "question": "Which charting library should a zero-build, offline-first HTML dossier embed?",
+  "as_of": "2026-07-29",
+  "audience": "engineer",
+  "stakes": "low",
+  "title": "NEGATIVE FIXTURE — three near-identical blues",
+  "summary": "Chart.js is the pick. It is the smallest library that still covers every form the dossier template needs, and its one real weakness — no native accessibility — is already closed by the mandatory table view. ECharts generates better ARIA descriptions but costs roughly five times the bytes for a benefit we get for free elsewhere.",
+  "entities": [
+    {
+      "id": "chartjs",
+      "label": "Chart.js",
+      "url": "https://www.chartjs.org/"
+    },
+    {
+      "id": "echarts",
+      "label": "Apache ECharts",
+      "url": "https://echarts.apache.org/"
+    },
+    {
+      "id": "frappe",
+      "label": "Frappe Charts",
+      "url": "https://frappe.io/charts"
+    }
+  ],
+  "claims": [
+    {
+      "id": "chartjs-size",
+      "text": "Chart.js UMD build is about 208 KB raw, roughly 68 KB gzipped.",
+      "source": {
+        "label": "Chart.js dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 208,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "echarts-size",
+      "text": "ECharts full build is about 1020 KB raw; a custom build trims it but requires a bundler, which the zero-build constraint rules out.",
+      "source": {
+        "label": "ECharts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 1020,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "frappe-size",
+      "text": "Frappe Charts is about 69 KB raw — the smallest of the three.",
+      "source": {
+        "label": "Frappe Charts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "frappe",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 69,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "chartjs-a11y",
+      "text": "Chart.js renders to canvas and ships no native accessibility layer; its documentation directs authors to supply their own fallback content.",
+      "source": {
+        "label": "Chart.js accessibility documentation",
+        "kind": "doc",
+        "url": "https://www.chartjs.org/docs/latest/general/accessibility.html",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs"
+    },
+    {
+      "id": "echarts-a11y",
+      "text": "ECharts can generate ARIA descriptions from the series data when aria.enabled is set.",
+      "source": {
+        "label": "ECharts aria option documentation",
+        "kind": "doc",
+        "url": "https://echarts.apache.org/en/option.html#aria",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts"
+    },
+    {
+      "id": "frappe-forms",
+      "text": "Frappe Charts covers bar, line, and percentage forms but has no heatmap or scatter, both of which the dossier template requires.",
+      "source": {
+        "label": "Frappe Charts feature docs",
+        "kind": "doc",
+        "url": "https://frappe.io/charts/docs",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "medium",
+      "entity": "frappe"
+    },
+    {
+      "id": "table-view-closes-a11y",
+      "text": "The dossier template emits a <table> carrying the same numbers for every chart, which is the accessible rendering regardless of the library's own ARIA support.",
+      "source": {
+        "label": "dossier.html template contract",
+        "kind": "internal"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high"
+    }
+  ],
+  "scorecard": {
+    "options": [
+      "chartjs",
+      "echarts",
+      "frappe"
+    ],
+    "criteria": [
+      {
+        "id": "size",
+        "label": "Bundle (raw)",
+        "unit": "KB",
+        "direction": "lower-better",
+        "weight": 3
+      },
+      {
+        "id": "forms",
+        "label": "Covers required forms",
+        "direction": "higher-better",
+        "weight": 3
+      },
+      {
+        "id": "a11y",
+        "label": "Native accessibility",
+        "direction": "higher-better",
+        "weight": 1
+      }
+    ],
+    "cells": [
+      {
+        "option": "chartjs",
+        "criterion": "size",
+        "value": 208,
+        "display": "208 KB",
+        "source_claims": [
+          "chartjs-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "echarts",
+        "criterion": "size",
+        "value": 1020,
+        "display": "1020 KB",
+        "source_claims": [
+          "echarts-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "size",
+        "value": 69,
+        "display": "69 KB",
+        "source_claims": [
+          "frappe-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "forms",
+        "value": false,
+        "display": "no heatmap / scatter",
+        "source_claims": [
+          "frappe-forms"
+        ],
+        "confidence": "medium"
+      },
+      {
+        "option": "chartjs",
+        "criterion": "a11y",
+        "value": false,
+        "display": "none (docs-confirmed)",
+        "source_claims": [
+          "chartjs-a11y"
+        ],
+        "confidence": "high"
+      },
+      {
+        "option": "echarts",
+        "criterion": "a11y",
+        "value": true,
+        "display": "generated ARIA",
+        "source_claims": [
+          "echarts-a11y"
+        ],
+        "confidence": "high"
+      }
+    ],
+    "verdict": {
+      "winner": "chartjs",
+      "rationale": "Smallest library that still covers every required form; the accessibility hole is closed by the template's mandatory table view rather than by the library.",
+      "runner_up": "echarts",
+      "rejected_because": "Better generated ARIA, but roughly 5x the bytes for a benefit the table view already delivers."
+    }
+  },
+  "charts": [
+    {
+      "id": "bundle-size",
+      "form": "bar",
+      "title": "Bundle size, raw",
+      "subtitle": "Lower is better; zero-baseline preserved so the ratio reads honestly",
+      "source_claims": [
+        "chartjs-size",
+        "echarts-size",
+        "frappe-size"
+      ],
+      "color_job": "categorical",
+      "axis": {
+        "y_label": "KB (raw)",
+        "y_min": 0
+      },
+      "series": [
+        {
+          "label": "Bundle (raw KB)",
+          "data": [
+            {
+              "x": "Frappe Charts",
+              "y": 69,
+              "claim": "frappe-size"
+            },
+            {
+              "x": "Chart.js",
+              "y": 208,
+              "claim": "chartjs-size"
+            },
+            {
+              "x": "Apache ECharts",
+              "y": 1020,
+              "claim": "echarts-size"
+            }
+          ]
+        }
+      ],
+      "table_view": true
+    }
+  ],
+  "insights": [
+    {
+      "id": "smallest-is-not-cheapest",
+      "text": "The smallest library is not the cheapest choice: Frappe saves 139 KB but cannot draw two of the required forms, so adopting it means adding a second library and losing the saving.",
+      "source_claims": [
+        "frappe-size",
+        "frappe-forms",
+        "chartjs-size"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "risks": [
+    {
+      "id": "canvas-a11y",
+      "text": "A canvas-rendered chart is invisible to a screen reader without an explicit text equivalent.",
+      "severity": "serious",
+      "likelihood": "high",
+      "mitigation": "The template emits role=\"img\" plus aria-label plus a <table> with the same numbers for every chart; grep-verified in the test suite.",
+      "source_claims": [
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "adopt-chartjs",
+      "text": "Inline Chart.js in the fallback template and keep the table view mandatory rather than optional.",
+      "owner": "dossier maintainer",
+      "eta": "immediate",
+      "priority": "P1",
+      "effort": "S",
+      "source_claims": [
+        "chartjs-size",
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ]
+    }
+  ],
+  "not_checked": [
+    {
+      "text": "Runtime rendering performance at high series counts.",
+      "reason": "Dossiers cap at eight series by design (the dataviz token ceiling), well below where any of the three degrades.",
+      "impact": "low"
+    },
+    {
+      "text": "Long-term maintenance health — release cadence, open-issue trend, bus factor.",
+      "reason": "Out of scope for a single-file embedding decision that is cheap to reverse.",
+      "impact": "low"
+    }
+  ],
+  "methodology": {
+    "approach": "Direct inspection of each library's distributed bundle plus a read of its published accessibility and feature documentation. No benchmarks were run; the decision turns on size, form coverage, and accessibility, all of which are observable without one.",
+    "sources_consulted": 6,
+    "window": {
+      "from": "2026-07-29",
+      "to": "2026-07-29"
+    },
+    "tools": [
+      "dist inspection",
+      "vendor documentation"
+    ],
+    "limitations": [
+      "Sizes are raw dist bytes, not per-application tree-shaken output.",
+      "Accessibility assessed from documentation, not from a screen-reader session."
+    ]
+  },
+  "provenance": {
+    "generated_by": "research-dossier (dogfood fixture)",
+    "corpus_path": "session recon 2026-07-29"
+  },
+  "theme": {
+    "palette": {
+      "categorical_light": [
+        "#1f77b4",
+        "#2077b8",
+        "#1e76b2"
+      ],
+      "categorical_dark": [
+        "#3987e5",
+        "#3a88e6",
+        "#3886e4"
+      ]
+    }
+  }
+}

--- a/skills/research-dossier/examples/ir-dangling-refs.json
+++ b/skills/research-dossier/examples/ir-dangling-refs.json
@@ -1,0 +1,330 @@
+{
+  "schema_version": "1.0.0",
+  "question": "Which charting library should a zero-build, offline-first HTML dossier embed?",
+  "as_of": "2026-07-29",
+  "audience": "engineer",
+  "stakes": "low",
+  "title": "NEGATIVE FIXTURE — dangling claim refs + empty not_checked",
+  "summary": "Chart.js is the pick. It is the smallest library that still covers every form the dossier template needs, and its one real weakness — no native accessibility — is already closed by the mandatory table view. ECharts generates better ARIA descriptions but costs roughly five times the bytes for a benefit we get for free elsewhere.",
+  "entities": [
+    {
+      "id": "chartjs",
+      "label": "Chart.js",
+      "url": "https://www.chartjs.org/"
+    },
+    {
+      "id": "echarts",
+      "label": "Apache ECharts",
+      "url": "https://echarts.apache.org/"
+    },
+    {
+      "id": "frappe",
+      "label": "Frappe Charts",
+      "url": "https://frappe.io/charts"
+    }
+  ],
+  "claims": [
+    {
+      "id": "chartjs-size",
+      "text": "Chart.js UMD build is about 208 KB raw, roughly 68 KB gzipped.",
+      "source": {
+        "label": "Chart.js dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 208,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "echarts-size",
+      "text": "ECharts full build is about 1020 KB raw; a custom build trims it but requires a bundler, which the zero-build constraint rules out.",
+      "source": {
+        "label": "ECharts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 1020,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "frappe-size",
+      "text": "Frappe Charts is about 69 KB raw — the smallest of the three.",
+      "source": {
+        "label": "Frappe Charts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "frappe",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 69,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "chartjs-a11y",
+      "text": "Chart.js renders to canvas and ships no native accessibility layer; its documentation directs authors to supply their own fallback content.",
+      "source": {
+        "label": "Chart.js accessibility documentation",
+        "kind": "doc",
+        "url": "https://www.chartjs.org/docs/latest/general/accessibility.html",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs"
+    },
+    {
+      "id": "echarts-a11y",
+      "text": "ECharts can generate ARIA descriptions from the series data when aria.enabled is set.",
+      "source": {
+        "label": "ECharts aria option documentation",
+        "kind": "doc",
+        "url": "https://echarts.apache.org/en/option.html#aria",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts"
+    },
+    {
+      "id": "frappe-forms",
+      "text": "Frappe Charts covers bar, line, and percentage forms but has no heatmap or scatter, both of which the dossier template requires.",
+      "source": {
+        "label": "Frappe Charts feature docs",
+        "kind": "doc",
+        "url": "https://frappe.io/charts/docs",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "medium",
+      "entity": "frappe"
+    },
+    {
+      "id": "table-view-closes-a11y",
+      "text": "The dossier template emits a <table> carrying the same numbers for every chart, which is the accessible rendering regardless of the library's own ARIA support.",
+      "source": {
+        "label": "dossier.html template contract",
+        "kind": "internal"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high"
+    }
+  ],
+  "scorecard": {
+    "options": [
+      "chartjs",
+      "echarts",
+      "frappe"
+    ],
+    "criteria": [
+      {
+        "id": "size",
+        "label": "Bundle (raw)",
+        "unit": "KB",
+        "direction": "lower-better",
+        "weight": 3
+      },
+      {
+        "id": "forms",
+        "label": "Covers required forms",
+        "direction": "higher-better",
+        "weight": 3
+      },
+      {
+        "id": "a11y",
+        "label": "Native accessibility",
+        "direction": "higher-better",
+        "weight": 1
+      }
+    ],
+    "cells": [
+      {
+        "option": "chartjs",
+        "criterion": "size",
+        "value": 208,
+        "display": "208 KB",
+        "source_claims": [
+          "chartjs-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "echarts",
+        "criterion": "size",
+        "value": 1020,
+        "display": "1020 KB",
+        "source_claims": [
+          "echarts-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "size",
+        "value": 69,
+        "display": "69 KB",
+        "source_claims": [
+          "frappe-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "forms",
+        "value": false,
+        "display": "no heatmap / scatter",
+        "source_claims": [
+          "frappe-forms"
+        ],
+        "confidence": "medium"
+      },
+      {
+        "option": "chartjs",
+        "criterion": "a11y",
+        "value": false,
+        "display": "none (docs-confirmed)",
+        "source_claims": [
+          "chartjs-a11y"
+        ],
+        "confidence": "high"
+      },
+      {
+        "option": "echarts",
+        "criterion": "a11y",
+        "value": true,
+        "display": "generated ARIA",
+        "source_claims": [
+          "echarts-a11y"
+        ],
+        "confidence": "high"
+      }
+    ],
+    "verdict": {
+      "winner": "chartjs",
+      "rationale": "Smallest library that still covers every required form; the accessibility hole is closed by the template's mandatory table view rather than by the library.",
+      "runner_up": "echarts",
+      "rejected_because": "Better generated ARIA, but roughly 5x the bytes for a benefit the table view already delivers."
+    }
+  },
+  "charts": [
+    {
+      "id": "bundle-size",
+      "form": "bar",
+      "title": "Bundle size, raw",
+      "subtitle": "Lower is better; zero-baseline preserved so the ratio reads honestly",
+      "source_claims": [
+        "chartjs-size",
+        "does-not-exist"
+      ],
+      "color_job": "categorical",
+      "axis": {
+        "y_label": "KB (raw)",
+        "y_min": 0
+      },
+      "series": [
+        {
+          "label": "Bundle (raw KB)",
+          "data": [
+            {
+              "x": "Frappe Charts",
+              "y": 69,
+              "claim": "frappe-size"
+            },
+            {
+              "x": "Chart.js",
+              "y": 208,
+              "claim": "chartjs-size"
+            },
+            {
+              "x": "Apache ECharts",
+              "y": 1020,
+              "claim": "echarts-size"
+            }
+          ]
+        }
+      ],
+      "table_view": true
+    }
+  ],
+  "insights": [
+    {
+      "id": "smallest-is-not-cheapest",
+      "text": "The smallest library is not the cheapest choice: Frappe saves 139 KB but cannot draw two of the required forms, so adopting it means adding a second library and losing the saving.",
+      "source_claims": [
+        "frappe-size",
+        "frappe-forms",
+        "chartjs-size"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "risks": [
+    {
+      "id": "canvas-a11y",
+      "text": "A canvas-rendered chart is invisible to a screen reader without an explicit text equivalent.",
+      "severity": "serious",
+      "likelihood": "high",
+      "mitigation": "The template emits role=\"img\" plus aria-label plus a <table> with the same numbers for every chart; grep-verified in the test suite.",
+      "source_claims": [
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "adopt-chartjs",
+      "text": "Inline Chart.js in the fallback template and keep the table view mandatory rather than optional.",
+      "owner": "dossier maintainer",
+      "eta": "immediate",
+      "priority": "P1",
+      "effort": "S",
+      "source_claims": [
+        "ghost-claim"
+      ]
+    }
+  ],
+  "not_checked": [],
+  "methodology": {
+    "approach": "Direct inspection of each library's distributed bundle plus a read of its published accessibility and feature documentation. No benchmarks were run; the decision turns on size, form coverage, and accessibility, all of which are observable without one.",
+    "sources_consulted": 6,
+    "window": {
+      "from": "2026-07-29",
+      "to": "2026-07-29"
+    },
+    "tools": [
+      "dist inspection",
+      "vendor documentation"
+    ],
+    "limitations": [
+      "Sizes are raw dist bytes, not per-application tree-shaken output.",
+      "Accessibility assessed from documentation, not from a screen-reader session."
+    ]
+  },
+  "provenance": {
+    "generated_by": "research-dossier (dogfood fixture)",
+    "corpus_path": "session recon 2026-07-29"
+  }
+}

--- a/skills/research-dossier/examples/ir-missing-source.json
+++ b/skills/research-dossier/examples/ir-missing-source.json
@@ -1,0 +1,337 @@
+{
+  "schema_version": "1.0.0",
+  "question": "Which charting library should a zero-build, offline-first HTML dossier embed?",
+  "as_of": "2026-07-29",
+  "audience": "engineer",
+  "stakes": "low",
+  "title": "NEGATIVE FIXTURE — claims stripped of source / confidence / as_of",
+  "summary": "Chart.js is the pick. It is the smallest library that still covers every form the dossier template needs, and its one real weakness — no native accessibility — is already closed by the mandatory table view. ECharts generates better ARIA descriptions but costs roughly five times the bytes for a benefit we get for free elsewhere.",
+  "entities": [
+    {
+      "id": "chartjs",
+      "label": "Chart.js",
+      "url": "https://www.chartjs.org/"
+    },
+    {
+      "id": "echarts",
+      "label": "Apache ECharts",
+      "url": "https://echarts.apache.org/"
+    },
+    {
+      "id": "frappe",
+      "label": "Frappe Charts",
+      "url": "https://frappe.io/charts"
+    }
+  ],
+  "claims": [
+    {
+      "id": "chartjs-size",
+      "text": "Chart.js UMD build is about 208 KB raw, roughly 68 KB gzipped.",
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 208,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "echarts-size",
+      "text": "ECharts full build is about 1020 KB raw; a custom build trims it but requires a bundler, which the zero-build constraint rules out.",
+      "source": {
+        "label": "ECharts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "entity": "echarts",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 1020,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "frappe-size",
+      "text": "Frappe Charts is about 69 KB raw — the smallest of the three.",
+      "source": {
+        "label": "Frappe Charts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "confidence": "high",
+      "entity": "frappe",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 69,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "chartjs-a11y",
+      "text": "Chart.js renders to canvas and ships no native accessibility layer; its documentation directs authors to supply their own fallback content.",
+      "source": {
+        "label": "Chart.js accessibility documentation",
+        "kind": "doc",
+        "url": "https://www.chartjs.org/docs/latest/general/accessibility.html",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs"
+    },
+    {
+      "id": "echarts-a11y",
+      "text": "ECharts can generate ARIA descriptions from the series data when aria.enabled is set.",
+      "source": {
+        "label": "ECharts aria option documentation",
+        "kind": "doc",
+        "url": "https://echarts.apache.org/en/option.html#aria",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts"
+    },
+    {
+      "id": "frappe-forms",
+      "text": "Frappe Charts covers bar, line, and percentage forms but has no heatmap or scatter, both of which the dossier template requires.",
+      "source": {
+        "label": "Frappe Charts feature docs",
+        "kind": "doc",
+        "url": "https://frappe.io/charts/docs",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "medium",
+      "entity": "frappe"
+    },
+    {
+      "id": "table-view-closes-a11y",
+      "text": "The dossier template emits a <table> carrying the same numbers for every chart, which is the accessible rendering regardless of the library's own ARIA support.",
+      "source": {
+        "label": "dossier.html template contract",
+        "kind": "internal"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high"
+    }
+  ],
+  "scorecard": {
+    "options": [
+      "chartjs",
+      "echarts",
+      "frappe"
+    ],
+    "criteria": [
+      {
+        "id": "size",
+        "label": "Bundle (raw)",
+        "unit": "KB",
+        "direction": "lower-better",
+        "weight": 3
+      },
+      {
+        "id": "forms",
+        "label": "Covers required forms",
+        "direction": "higher-better",
+        "weight": 3
+      },
+      {
+        "id": "a11y",
+        "label": "Native accessibility",
+        "direction": "higher-better",
+        "weight": 1
+      }
+    ],
+    "cells": [
+      {
+        "option": "chartjs",
+        "criterion": "size",
+        "value": 208,
+        "display": "208 KB",
+        "source_claims": [
+          "chartjs-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "echarts",
+        "criterion": "size",
+        "value": 1020,
+        "display": "1020 KB",
+        "source_claims": [
+          "echarts-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "size",
+        "value": 69,
+        "display": "69 KB",
+        "source_claims": [
+          "frappe-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "forms",
+        "value": false,
+        "display": "no heatmap / scatter",
+        "source_claims": [
+          "frappe-forms"
+        ],
+        "confidence": "medium"
+      },
+      {
+        "option": "chartjs",
+        "criterion": "a11y",
+        "value": false,
+        "display": "none (docs-confirmed)",
+        "source_claims": [
+          "chartjs-a11y"
+        ],
+        "confidence": "high"
+      },
+      {
+        "option": "echarts",
+        "criterion": "a11y",
+        "value": true,
+        "display": "generated ARIA",
+        "source_claims": [
+          "echarts-a11y"
+        ],
+        "confidence": "high"
+      }
+    ],
+    "verdict": {
+      "winner": "chartjs",
+      "rationale": "Smallest library that still covers every required form; the accessibility hole is closed by the template's mandatory table view rather than by the library.",
+      "runner_up": "echarts",
+      "rejected_because": "Better generated ARIA, but roughly 5x the bytes for a benefit the table view already delivers."
+    }
+  },
+  "charts": [
+    {
+      "id": "bundle-size",
+      "form": "bar",
+      "title": "Bundle size, raw",
+      "subtitle": "Lower is better; zero-baseline preserved so the ratio reads honestly",
+      "source_claims": [
+        "chartjs-size",
+        "echarts-size",
+        "frappe-size"
+      ],
+      "color_job": "categorical",
+      "axis": {
+        "y_label": "KB (raw)",
+        "y_min": 0
+      },
+      "series": [
+        {
+          "label": "Bundle (raw KB)",
+          "data": [
+            {
+              "x": "Frappe Charts",
+              "y": 69,
+              "claim": "frappe-size"
+            },
+            {
+              "x": "Chart.js",
+              "y": 208,
+              "claim": "chartjs-size"
+            },
+            {
+              "x": "Apache ECharts",
+              "y": 1020,
+              "claim": "echarts-size"
+            }
+          ]
+        }
+      ],
+      "table_view": true
+    }
+  ],
+  "insights": [
+    {
+      "id": "smallest-is-not-cheapest",
+      "text": "The smallest library is not the cheapest choice: Frappe saves 139 KB but cannot draw two of the required forms, so adopting it means adding a second library and losing the saving.",
+      "source_claims": [
+        "frappe-size",
+        "frappe-forms",
+        "chartjs-size"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "risks": [
+    {
+      "id": "canvas-a11y",
+      "text": "A canvas-rendered chart is invisible to a screen reader without an explicit text equivalent.",
+      "severity": "serious",
+      "likelihood": "high",
+      "mitigation": "The template emits role=\"img\" plus aria-label plus a <table> with the same numbers for every chart; grep-verified in the test suite.",
+      "source_claims": [
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "adopt-chartjs",
+      "text": "Inline Chart.js in the fallback template and keep the table view mandatory rather than optional.",
+      "owner": "dossier maintainer",
+      "eta": "immediate",
+      "priority": "P1",
+      "effort": "S",
+      "source_claims": [
+        "chartjs-size",
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ]
+    }
+  ],
+  "not_checked": [
+    {
+      "text": "Runtime rendering performance at high series counts.",
+      "reason": "Dossiers cap at eight series by design (the dataviz token ceiling), well below where any of the three degrades.",
+      "impact": "low"
+    },
+    {
+      "text": "Long-term maintenance health — release cadence, open-issue trend, bus factor.",
+      "reason": "Out of scope for a single-file embedding decision that is cheap to reverse.",
+      "impact": "low"
+    }
+  ],
+  "methodology": {
+    "approach": "Direct inspection of each library's distributed bundle plus a read of its published accessibility and feature documentation. No benchmarks were run; the decision turns on size, form coverage, and accessibility, all of which are observable without one.",
+    "sources_consulted": 6,
+    "window": {
+      "from": "2026-07-29",
+      "to": "2026-07-29"
+    },
+    "tools": [
+      "dist inspection",
+      "vendor documentation"
+    ],
+    "limitations": [
+      "Sizes are raw dist bytes, not per-application tree-shaken output.",
+      "Accessibility assessed from documentation, not from a screen-reader session."
+    ]
+  },
+  "provenance": {
+    "generated_by": "research-dossier (dogfood fixture)",
+    "corpus_path": "session recon 2026-07-29"
+  }
+}

--- a/skills/research-dossier/examples/ir-truncated-axis.json
+++ b/skills/research-dossier/examples/ir-truncated-axis.json
@@ -1,0 +1,344 @@
+{
+  "schema_version": "1.0.0",
+  "question": "Which charting library should a zero-build, offline-first HTML dossier embed?",
+  "as_of": "2026-07-29",
+  "audience": "engineer",
+  "stakes": "low",
+  "title": "NEGATIVE FIXTURE — bar chart y_min raised without axis_truncated",
+  "summary": "Chart.js is the pick. It is the smallest library that still covers every form the dossier template needs, and its one real weakness — no native accessibility — is already closed by the mandatory table view. ECharts generates better ARIA descriptions but costs roughly five times the bytes for a benefit we get for free elsewhere.",
+  "entities": [
+    {
+      "id": "chartjs",
+      "label": "Chart.js",
+      "url": "https://www.chartjs.org/"
+    },
+    {
+      "id": "echarts",
+      "label": "Apache ECharts",
+      "url": "https://echarts.apache.org/"
+    },
+    {
+      "id": "frappe",
+      "label": "Frappe Charts",
+      "url": "https://frappe.io/charts"
+    }
+  ],
+  "claims": [
+    {
+      "id": "chartjs-size",
+      "text": "Chart.js UMD build is about 208 KB raw, roughly 68 KB gzipped.",
+      "source": {
+        "label": "Chart.js dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 208,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "echarts-size",
+      "text": "ECharts full build is about 1020 KB raw; a custom build trims it but requires a bundler, which the zero-build constraint rules out.",
+      "source": {
+        "label": "ECharts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 1020,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "frappe-size",
+      "text": "Frappe Charts is about 69 KB raw — the smallest of the three.",
+      "source": {
+        "label": "Frappe Charts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "frappe",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 69,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "chartjs-a11y",
+      "text": "Chart.js renders to canvas and ships no native accessibility layer; its documentation directs authors to supply their own fallback content.",
+      "source": {
+        "label": "Chart.js accessibility documentation",
+        "kind": "doc",
+        "url": "https://www.chartjs.org/docs/latest/general/accessibility.html",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs"
+    },
+    {
+      "id": "echarts-a11y",
+      "text": "ECharts can generate ARIA descriptions from the series data when aria.enabled is set.",
+      "source": {
+        "label": "ECharts aria option documentation",
+        "kind": "doc",
+        "url": "https://echarts.apache.org/en/option.html#aria",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts"
+    },
+    {
+      "id": "frappe-forms",
+      "text": "Frappe Charts covers bar, line, and percentage forms but has no heatmap or scatter, both of which the dossier template requires.",
+      "source": {
+        "label": "Frappe Charts feature docs",
+        "kind": "doc",
+        "url": "https://frappe.io/charts/docs",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "medium",
+      "entity": "frappe"
+    },
+    {
+      "id": "table-view-closes-a11y",
+      "text": "The dossier template emits a <table> carrying the same numbers for every chart, which is the accessible rendering regardless of the library's own ARIA support.",
+      "source": {
+        "label": "dossier.html template contract",
+        "kind": "internal"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high"
+    }
+  ],
+  "scorecard": {
+    "options": [
+      "chartjs",
+      "echarts",
+      "frappe"
+    ],
+    "criteria": [
+      {
+        "id": "size",
+        "label": "Bundle (raw)",
+        "unit": "KB",
+        "direction": "lower-better",
+        "weight": 3
+      },
+      {
+        "id": "forms",
+        "label": "Covers required forms",
+        "direction": "higher-better",
+        "weight": 3
+      },
+      {
+        "id": "a11y",
+        "label": "Native accessibility",
+        "direction": "higher-better",
+        "weight": 1
+      }
+    ],
+    "cells": [
+      {
+        "option": "chartjs",
+        "criterion": "size",
+        "value": 208,
+        "display": "208 KB",
+        "source_claims": [
+          "chartjs-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "echarts",
+        "criterion": "size",
+        "value": 1020,
+        "display": "1020 KB",
+        "source_claims": [
+          "echarts-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "size",
+        "value": 69,
+        "display": "69 KB",
+        "source_claims": [
+          "frappe-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "forms",
+        "value": false,
+        "display": "no heatmap / scatter",
+        "source_claims": [
+          "frappe-forms"
+        ],
+        "confidence": "medium"
+      },
+      {
+        "option": "chartjs",
+        "criterion": "a11y",
+        "value": false,
+        "display": "none (docs-confirmed)",
+        "source_claims": [
+          "chartjs-a11y"
+        ],
+        "confidence": "high"
+      },
+      {
+        "option": "echarts",
+        "criterion": "a11y",
+        "value": true,
+        "display": "generated ARIA",
+        "source_claims": [
+          "echarts-a11y"
+        ],
+        "confidence": "high"
+      }
+    ],
+    "verdict": {
+      "winner": "chartjs",
+      "rationale": "Smallest library that still covers every required form; the accessibility hole is closed by the template's mandatory table view rather than by the library.",
+      "runner_up": "echarts",
+      "rejected_because": "Better generated ARIA, but roughly 5x the bytes for a benefit the table view already delivers."
+    }
+  },
+  "charts": [
+    {
+      "id": "bundle-size",
+      "form": "bar",
+      "title": "Bundle size, raw",
+      "subtitle": "Lower is better; zero-baseline preserved so the ratio reads honestly",
+      "source_claims": [
+        "chartjs-size",
+        "echarts-size",
+        "frappe-size"
+      ],
+      "color_job": "categorical",
+      "axis": {
+        "y_label": "KB (raw)",
+        "y_min": 60
+      },
+      "series": [
+        {
+          "label": "Bundle (raw KB)",
+          "data": [
+            {
+              "x": "Frappe Charts",
+              "y": 69,
+              "claim": "frappe-size"
+            },
+            {
+              "x": "Chart.js",
+              "y": 208,
+              "claim": "chartjs-size"
+            },
+            {
+              "x": "Apache ECharts",
+              "y": 1020,
+              "claim": "echarts-size"
+            }
+          ]
+        }
+      ],
+      "table_view": true
+    }
+  ],
+  "insights": [
+    {
+      "id": "smallest-is-not-cheapest",
+      "text": "The smallest library is not the cheapest choice: Frappe saves 139 KB but cannot draw two of the required forms, so adopting it means adding a second library and losing the saving.",
+      "source_claims": [
+        "frappe-size",
+        "frappe-forms",
+        "chartjs-size"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "risks": [
+    {
+      "id": "canvas-a11y",
+      "text": "A canvas-rendered chart is invisible to a screen reader without an explicit text equivalent.",
+      "severity": "serious",
+      "likelihood": "high",
+      "mitigation": "The template emits role=\"img\" plus aria-label plus a <table> with the same numbers for every chart; grep-verified in the test suite.",
+      "source_claims": [
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "adopt-chartjs",
+      "text": "Inline Chart.js in the fallback template and keep the table view mandatory rather than optional.",
+      "owner": "dossier maintainer",
+      "eta": "immediate",
+      "priority": "P1",
+      "effort": "S",
+      "source_claims": [
+        "chartjs-size",
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ]
+    }
+  ],
+  "not_checked": [
+    {
+      "text": "Runtime rendering performance at high series counts.",
+      "reason": "Dossiers cap at eight series by design (the dataviz token ceiling), well below where any of the three degrades.",
+      "impact": "low"
+    },
+    {
+      "text": "Long-term maintenance health — release cadence, open-issue trend, bus factor.",
+      "reason": "Out of scope for a single-file embedding decision that is cheap to reverse.",
+      "impact": "low"
+    }
+  ],
+  "methodology": {
+    "approach": "Direct inspection of each library's distributed bundle plus a read of its published accessibility and feature documentation. No benchmarks were run; the decision turns on size, form coverage, and accessibility, all of which are observable without one.",
+    "sources_consulted": 6,
+    "window": {
+      "from": "2026-07-29",
+      "to": "2026-07-29"
+    },
+    "tools": [
+      "dist inspection",
+      "vendor documentation"
+    ],
+    "limitations": [
+      "Sizes are raw dist bytes, not per-application tree-shaken output.",
+      "Accessibility assessed from documentation, not from a screen-reader session."
+    ]
+  },
+  "provenance": {
+    "generated_by": "research-dossier (dogfood fixture)",
+    "corpus_path": "session recon 2026-07-29"
+  }
+}

--- a/skills/research-dossier/examples/ir-valid.json
+++ b/skills/research-dossier/examples/ir-valid.json
@@ -1,0 +1,184 @@
+{
+  "schema_version": "1.0.0",
+  "question": "Which charting library should a zero-build, offline-first HTML dossier embed?",
+  "as_of": "2026-07-29",
+  "audience": "engineer",
+  "stakes": "low",
+  "title": "Chart library selection for offline single-file dossiers",
+  "summary": "Chart.js is the pick. It is the smallest library that still covers every form the dossier template needs, and its one real weakness — no native accessibility — is already closed by the mandatory table view. ECharts generates better ARIA descriptions but costs roughly five times the bytes for a benefit we get for free elsewhere.",
+
+  "entities": [
+    {"id": "chartjs", "label": "Chart.js", "url": "https://www.chartjs.org/"},
+    {"id": "echarts", "label": "Apache ECharts", "url": "https://echarts.apache.org/"},
+    {"id": "frappe", "label": "Frappe Charts", "url": "https://frappe.io/charts"}
+  ],
+
+  "claims": [
+    {
+      "id": "chartjs-size",
+      "text": "Chart.js UMD build is about 208 KB raw, roughly 68 KB gzipped.",
+      "source": {"label": "Chart.js dist inspection", "kind": "measurement", "accessed": "2026-07-29"},
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs",
+      "metric": {"name": "bundle_raw", "value": 208, "unit": "KB", "direction": "lower-better"}
+    },
+    {
+      "id": "echarts-size",
+      "text": "ECharts full build is about 1020 KB raw; a custom build trims it but requires a bundler, which the zero-build constraint rules out.",
+      "source": {"label": "ECharts dist inspection", "kind": "measurement", "accessed": "2026-07-29"},
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts",
+      "metric": {"name": "bundle_raw", "value": 1020, "unit": "KB", "direction": "lower-better"}
+    },
+    {
+      "id": "frappe-size",
+      "text": "Frappe Charts is about 69 KB raw — the smallest of the three.",
+      "source": {"label": "Frappe Charts dist inspection", "kind": "measurement", "accessed": "2026-07-29"},
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "frappe",
+      "metric": {"name": "bundle_raw", "value": 69, "unit": "KB", "direction": "lower-better"}
+    },
+    {
+      "id": "chartjs-a11y",
+      "text": "Chart.js renders to canvas and ships no native accessibility layer; its documentation directs authors to supply their own fallback content.",
+      "source": {"label": "Chart.js accessibility documentation", "kind": "doc", "url": "https://www.chartjs.org/docs/latest/general/accessibility.html", "accessed": "2026-07-29"},
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs"
+    },
+    {
+      "id": "echarts-a11y",
+      "text": "ECharts can generate ARIA descriptions from the series data when aria.enabled is set.",
+      "source": {"label": "ECharts aria option documentation", "kind": "doc", "url": "https://echarts.apache.org/en/option.html#aria", "accessed": "2026-07-29"},
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts"
+    },
+    {
+      "id": "frappe-forms",
+      "text": "Frappe Charts covers bar, line, and percentage forms but has no heatmap or scatter, both of which the dossier template requires.",
+      "source": {"label": "Frappe Charts feature docs", "kind": "doc", "url": "https://frappe.io/charts/docs", "accessed": "2026-07-29"},
+      "as_of": "2026-07-29",
+      "confidence": "medium",
+      "entity": "frappe"
+    },
+    {
+      "id": "table-view-closes-a11y",
+      "text": "The dossier template emits a <table> carrying the same numbers for every chart, which is the accessible rendering regardless of the library's own ARIA support.",
+      "source": {"label": "dossier.html template contract", "kind": "internal"},
+      "as_of": "2026-07-29",
+      "confidence": "high"
+    }
+  ],
+
+  "scorecard": {
+    "options": ["chartjs", "echarts", "frappe"],
+    "criteria": [
+      {"id": "size", "label": "Bundle (raw)", "unit": "KB", "direction": "lower-better", "weight": 3},
+      {"id": "forms", "label": "Covers required forms", "direction": "higher-better", "weight": 3},
+      {"id": "a11y", "label": "Native accessibility", "direction": "higher-better", "weight": 1}
+    ],
+    "cells": [
+      {"option": "chartjs", "criterion": "size", "value": 208, "display": "208 KB", "source_claims": ["chartjs-size"], "confidence": "high", "as_of": "2026-07-29"},
+      {"option": "echarts", "criterion": "size", "value": 1020, "display": "1020 KB", "source_claims": ["echarts-size"], "confidence": "high", "as_of": "2026-07-29"},
+      {"option": "frappe", "criterion": "size", "value": 69, "display": "69 KB", "source_claims": ["frappe-size"], "confidence": "high", "as_of": "2026-07-29"},
+      {"option": "frappe", "criterion": "forms", "value": false, "display": "no heatmap / scatter", "source_claims": ["frappe-forms"], "confidence": "medium"},
+      {"option": "chartjs", "criterion": "a11y", "value": false, "display": "none (docs-confirmed)", "source_claims": ["chartjs-a11y"], "confidence": "high"},
+      {"option": "echarts", "criterion": "a11y", "value": true, "display": "generated ARIA", "source_claims": ["echarts-a11y"], "confidence": "high"}
+    ],
+    "verdict": {
+      "winner": "chartjs",
+      "rationale": "Smallest library that still covers every required form; the accessibility hole is closed by the template's mandatory table view rather than by the library.",
+      "runner_up": "echarts",
+      "rejected_because": "Better generated ARIA, but roughly 5x the bytes for a benefit the table view already delivers."
+    }
+  },
+
+  "charts": [
+    {
+      "id": "bundle-size",
+      "form": "bar",
+      "title": "Bundle size, raw",
+      "subtitle": "Lower is better; zero-baseline preserved so the ratio reads honestly",
+      "source_claims": ["chartjs-size", "echarts-size", "frappe-size"],
+      "color_job": "categorical",
+      "axis": {"y_label": "KB (raw)", "y_min": 0},
+      "series": [
+        {
+          "label": "Bundle (raw KB)",
+          "data": [
+            {"x": "Frappe Charts", "y": 69, "claim": "frappe-size"},
+            {"x": "Chart.js", "y": 208, "claim": "chartjs-size"},
+            {"x": "Apache ECharts", "y": 1020, "claim": "echarts-size"}
+          ]
+        }
+      ],
+      "table_view": true
+    }
+  ],
+
+  "insights": [
+    {
+      "id": "smallest-is-not-cheapest",
+      "text": "The smallest library is not the cheapest choice: Frappe saves 139 KB but cannot draw two of the required forms, so adopting it means adding a second library and losing the saving.",
+      "source_claims": ["frappe-size", "frappe-forms", "chartjs-size"],
+      "confidence": "high"
+    }
+  ],
+
+  "risks": [
+    {
+      "id": "canvas-a11y",
+      "text": "A canvas-rendered chart is invisible to a screen reader without an explicit text equivalent.",
+      "severity": "serious",
+      "likelihood": "high",
+      "mitigation": "The template emits role=\"img\" plus aria-label plus a <table> with the same numbers for every chart; grep-verified in the test suite.",
+      "source_claims": ["chartjs-a11y", "table-view-closes-a11y"],
+      "confidence": "high"
+    }
+  ],
+
+  "recommendations": [
+    {
+      "id": "adopt-chartjs",
+      "text": "Inline Chart.js in the fallback template and keep the table view mandatory rather than optional.",
+      "owner": "dossier maintainer",
+      "eta": "immediate",
+      "priority": "P1",
+      "effort": "S",
+      "source_claims": ["chartjs-size", "chartjs-a11y", "table-view-closes-a11y"]
+    }
+  ],
+
+  "not_checked": [
+    {
+      "text": "Runtime rendering performance at high series counts.",
+      "reason": "Dossiers cap at eight series by design (the dataviz token ceiling), well below where any of the three degrades.",
+      "impact": "low"
+    },
+    {
+      "text": "Long-term maintenance health — release cadence, open-issue trend, bus factor.",
+      "reason": "Out of scope for a single-file embedding decision that is cheap to reverse.",
+      "impact": "low"
+    }
+  ],
+
+  "methodology": {
+    "approach": "Direct inspection of each library's distributed bundle plus a read of its published accessibility and feature documentation. No benchmarks were run; the decision turns on size, form coverage, and accessibility, all of which are observable without one.",
+    "sources_consulted": 6,
+    "window": {"from": "2026-07-29", "to": "2026-07-29"},
+    "tools": ["dist inspection", "vendor documentation"],
+    "limitations": [
+      "Sizes are raw dist bytes, not per-application tree-shaken output.",
+      "Accessibility assessed from documentation, not from a screen-reader session."
+    ]
+  },
+
+  "provenance": {
+    "generated_by": "research-dossier (dogfood fixture)",
+    "corpus_path": "session recon 2026-07-29"
+  }
+}

--- a/skills/research-dossier/examples/ir-wish-not-decision.json
+++ b/skills/research-dossier/examples/ir-wish-not-decision.json
@@ -1,0 +1,342 @@
+{
+  "schema_version": "1.0.0",
+  "question": "Which charting library should a zero-build, offline-first HTML dossier embed?",
+  "as_of": "2026-07-29",
+  "audience": "engineer",
+  "stakes": "low",
+  "title": "NEGATIVE FIXTURE — recommendation with no owner and no eta",
+  "summary": "Chart.js is the pick. It is the smallest library that still covers every form the dossier template needs, and its one real weakness — no native accessibility — is already closed by the mandatory table view. ECharts generates better ARIA descriptions but costs roughly five times the bytes for a benefit we get for free elsewhere.",
+  "entities": [
+    {
+      "id": "chartjs",
+      "label": "Chart.js",
+      "url": "https://www.chartjs.org/"
+    },
+    {
+      "id": "echarts",
+      "label": "Apache ECharts",
+      "url": "https://echarts.apache.org/"
+    },
+    {
+      "id": "frappe",
+      "label": "Frappe Charts",
+      "url": "https://frappe.io/charts"
+    }
+  ],
+  "claims": [
+    {
+      "id": "chartjs-size",
+      "text": "Chart.js UMD build is about 208 KB raw, roughly 68 KB gzipped.",
+      "source": {
+        "label": "Chart.js dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 208,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "echarts-size",
+      "text": "ECharts full build is about 1020 KB raw; a custom build trims it but requires a bundler, which the zero-build constraint rules out.",
+      "source": {
+        "label": "ECharts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 1020,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "frappe-size",
+      "text": "Frappe Charts is about 69 KB raw — the smallest of the three.",
+      "source": {
+        "label": "Frappe Charts dist inspection",
+        "kind": "measurement",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "frappe",
+      "metric": {
+        "name": "bundle_raw",
+        "value": 69,
+        "unit": "KB",
+        "direction": "lower-better"
+      }
+    },
+    {
+      "id": "chartjs-a11y",
+      "text": "Chart.js renders to canvas and ships no native accessibility layer; its documentation directs authors to supply their own fallback content.",
+      "source": {
+        "label": "Chart.js accessibility documentation",
+        "kind": "doc",
+        "url": "https://www.chartjs.org/docs/latest/general/accessibility.html",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "chartjs"
+    },
+    {
+      "id": "echarts-a11y",
+      "text": "ECharts can generate ARIA descriptions from the series data when aria.enabled is set.",
+      "source": {
+        "label": "ECharts aria option documentation",
+        "kind": "doc",
+        "url": "https://echarts.apache.org/en/option.html#aria",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high",
+      "entity": "echarts"
+    },
+    {
+      "id": "frappe-forms",
+      "text": "Frappe Charts covers bar, line, and percentage forms but has no heatmap or scatter, both of which the dossier template requires.",
+      "source": {
+        "label": "Frappe Charts feature docs",
+        "kind": "doc",
+        "url": "https://frappe.io/charts/docs",
+        "accessed": "2026-07-29"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "medium",
+      "entity": "frappe"
+    },
+    {
+      "id": "table-view-closes-a11y",
+      "text": "The dossier template emits a <table> carrying the same numbers for every chart, which is the accessible rendering regardless of the library's own ARIA support.",
+      "source": {
+        "label": "dossier.html template contract",
+        "kind": "internal"
+      },
+      "as_of": "2026-07-29",
+      "confidence": "high"
+    }
+  ],
+  "scorecard": {
+    "options": [
+      "chartjs",
+      "echarts",
+      "frappe"
+    ],
+    "criteria": [
+      {
+        "id": "size",
+        "label": "Bundle (raw)",
+        "unit": "KB",
+        "direction": "lower-better",
+        "weight": 3
+      },
+      {
+        "id": "forms",
+        "label": "Covers required forms",
+        "direction": "higher-better",
+        "weight": 3
+      },
+      {
+        "id": "a11y",
+        "label": "Native accessibility",
+        "direction": "higher-better",
+        "weight": 1
+      }
+    ],
+    "cells": [
+      {
+        "option": "chartjs",
+        "criterion": "size",
+        "value": 208,
+        "display": "208 KB",
+        "source_claims": [
+          "chartjs-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "echarts",
+        "criterion": "size",
+        "value": 1020,
+        "display": "1020 KB",
+        "source_claims": [
+          "echarts-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "size",
+        "value": 69,
+        "display": "69 KB",
+        "source_claims": [
+          "frappe-size"
+        ],
+        "confidence": "high",
+        "as_of": "2026-07-29"
+      },
+      {
+        "option": "frappe",
+        "criterion": "forms",
+        "value": false,
+        "display": "no heatmap / scatter",
+        "source_claims": [
+          "frappe-forms"
+        ],
+        "confidence": "medium"
+      },
+      {
+        "option": "chartjs",
+        "criterion": "a11y",
+        "value": false,
+        "display": "none (docs-confirmed)",
+        "source_claims": [
+          "chartjs-a11y"
+        ],
+        "confidence": "high"
+      },
+      {
+        "option": "echarts",
+        "criterion": "a11y",
+        "value": true,
+        "display": "generated ARIA",
+        "source_claims": [
+          "echarts-a11y"
+        ],
+        "confidence": "high"
+      }
+    ],
+    "verdict": {
+      "winner": "chartjs",
+      "rationale": "Smallest library that still covers every required form; the accessibility hole is closed by the template's mandatory table view rather than by the library.",
+      "runner_up": "echarts",
+      "rejected_because": "Better generated ARIA, but roughly 5x the bytes for a benefit the table view already delivers."
+    }
+  },
+  "charts": [
+    {
+      "id": "bundle-size",
+      "form": "bar",
+      "title": "Bundle size, raw",
+      "subtitle": "Lower is better; zero-baseline preserved so the ratio reads honestly",
+      "source_claims": [
+        "chartjs-size",
+        "echarts-size",
+        "frappe-size"
+      ],
+      "color_job": "categorical",
+      "axis": {
+        "y_label": "KB (raw)",
+        "y_min": 0
+      },
+      "series": [
+        {
+          "label": "Bundle (raw KB)",
+          "data": [
+            {
+              "x": "Frappe Charts",
+              "y": 69,
+              "claim": "frappe-size"
+            },
+            {
+              "x": "Chart.js",
+              "y": 208,
+              "claim": "chartjs-size"
+            },
+            {
+              "x": "Apache ECharts",
+              "y": 1020,
+              "claim": "echarts-size"
+            }
+          ]
+        }
+      ],
+      "table_view": true
+    }
+  ],
+  "insights": [
+    {
+      "id": "smallest-is-not-cheapest",
+      "text": "The smallest library is not the cheapest choice: Frappe saves 139 KB but cannot draw two of the required forms, so adopting it means adding a second library and losing the saving.",
+      "source_claims": [
+        "frappe-size",
+        "frappe-forms",
+        "chartjs-size"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "risks": [
+    {
+      "id": "canvas-a11y",
+      "text": "A canvas-rendered chart is invisible to a screen reader without an explicit text equivalent.",
+      "severity": "serious",
+      "likelihood": "high",
+      "mitigation": "The template emits role=\"img\" plus aria-label plus a <table> with the same numbers for every chart; grep-verified in the test suite.",
+      "source_claims": [
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ],
+      "confidence": "high"
+    }
+  ],
+  "recommendations": [
+    {
+      "id": "adopt-chartjs",
+      "text": "Inline Chart.js in the fallback template and keep the table view mandatory rather than optional.",
+      "priority": "P1",
+      "effort": "S",
+      "source_claims": [
+        "chartjs-size",
+        "chartjs-a11y",
+        "table-view-closes-a11y"
+      ]
+    }
+  ],
+  "not_checked": [
+    {
+      "text": "Runtime rendering performance at high series counts.",
+      "reason": "Dossiers cap at eight series by design (the dataviz token ceiling), well below where any of the three degrades.",
+      "impact": "low"
+    },
+    {
+      "text": "Long-term maintenance health — release cadence, open-issue trend, bus factor.",
+      "reason": "Out of scope for a single-file embedding decision that is cheap to reverse.",
+      "impact": "low"
+    }
+  ],
+  "methodology": {
+    "approach": "Direct inspection of each library's distributed bundle plus a read of its published accessibility and feature documentation. No benchmarks were run; the decision turns on size, form coverage, and accessibility, all of which are observable without one.",
+    "sources_consulted": 6,
+    "window": {
+      "from": "2026-07-29",
+      "to": "2026-07-29"
+    },
+    "tools": [
+      "dist inspection",
+      "vendor documentation"
+    ],
+    "limitations": [
+      "Sizes are raw dist bytes, not per-application tree-shaken output.",
+      "Accessibility assessed from documentation, not from a screen-reader session."
+    ]
+  },
+  "provenance": {
+    "generated_by": "research-dossier (dogfood fixture)",
+    "corpus_path": "session recon 2026-07-29"
+  }
+}

--- a/skills/research-dossier/references/audience-map.md
+++ b/skills/research-dossier/references/audience-map.md
@@ -1,0 +1,97 @@
+# Audience → design system → the parameters `dataviz` consumes
+
+`--audience` used to stop at lens selection: it changed how prose was written and
+nothing else. Every dossier then rendered with the same density, the same chart
+count, and the same palette regardless of who opened it. This file is the missing
+half of that flag.
+
+The chain is: **audience → design system → the eight parameters the `dataviz`
+method consumes.** `dataviz` is design-system-agnostic by construction — it takes
+those parameters and leaves the method untouched — so pointing a different system
+at it is a substitution, never a fork.
+
+## The eight parameters
+
+Straight from `dataviz`'s own plug-in contract. A design system supplies these; the
+procedure, the form heuristic, the six checks, and the mark specs do not change.
+
+| # | Parameter | What it supplies |
+|---|---|---|
+| 1 | **Ramps** | the hue scales the palette draws from |
+| 2 | **Categorical theme** | the fixed hue order (never cycled) |
+| 3 | **Sequential hue** | the default single hue for magnitude |
+| 4 | **Diverging pair** | two warm/cool poles + a neutral midpoint |
+| 5 | **Status palette** | good / warning / serious / critical, distinct from categorical |
+| 6 | **Texture fill** | one directional fill at 45°/135°, for CVD / print / forced-colors |
+| 7 | **Surfaces** | light and dark chart-surface colors — the validator needs both |
+| 8 | **Filter controls** | date-range and dimension controls |
+
+## The map
+
+`design_system` names an `open-design` system when the `od` daemon is available.
+When it is not, the built-in fallback template applies the same *density* and
+*emphasis* decisions with the reference palette — so the audience still changes the
+output, just with fewer typographic options.
+
+| Audience | Design system | Density | Charts | Emphasis |
+|---|---|---|---|---|
+| `exec` | `publication` | low — one idea per screen | ≤3, each answering one question | hero figure + verdict; evidence collapsed |
+| `engineer` | `mission-control` | high — comfortable with detail | as many as the data earns | tables expanded, full evidence visible |
+| `team` | `dashboard` | medium | ≤5 | recommendations with owner + eta foregrounded |
+| `client` | `publication` | low, generous whitespace | ≤3, heavily labelled | verdict and methodology; `not_checked[]` prominent |
+| `public` | `publication` | low | ≤2, self-explanatory | no jargon; every abbreviation expanded on first use |
+
+### Density is a real parameter, not a mood
+
+It changes three concrete things: how many charts survive into the render, whether
+the evidence table starts expanded or collapsed, and whether a chart under ~4 data
+points is demoted to a stat tile. That last one comes straight from `dataviz`'s
+"is it even a chart?" table — three numbers are a KPI row, not a bar chart, and an
+exec dossier is exactly where that mistake gets made.
+
+## What audience does NOT change
+
+This is the important half.
+
+**The claims. The scorecard cells. The `not_checked[]` list. The gates.**
+
+An exec dossier and an engineer dossier built from the same IR contain the same
+evidence and pass the same two gates. Audience selects **presentation** — how much
+is on screen at once, which design system's parameters are loaded, what is
+collapsed by default. It never selects **content**.
+
+The failure this rules out: quietly dropping `not_checked[]` or the contested-claim
+markers for an executive audience because they "clutter the story." That is the
+strongest reason to keep an audience map explicit rather than leaving it to per-render
+judgement — the temptation is real, it always argues from good taste, and the person
+with the least context gets the least-qualified version of the truth.
+
+`stakes: high` overrides density downward everywhere: gaps and `not_checked[]` are
+expanded regardless of audience.
+
+## Palette resolution
+
+1. `ir.theme.palette` if the author set it explicitly.
+2. Otherwise the design system's categorical order for the audience.
+3. Otherwise the `dataviz` reference palette (blue → orange → aqua).
+
+Whichever path resolves, **gate 2 validates the result in both modes** before
+anything renders. There is no path to output that skips it.
+
+Two constraints inherited from `dataviz` and worth restating because they bite here:
+
+- **Three slots for all-pairs forms.** The reference palette's first three slots
+  validate under `--pairs all` (scatter, bubble, choropleth, small multiples). The
+  fourth puts yellow next to orange, which fails the all-pairs floors. Past three,
+  fold into "Other" or facet — never generate a ninth hue.
+- **The relief rule.** Three light-mode slots sit below 3:1 against the light
+  surface. That is a WARN, not a failure, and it is discharged by visible direct
+  labels or a table view. The fallback template ships both, so the warning is
+  answered by construction rather than dismissed.
+
+## Refs
+
+- Parameter contract + the non-negotiables: the bundled `dataviz` skill
+  (`SKILL.md`, `references/palette.md`, `references/choosing-a-form.md`)
+- Validation: `bin/research-dossier-render.mjs` gate 2 → `validate_palette.js`
+- Systems: the `open-design` marketplace (~150 design systems, ~110 templates)

--- a/skills/research-dossier/references/audience-map.md
+++ b/skills/research-dossier/references/audience-map.md
@@ -43,11 +43,21 @@ output, just with fewer typographic options.
 
 ### Density is a real parameter, not a mood
 
-It changes three concrete things: how many charts survive into the render, whether
-the evidence table starts expanded or collapsed, and whether a chart under ~4 data
-points is demoted to a stat tile. That last one comes straight from `dataviz`'s
-"is it even a chart?" table — three numbers are a KPI row, not a bar chart, and an
-exec dossier is exactly where that mistake gets made.
+Two things are **implemented in the renderer** today (`DENSITY` in
+`bin/research-dossier-render.mjs`, covered by `bin/tests/research-dossier.test.sh`):
+
+| Effect | Behaviour |
+|---|---|
+| **Chart cap** | charts beyond the audience's cap are not rendered — and the omission is **disclosed** on the page ("N further charts omitted at … density"). An omission the reader cannot see is an edit, not a summary. |
+| **Evidence table default** | `<details open>` for `engineer`, collapsed elsewhere. Collapsed is still reachable with JS off — `<details>` is a native element, so the evidence is never script-gated. |
+
+`stakes: high` overrides the collapse: evidence re-expands at every audience.
+
+**Not yet implemented:** demoting a chart under ~4 data points to a stat tile.
+That one comes straight from `dataviz`'s "is it even a chart?" table — three
+numbers are a KPI row, not a bar chart, and an exec dossier is exactly where that
+mistake gets made. It is listed here as a gap rather than described as behaviour,
+because a documented-but-inert parameter is the theater the gates exist to prevent.
 
 ## What audience does NOT change
 

--- a/skills/research-dossier/references/scorecard.md
+++ b/skills/research-dossier/references/scorecard.md
@@ -1,0 +1,143 @@
+# The scorecard — comparison with evidence per cell
+
+The shape lives in `templates/ir.schema.json` (`$defs.scorecard`). This file is the
+discipline: how to build one that survives a reader who disagrees with its verdict.
+
+A scorecard is **N options × M criteria**, where every cell carries its own value,
+evidence, confidence and date. That per-cell provenance is the whole point. A
+comparison table where the numbers float free of their sources is a conclusion
+wearing the costume of an analysis.
+
+## The unit is the cell, not the row
+
+Most comparison tables are authored row-by-row — "let me describe tool A" — which
+produces cells written to be consistent with each other rather than with the evidence.
+Author **cell-by-cell instead**: pick a criterion, gather what each option actually
+measured on it, and let the row be whatever falls out.
+
+Each cell needs five things (all required by the schema):
+
+| Field | Why it's mandatory |
+|---|---|
+| `option` + `criterion` | the coordinate |
+| `value` | number, string, or boolean — whatever the evidence supports |
+| `source_claims` | resolves to real `claims[]` ids; the gate fails on a dangling one |
+| `confidence` | `high` / `medium` / `low` — how much you'd bet on THIS cell |
+
+`display` is optional and worth using whenever the raw value reads badly (`208` →
+`"208 KB"`). `as_of` per cell matters when the options were measured at different
+times — a bundle size from 2024 next to one from 2026 is not a comparison.
+
+## Sparse is honest; complete is often fabricated
+
+The schema does not require a cell for every (option, criterion) pair, and you should
+not force one. A missing cell renders as an explicit gap. A cell invented to fill the
+grid renders as evidence.
+
+The pressure to complete the matrix is real and worth naming: a table with holes
+*looks* like sloppy work, so authors fill them by inference, and inference in a cell
+is indistinguishable from measurement once it's in the grid. Leave the hole. If the
+hole matters, it belongs in `not_checked[]` with a reason.
+
+## Weights are declared or they are smuggled
+
+`criteria[].weight` is optional; omitted means equal. Whichever you choose, the reader
+sees it.
+
+This is the load-bearing rule of the whole primitive. An unweighted scorecard where
+one criterion has eight sub-criteria and another has one is weighted — just
+invisibly, by row count. If bundle size matters three times as much as star count for
+this decision, say `weight: 3`, and let someone argue with the 3 instead of trying to
+reverse-engineer it from the verdict.
+
+**Set weights before filling cells.** Weighting after you've seen the numbers is how a
+scorecard gets tuned until it agrees with the conclusion you already had.
+
+## Direction, so you don't pre-invert
+
+`direction` (`higher-better` / `lower-better` / `neutral`) lives on the criterion and
+on `claim.metric`. Declare it and store the raw number. Do not helpfully flip a
+lower-is-better metric so the aggregation works — the raw value is what the source
+said, and a reader checking your work needs to find that number, not its complement.
+
+`neutral` is for criteria where more is not better in any direction (license type,
+rendering technology) — these are compared, not ranked.
+
+## The verdict states itself
+
+`verdict.winner` + `rationale` + `runner_up` + `rejected_because`.
+
+Naming the runner-up and *why it lost* is what distinguishes a decision from an
+endorsement. It's also the field that ages best: six months later, when the winner
+disappoints, the runner-up entry is the first thing anyone will want.
+
+If the scorecard does not support a clean winner, say that in `rationale` rather than
+manufacturing one. "Two options are within noise on the criteria that matter; the
+tiebreaker is outside this comparison" is a legitimate verdict.
+
+## Rendering
+
+The renderer emits a scorecard as a **table plus, optionally, a heatmap**. Both, not
+either — per the `dataviz` form guidance, more than ~7 classes that all carry meaning
+belong in a table, and a comparison grid is exactly that case.
+
+Cell **confidence is encoded separately from value** — never by fading the value's
+color. Muting a low-confidence number makes it look like a small number. Use the
+confidence column, a marker, or a second heatmap layer.
+
+Color follows the **entity**, not the rank (a `dataviz` non-negotiable). If a filter
+drops an option, the survivors keep their colors.
+
+## Anti-patterns
+
+- **Filling the grid by inference** — the failure this format is built against.
+- **Weighting after seeing the numbers** — tuning to a predetermined answer.
+- **Pre-inverting `lower-better` values** — destroys the reader's ability to verify.
+- **Confidence-as-opacity** — reads as magnitude, not certainty.
+- **A verdict with no runner-up** — an endorsement, not a decision.
+- **Uniform `high` confidence across every cell** — near-certainly unexamined; the
+  provenance gate warns on it, because a real comparison has softer and harder cells.
+- **Options that aren't comparable** — three libraries and a managed service on one
+  grid produces cells that don't mean the same thing across a row.
+
+## Worked shape
+
+```jsonc
+{
+  "options": ["chartjs", "echarts", "frappe"],
+  "criteria": [
+    {"id": "size",  "label": "Bundle (raw)", "unit": "KB", "direction": "lower-better", "weight": 3},
+    {"id": "a11y",  "label": "Native a11y",  "direction": "higher-better", "weight": 2},
+    {"id": "print", "label": "Print/export", "direction": "higher-better"}
+  ],
+  "cells": [
+    {
+      "option": "chartjs", "criterion": "size", "value": 208, "display": "208 KB",
+      "source_claims": ["chartjs-bundle-size"], "confidence": "high", "as_of": "2026-07-29"
+    },
+    {
+      "option": "chartjs", "criterion": "a11y", "value": false, "display": "none (docs-confirmed)",
+      "source_claims": ["chartjs-no-native-a11y"], "confidence": "high"
+    }
+    // 'print' for chartjs deliberately absent — not measured; see not_checked[]
+  ],
+  "verdict": {
+    "winner": "chartjs",
+    "rationale": "Smallest that still covers every required form; the a11y hole is closed by the mandatory table view.",
+    "runner_up": "echarts",
+    "rejected_because": "Generated ARIA descriptions are better, but the bundle cost is not justified when the table view already delivers accessibility."
+  }
+}
+```
+
+Note what that fragment does: it leaves a cell out rather than guessing, it stores
+`208` with `lower-better` rather than inverting it, it says why the runner-up lost,
+and the verdict's rationale is checkable against the cells above it.
+
+## Refs
+
+- Shape: `templates/ir.schema.json` `$defs.scorecard`
+- Form/color authority: the bundled `dataviz` skill —
+  `references/choosing-a-form.md` (table vs chart), `references/color-formula.md`
+- Gate: `bin/research-dossier-render.mjs` (provenance) — dangling `source_claims`,
+  weight/direction sanity, uniform-confidence warning

--- a/skills/research-dossier/templates/dossier.html
+++ b/skills/research-dossier/templates/dossier.html
@@ -142,6 +142,9 @@
   .notchecked { border-left: 3px solid var(--warning); }
   footer.foot { margin-top: 44px; padding-top: 18px; border-top: 1px solid var(--grid);
                 color: var(--muted); font-size: 12px; }
+  /* Emitter signature: recessive, but present in print — the provenance is part of
+     the artifact, not chrome, so a printed copy must still say what produced it. */
+  .prov { display: inline-block; margin-top: 8px; font-size: 11px; letter-spacing: .02em; opacity: .85; }
   a { color: inherit; }
 
   @media (prefers-reduced-motion: reduce) {
@@ -180,6 +183,13 @@
   var stored = null;
   try { stored = localStorage.getItem("rd-theme"); } catch (e) { /* private mode */ }
   if (stored === "light" || stored === "dark") root.setAttribute("data-theme", stored);
+  // Announce the CURRENT state at reveal, not just after the first click. The button
+  // is hidden until JS runs, so this is the first moment it exists for assistive
+  // tech — shipping it unset (or false while the page is dark) makes it lie exactly
+  // to the users who cannot see the contradiction.
+  var effective = root.getAttribute("data-theme")
+    || (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+  btn.setAttribute("aria-pressed", String(effective === "dark"));
   btn.style.display = "inline-block";
   btn.addEventListener("click", function () {
     var t = root.getAttribute("data-theme"), dark;

--- a/skills/research-dossier/templates/dossier.html
+++ b/skills/research-dossier/templates/dossier.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<!--
+  research-dossier · fallback template (shell)
+
+  The LAST resort, not the flagship: with the open-design daemon present the renderer
+  uses one of its ~110 templates instead. This exists so the skill degrades to
+  something honest rather than to nothing.
+
+  Design decision that drives everything below: the BODY IS SERVER-RENDERED by
+  bin/research-dossier-render.mjs. JavaScript is a progressive enhancement for the
+  theme toggle alone. With JS disabled the full dossier — every table, chart, and
+  citation — is still there. An archival decision artifact that needs a script to
+  show its evidence is not archival.
+
+  That is only affordable because theming is PURE CSS: the validated palette is
+  injected as --series-N custom properties under both the light and dark scopes,
+  and the SVG marks reference them via fill="var(--series-N)". Switching theme
+  recolors the charts with no redraw and no script.
+
+  Non-negotiables, all grep-verifiable on the OUTPUT:
+    · zero network — no CDN, no font fetch, no analytics. Opens over file://.
+    · charts are inline SVG built by the renderer; nothing to inline, no canvas.
+    · every chart: role="img" + aria-label + a real <table> of the same numbers.
+      Per dataviz, the table IS the accessible rendering, not a courtesy.
+    · colors come only from the palette the gate already validated in both modes.
+    · dark mode is selected, not flipped — own steps, OS query + data-theme toggle,
+      toggle winning both ways.
+    · @media print and prefers-reduced-motion present.
+
+  Substitution slots are written as double-underscored tokens in the markup below
+  (title, lang, the two palette-var blocks, the body comment, the IR-JSON comment).
+  They are deliberately NOT spelled out literally in this comment: string
+  replacement takes the FIRST match, so a doc line naming them would consume the
+  substitution and leave the real slot unfilled — a failure that renders as a
+  plausible-looking page. The renderer replaces globally and then asserts that no
+  slot survives.
+-->
+<html lang="__LANG__" data-theme="auto">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>__TITLE__</title>
+<style>
+  :root {
+    color-scheme: light;
+    --surface-1: #fcfcfb;
+    --page: #f9f9f7;
+    --text-primary: #0b0b0b;
+    --text-secondary: #52514e;
+    --muted: #898781;
+    --grid: #e1e0d9;
+    --baseline: #c3c2b7;
+    --border: rgba(11,11,11,0.10);
+    --good: #0ca30c; --warning: #fab219; --serious: #ec835a; --critical: #d03b3b;
+    --success-text: #006300;
+    /*__PALETTE_VARS_LIGHT__*/
+  }
+  @media (prefers-color-scheme: dark) {
+    :root:where(:not([data-theme="light"])) {
+      color-scheme: dark;
+      --surface-1: #1a1a19; --page: #0d0d0d;
+      --text-primary: #ffffff; --text-secondary: #c3c2b7; --muted: #898781;
+      --grid: #2c2c2a; --baseline: #383835;
+      --border: rgba(255,255,255,0.10);
+      --success-text: #0ca30c;
+      /*__PALETTE_VARS_DARK__*/
+    }
+  }
+  :root[data-theme="dark"] {
+    color-scheme: dark;
+    --surface-1: #1a1a19; --page: #0d0d0d;
+    --text-primary: #ffffff; --text-secondary: #c3c2b7; --muted: #898781;
+    --grid: #2c2c2a; --baseline: #383835;
+    --border: rgba(255,255,255,0.10);
+    --success-text: #0ca30c;
+    /*__PALETTE_VARS_DARK__*/
+  }
+
+  *, *::before, *::after { box-sizing: border-box; }
+  body {
+    margin: 0; padding: 0;
+    background: var(--page); color: var(--text-primary);
+    font: 15px/1.55 system-ui, -apple-system, "Segoe UI", sans-serif;
+  }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 32px 20px 72px; }
+  header.head { display: flex; justify-content: space-between; align-items: flex-start; gap: 24px; margin-bottom: 8px; }
+  h1 { font-size: 26px; line-height: 1.25; margin: 0 0 4px; font-weight: 650; }
+  .meta { color: var(--text-secondary); font-size: 13px; }
+  .meta b { color: var(--text-primary); font-weight: 600; }
+
+  /* Hidden until the enhancement runs — a dead button is worse than none. */
+  button.theme {
+    display: none;
+    border: 1px solid var(--border); background: var(--surface-1); color: var(--text-secondary);
+    border-radius: 8px; padding: 6px 12px; font: inherit; font-size: 13px; cursor: pointer; white-space: nowrap;
+  }
+  button.theme:hover { color: var(--text-primary); }
+  button.theme:focus-visible { outline: 2px solid var(--series-1); outline-offset: 2px; }
+
+  section { margin-top: 34px; }
+  h2 { font-size: 13px; text-transform: uppercase; letter-spacing: 0.07em; color: var(--muted);
+       margin: 0 0 12px; font-weight: 650; }
+  .card { background: var(--surface-1); border: 1px solid var(--border); border-radius: 12px; padding: 20px 22px; }
+  .card + .card { margin-top: 16px; }
+  .lede { font-size: 16px; line-height: 1.6; margin: 0; }
+
+  table { width: 100%; border-collapse: collapse; font-size: 14px; }
+  th, td { text-align: left; padding: 9px 12px; border-bottom: 1px solid var(--grid); vertical-align: top; }
+  th { color: var(--text-secondary); font-weight: 600; font-size: 12.5px; }
+  td.num, th.num { text-align: right; font-variant-numeric: tabular-nums; }
+  tbody tr:last-child td, tbody tr:last-child th { border-bottom: none; }
+  caption { caption-side: top; text-align: left; color: var(--muted); font-size: 12.5px; padding: 0 0 8px; }
+  code.cid { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; white-space: nowrap; }
+
+  ul.items { list-style: none; margin: 0; padding: 0; }
+  ul.items li { padding: 11px 0; border-bottom: 1px solid var(--grid); }
+  ul.items li:last-child { border-bottom: none; }
+
+  .tag { display: inline-block; font-size: 11px; font-weight: 650; letter-spacing: 0.04em;
+         text-transform: uppercase; padding: 2px 7px; border-radius: 5px; margin-right: 8px;
+         border: 1px solid var(--border); color: var(--text-secondary); white-space: nowrap; }
+  /* Status always ships icon + label — never colour alone (dataviz non-negotiable). */
+  .st-good { color: var(--good); } .st-warning { color: var(--warning); }
+  .st-serious { color: var(--serious); } .st-critical { color: var(--critical); }
+
+  .cite { font-size: 11px; color: var(--muted); text-decoration: none; vertical-align: super; margin-left: 2px; }
+  .cite:hover, .cite:focus-visible { color: var(--text-primary); text-decoration: underline; }
+  .conf { font-size: 11px; color: var(--muted); margin-left: 6px; white-space: nowrap; }
+  .nomeasure { font-size: 12px; color: var(--muted); font-style: italic; }
+
+  figure.chart { margin: 0; }
+  figure.chart figcaption { font-size: 13px; color: var(--text-secondary); margin-bottom: 14px; }
+  .bar-label { font-size: 12.5px; fill: var(--text-secondary); }
+  .bar-value { font-size: 12.5px; fill: var(--text-primary); font-weight: 600; }
+  .axis-note { font-size: 12px; color: var(--critical); font-weight: 600; margin-top: 10px; }
+  .chart-title { margin: 0 0 4px; font-weight: 650; }
+
+  details.tableview { margin-top: 16px; }
+  details.tableview summary { cursor: pointer; color: var(--text-secondary); font-size: 13px; padding: 4px 0; }
+  details.tableview summary:focus-visible { outline: 2px solid var(--series-1); outline-offset: 2px; }
+
+  .notchecked { border-left: 3px solid var(--warning); }
+  footer.foot { margin-top: 44px; padding-top: 18px; border-top: 1px solid var(--grid);
+                color: var(--muted); font-size: 12px; }
+  a { color: inherit; }
+
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important;
+                             transition-duration: 0.01ms !important; scroll-behavior: auto !important; }
+  }
+  @media print {
+    :root { color-scheme: light; }
+    body { background: #fff; }
+    .wrap { max-width: none; padding: 0; }
+    button.theme { display: none !important; }
+    .card { border: 1px solid #ccc; break-inside: avoid; }
+    section { break-inside: avoid; }
+    /* Tables must print even when collapsed on screen. */
+    details.tableview summary { display: none; }
+    details.tableview > *:not(summary) { display: block !important; }
+    a[href^="http"]::after { content: " (" attr(href) ")"; font-size: 10px; color: #666; }
+  }
+</style>
+</head>
+<body>
+<div class="wrap"><!--__BODY__--></div>
+
+<!-- The full IR, embedded. No fetch, no network, no build step. Machine-readable
+     companion to the human rendering above — same data, same provenance. -->
+<script type="application/json" id="dossier-data"><!--__IR_JSON__--></script>
+
+<script>
+/* Progressive enhancement, and only that: reveal the theme toggle and remember the
+   choice. Every byte of content above already rendered without this running.
+   Theme switching is pure CSS (--series-N under both scopes), so there is no redraw. */
+(function () {
+  "use strict";
+  var root = document.documentElement, btn = document.getElementById("theme-toggle");
+  if (!btn) return;
+  var stored = null;
+  try { stored = localStorage.getItem("rd-theme"); } catch (e) { /* private mode */ }
+  if (stored === "light" || stored === "dark") root.setAttribute("data-theme", stored);
+  btn.style.display = "inline-block";
+  btn.addEventListener("click", function () {
+    var t = root.getAttribute("data-theme"), dark;
+    if (t === "dark") dark = true;
+    else if (t === "light") dark = false;
+    else dark = !!(window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches);
+    var next = dark ? "light" : "dark";
+    root.setAttribute("data-theme", next);
+    btn.setAttribute("aria-pressed", String(next === "dark"));
+    try { localStorage.setItem("rd-theme", next); } catch (e) {}
+  });
+})();
+</script>
+</body>
+</html>

--- a/skills/research-dossier/templates/ir.schema.json
+++ b/skills/research-dossier/templates/ir.schema.json
@@ -376,7 +376,12 @@
             "winner": {"$ref": "#/$defs/id"},
             "rationale": {"type": "string"},
             "runner_up": {"$ref": "#/$defs/id"},
-            "rejected_because": {"type": "string"}
+            "rejected_because": {"type": "string"},
+            "override_rationale": {
+              "type": "string",
+              "minLength": 20,
+              "description": "Declares a judgement that deliberately overrides the weighted arithmetic, and satisfies VERDICT_UNSUPPORTED. A verdict may depart from its own grid — an incommensurable factor, a strategic constraint, a veto the criteria do not model — but only in writing. The cost is the disclosure: the reader sees that the decision was made outside the numbers, which is honest, rather than finding a grid quietly bent to fit it."
+            }
           }
         }
       }
@@ -454,6 +459,21 @@
           "type": "boolean",
           "default": true,
           "description": "Emit an accessible <table> carrying the same numbers. Default true and rarely worth disabling: Chart.js has no native accessibility, so the table IS the accessible rendering, not a courtesy."
+        },
+        "transform": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Declares a deterministic conversion between a cited claim's metric.value and the value plotted, so CHART_POINT_VALUE_MISMATCH can tell a unit conversion apart from a contradiction. A chart plotting 0.208 against a claim of 208 KB is honest at scale 0.001 and a lie at scale 1 — and the gate cannot know which without being told.",
+          "properties": {
+            "scale": {
+              "type": "number",
+              "description": "Multiplier applied to metric.value to obtain the plotted y (208 KB → 0.208 MB is scale 0.001). Must be exact: the gate compares within floating-point epsilon, not a tolerance band, because an approximate scale is indistinguishable from a small fabrication."
+            },
+            "unit": {
+              "type": "string",
+              "description": "The unit the plotted values are in after scaling — what the axis label should say."
+            }
+          }
         }
       }
     }

--- a/skills/research-dossier/templates/ir.schema.json
+++ b/skills/research-dossier/templates/ir.schema.json
@@ -1,0 +1,461 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://multi-agent-os/skills/research-dossier/ir.schema.json",
+  "title": "research-dossier IR",
+  "description": "The intermediate representation between finished research and every renderer. The LLM authors this from a prose corpus; bin/research-dossier-render.mjs consumes it and never mutates it. Shape is enforced here; the referential and semantic rules a schema cannot express (source_claims resolve to real claim ids, truncated axes are declared, confidence is not asserted without a source) are enforced by the provenance gate in the renderer. Both must pass.",
+  "type": "object",
+  "required": ["question", "as_of", "audience", "claims", "not_checked", "methodology"],
+  "additionalProperties": false,
+
+  "properties": {
+    "schema_version": {
+      "type": "string",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "SemVer of THIS contract, so a stored IR outlives the renderer that wrote it. Absent is treated as 1.0.0."
+    },
+
+    "question": {
+      "type": "string",
+      "minLength": 8,
+      "description": "The one question this dossier answers. Not a topic — a question. 'Which chart library should we adopt?' not 'chart libraries'. A dossier that cannot state its question has no criterion for what belongs in it."
+    },
+
+    "as_of": {
+      "$ref": "#/$defs/date",
+      "description": "The date the corpus was current. Dossier-level; individual claims may be older (see claim.as_of) but never newer."
+    },
+
+    "audience": {
+      "enum": ["exec", "engineer", "team", "client", "public"],
+      "description": "Drives design-system selection and density (see references/audience-map.md). NOT cosmetic: it changes which parameters reach dataviz."
+    },
+
+    "stakes": {
+      "enum": ["low", "high"],
+      "default": "low",
+      "description": "high tightens the gate: every claim must be confidence>=medium OR explicitly flagged in not_checked."
+    },
+
+    "title": {
+      "type": "string",
+      "description": "Optional display title. Defaults to question."
+    },
+
+    "summary": {
+      "type": "string",
+      "description": "Executive summary prose. Every factual assertion here SHOULD trace to a claim; the gate warns on numerals present in summary but absent from any claim."
+    },
+
+    "entities": {
+      "type": "array",
+      "description": "The things being described or compared — tools, vendors, cohorts, periods. Chart series and scorecard options reference these by id, so color follows the ENTITY and never its rank (dataviz non-negotiable).",
+      "items": {
+        "type": "object",
+        "required": ["id", "label"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {"$ref": "#/$defs/id"},
+          "label": {"type": "string", "minLength": 1},
+          "url": {"type": "string", "format": "uri"},
+          "note": {"type": "string"}
+        }
+      }
+    },
+
+    "claims": {
+      "type": "array",
+      "minItems": 1,
+      "description": "The atomic evidential units. EVERYTHING downstream — charts, scorecard cells, recommendations — cites these by id. A number that appears in a chart but in no claim is unsourced by construction, which is exactly what the provenance gate exists to catch.",
+      "items": {"$ref": "#/$defs/claim"}
+    },
+
+    "scorecard": {
+      "$ref": "#/$defs/scorecard",
+      "description": "Present only for comparisons. See references/scorecard.md."
+    },
+
+    "charts": {
+      "type": "array",
+      "description": "Chart SPECIFICATIONS, not rendered charts. Form and color follow the bundled dataviz skill (cited, never copied): pick the form from the data's job, assign color by job, validate the palette by running the script.",
+      "items": {"$ref": "#/$defs/chart"}
+    },
+
+    "insights": {
+      "type": "array",
+      "description": "What the evidence means. Distinct from claims (what the evidence IS) — an insight is an interpretation and must cite the claims it rests on.",
+      "items": {"$ref": "#/$defs/derived"}
+    },
+
+    "gaps": {
+      "type": "array",
+      "description": "Known holes in the evidence — a question the corpus raised but did not answer. Distinct from not_checked (what was never looked at).",
+      "items": {"$ref": "#/$defs/derived"}
+    },
+
+    "risks": {
+      "type": "array",
+      "items": {
+        "allOf": [
+          {"$ref": "#/$defs/derived"},
+          {
+            "type": "object",
+            "properties": {
+              "severity": {"enum": ["good", "warning", "serious", "critical"]},
+              "likelihood": {"enum": ["low", "medium", "high"]},
+              "mitigation": {"type": "string"}
+            }
+          }
+        ],
+        "description": "severity maps to the dataviz status palette, which always ships icon + label — a status color never carries meaning alone."
+      }
+    },
+
+    "opportunities": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/derived"}
+    },
+
+    "recommendations": {
+      "type": "array",
+      "description": "The actionable output. owner and eta are REQUIRED: a recommendation with no owner and no date is a wish, and this format refuses to render wishes as decisions.",
+      "items": {
+        "type": "object",
+        "required": ["text", "owner", "eta", "source_claims"],
+        "additionalProperties": false,
+        "properties": {
+          "id": {"$ref": "#/$defs/id"},
+          "text": {"type": "string", "minLength": 1},
+          "owner": {
+            "type": "string",
+            "minLength": 1,
+            "description": "A ROLE by preference (e.g. 'backend lead'), not a personal name — dossiers travel further than the people in them."
+          },
+          "eta": {
+            "oneOf": [
+              {"$ref": "#/$defs/date"},
+              {"enum": ["immediate", "next-cycle", "backlog"]}
+            ]
+          },
+          "priority": {"enum": ["P0", "P1", "P2", "P3"]},
+          "effort": {"enum": ["S", "M", "L", "XL"]},
+          "source_claims": {"$ref": "#/$defs/claim_refs"},
+          "note": {"type": "string"}
+        }
+      }
+    },
+
+    "not_checked": {
+      "type": "array",
+      "minItems": 1,
+      "description": "REQUIRED and non-empty. The blind spots: what this research did NOT examine, and why. An empty array is not a passing state — it is a claim of omniscience, and the gate rejects it. If nothing was left unchecked, say so explicitly with a reason (e.g. 'scope was fully enumerable: only 3 candidate libraries exist').",
+      "items": {
+        "type": "object",
+        "required": ["text", "reason"],
+        "additionalProperties": false,
+        "properties": {
+          "text": {"type": "string", "minLength": 1, "description": "What was not examined."},
+          "reason": {"type": "string", "minLength": 1, "description": "Why not — out of scope / no data / time-boxed / access denied."},
+          "impact": {
+            "enum": ["none", "low", "medium", "high"],
+            "description": "How much the missing evidence could change the conclusion. 'high' with stakes=high is a gate WARN: the dossier is admitting its own conclusion may not hold."
+          }
+        }
+      }
+    },
+
+    "methodology": {
+      "type": "object",
+      "required": ["approach"],
+      "additionalProperties": false,
+      "description": "How the corpus was produced. Without it a reader cannot weigh the evidence, only accept it.",
+      "properties": {
+        "approach": {"type": "string", "minLength": 1},
+        "sources_consulted": {"type": "integer", "minimum": 0},
+        "window": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "from": {"$ref": "#/$defs/date"},
+            "to": {"$ref": "#/$defs/date"}
+          }
+        },
+        "tools": {"type": "array", "items": {"type": "string"}},
+        "limitations": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+
+    "theme": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Resolved rendering parameters. Normally derived from audience via references/audience-map.md; set explicitly only to override. The palette here is what the palette gate validates — in BOTH modes.",
+      "properties": {
+        "design_system": {"type": "string"},
+        "palette": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "categorical_light": {"$ref": "#/$defs/hex_list"},
+            "categorical_dark": {"$ref": "#/$defs/hex_list"},
+            "surface_light": {"$ref": "#/$defs/hex"},
+            "surface_dark": {"$ref": "#/$defs/hex"}
+          }
+        }
+      }
+    },
+
+    "provenance": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Who/what produced this IR. Honest authorship, per the agent-ticket-provenance discipline.",
+      "properties": {
+        "generated_by": {"type": "string"},
+        "generated_at": {"type": "string", "format": "date-time"},
+        "corpus_path": {"type": "string"},
+        "session": {"type": "string"}
+      }
+    }
+  },
+
+  "$defs": {
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9-]*$",
+      "description": "kebab-case stable identifier, referenced from elsewhere in the document."
+    },
+
+    "date": {
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$",
+      "description": "ISO 8601 calendar date. Absolute always — a dossier outlives the session that wrote it, so 'last Thursday' is meaningless in it."
+    },
+
+    "hex": {
+      "type": "string",
+      "pattern": "^#[0-9a-fA-F]{6}$"
+    },
+
+    "hex_list": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/hex"}
+    },
+
+    "confidence": {
+      "enum": ["high", "medium", "low"],
+      "description": "The author's confidence in THIS claim. Three bands, deliberately: a percentage invites false precision on an unmeasured quantity."
+    },
+
+    "claim_refs": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/id"},
+      "description": "Ids of claims in claims[]. The renderer's provenance gate resolves every one of these and fails the build on a dangling reference — a chart or recommendation pointing at a claim that does not exist is worse than one pointing at nothing, because it looks sourced."
+    },
+
+    "source": {
+      "type": "object",
+      "required": ["label"],
+      "additionalProperties": false,
+      "description": "Where the claim came from. A URL is preferred but a labelled non-web source (an interview, an internal dashboard, a measurement run) is valid — what is NOT valid is no source at all.",
+      "properties": {
+        "label": {"type": "string", "minLength": 1},
+        "url": {"type": "string", "format": "uri"},
+        "kind": {"enum": ["web", "doc", "repo", "measurement", "interview", "dataset", "internal", "other"]},
+        "accessed": {"$ref": "#/$defs/date"},
+        "quote": {"type": "string", "description": "Optional verbatim excerpt supporting the claim."}
+      }
+    },
+
+    "claim": {
+      "type": "object",
+      "required": ["id", "text", "source", "as_of", "confidence"],
+      "additionalProperties": false,
+      "description": "One evidential unit. All five fields are required — this is the contract that makes the provenance gate possible at all.",
+      "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "text": {"type": "string", "minLength": 1},
+        "source": {"$ref": "#/$defs/source"},
+        "as_of": {"$ref": "#/$defs/date"},
+        "confidence": {"$ref": "#/$defs/confidence"},
+        "entity": {"$ref": "#/$defs/id", "description": "Optional link to entities[] — which thing this claim is about."},
+        "metric": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Present when the claim carries a number. Separating the quantity from the prose is what lets a chart cite the claim instead of restating it.",
+          "properties": {
+            "name": {"type": "string"},
+            "value": {"type": "number"},
+            "unit": {"type": "string"},
+            "direction": {
+              "enum": ["higher-better", "lower-better", "neutral"],
+              "description": "Required for the scorecard to normalize a cell without the author having to pre-invert the number."
+            }
+          },
+          "required": ["value"]
+        },
+        "contested": {
+          "type": "boolean",
+          "default": false,
+          "description": "Sources disagree on this. Rendered visibly — a contested claim silently averaged into a chart is a lie of omission."
+        },
+        "tags": {"type": "array", "items": {"type": "string"}}
+      }
+    },
+
+    "derived": {
+      "type": "object",
+      "required": ["text", "source_claims"],
+      "additionalProperties": true,
+      "description": "Anything the author concluded rather than observed. source_claims is required: an interpretation with no evidence under it is an opinion, and this format makes that distinction structural rather than stylistic.",
+      "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "text": {"type": "string", "minLength": 1},
+        "source_claims": {"$ref": "#/$defs/claim_refs"},
+        "confidence": {"$ref": "#/$defs/confidence"}
+      }
+    },
+
+    "scorecard": {
+      "type": "object",
+      "required": ["options", "criteria", "cells"],
+      "additionalProperties": false,
+      "description": "N options x M criteria, with evidence per CELL. Generalizes the evidence-ledger / confidence-heatmap pattern beyond qualitative UX research.",
+      "properties": {
+        "options": {
+          "type": "array",
+          "minItems": 2,
+          "items": {"$ref": "#/$defs/id"},
+          "description": "Ids from entities[]. Two or more — a scorecard of one is a profile."
+        },
+        "criteria": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id", "label"],
+            "additionalProperties": false,
+            "properties": {
+              "id": {"$ref": "#/$defs/id"},
+              "label": {"type": "string", "minLength": 1},
+              "weight": {"type": "number", "minimum": 0, "description": "Relative weight. Omitted means equal. Weights are DECLARED, never inferred — a hidden weight is how a scorecard smuggles in a conclusion."},
+              "direction": {"enum": ["higher-better", "lower-better", "neutral"], "default": "higher-better"},
+              "unit": {"type": "string"}
+            }
+          }
+        },
+        "cells": {
+          "type": "array",
+          "description": "One entry per (option, criterion) pair the author has evidence for. Sparse by design: a missing cell renders as an explicit gap, which is honest. A cell fabricated to fill the grid is not.",
+          "items": {
+            "type": "object",
+            "required": ["option", "criterion", "value", "source_claims", "confidence"],
+            "additionalProperties": false,
+            "properties": {
+              "option": {"$ref": "#/$defs/id"},
+              "criterion": {"$ref": "#/$defs/id"},
+              "value": {
+                "oneOf": [
+                  {"type": "number"},
+                  {"type": "string"},
+                  {"type": "boolean"}
+                ]
+              },
+              "display": {"type": "string", "description": "Optional human rendering of value, e.g. '208 KB'."},
+              "source_claims": {"$ref": "#/$defs/claim_refs"},
+              "confidence": {"$ref": "#/$defs/confidence"},
+              "as_of": {"$ref": "#/$defs/date"},
+              "note": {"type": "string"}
+            }
+          }
+        },
+        "verdict": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "The recommendation the scorecard supports — stated, so the reader can check the arithmetic against the conclusion instead of guessing it.",
+          "properties": {
+            "winner": {"$ref": "#/$defs/id"},
+            "rationale": {"type": "string"},
+            "runner_up": {"$ref": "#/$defs/id"},
+            "rejected_because": {"type": "string"}
+          }
+        }
+      }
+    },
+
+    "chart": {
+      "type": "object",
+      "required": ["id", "form", "title", "source_claims", "series"],
+      "additionalProperties": false,
+      "properties": {
+        "id": {"$ref": "#/$defs/id"},
+        "form": {
+          "enum": ["bar", "column", "line", "area", "stacked-bar", "diverging-bar", "dumbbell", "heatmap", "scatter", "stat-tile", "kpi-row", "meter", "table"],
+          "description": "Pick from the data's JOB, per the bundled dataviz reference choosing-a-form.md — and note that stat-tile / kpi-row / table are first-class answers there: sometimes the right form is not a chart."
+        },
+        "title": {"type": "string", "minLength": 1},
+        "subtitle": {"type": "string"},
+        "source_claims": {
+          "$ref": "#/$defs/claim_refs",
+          "description": "REQUIRED. This is the field that carries the faithfulness gate into the visual layer: a chart is a rendering of claims, so it must name them."
+        },
+        "series": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["label", "data"],
+            "additionalProperties": false,
+            "properties": {
+              "label": {"type": "string", "minLength": 1},
+              "entity": {"$ref": "#/$defs/id", "description": "Binds the series to an entity so color follows identity across charts and survives filtering."},
+              "data": {
+                "type": "array",
+                "minItems": 1,
+                "items": {
+                  "type": "object",
+                  "required": ["x", "y"],
+                  "additionalProperties": false,
+                  "properties": {
+                    "x": {"oneOf": [{"type": "string"}, {"type": "number"}]},
+                    "y": {"type": ["number", "null"], "description": "null = genuinely missing. Rendered as a gap, never interpolated into a line that implies data we do not have."},
+                    "claim": {"$ref": "#/$defs/id", "description": "Optional per-point provenance, for when one chart draws on many claims."}
+                  }
+                }
+              }
+            }
+          }
+        },
+        "axis": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "x_label": {"type": "string"},
+            "y_label": {"type": "string"},
+            "y_min": {"type": "number"},
+            "y_max": {"type": "number"},
+            "axis_truncated": {
+              "type": "boolean",
+              "default": false,
+              "description": "MUST be true when y_min is set above the data's natural zero baseline on a magnitude form. The gate cross-checks this and fails on an undeclared truncation: a bar chart starting at 90 exaggerates a 2% difference into a visual landslide, and that is magnitude distortion whether or not it was intended."
+            },
+            "truncation_rationale": {"type": "string", "description": "Required by the gate when axis_truncated is true. Sometimes truncation is correct (a temperature range); saying why is the price."}
+          }
+        },
+        "emphasis": {
+          "$ref": "#/$defs/id",
+          "description": "Entity to highlight while the rest recede to gray. Per dataviz, this is the most underused form and often the honest answer to 'make this chart clearer'."
+        },
+        "color_job": {
+          "enum": ["categorical", "sequential", "diverging", "status", "emphasis"],
+          "description": "Which of the four color jobs this chart needs. Drives palette resolution, and therefore what the palette gate validates."
+        },
+        "note": {"type": "string"},
+        "table_view": {
+          "type": "boolean",
+          "default": true,
+          "description": "Emit an accessible <table> carrying the same numbers. Default true and rarely worth disabling: Chart.js has no native accessibility, so the table IS the accessible rendering, not a courtesy."
+        }
+      }
+    }
+  }
+}

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -353,6 +353,19 @@ else
     fail "bin/tests/continuation-broadcast.test.sh missing"
 fi
 
+# research-dossier: the two f=0 gates, proven in BOTH directions (valid passes,
+# each negative fixture fails for its OWN reason). Skips cleanly without node.
+RD_TESTS="$PLUGIN_ROOT/bin/tests/research-dossier.test.sh"
+if [ -f "$RD_TESTS" ]; then
+    if bash "$RD_TESTS" >/dev/null 2>&1; then
+        pass "bin/tests/research-dossier.test.sh passes"
+    else
+        fail "bin/tests/research-dossier.test.sh FAILED (run 'bash bin/tests/research-dossier.test.sh')"
+    fi
+else
+    fail "bin/tests/research-dossier.test.sh missing"
+fi
+
 # signoff skill + command frontmatter
 if [ -f "$PLUGIN_ROOT/skills/signoff/SKILL.md" ] && grep -q "^name: signoff$" "$PLUGIN_ROOT/skills/signoff/SKILL.md"; then
     pass "skills/signoff/SKILL.md has correct frontmatter"


### PR DESCRIPTION
**[PR-as-Documentation-Prompt]**

Closes #287

## Context

Research emits prose. Every renderer wants structured input. Nothing converted one to the other — so each dashboard was hand-rolled, with no provenance and no reuse of the ~110 `design-templates/` and ~150 `design-systems/` already installed. That corpus was unreachable from any research pipeline.

The ask was "generate beautiful multi-format dashboards". Recon inverted it: **~95% already exists**. The gap is not a renderer — it is the missing spine between the researcher and the renderers. So this adds a contract, not a design system: once research becomes JSON with per-claim provenance, the existing renderers are reachable for free. One contract unlocks N consumers.

## Objectives

- **Primary** — an IR that carries provenance per claim, plus two deterministic gates that can fail a build.
- **Secondary** — close two inherited defects: the faithfulness gate never survived into the *visual* layer, and `--audience` never reached the design system.
- **Explicit non-goal** — performing the research. `/deep-research`, `last30days` and `exa` own that; this consumes finished work.

## What is new here

Only four things. Everything else is routing.

| New | Delegated (never duplicated) |
|---|---|
| the IR contract | chart form + colour → bundled **`dataviz`** |
| the scorecard primitive | html templates → **`open-design`** |
| the two `f=0` gates | pdf → **`make-pdf`** · pptx/xlsx → **`document-skills`** |
| the audience map | prose → **`content-recast`** |

Zero new design systems, zero new per-format renderers, zero copies of `dataviz` guidance.

## The part that earns the review: it was red-teamed, and it broke

An independent adversary (≠ author) was tasked with passing the provenance gate while producing a *misleading* dossier. **It succeeded** — a board-grade artifact that inverted a $1.18M-vs-$0.34M cost comparison, hid a 6-hour settlement outage and a lapsed PCI attestation, and drew a 19× reversed chart, at **exit 0, zero failures**.

The diagnosis was exact and worth stating plainly: **the gate verified that citations resolve, never that they agree.** Referential integrity was airtight (19/19 structural attacks caught); every *semantic* relationship was unchecked. The IR already carried everything needed — `metric.value`, `direction`, `weight`, per-cell `source_claims` — so the data model was right and the checks were simply never written.

Nine checks now close it, each with a test, each mutation-verified:

- `CHART_POINT_VALUE_MISMATCH` — a point plotting `41` while citing a claim stating `208` was cited, resolving, rendered, and false. This is what makes `metric.value` load-bearing.
- `CELL_DISPLAY_DIVERGES` — `display` overrode `value` verbatim, so one field with no arithmetic inverted a price while the JSON audit trail stayed correct.
- `UNDECLARED_TRUNCATION` now gates on what is **drawn**, not what is **declared** (see below).
- `UNDECLARED_COMPRESSION` — truncation is only one of two ways to lie with an axis; an inflated `y_max` flattened 4% and 96% into identical stubs.
- `STACKED_PARTS_MISMATCH` — parts summing to $50k under a cited $482k total: every part matched its own claim while the composition omitted 90%.
- `SCORECARD_ASYMMETRIC_COVERAGE` — a blank cell must mean *unmeasured*, not *omitted*.
- `VERDICT_UNSUPPORTED` — computes the weighted score over declared weights and directions; fails when the winner is not the argmax.
- `NOT_CHECKED_VACUOUS` / `ALL_INCONSEQUENTIAL` — the empty-array check was evaded by writing the omniscience claim out longhand.
- `CLAIM_STALE` — only *future* dates failed, so 2019 evidence read as current.

**The sharpest structural finding:** `ch.form` was read by the gate and **ignored by the renderer**, which draws every chart as proportional bars. So `form: "line"` bypassed the truncation check while still rendering truncated bars — `MAGNITUDE_FORMS` was guarding a rendering that did not exist.

### Two limits surfaced rather than hidden

- A **weighting** can decide an outcome by itself. When one criterion outweighs all others combined the build warns, because arithmetic cannot refute a rigged weight — only disclosure can.
- **Summary-vs-claims** and **recommendation-vs-its-own-citations** remain semantic judgements outside `f=0` reach. `SKILL.md` now says so instead of implying otherwise.

The rendered footer no longer claims *"gates passed"* — that read as a certificate over the **conclusion**, and was load-bearing in the adversary's deception (a hand-rolled dashboard asks you to trust its author; this one asserted a machine had already checked). It now states exactly what was verified and closes with *"a check of the evidence, not an endorsement of the conclusion."*

## Also fixed while verifying

Three defects, all the same family — **a check passing for the wrong reason**:

1. The body was initially **client-rendered**: JS off → blank page. Now server-side; JS only reveals the theme toggle.
2. Substitution used single-match `.replace()` while the template's own header comment *named* the placeholders — so the first match was the **documentation** and the live slot never filled. Output looked plausible while carrying no dossier, and my first verification scored it as 12,613 chars of content (real figure: 4,657). Fixed globally; the renderer now **asserts no slot survives**.
3. `--audience` was **inert at render time** — `ir.audience` was read only to print it in the header, so gap #5 was half-closed and `audience-map.md` described effects the renderer did not implement. A documented-but-inert parameter is exactly the theater these gates exist to prevent.

## Acceptance criteria

- [x] `validate-plugin.sh` — 0 errors
- [x] Gate 1 **rejects** an IR missing `source`/`as_of`/`confidence` (negative test green)
- [x] Gate 2 **rejects** a CVD-hostile palette; **degrades with a loud WARN** without the bundled validator, and `--strict` makes that a failure
- [x] Zero `chart-forms.md` — `dataviz` is cited, never copied
- [x] HTML opens over `file://` — **0 remote subresources** (citation URLs remain: those are provenance, not dependencies)
- [x] One IR → 3 formats with consistent theme
- [x] Fallback works without the `od` daemon — verified under `env -i PATH=/usr/bin:/bin`
- [x] `--audience` changes the render (charts capped, evidence collapsed) while claims/cells/`not_checked[]` stay byte-identical
- [x] Dogfood reproduces the recon's decision
- [x] Independent red-team run; findings **fixed**, not filed
- [x] Zero Eko/Vek strings (Layer Purity)

## Verification

```bash
bash bin/tests/research-dossier.test.sh   # 68 passed, 0 failed
bash tests/validate-plugin.sh             # 0 errors
```

Capture exit codes **directly** — a pipe returns the exit of its *last* command, so `cmd | grep` reports grep's status and a failing build reads green. That trap bit twice during this work and is documented in `SKILL.md`.

The suite is **mutation-tested**: neutering `MAGNITUDE_FORMS` or `CELL_DISPLAY_DIVERGES` turns assertions red, so it is known capable of failing. Every negative fixture asserts its **specific** failure code — a fixture failing for an unintended reason would satisfy a naive check while proving nothing.

## Risk + rollback

Additive: one new skill, one command, one renderer, one test file. No existing behaviour is modified beyond two wiring lines in `validate-plugin.sh` and the version/changelog bump. Rollback is `git revert` of the range.

## Cross-links

Issue #287 · `skills/research-dossier/SKILL.md` · `references/scorecard.md` · `references/audience-map.md` · `examples/DOGFOOD.md` · bundled `dataviz` (form + colour authority)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
