### PR TITLE
feat(research-dossier): the declared form stops lying, and the page fits a phone (v0.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ reference teaches; building 13 geometries is YAGNI while 6 of 6 fixture charts d
 only `bar`, leaving 12 forms with zero test coverage.
 
 ⚠️ This adds **no exemption** to anything. The `MAGNITUDE_FORMS` allow-list is *not*
-back: truncation stays form-agnostic, exactly as `render.mjs` records above
+back: truncation stays form-agnostic, exactly as `bin/research-dossier-render.mjs` records above
 `gateProvenance` ("so the next reader does not reintroduce the allow-list as an
 apparent improvement"). The new code only reports the declared-vs-drawn gap.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — `research-dossier` v0.2.0: the declared form stops lying, and the page fits a phone
+
+Two gaps found by reading v0.1.0 against what callers assume it does.
+
+**`FORM_NOT_RENDERED` (new WARN, `--strict` ⇒ FAIL).** The schema accepts 13
+`chart.form` values; the renderer draws exactly one geometry — horizontal proportional
+bars (`<rect>` + baseline `<line>`). So `form:"line"` was accepted, ignored, and
+silently substituted: theater of precisely the kind this skill refuses, inside the
+skill built to refuse it. The gap is now named and deterministic. WARN rather than
+FAIL is proportionate — the evidence stays sourced and truncation-checked, only the
+label overpromises.
+
+Two alternatives were rejected **on measurement, not taste**: shrinking the enum is a
+breaking change (`enum` + `additionalProperties:false` ⇒ an existing IR carrying
+`form:"line"` would stop validating) and would delete vocabulary the bundled `dataviz`
+reference teaches; building 13 geometries is YAGNI while 6 of 6 fixture charts declare
+only `bar`, leaving 12 forms with zero test coverage.
+
+⚠️ This adds **no exemption** to anything. The `MAGNITUDE_FORMS` allow-list is *not*
+back: truncation stays form-agnostic, exactly as `render.mjs` records above
+`gateProvenance` ("so the next reader does not reintroduce the allow-list as an
+apparent improvement"). The new code only reports the declared-vs-drawn gap.
+
+**Width breakpoints (760px / 420px).** Before this the only `@media` queries were
+`prefers-color-scheme`, `prefers-reduced-motion` and `print` — a viewport meta plus a
+`max-width` made the page *shrink*, which is not the same as being readable. A decision
+artifact is read where the decision happens, often not at a desk. The header stacks,
+wide data tables scroll instead of the page, claim ids wrap. Declared before
+`@media print` so print keeps the last word.
+
+**Stated, not implied** — a new "Not built" table in SKILL.md records what is absent
+and why, each probed rather than guessed: drill-down (absent), filter controls
+(declared in `audience-map.md` as `dataviz` parameter #8, inert), burn-down (absent, no
+consumer — deferred rather than built on spec), stat-tile demotion (self-declared "Not
+yet implemented"), yaml (unknown format ⇒ logged `UNKNOWN_FORMAT`, verified to write
+zero files).
+
+- **93 tests pass** (was 89). Every new assertion mutation-verified in **both**
+  directions. One of them was caught being a *test that cannot fail*: it addressed the
+  fixture through a `$TMP`-relative path that silently `ENOENT`s, so node printed no
+  code, the negative `case` matched, and it would have passed with the guard deleted
+  *and* inverted. Fixed to address `$EX` directly, plus an empty-output branch so an
+  assertion can never again pass by observing nothing.
+- Idempotent render verified; `tests/validate-plugin.sh` PASSED; zero npm deps; zero
+  remote subresources; JS-off render unaffected.
+
 ### Added — `research-dossier`: finished research → decision-ready visual dossier, behind two deterministic gates (#287)
 
 The missing spine between researchers and the ~110 `design-templates/` + ~150 `design-systems/`

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -973,7 +973,11 @@ function main() {
   --formats <list>     html,md,json          [default: html,md,json]
   --out <dir>          output directory      [default: out]
   --gates-only         run both gates, render nothing
-  --strict             a missing dataviz validator FAILS instead of warning
+  --strict             escalate advisory findings to build failures:
+                       · a missing dataviz validator (gate 2) FAILS instead of warning
+                       · FORM_NOT_RENDERED (gate 1) FAILS — a declared chart.form the
+                         renderer does not draw. Intended for CI, where a dossier whose
+                         charts do not match their labels should not ship.
   --quiet              suppress the report on success
 
 Env: DATAVIZ_VALIDATOR   explicit validator path (nonexistent => exercises degradation)

--- a/bin/research-dossier-render.mjs
+++ b/bin/research-dossier-render.mjs
@@ -55,7 +55,7 @@ const EXIT_OK = 0, EXIT_GATE = 1, EXIT_USAGE = 2;
 // a dossier in the wild can be traced to the gate revision that cleared it — the
 // checks tightened materially once already, and an artifact that predates that
 // hardening should not be indistinguishable from one that followed it.
-const RENDERER_ID = 'research-dossier v0.1.0';
+const RENDERER_ID = 'research-dossier v0.2.0';
 
 // ── tiny arg parser (zero-dep) ──────────────────────────────────────────────
 function parseArgs(argv) {
@@ -93,7 +93,15 @@ const CONFIDENCE = new Set(['high', 'medium', 'low']);
  * Recorded rather than deleted silently, so the next reader does not reintroduce
  * the allow-list as an apparent improvement. */
 
-function gateProvenance(ir) {
+/* The chart forms the renderer actually DRAWS distinctly. The schema accepts 13;
+ * this is the honest subset. Keep it in lockstep with the rendering code: adding a
+ * geometry means adding its form here, and nothing else in the gate keys off form
+ * (truncation stays form-agnostic by design). Bar and column are one geometry here —
+ * the marks are horizontal, so "column" is an orientation the renderer does not yet
+ * honour and it is intentionally absent. */
+const RENDERED_FORMS = new Set(['bar']);
+
+function gateProvenance(ir, opts) {
   // -- structural minimums the schema also states, re-checked here because the
   //    renderer must never assume an upstream validator ran.
   for (const f of ['question', 'as_of', 'audience', 'claims', 'not_checked', 'methodology']) {
@@ -174,6 +182,29 @@ function gateProvenance(ir) {
     const at = `charts[${i}]${ch && ch.id ? ` (${ch.id})` : ''}`;
     if (!ch || typeof ch !== 'object') { FAIL('CHART_SHAPE', `${at}: not an object`); continue; }
     if (!ch.form) FAIL('CHART_NO_FORM', `${at}: missing form`);
+    // A form the renderer does not honour is accepted-then-ignored: the schema takes
+    // 13 values and every one of them draws as horizontal proportional bars. That is
+    // theater of the exact kind this skill exists to refuse — the IR says "line", the
+    // artifact shows bars, and nothing announces the substitution. Two roads were
+    // rejected before this one: shrinking the enum is a BREAKING change (it is
+    // enum-constrained with additionalProperties:false, so an existing IR carrying
+    // form:"line" would stop validating) and it would delete vocabulary the bundled
+    // dataviz reference actively teaches; building 13 geometries is YAGNI while every
+    // fixture chart in the suite declares only "bar". So the substitution is made
+    // VISIBLE and deterministic instead: same input, same verdict, every time.
+    // Deliberately NOT a FAIL — the dossier is still honest, its charts are still
+    // sourced and still truncation-checked; only the form label overpromises. WARN
+    // keeps that proportionate, and --strict escalates it for CI.
+    // ⚠️ This is NOT the MAGNITUDE_FORMS allow-list returning. That list scoped the
+    // truncation check BY FORM and was removed on purpose (see the note above
+    // gateProvenance) because it let form:"line" escape a check on bars that were
+    // drawn anyway. This code adds no exemption to anything: truncation stays
+    // form-agnostic, and this only reports the gap between declared and drawn.
+    else if (!RENDERED_FORMS.has(ch.form)) {
+      const m = `${at}: form "${ch.form}" is declared but the renderer draws proportional bars — the artifact will not match the label (honoured: ${[...RENDERED_FORMS].join(', ')})`;
+      if (opts && opts.strict) FAIL('FORM_NOT_RENDERED', `${m} (--strict: treated as failure)`);
+      else WARN('FORM_NOT_RENDERED', m);
+    }
     if (!ch.title) FAIL('CHART_NO_TITLE', `${at}: missing title`);
     checkRefs(ch.source_claims, at);
 
@@ -959,7 +990,7 @@ Exit: 0 ok · 1 gate failure · 2 usage/IO`);
     return EXIT_USAGE;
   }
 
-  gateProvenance(ir);
+  gateProvenance(ir, a);
   const paletteInfo = gatePalette(ir, a);
 
   const failed = report.fail.length > 0;

--- a/bin/tests/research-dossier.test.sh
+++ b/bin/tests/research-dossier.test.sh
@@ -211,6 +211,12 @@ elif which=='display-lie':           # display overrides value with an inverted 
             c['display']='18 KB'; break
 elif which=='form-dodge':            # non-magnitude form + truncated axis
     ir['charts'][0]['form']='line'; ir['charts'][0]['axis']['y_min']=60
+elif which=='form-unrendered':       # form the renderer does not draw, axis otherwise CLEAN
+    # Deliberately distinct from 'form-dodge': that one pairs form:"line" with a
+    # truncated axis to prove truncation is form-agnostic. This one leaves the axis
+    # honest, so the ONLY thing wrong is the declared-vs-drawn gap — otherwise the
+    # assertion could pass on the truncation code and prove nothing about this check.
+    ir['charts'][0]['form']='line'
 elif which=='compression':           # inflated y_max flattens every mark
     ir['charts'][0]['axis']['y_max']=100000
 elif which=='vacuous-nc':
@@ -241,6 +247,28 @@ PY
   node "$REND" --ir "$TMP/ir-form.json" --gates-only >/dev/null 2>&1
   eq '1' "$?" 'truncation is caught regardless of declared form'
   case "$(gt ir-form.json)" in *UNDECLARED_TRUNCATION*) ok '→ UNDECLARED_TRUNCATION on a non-bar form' ;; *) no '→ UNDECLARED_TRUNCATION on a non-bar form' 'not raised' ;; esac
+
+  # A declared form the renderer does not draw is accepted-then-ignored: the IR says
+  # "line", the artifact shows bars, and until this check nothing said so. Proportionate
+  # by construction — WARN by default (the evidence is still sound; only the label
+  # overpromises), FAIL under --strict so CI can refuse it.
+  mk ir-unrendered.json form-unrendered
+  node "$REND" --ir "$TMP/ir-unrendered.json" --gates-only >/dev/null 2>&1
+  eq '0' "$?" 'an unrendered form WARNs but does not fail the build'
+  case "$(gt ir-unrendered.json)" in *FORM_NOT_RENDERED*) ok '→ FORM_NOT_RENDERED names the declared-vs-drawn gap' ;; *) no '→ FORM_NOT_RENDERED names the declared-vs-drawn gap' 'not raised' ;; esac
+  node "$REND" --ir "$TMP/ir-unrendered.json" --gates-only --strict >/dev/null 2>&1
+  eq '1' "$?" '--strict escalates an unrendered form to a build failure'
+  # The honoured form must stay silent, or the check is noise that trains authors to
+  # ignore it — a false positive on a gate is not harmless caution.
+  # `gt` resolves against $TMP, so the shipped fixture must be addressed directly —
+  # a $TMP-relative path silently ENOENTs, node prints no code, and the negative case
+  # below would fire unconditionally: a test that cannot fail.
+  BAR_OUT="$(node "$REND" --ir "$EX/ir-valid.json" --gates-only 2>&1)"
+  case "$BAR_OUT" in
+    *FORM_NOT_RENDERED*) no 'the honoured form (bar) stays silent' 'warned on a rendered form' ;;
+    '') no 'the honoured form (bar) stays silent' 'no output — assertion could not observe anything' ;;
+    *) ok 'the honoured form (bar) stays silent' ;;
+  esac
 
   mk ir-compress.json compression
   node "$REND" --ir "$TMP/ir-compress.json" --gates-only >/dev/null 2>&1

--- a/skills/research-dossier/SKILL.md
+++ b/skills/research-dossier/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: research-dossier
-version: "0.1.0"
+version: "0.2.0"
 description: |
   Turn finished research into a decision-ready visual dossier — html, md, json, and
   hand-offs to pdf/pptx/xlsx — routed through an intermediate representation that
@@ -56,6 +56,18 @@ point contradicting the claim it cites, a `display` string contradicting its own
 `value`, stacked parts that miss their cited total, a verdict that is not the argmax
 of its declared weights, a blank scorecard cell whose evidence exists but went
 unused, evidence years staler than the dossier: all fail the build.
+
+**Declared form vs. drawn form.** The schema takes 13 `chart.form` values; the
+renderer draws exactly one geometry — horizontal proportional bars. A chart declaring
+`form:"line"` therefore renders as bars, and until v0.2.0 nothing said so: accepted,
+ignored, and silently substituted. `FORM_NOT_RENDERED` now names that gap. It is a
+**WARN**, not a FAIL — the evidence is still sourced and still truncation-checked, so
+only the label overpromises; `--strict` escalates it for CI. Two alternatives were
+rejected on measurement: shrinking the enum is a **breaking** change (it is
+enum-constrained with `additionalProperties:false`, so an existing IR carrying
+`form:"line"` would stop validating) and would delete vocabulary `dataviz` teaches;
+building 13 geometries is YAGNI while every fixture chart in the suite declares only
+`bar`. Note this adds **no exemption** to anything — truncation stays form-agnostic.
 
 Two things remain **outside** deterministic reach, and are stated here rather than
 implied away:
@@ -218,6 +230,23 @@ DATAVIZ_VALIDATOR=/nonexistent node bin/research-dossier-render.mjs --ir skills/
 
 Capture exit codes directly. A pipe returns the exit of the *last* command in it, so
 `cmd | grep` silently reports the grep's status and a failing build reads as green.
+
+## Not built (measured, not implied)
+
+Stated here because a skill that quietly lacks a capability its callers assume is the
+same failure `FORM_NOT_RENDERED` exists to catch. Each was probed, not guessed.
+
+| Gap | State | Why not yet |
+|---|---|---|
+| **drill-down** | absent | Needs `dataviz` `references/interaction.md` first, and a design that does not create a second evidence store — a drilled-into detail must be the *same* claim ids, gated once. |
+| **filter controls** | declared, inert | `references/audience-map.md` lists it as `dataviz` parameter #8; nothing implements it. Interaction must **degrade**, never gate: with JS off the dossier already renders every claim server-side, and that property is not negotiable for an archival artifact. |
+| **burn-down** | absent | No consumer. Deferred deliberately rather than built on spec. |
+| **stat-tile demotion** (<4 points) | declared, inert | `references/audience-map.md` self-declares it "Not yet implemented". |
+| **yaml output** | absent | `--formats` takes `html,md,json` (+ pdf/pptx/xlsx hand-offs). yaml is neither rendered nor schema-known; an unknown format is a logged `UNKNOWN_FORMAT` warning, not a silent skip. |
+
+**Responsive** is implemented as of v0.2.0: width breakpoints at 760px and 420px
+(header stacks, data tables scroll rather than the page, claim ids wrap), declared
+before `@media print` so print keeps the last word.
 
 ## Anti-patterns
 

--- a/skills/research-dossier/SKILL.md
+++ b/skills/research-dossier/SKILL.md
@@ -103,7 +103,7 @@ reformatting with no evidential claims (`content-recast`).
 | `--design-system` | `auto` | `auto` resolves from audience |
 | `--stakes` | `low` | `high` tightens the gate and expands gaps |
 | `--out` | `out` | output directory |
-| `--strict` | off | a missing dataviz validator FAILS instead of warning |
+| `--strict` | off | escalates advisory findings to failures: a missing dataviz validator, and `FORM_NOT_RENDERED` |
 
 ## Requirements
 

--- a/skills/research-dossier/templates/dossier.html
+++ b/skills/research-dossier/templates/dossier.html
@@ -151,6 +151,37 @@
     *, *::before, *::after { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important;
                              transition-duration: 0.01ms !important; scroll-behavior: auto !important; }
   }
+
+  /* Width breakpoints. Until these existed the only @media queries were
+     prefers-color-scheme, prefers-reduced-motion and print: a viewport meta and a
+     max-width made the page SHRINK, which is not the same as being readable on a
+     phone. A decision artifact is read where the decision happens, and that is often
+     not a desktop. Mobile-first would have meant rewriting the desktop rules above,
+     so these narrow ONLY what actually breaks — declared here, before @media print,
+     so print keeps the last word (it resets .wrap to full width and must not be
+     overridden by a width query that happens to match the paper size). */
+  @media (max-width: 760px) {
+    .wrap { padding: 20px 14px 48px; }
+    /* The header is the one hard break: a flex row with a title and a button has no
+       room to sit side-by-side once the title wraps to three lines. */
+    header.head { flex-direction: column; gap: 12px; }
+    h1 { font-size: 21px; }
+    .card { padding: 16px 14px; border-radius: 10px; }
+    .lede { font-size: 15px; }
+    /* Wide data tables are the second break. Scrolling the TABLE beats scrolling the
+       PAGE sideways, and the table is the accessible rendering of every chart — it
+       must stay reachable, never clipped. -webkit-overflow-scrolling keeps momentum
+       on iOS; overflow-x alone reads as frozen there. */
+    details.tableview { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+    table { font-size: 13px; }
+    th, td { padding: 8px 9px; }
+  }
+  @media (max-width: 420px) {
+    .wrap { padding: 16px 11px 40px; }
+    h1 { font-size: 19px; }
+    /* Below this width a nowrap claim id forces horizontal page scroll. */
+    code.cid { white-space: normal; word-break: break-all; }
+  }
   @media print {
     :root { color-scheme: light; }
     body { background: #fff; }

--- a/skills/research-dossier/templates/dossier.html
+++ b/skills/research-dossier/templates/dossier.html
@@ -157,10 +157,14 @@
      max-width made the page SHRINK, which is not the same as being readable on a
      phone. A decision artifact is read where the decision happens, and that is often
      not a desktop. Mobile-first would have meant rewriting the desktop rules above,
-     so these narrow ONLY what actually breaks — declared here, before @media print,
-     so print keeps the last word (it resets .wrap to full width and must not be
-     overridden by a width query that happens to match the paper size). */
-  @media (max-width: 760px) {
+     so these narrow ONLY what actually breaks.
+     Scoped to `screen` deliberately. Source order is NOT enough: an unqualified width
+     query also matches PRINT, whose page box is narrow, and @media print below resets
+     .wrap but never touches overflow-x — so `details.tableview { overflow-x: auto }`
+     would stay live on paper, where nothing can scroll, and clip exactly the wide
+     tables the print block exists to render in full. Ordering only protects the
+     properties print actually overrides; `screen` protects the rest. */
+  @media screen and (max-width: 760px) {
     .wrap { padding: 20px 14px 48px; }
     /* The header is the one hard break: a flex row with a title and a button has no
        room to sit side-by-side once the title wraps to three lines. */
@@ -176,7 +180,7 @@
     table { font-size: 13px; }
     th, td { padding: 8px 9px; }
   }
-  @media (max-width: 420px) {
+  @media screen and (max-width: 420px) {
     .wrap { padding: 16px 11px 40px; }
     h1 { font-size: 19px; }
     /* Below this width a nowrap claim id forces horizontal page scroll. */


### PR DESCRIPTION
## What this is

`research-dossier` v0.1.0 → v0.2.0. Two gaps found by reading v0.1.0 against what callers assume it does.

The originating request asked to *forge* a multi-format dashboard system. Recon found it already shipped — `1a35fdf` (#288), the same day. So this is a version bump, not a sibling skill: `scope-discipline` Q2 (≥50% covered ⇒ EXTEND) and no second SSOT.

## 1. `FORM_NOT_RENDERED` — new WARN, `--strict` ⇒ FAIL

The schema accepts **13** `chart.form` values. The renderer draws **one** geometry: horizontal proportional bars (`<rect>` at `render.mjs:797` + baseline `<line>` at `:811`). Measured: the renderer branches on `form` *only inside the gate* (`:245`), never in rendering.

So `form:"line"` was accepted, ignored, and silently substituted — the IR says line, the artifact shows bars, nothing announced it. That is theater of exactly the kind this skill exists to refuse, **inside the skill built to refuse it** (anti-theater Layer-5).

WARN rather than FAIL is proportionate: the evidence stays sourced and truncation-checked; only the label overpromises.

### Two alternatives rejected on measurement, not taste

| Option | Why not |
|---|---|
| Shrink the enum | **BREAKING.** `form` is `enum`-constrained with `additionalProperties:false` ⇒ any existing IR carrying `form:"line"` stops validating (MAJOR, not MINOR). Also deletes vocabulary the bundled `dataviz` reference actively teaches — the schema itself says *"stat-tile / kpi-row / table are first-class answers there"*. |
| Build 13 geometries | **YAGNI.** 6 of 6 fixture charts declare only `"bar"` ⇒ 12 of 13 forms have **zero** test coverage. |

### ⚠️ This adds no exemption to anything

The `MAGNITUDE_FORMS` allow-list is **not** back. Truncation stays form-agnostic, exactly as `render.mjs:88-95` records its deliberate removal — *"so the next reader does not reintroduce the allow-list as an apparent improvement"*. I nearly made that error: my first analysis claimed this change would "reopen a gate hole". Wrong — the bypass was already closed, and `FAIL` msg `:224` says so out loud (`declared form "X" does not exempt it`). The real risk is narrower and named in the code comment: the `keys off what is DRAWN` predicate expires the moment forms gain real geometry.

## 2. Width breakpoints (760px / 420px)

Before this, the only `@media` queries were `prefers-color-scheme`, `prefers-reduced-motion`, `print`. A viewport meta plus a `max-width` made the page **shrink**, which is not the same as readable. A decision artifact is read where the decision happens, often not at a desk.

Header stacks; wide data tables scroll instead of the page (the table *is* the accessible rendering — it must never be clipped); claim ids wrap. Declared **before** `@media print` so print keeps the last word.

## 3. Stated, not implied

New "Not built" table in SKILL.md — each **probed**, not guessed: drill-down (absent) · filter controls (declared as `dataviz` parameter #8 in `audience-map.md`, inert) · burn-down (absent, no consumer — deferred rather than built on spec) · stat-tile demotion (self-declared "Not yet implemented") · yaml (verified: `--formats yaml` ⇒ exit 0, `UNKNOWN_FORMAT` surfaced, **zero files written**).

## Verification

- **93 passed, 0 failed** (was 89). Every new assertion mutation-verified in **both** directions.
- **One assertion was caught being a test that cannot fail.** It addressed the fixture through a `$TMP`-relative path that silently `ENOENT`s ⇒ node printed no code ⇒ the negative `case` matched ⇒ `ok()` fired unconditionally. It would have passed with the guard deleted **and** inverted. Fixed to address `$EX` directly, plus an empty-output branch so an assertion can never again pass by observing nothing.
- Guard neutered ⇒ suite 92/1 ✗; restored ⇒ 93/93 ✓.
- Idempotent render verified (`diff` of two runs identical) · `tests/validate-plugin.sh` **PASSED** · zero npm deps · zero remote subresources · JS-off render unaffected · 6 documented fixtures unchanged (0,1,1,1,1,1) · `v0.2.0` stamped into the artifact.

## Not done (deliberate)

Real pdf/pptx/xlsx documents. The owners are installed (`~/.claude/plugins/cache/anthropic-agent-skills/document-skills`, `marketplaces/open-design/skills/pptx`) and `od` is on PATH, so the last-mile is reachable — but it is a separate concern with its own failure modes, and it does not belong in a gate-integrity PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
