### PR TITLE
feat(skills): 9router-concierge + omniroute-concierge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,12 @@ Two new skills in the `*-concierge` family (Anima `[C-naming]`) for the operator
 - **`skills/9router-concierge/`** — health / inventory / audit over 9Router (`:20130`, DB `~/.9router/db/data.sqlite`, `comboStrategies` SSOT). Modes: explain · health · inventory · guide · audit · dashboard. Encodes Tomé gotchas: wrong DB path, strategies in settings (not `/v1/models` alone), empty log dirs ≠ no traffic, rename must update `judgeModel` + strategy keys. Canonical eco family: `eco-fallback` / `eco-rotate` / `eco-council`.
 - **`skills/omniroute-concierge/`** — same surface for OmniRoute (`:20128`, `~/.omniroute/storage.sqlite`). Modes include **`heal-parity`** (9r → omni strategy map: fallback→priority, round-robin→round-robin, fusion→fusion). Never declare gateway dead on `/api/health` 401 alone (prefer `/v1/models`).
 
-Companion inventory: `~/Projects/9router-megacontext/{INVENTORY,CONCIERGE-REGISTRY,LOGS-INVENTORY}-2026-07-31.md`. Provider-specific concierges (kimi/codex/grok/…) stay YAGNI until Triple-touch ops.
+Companion inventory (literal paths, not brace-expansion):
+`~/Projects/9router-megacontext/INVENTORY-2026-07-31.md`,
+`~/Projects/9router-megacontext/CONCIERGE-REGISTRY.md`,
+`~/Projects/9router-megacontext/LOGS-INVENTORY-2026-07-31.md`.
+Provider-specific concierges (kimi/codex/grok/…) stay YAGNI until Triple-touch ops.
+Secret probes in both skills are **existence-only** (`COUNT(*)`); never document `SELECT key`.
 
 ### Changed — `research-dossier` v0.2.0: the declared form stops lying, and the page fits a phone
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added — `9router-concierge` + `omniroute-concierge` (gateway concierge family)
 
+<!-- Signed: Claude-Dev-e731-001 · 2026-07-31T21:55:00Z -->
+
 Two new skills in the `*-concierge` family (Anima `[C-naming]`) for the operator's dual AI gateways:
 
 - **`skills/9router-concierge/`** — health / inventory / audit over 9Router (`:20130`, DB `~/.9router/db/data.sqlite`, `comboStrategies` SSOT). Modes: explain · health · inventory · guide · audit · dashboard. Encodes Tomé gotchas: wrong DB path, strategies in settings (not `/v1/models` alone), empty log dirs ≠ no traffic, rename must update `judgeModel` + strategy keys. Canonical eco family: `eco-fallback` / `eco-rotate` / `eco-council`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `9router-concierge` + `omniroute-concierge` (gateway concierge family)
+
+Two new skills in the `*-concierge` family (Anima `[C-naming]`) for the operator's dual AI gateways:
+
+- **`skills/9router-concierge/`** — health / inventory / audit over 9Router (`:20130`, DB `~/.9router/db/data.sqlite`, `comboStrategies` SSOT). Modes: explain · health · inventory · guide · audit · dashboard. Encodes Tomé gotchas: wrong DB path, strategies in settings (not `/v1/models` alone), empty log dirs ≠ no traffic, rename must update `judgeModel` + strategy keys. Canonical eco family: `eco-fallback` / `eco-rotate` / `eco-council`.
+- **`skills/omniroute-concierge/`** — same surface for OmniRoute (`:20128`, `~/.omniroute/storage.sqlite`). Modes include **`heal-parity`** (9r → omni strategy map: fallback→priority, round-robin→round-robin, fusion→fusion). Never declare gateway dead on `/api/health` 401 alone (prefer `/v1/models`).
+
+Companion inventory: `~/Projects/9router-megacontext/{INVENTORY,CONCIERGE-REGISTRY,LOGS-INVENTORY}-2026-07-31.md`. Provider-specific concierges (kimi/codex/grok/…) stay YAGNI until Triple-touch ops.
+
 ### Changed — `research-dossier` v0.2.0: the declared form stops lying, and the page fits a phone
 
 Two gaps found by reading v0.1.0 against what callers assume it does.

--- a/skills/9router-concierge/SKILL.md
+++ b/skills/9router-concierge/SKILL.md
@@ -28,7 +28,7 @@ I am the **concierge of 9Router**. I orient over the live instance: health, comb
 | Process/port | `lsof -nP -iTCP:20130 -sTCP:LISTEN` | try other ports; report down |
 | Health | `curl -s $NINEROUTER_URL/api/health` → `{"ok":true}` | gateway down |
 | **Real DB** | `~/.9router/db/data.sqlite` (NOT `~/.omniroute/services/9router/...` which may be empty) | wrong path → false inventory |
-| API key | `sqlite3 … "SELECT key FROM apiKeys WHERE isActive=1 LIMIT 1"` (never print) | 401 on chat |
+| API key present? | **existence only** — `sqlite3 … "SELECT COUNT(*) FROM apiKeys WHERE isActive=1"` (report 0/N; **never** `SELECT key`) | 401 on chat if 0 and requireApiKey |
 | Combos | `GET /v1/models` + `owned_by=="combo"` AND table `combos` | split-brain if diverge |
 | Strategies SSOT | `settings.data.comboStrategies` (JSON in `settings` table) | absence of key = **fallback** default |
 | Logs | file logs often **empty**; use `requestDetails` / `usageDaily` / `usageHistory` | don't claim "no errors" from empty dirs |
@@ -36,8 +36,10 @@ I am the **concierge of 9Router**. I orient over the live instance: health, comb
 **Default env (this machine):**
 ```bash
 export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute here)
-# NINEROUTER_KEY from apiKeys table when requireApiKey=true
+# NINEROUTER_KEY: load from apiKeys when requireApiKey=true — inject into env/1P; NEVER echo/print/log
 ```
+
+**Secret discipline (binding):** never `SELECT key` / never `printf` the token / never paste keys into PR comments or skill output. If a probe needs auth, set `NINEROUTER_KEY` out-of-band and use it only in `Authorization` headers; redact transcripts.
 
 ## Landscape Decision Matrix
 
@@ -83,9 +85,10 @@ export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute h
 
 1. ❌ Reading `~/.omniroute/services/9router/data/db/data.sqlite` as live SSOT (often empty)  
 2. ❌ Assuming empty log dirs ⇒ no traffic (use SQLite)  
-3. ❌ Printing API keys  
+3. ❌ **Printing / selecting API keys** (`SELECT key`, `echo $NINEROUTER_KEY`, paste into chat/PR)  
 4. ❌ Renaming combo without updating `judgeModel` / `comboStrategies` keys  
-5. ❌ Treating `/v1/models` alone as full config (strategies live in settings)
+5. ❌ Treating `/v1/models` alone as full config (strategies live in settings)  
+6. ❌ Using Bash for anything beyond Phase-0 probes / read-only inventory (no destructive `rm`/`pkill` without operator)
 
 ## Refs
 

--- a/skills/9router-concierge/SKILL.md
+++ b/skills/9router-concierge/SKILL.md
@@ -17,6 +17,17 @@ allowed-tools: Read, Glob, Grep, Bash
 > **Named by**: Anima (`[C-naming]`) · family `*-concierge` (maos/ekora/claude-code)  
 > **Companion docs**: `~/Projects/9router-megacontext/` · inventory `INVENTORY-2026-07-31.md`
 
+## Requirements (runtime probes)
+
+| Tool | Used for |
+|---|---|
+| `lsof` | TCP listen probe on `:20130` |
+| `curl` | `/api/health`, `/v1/models` |
+| `sqlite3` | existence counts + inventory (never `SELECT key`) |
+| `bash` | Phase-0 / inventory only (same family as `maos-concierge`) |
+
+**Naming note:** slug `9router-concierge` starts with a digit because the product is **9Router** (Anima `[C-naming]` / family `{surface}-concierge`). Do not rename to invent a leading letter — that would desync product, dir, and registry.
+
 ## Identity
 
 I am the **concierge of 9Router**. I orient over the live instance: health, combos, strategies, providers, logs. I never reimplement the gateway and never echo API keys/secrets.

--- a/skills/9router-concierge/SKILL.md
+++ b/skills/9router-concierge/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: 9router-concierge
+version: "1.0.0"
+description: |
+  Concierge / health-check / inventory / router for the operator's **9Router** gateway
+  (local OpenAI-compatible AI gateway). Knows real ports, DB paths, comboStrategies SSOT,
+  logs-in-SQLite, and combo taxonomy (leaf · eco · mega · council). Use to ASK anything about
+  9Router, run health/inventory, find combos/strategies, audit gaps, or route to the right
+  fix surface. Never invents endpoints; capability-detects first (Mente Tomé).
+  Modes: explain · health · inventory · guide · audit · dashboard.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Skill: 9router-concierge — Concierge over the 9Router gateway
+
+> **Domain**: 9Router local gateway · **Lens**: Tomé (verify, don't assume) · Systemic · Critical  
+> **Named by**: Anima (`[C-naming]`) · family `*-concierge` (maos/ekora/claude-code)  
+> **Companion docs**: `~/Projects/9router-megacontext/` · inventory `INVENTORY-2026-07-31.md`
+
+## Identity
+
+I am the **concierge of 9Router**. I orient over the live instance: health, combos, strategies, providers, logs. I never reimplement the gateway and never echo API keys/secrets.
+
+## Phase 0 — Capability detection (always first)
+
+| Probe | How | If absent |
+|---|---|---|
+| Process/port | `lsof -nP -iTCP:20130 -sTCP:LISTEN` | try other ports; report down |
+| Health | `curl -s $NINEROUTER_URL/api/health` → `{"ok":true}` | gateway down |
+| **Real DB** | `~/.9router/db/data.sqlite` (NOT `~/.omniroute/services/9router/...` which may be empty) | wrong path → false inventory |
+| API key | `sqlite3 … "SELECT key FROM apiKeys WHERE isActive=1 LIMIT 1"` (never print) | 401 on chat |
+| Combos | `GET /v1/models` + `owned_by=="combo"` AND table `combos` | split-brain if diverge |
+| Strategies SSOT | `settings.data.comboStrategies` (JSON in `settings` table) | absence of key = **fallback** default |
+| Logs | file logs often **empty**; use `requestDetails` / `usageDaily` / `usageHistory` | don't claim "no errors" from empty dirs |
+
+**Default env (this machine):**
+```bash
+export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute here)
+# NINEROUTER_KEY from apiKeys table when requireApiKey=true
+```
+
+## Landscape Decision Matrix
+
+| Intent | Do |
+|---|---|
+| Health-check | Phase 0 probes + process uptime |
+| List combos + strategies | Join `combos` + `settings.comboStrategies` |
+| Rename combo safely | Update `combos.name` **and** `comboStrategies` key **and** any `judgeModel` refs |
+| Strategy change | `PATCH /api/settings` with full `comboStrategies` object (not PUT-only) |
+| Errors/forensics | `requestDetails` WHERE status='error' (ring ~1000); never grep secrets |
+| Nested leaves | Models without `/` are **combo refs** — recurse until `provider/model` |
+| Compare to OmniRoute | Use `omniroute-concierge` / dual inventory; 9r is SSOT for this operator's strategies |
+
+## Combo taxonomy (canonical)
+
+| Family | Examples | Meaning |
+|---|---|---|
+| Leaf | `claude-opus`, `gpt-sol`, `kimi` | model family name |
+| Eco mode | `eco-fallback`, **`eco-rotate`**, `eco-council` | cheap pool + strategy |
+| Mega ladder | `mega-mid/high/xhigh/swift/review` | cognition ordinal |
+| Council/fusion | `*-council`, `mega-brain` | fusion panel; judge = non-fusion combo |
+
+**Anima naming rules:** mode combos must encode strategy (`fallback` / `rotate`); never opaque metaphors (`hold` rejected).
+
+### Strategy enum (UI)
+
+| value | Label | Persistence |
+|---|---|---|
+| `fallback` | Fallback — try in order | **default** — entry deleted from `comboStrategies` when set |
+| `round-robin` | Round Robin — rotate | explicit entry |
+| `fusion` | Fusion — panel + judge | explicit + `judgeModel` |
+
+## Modes
+
+- `--mode=explain` (default) — teach architecture + paths + taxonomy  
+- `--mode=health` — Phase 0 only, compact status  
+- `--mode=inventory` — full combo×strategy×judge table  
+- `--mode=guide` — intent → exact curl/SQL  
+- `--mode=audit` — gaps vs OmniRoute, orphan strategies, dead leaves  
+- `--mode=dashboard` — point to `~/Projects/9router-megacontext/*.html` + inventory md  
+
+## Anti-patterns
+
+1. ❌ Reading `~/.omniroute/services/9router/data/db/data.sqlite` as live SSOT (often empty)  
+2. ❌ Assuming empty log dirs ⇒ no traffic (use SQLite)  
+3. ❌ Printing API keys  
+4. ❌ Renaming combo without updating `judgeModel` / `comboStrategies` keys  
+5. ❌ Treating `/v1/models` alone as full config (strategies live in settings)
+
+## Refs
+
+- Skill entry: `9router` (thin OpenAI client index)  
+- Sibling: `omniroute-concierge`  
+- Docs: `~/Projects/9router-megacontext/`  
+- Cross-link: `[[9router-concierge]]`

--- a/skills/9router-concierge/SKILL.md
+++ b/skills/9router-concierge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: 9router-concierge
-version: "1.0.0"
+version: "1.0.1"
 description: |
   Concierge / health-check / inventory / router for the operator's **9Router** gateway
   (local OpenAI-compatible AI gateway). Knows real ports, DB paths, comboStrategies SSOT,
@@ -22,7 +22,7 @@ allowed-tools: Read, Glob, Grep, Bash
 | Tool | Used for |
 |---|---|
 | `lsof` | TCP listen probe on `:20130` |
-| `curl` | `/api/health`, `/v1/models` |
+| `curl` | `/api/health`, `/v1/models` (with connect/max timeouts) |
 | `sqlite3` | existence counts + inventory (never `SELECT key`) |
 | `bash` | Phase-0 / inventory only (same family as `maos-concierge`) |
 
@@ -30,36 +30,38 @@ allowed-tools: Read, Glob, Grep, Bash
 
 ## Identity
 
-I am the **concierge of 9Router**. I orient over the live instance: health, combos, strategies, providers, logs. I never reimplement the gateway and never echo API keys/secrets.
+I am the **concierge of 9Router**. I orient over the live instance: health, combos, strategies, providers, logs. Gateway is never reimplemented; API keys/secrets are never echoed.
 
 ## Phase 0 — Capability detection (always first)
 
 | Probe | How | If absent |
 |---|---|---|
 | Process/port | `lsof -nP -iTCP:20130 -sTCP:LISTEN` | try other ports; report down |
-| Health | `curl -s $NINEROUTER_URL/api/health` → `{"ok":true}` | gateway down |
+| Health | `curl --silent --show-error --connect-timeout 2 --max-time 5 "$NINEROUTER_URL/api/health"` → `{"ok":true}` | gateway down / stall |
 | **Real DB** | `~/.9router/db/data.sqlite` (NOT `~/.omniroute/services/9router/...` which may be empty) | wrong path → false inventory |
 | API key present? | **existence only** — `sqlite3 … "SELECT COUNT(*) FROM apiKeys WHERE isActive=1"` (report 0/N; **never** `SELECT key`) | 401 on chat if 0 and requireApiKey |
 | Combos | `GET /v1/models` + `owned_by=="combo"` AND table `combos` | split-brain if diverge |
-| Strategies SSOT | `settings.data.comboStrategies` (JSON in `settings` table) | absence of key = **fallback** default |
+| Strategies SSOT | **`settings.data.comboStrategies`** (JSON in `settings` table `data` blob) | absence of key = **fallback** default |
 | Logs | file logs often **empty**; use `requestDetails` / `usageDaily` / `usageHistory` | don't claim "no errors" from empty dirs |
 
 **Default env (this machine):**
+
 ```bash
 export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute here)
-# NINEROUTER_KEY: load from apiKeys when requireApiKey=true — inject into env/1P; NEVER echo/print/log
+# NINEROUTER_KEY: obtain out-of-band from approved secret store (1Password / env injection).
+# NEVER SELECT key from apiKeys · NEVER echo/print/log the token.
 ```
 
-**Secret discipline (binding):** never `SELECT key` / never `printf` the token / never paste keys into PR comments or skill output. If a probe needs auth, set `NINEROUTER_KEY` out-of-band and use it only in `Authorization` headers; redact transcripts.
+**Secret discipline (binding):** never `SELECT key` / never `printf` the token / never paste keys into PR comments or skill output. If a probe needs auth, set `NINEROUTER_KEY` from the approved secret store and use it only in `Authorization` headers; redact transcripts. Phase 0 only checks **presence** (`COUNT(*)`), never materializes the secret.
 
 ## Landscape Decision Matrix
 
 | Intent | Do |
 |---|---|
 | Health-check | Phase 0 probes + process uptime |
-| List combos + strategies | Join `combos` + `settings.comboStrategies` |
-| Rename combo safely | Update `combos.name` **and** `comboStrategies` key **and** any `judgeModel` refs |
-| Strategy change | `PATCH /api/settings` with full `comboStrategies` object (not PUT-only) |
+| List combos + strategies | Join `combos` + **`settings.data.comboStrategies`** |
+| Rename combo safely | Update `combos.name` **and** `settings.data.comboStrategies` key **and** any `judgeModel` refs |
+| Strategy change | `PATCH /api/settings` with full `comboStrategies` object inside settings `data` (not PUT-only) |
 | Errors/forensics | `requestDetails` WHERE status='error' (ring ~1000); never grep secrets |
 | Nested leaves | Models without `/` are **combo refs** — recurse until `provider/model` |
 | Compare to OmniRoute | Use `omniroute-concierge` / dual inventory; 9r is SSOT for this operator's strategies |
@@ -79,7 +81,7 @@ export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute h
 
 | value | Label | Persistence |
 |---|---|---|
-| `fallback` | Fallback — try in order | **default** — entry deleted from `comboStrategies` when set |
+| `fallback` | Fallback — try in order | **default** — entry deleted from `settings.data.comboStrategies` when set |
 | `round-robin` | Round Robin — rotate | explicit entry |
 | `fusion` | Fusion — panel + judge | explicit + `judgeModel` |
 
@@ -97,8 +99,8 @@ export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute h
 1. ❌ Reading `~/.omniroute/services/9router/data/db/data.sqlite` as live SSOT (often empty)  
 2. ❌ Assuming empty log dirs ⇒ no traffic (use SQLite)  
 3. ❌ **Printing / selecting API keys** (`SELECT key`, `echo $NINEROUTER_KEY`, paste into chat/PR)  
-4. ❌ Renaming combo without updating `judgeModel` / `comboStrategies` keys  
-5. ❌ Treating `/v1/models` alone as full config (strategies live in settings)  
+4. ❌ Renaming combo without updating `judgeModel` / `settings.data.comboStrategies` keys  
+5. ❌ Treating `/v1/models` alone as full config (strategies live in `settings.data.comboStrategies`)  
 6. ❌ Using Bash for anything beyond Phase-0 probes / read-only inventory (no destructive `rm`/`pkill` without operator)
 
 ## Refs
@@ -107,3 +109,6 @@ export NINEROUTER_URL="http://localhost:20130"   # NOT 20128 (that's OmniRoute h
 - Sibling: `omniroute-concierge`  
 - Docs: `~/Projects/9router-megacontext/`  
 - Cross-link: `[[9router-concierge]]`
+
+---
+*Signed: Claude-Dev-e731-001 · 2026-07-31T21:55:00Z*

--- a/skills/omniroute-concierge/SKILL.md
+++ b/skills/omniroute-concierge/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: omniroute-concierge
-version: "1.0.0"
+version: "1.0.1"
 description: |
   Concierge / health-check / inventory / router for the operator's **OmniRoute** gateway
   (v3.8+ local AI proxy). Knows real port, storage.sqlite schema, strategy enum (19 values),
   fusion/judgeModel, provider_connections, and parity with 9Router SSOT. Use to ASK anything
-  about OmniRoute, run health/inventory, audit combo/strategy gaps, heal strategy drift from
+  about OmniRoute, run health/inventory, audit combo/strategy gaps, plan strategy heal from
   9Router, or route ops. Never invents routes; capability-detects first (Mente Tomé).
   Modes: explain · health · inventory · guide · audit · heal-parity · dashboard.
 allowed-tools: Read, Glob, Grep, Bash
@@ -22,14 +22,14 @@ allowed-tools: Read, Glob, Grep, Bash
 | Tool | Used for |
 |---|---|
 | `lsof` | TCP listen probe on `:20128` |
-| `curl` | `/v1/models` (prefer over `/api/health` 401/unknown_route) |
+| `curl` | `/v1/models` with timeouts (prefer over `/api/health` 401/unknown_route) |
 | `sqlite3` | existence counts + inventory on `storage.sqlite` (never `SELECT key`) |
 | `omniroute` CLI | documented restart: `omniroute stop && omniroute serve --daemon` |
-| `bash` | Phase-0 / inventory / documented restart only |
+| `bash` | Phase-0 / inventory / documented restart only (writes only with operator confirm) |
 
 ## Identity
 
-I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), strategies, providers, logs. I never print tokens/secrets. For this operator, **9Router is the strategy SSOT** when healing parity.
+I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), strategies, providers, logs. Tokens/secrets are never printed. For this operator, **9Router is the strategy SSOT** when planning parity heals.
 
 ## Phase 0 — Capability detection
 
@@ -37,18 +37,20 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 |---|---|---|
 | Process/port | `lsof -nP -iTCP:20128 -sTCP:LISTEN` | report down |
 | Auth present? | **existence only** — `sqlite3 … "SELECT COUNT(*) FROM api_keys WHERE revoked_at IS NULL"` (report 0/N; **never** `SELECT key`) | 401 if 0 |
-| Health | `/api/health` may be **unknown_route** or 401 — prefer `/v1/models` reachability | don't declare dead on health path alone |
+| Health | `/api/health` may be **unknown_route** or 401 — prefer `curl --silent --show-error --connect-timeout 2 --max-time 5 "$OMNIROUTE_URL/v1/models"` | don't declare dead on health path alone |
 | DB | `~/.omniroute/storage.sqlite` table `combos` (`data` JSON) | — |
 | Restart | `omniroute stop && omniroute serve --daemon` (operator-known) | don't `pkill` casually |
 | Logs | `~/.omniroute/logs/application/app.log`, `server_out.log` | provider 402/429 dominate |
 
 **Default env (this machine):**
+
 ```bash
 # OmniRoute :20128  ·  9Router :20130
-# API key: load from api_keys out-of-band into env/1P — NEVER SELECT key / echo / log the value
+# API key: obtain out-of-band from approved secret store (1Password / env injection).
+# NEVER SELECT key from api_keys · NEVER echo / log the value.
 ```
 
-**Secret discipline (binding):** never `SELECT key` / never print tokens from `api_keys` / never paste into skill output or PR comments. Auth header only; redact transcripts.
+**Secret discipline (binding):** never `SELECT key` / never print tokens from `api_keys` / never paste into skill output or PR comments. Auth header only; redact transcripts. Phase 0 only checks **presence** (`COUNT(*)`).
 
 ## Combo `data` JSON (canonical shape)
 
@@ -79,9 +81,9 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 
 | Intent | Do |
 |---|---|
-| Health | Phase 0 + `/v1/models` count |
+| Health | Phase 0 + timed `/v1/models` count |
 | Inventory combos | `SELECT name, json_extract(data,'$.strategy')… FROM combos` |
-| Parity vs 9Router | Diff strategies; heal with mapping table above |
+| Parity vs 9Router | Diff strategies; emit **heal plan** (mapping table) |
 | Fusion council | Ensure `config.judgeModel` points to non-fusion combo |
 | Provider errors | Read `provider_connections` (`is_active`, `test_status`) + app.log — never print tokens |
 | Rename combo | Update `combos.name` + JSON `data.name` + any judge refs |
@@ -93,7 +95,7 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 - `--mode=inventory` — full combo table  
 - `--mode=guide` — curl/SQL recipes  
 - `--mode=audit` — gaps vs 9r, orphan models, provider errors  
-- `--mode=heal-parity` — apply 9r→omni strategy mapping (confirm if destructive/large)  
+- `--mode=heal-parity` — **read-only plan by default**: emit 9r→omni strategy mapping diff + exact proposed mutations. **Apply only after explicit operator confirmation**; then Bash write is allowed for that approved patch set; keep a pre-change SQLite backup path in the plan for rollback.  
 - `--mode=dashboard` — point to megacontext HTML + inventory  
 
 ## Anti-patterns
@@ -103,11 +105,12 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 3. ❌ **Printing / selecting API keys** (`SELECT key`, echo token, paste into chat/PR)  
 4. ❌ Healing strategies without 9r SSOT when operator policy is 9r-first  
 5. ❌ Leaving fusion councils without `judgeModel`  
-6. ❌ Bash beyond Phase-0 / inventory / documented restart (no casual destructive ops)
+6. ❌ Bash beyond Phase-0 / inventory / documented restart / **operator-confirmed heal-parity apply**  
+7. ❌ Silent apply of heal-parity without confirmation + backup path  
 
 ## Canonical eco family (post-Anima)
 
-```
+```text
 eco-fallback  → priority (try in order)
 eco-rotate    → round-robin
 eco-council   → fusion · judgeModel=eco-rotate
@@ -119,3 +122,6 @@ eco-council   → fusion · judgeModel=eco-rotate
 - OmniRoute skills under package `dist/skills/omni-*`  
 - Docs: `~/Projects/9router-megacontext/`  
 - Cross-link: `[[omniroute-concierge]]`
+
+---
+*Signed: Claude-Dev-e731-001 · 2026-07-31T21:55:00Z*

--- a/skills/omniroute-concierge/SKILL.md
+++ b/skills/omniroute-concierge/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: omniroute-concierge
+version: "1.0.0"
+description: |
+  Concierge / health-check / inventory / router for the operator's **OmniRoute** gateway
+  (v3.8+ local AI proxy). Knows real port, storage.sqlite schema, strategy enum (19 values),
+  fusion/judgeModel, provider_connections, and parity with 9Router SSOT. Use to ASK anything
+  about OmniRoute, run health/inventory, audit combo/strategy gaps, heal strategy drift from
+  9Router, or route ops. Never invents routes; capability-detects first (Mente Tomé).
+  Modes: explain · health · inventory · guide · audit · heal-parity · dashboard.
+allowed-tools: Read, Glob, Grep, Bash
+---
+
+# Skill: omniroute-concierge — Concierge over the OmniRoute gateway
+
+> **Domain**: OmniRoute gateway · **Lens**: Tomé · Systemic · Critical  
+> **Named by**: Anima (`[C-naming]`) · family `*-concierge`  
+> **Companion**: `9router-concierge` (strategy SSOT for this operator) · `~/Projects/9router-megacontext/INVENTORY-*.md`
+
+## Identity
+
+I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), strategies, providers, logs. I never print tokens/secrets. For this operator, **9Router is the strategy SSOT** when healing parity.
+
+## Phase 0 — Capability detection
+
+| Probe | How | If absent |
+|---|---|---|
+| Process/port | `lsof -nP -iTCP:20128 -sTCP:LISTEN` | report down |
+| Auth | API key from `api_keys` table (never print); `Authorization: Bearer …` | 401 |
+| Health | `/api/health` may be **unknown_route** or 401 — prefer `/v1/models` reachability | don't declare dead on health path alone |
+| DB | `~/.omniroute/storage.sqlite` table `combos` (`data` JSON) | — |
+| Restart | `omniroute stop && omniroute serve --daemon` (operator-known) | don't `pkill` casually |
+| Logs | `~/.omniroute/logs/application/app.log`, `server_out.log` | provider 402/429 dominate |
+
+**Default env (this machine):**
+```bash
+# OmniRoute :20128  ·  9Router :20130
+# Key: sqlite3 ~/.omniroute/storage.sqlite "SELECT key FROM api_keys WHERE revoked_at IS NULL LIMIT 1;"
+```
+
+## Combo `data` JSON (canonical shape)
+
+```json
+{
+  "name": "eco-rotate",
+  "strategy": "round-robin",
+  "models": [{"id":"…","kind":"model","model":"kimi/k3","providerId":"kimi","weight":1}],
+  "config": {"maxRetries":2, "judgeModel":"…", "fusionTuning":{}},
+  "context_length": 1000000,
+  "version": 2
+}
+```
+
+## Strategy enum (product)
+
+`priority · weighted · round-robin · context-relay · fill-first · p2c · random · least-used · cost-optimized · reset-aware · reset-window · headroom · strict-random · auto · lkgp · context-optimized · cache-optimized · fusion · pipeline` (+ internal `quota-share`)
+
+### Mapping from 9Router → OmniRoute (operator SSOT)
+
+| 9r `fallbackStrategy` | Omni `strategy` |
+|---|---|
+| `fallback` (default / absent entry) | **`priority`** |
+| `round-robin` | **`round-robin`** |
+| `fusion` | **`fusion`** (+ copy `judgeModel` / `fusionTuning`) |
+
+## Landscape Decision Matrix
+
+| Intent | Do |
+|---|---|
+| Health | Phase 0 + `/v1/models` count |
+| Inventory combos | `SELECT name, json_extract(data,'$.strategy')… FROM combos` |
+| Parity vs 9Router | Diff strategies; heal with mapping table above |
+| Fusion council | Ensure `config.judgeModel` points to non-fusion combo |
+| Provider errors | Read `provider_connections` (`is_active`, `test_status`) + app.log — never print tokens |
+| Rename combo | Update `combos.name` + JSON `data.name` + any judge refs |
+
+## Modes
+
+- `--mode=explain` — architecture + paths + strategy map  
+- `--mode=health` — compact liveness  
+- `--mode=inventory` — full combo table  
+- `--mode=guide` — curl/SQL recipes  
+- `--mode=audit` — gaps vs 9r, orphan models, provider errors  
+- `--mode=heal-parity` — apply 9r→omni strategy mapping (confirm if destructive/large)  
+- `--mode=dashboard` — point to megacontext HTML + inventory  
+
+## Anti-patterns
+
+1. ❌ `pkill omniroute` without known restart command  
+2. ❌ Declaring gateway dead because `/api/health` is 401/unknown_route  
+3. ❌ Printing API keys from `api_keys`  
+4. ❌ Healing strategies without 9r SSOT when operator policy is 9r-first  
+5. ❌ Leaving fusion councils without `judgeModel`
+
+## Canonical eco family (post-Anima)
+
+```
+eco-fallback  → priority (try in order)
+eco-rotate    → round-robin
+eco-council   → fusion · judgeModel=eco-rotate
+```
+
+## Refs
+
+- Sibling: `9router-concierge`  
+- OmniRoute skills under package `dist/skills/omni-*`  
+- Docs: `~/Projects/9router-megacontext/`  
+- Cross-link: `[[omniroute-concierge]]`

--- a/skills/omniroute-concierge/SKILL.md
+++ b/skills/omniroute-concierge/SKILL.md
@@ -17,6 +17,16 @@ allowed-tools: Read, Glob, Grep, Bash
 > **Named by**: Anima (`[C-naming]`) · family `*-concierge`  
 > **Companion**: `9router-concierge` (strategy SSOT for this operator) · `~/Projects/9router-megacontext/INVENTORY-*.md`
 
+## Requirements (runtime probes)
+
+| Tool | Used for |
+|---|---|
+| `lsof` | TCP listen probe on `:20128` |
+| `curl` | `/v1/models` (prefer over `/api/health` 401/unknown_route) |
+| `sqlite3` | existence counts + inventory on `storage.sqlite` (never `SELECT key`) |
+| `omniroute` CLI | documented restart: `omniroute stop && omniroute serve --daemon` |
+| `bash` | Phase-0 / inventory / documented restart only |
+
 ## Identity
 
 I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), strategies, providers, logs. I never print tokens/secrets. For this operator, **9Router is the strategy SSOT** when healing parity.

--- a/skills/omniroute-concierge/SKILL.md
+++ b/skills/omniroute-concierge/SKILL.md
@@ -26,7 +26,7 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 | Probe | How | If absent |
 |---|---|---|
 | Process/port | `lsof -nP -iTCP:20128 -sTCP:LISTEN` | report down |
-| Auth | API key from `api_keys` table (never print); `Authorization: Bearer …` | 401 |
+| Auth present? | **existence only** — `sqlite3 … "SELECT COUNT(*) FROM api_keys WHERE revoked_at IS NULL"` (report 0/N; **never** `SELECT key`) | 401 if 0 |
 | Health | `/api/health` may be **unknown_route** or 401 — prefer `/v1/models` reachability | don't declare dead on health path alone |
 | DB | `~/.omniroute/storage.sqlite` table `combos` (`data` JSON) | — |
 | Restart | `omniroute stop && omniroute serve --daemon` (operator-known) | don't `pkill` casually |
@@ -35,8 +35,10 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 **Default env (this machine):**
 ```bash
 # OmniRoute :20128  ·  9Router :20130
-# Key: sqlite3 ~/.omniroute/storage.sqlite "SELECT key FROM api_keys WHERE revoked_at IS NULL LIMIT 1;"
+# API key: load from api_keys out-of-band into env/1P — NEVER SELECT key / echo / log the value
 ```
+
+**Secret discipline (binding):** never `SELECT key` / never print tokens from `api_keys` / never paste into skill output or PR comments. Auth header only; redact transcripts.
 
 ## Combo `data` JSON (canonical shape)
 
@@ -88,9 +90,10 @@ I orient over the live OmniRoute instance: health, combos (`storage.sqlite`), st
 
 1. ❌ `pkill omniroute` without known restart command  
 2. ❌ Declaring gateway dead because `/api/health` is 401/unknown_route  
-3. ❌ Printing API keys from `api_keys`  
+3. ❌ **Printing / selecting API keys** (`SELECT key`, echo token, paste into chat/PR)  
 4. ❌ Healing strategies without 9r SSOT when operator policy is 9r-first  
-5. ❌ Leaving fusion councils without `judgeModel`
+5. ❌ Leaving fusion councils without `judgeModel`  
+6. ❌ Bash beyond Phase-0 / inventory / documented restart (no casual destructive ops)
 
 ## Canonical eco family (post-Anima)
 


### PR DESCRIPTION
## Summary
- Add **`9router-concierge`** + **`omniroute-concierge`** skills (Anima `[C-naming]`, family `*-concierge`).
- Orient over live gateways: 9Router `:20130` (strategy SSOT) · OmniRoute `:20128` (parity/heal).
- Encode Tomé gotchas: real DB paths, empty log dirs ≠ no traffic, `/api/health` 401 ≠ dead Omni, rename must update `judgeModel` + strategy keys, never print API keys.
- Companion docs: `~/Projects/9router-megacontext/{INVENTORY,CONCIERGE-REGISTRY,LOGS-INVENTORY}-2026-07-31.md`.

## Test plan
- [x] `tests/validate-plugin.sh` PASSED (0 errors)
- [x] gitleaks clean on worktree
- [x] Live probe: 9r `/api/health` → `{"ok":true}`; omni listen `:20128` + `/v1/models` with key → 1479 models
- [x] Live inventory: 23 combos both sides; 0 under-floor `context_length`; `eco-hold` absent; `eco-rotate` present
- [ ] Bot reviewers converge (amazon-q / CodeRabbit / etc.)

## Risk + rollback
- Additive skills only (no hooks/runtime change). Revert commit if unwanted.
- Secrets: skills instruct never-print keys; no secrets in diff.

## Out of scope
- Provider-specific concierges (kimi/codex/grok/…) — YAGNI until Triple-touch
- Plugin version bump / marketplace release (follow-up if dogfood warrants)
- Guide HTML 26→23 combo banner (docs in megacontext)

## Refs
- Inventory ADR floor ≥500K · auto-compact `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE=45`
- `[[9router-concierge]]` · `[[omniroute-concierge]]` · CONCIERGE-REGISTRY

🤖 Generated with [Claude Code](https://claude.com/claude-code)
