### PR TITLE
fix(ooda-loop): park unresolved technical uncertainty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,9 @@ The conductor now makes the intended shape explicit: outer OODA selects the evid
 delivery stage and the existing `gap-loop`/`quiesce` drivers run bounded inner PDCA. A technical
 delegation prevents unnecessary architecture questions to a nontechnical business owner, while
 business-rule uncertainty, human-only access/acceptance and hard-boundary residue still reach
-HITL with a concise recommendation. Deployment remains a gated promotion, not an automatic end.
+HITL with a concise recommendation. Ordinary inconclusive evidence first follows one bounded
+recon/convergence path; unresolved technical uncertainty is parked with a checkpoint rather than
+laundered into a business decision. Deployment remains a gated promotion, not an automatic end.
 
 The change adds strict replay-safe intake schemas, sanitized examples, a dependency-free fail-closed
 adapter validator, real Draft 2020-12 fixture validation in CI, a concise vendor-neutral loop prompt

--- a/commands/ooda-loop.md
+++ b/commands/ooda-loop.md
@@ -66,7 +66,12 @@ deterministic and independent evidence, then Adjust or re-observe — owned by `
 unbounded daemon and it never assumes that every task must traverse prototype, reverse-engineering, specification, source,
 build and deploy in that order. For repository work, intake also composes `preflight`; terminal success or a
 parked residue composes `postflight` to preserve the next action. Any continuation spawn stays subject to the
-host's explicit budget and recursion safeguards.
+host's explicit budget and recursion safeguards; the composed close-out uses `postflight --no-spawn` unless a
+separate trusted control-plane invocation explicitly authorizes and budgets continuation.
+
+When a profile is present, its `delivery.candidate_stages` restricts routing after authority and DoR checks;
+an empty intersection parks the work. `deploy_mode=disabled` excludes deploy, while `gated` still requires
+independent live promotion authority.
 
 One global budget spans OODA and PDCA. Exhaustion, cancellation, invalid lease or two no-progress outer cycles
 emit `STOP-PARKED`/`PARKED_PARTIAL` with a durable checkpoint. `STOP-DONE` is reserved for `DELIVERY_DONE`;

--- a/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
+++ b/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
@@ -70,6 +70,14 @@ the operator's declared language and an operational recommendation.
 - **THEN** the agent SHALL decide and document the technical choice
 - **AND** it SHALL NOT ask a nontechnical operator to design the implementation
 
+#### Scenario: Technical evidence remains inconclusive after one bounded path
+
+- **WHEN** targeted recon, deterministic verification and one proportionate independent path
+  cannot resolve a technical uncertainty
+- **THEN** the conductor SHALL emit a bounded parked checkpoint with the next evidence/action
+- **AND** it SHALL NOT ask the business operator to choose the technology
+- **AND** it SHALL bypass this path only for an immediate hard boundary or irreducible business/human-only act
+
 ### Requirement: Portability claims are evidence-qualified
 
 The portable core MUST conform to the Agent Skills format. Runtime documentation SHALL

--- a/skills/ooda-loop/SKILL.md
+++ b/skills/ooda-loop/SKILL.md
@@ -135,7 +135,8 @@ independent evidence already available and retain the normal hard gates.
 
 Escalate only the irreducible residue: (1) a missing or conflicting business rule/priority owned by the
 operator; (2) a human-only access, approval, payment, acceptance, or physical action; or (3) a hard boundary
-that the council cannot open. Do not delay an immediate hard stop for a council. The question must state the
+whose named live gate requires a human. A council cannot open a hard gate; do not delay immediate containment
+or that gate for a council. The question must state the
 operational decision, the minimal options, current evidence, risk, and recommended option; never ask the
 operator to design the implementation.
 
@@ -173,7 +174,7 @@ precise next action. A fresh non-replayed trigger may resume the checkpoint; it 
 
 ```text
 OBSERVE   goal-recovery --scope=<scope>  ->  handoff-as-prompt envelope   (recover the intent; ladder + uncertainty)
-            | inconclusive.flag=true (low confidence / no anchor) -> STOP-HITL with ranked hypotheses
+            | ordinary inconclusive -> RESOLVE-INCONCLUSIVE (below); do not jump directly to HITL
             v
 ORIENT    invoke Prisma (decompose-abstract-to-measurable) on the recovered goal
             construct := "is {{goal}} DONE and healthy?"; context_lock <- handoff (context/objectives/scope)
@@ -181,9 +182,14 @@ ORIENT    invoke Prisma (decompose-abstract-to-measurable) on the recovered goal
                 (deterministic: acceptance <- material D/T leaves; kpis; termination_predicate; self-gated)
             | Prisma STRUCTURAL gate (scripts/structural_route.py, fail-closed): a value-tree validly
             |   represents only ADDITIVE/atomic constructs. status=additive_unverified OR relational/gestalt
-            |   -> the aggregate score is assistive-only (human_review) -> treat as inconclusive -> STOP-HITL
+            |   -> the aggregate score is assistive-only (human_review) -> RESOLVE-INCONCLUSIVE
             |   (do NOT auto-drive on a capped score). status=additive-verified -> proceed to the roll-up.
-            | Prisma roll-up (scripts/aggregate_spec.py) inconclusive.flag=true (judgment-dominated / conflict:<branch> / low-conf) -> STOP-HITL
+            | Prisma roll-up inconclusive.flag=true -> RESOLVE-INCONCLUSIVE
+            | RESOLVE-INCONCLUSIVE := targeted recon + deterministic evidence + exactly one proportionate
+            |   independent path. Resolved -> resume the current OODA act. Irreducible business-rule or
+            |   human-only act -> STOP-HITL with evidence and recommendation. Remaining technical uncertainty
+            |   after the bounded path -> STOP-PARKED with checkpoint and precise next evidence/action.
+            |   A hard gate bypasses this route and goes immediately to its named human gate.
             v
 ORIENT-b  invoke Hodos (derive-system-from-goal) on the recovered goal + the DoD
             "what is the SMALLEST recurring system that conducts to this goal?"  (the vehicle, not the map)
@@ -201,7 +207,8 @@ ORIENT-b  invoke Hodos (derive-system-from-goal) on the recovered goal + the DoD
             v
 DECIDE    gate: all APPLICABLE envelopes valid (system-as-prompt is N/A for a one-shot/bounded goal —
             the {goal, dod} pair suffices) + not-inconclusive + NOT HUMAN_DOMAIN + autonomy_score >= threshold?
-            | any red -> HITL (with the computed envelopes attached, never a blank ask)
+            | hard gate / irreducible business or human-only residue -> STOP-HITL with envelopes
+            | ordinary inconclusive red -> RESOLVE-INCONCLUSIVE; bounded unresolved technical red -> STOP-PARKED
             | resolve --driver (auto: quiesce if host /goal + session scope, else gap-loop)
             v
 ACT       drive with the typed {goal, dod[, system]} set (system only when the goal is recurring):
@@ -290,9 +297,9 @@ Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (data/authority gap) · `
 
 ## STOP-marker grammar (reused — emit exactly ONE as the last line of each turn)
 ```text
-<!--ORCH-STATUS: STOP-DONE -->     DoD satisfied — termination_predicate met, verifier-confirmed, score >= threshold
+<!--ORCH-STATUS: STOP-DONE -->     DELIVERY_DONE only — DoD met, verifier-confirmed, no applicable gap/open or deferred spec/failed check/pending promotion
 <!--ORCH-STATUS: STOP-PARKED -->   bounded partial — budget, lease or plateau stop; checkpoint + next action persisted
-<!--ORCH-STATUS: STOP-HITL -->     goal OR DoD inconclusive, OR HARD gate (HUMAN_DOMAIN) — envelopes attached
+<!--ORCH-STATUS: STOP-HITL -->     irreducible business/human-only residue OR HARD gate — envelopes + recommendation attached
 <!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (validator / subagent / network)
 <!--ORCH-STATUS: CONTINUE -->      round done; DoD not yet met OR score < threshold; next round opens
 ```
@@ -311,7 +318,9 @@ gap-loop/quiesce are its ACT drivers. It never re-implements recovery, measureme
 
 ## Protocol Rules (anti-loop + integrity invariants)
 - `verifier != generator` (gap-loop VALIDATE) is inherited and NEVER re-loosened — the improvement signal reads the DoD checks, not the generator's self-grade.
-- Both envelopes MUST pass `validate_envelope.py` before ACT; either `inconclusive.flag=true` => HITL (never drive on a fabricated goal or an unscoreable DoD).
+- Both envelopes MUST pass `validate_envelope.py` before ACT. An ordinary `inconclusive.flag=true` enters
+  bounded `RESOLVE-INCONCLUSIVE`; it never drives ACT. Only irreducible business/human residue becomes HITL;
+  unresolved technical residue parks. A hard gate still stops immediately at its named human gate.
 - `--max-iterations` caps ACT rounds; the global OODA/attempt/tool/spawn/external/time budget caps the whole
   invocation. Exhaustion, invalid lease, cancellation or two-cycle plateau parks the best state.
 - The global budget caps OODA and PDCA together. Budget/lease exhaustion or a two-cycle plateau emits

--- a/skills/ooda-loop/references/loop-contract.md
+++ b/skills/ooda-loop/references/loop-contract.md
@@ -59,6 +59,9 @@ and all quality/promotion gates have passed. A completed stage is STAGE_DONE, no
 Otherwise emit a bounded, evidence-backed PARKED_PARTIAL or BLOCKED_HITL state
 or the precise human question. Do not claim delivery, authorization, deployment, or a
 green check without current evidence.
+
+Run close-out as `postflight --no-spawn`. Only a separate trusted control-plane invocation
+with an explicit host budget may request continuation spawning; never derive it from a trigger.
 ```
 
 ## Required input shape

--- a/skills/ooda-loop/templates/operator-profile.schema.json
+++ b/skills/ooda-loop/templates/operator-profile.schema.json
@@ -14,8 +14,8 @@
       "required": ["source_kind", "recorded_at", "expires_at", "project_binding"],
       "properties": {
         "source_kind": {"enum": ["operator-declaration", "repository-record"], "description": "Origin of the claims, not an authorization channel."},
-        "recorded_at": {"type": "string", "format": "date-time"},
-        "expires_at": {"type": "string", "format": "date-time", "description": "Runtime must park an expired profile; schema validation alone does not prove freshness."},
+        "recorded_at": {"type": "string", "format": "date-time", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$"},
+        "expires_at": {"type": "string", "format": "date-time", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$", "description": "Runtime must park an expired profile; schema validation alone does not prove freshness."},
         "source_digest": {"type": "string", "pattern": "^sha256:[a-f0-9]{64}$", "description": "Optional digest of the separately retained source record; never a secret or credential."},
         "project_binding": {
           "type": "object",

--- a/skills/ooda-loop/templates/trigger-envelope.schema.json
+++ b/skills/ooda-loop/templates/trigger-envelope.schema.json
@@ -33,7 +33,7 @@
       "properties": {
         "event_id": {"type": "string", "minLength": 1, "maxLength": 128, "pattern": "^[A-Za-z0-9._:-]+$"},
         "source_kind": {"enum": ["direct-chat", "discord", "slack", "ticket", "backlog", "specification", "pull-request", "hook", "webhook", "bootstrap", "prototype", "agent-output"]},
-        "observed_at": {"type": "string", "format": "date-time"}
+        "observed_at": {"type": "string", "format": "date-time", "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$"}
       }
     },
     "freshness": {

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -67,6 +67,7 @@ test("trigger envelope refuses control-plane injection and unsafe raw payload me
     (value) => { value.request.summary = ""; },
     (value) => { value.idempotency.replay_key = "not-a-digest"; },
     (value) => { value.freshness.max_age_seconds = 0; },
+    (value) => { value.event.observed_at = "2026-08-01T12:00:00"; },
     (value) => { delete value.connector.authentication_state; },
     (value) => { value.binding.project_slug = "../escape"; }
   ];
@@ -114,6 +115,14 @@ test("skill treats profile delivery fields as restrictive routing constraints", 
   assert.match(skill, /never widen the list by inference/);
   assert.match(skill, /delivery\.deploy_mode=disabled/);
   assert.match(skill, /postflight sweep\/debrief\/handoff path[\s\S]*--no-spawn/);
+});
+
+test("skill resolves ordinary inconclusion before HITL and parks technical residue", async () => {
+  const skill = await readFile(path.join(root, "SKILL.md"), "utf8");
+  assert.match(skill, /ordinary inconclusive -> RESOLVE-INCONCLUSIVE/);
+  assert.match(skill, /Remaining technical uncertainty[\s\S]*STOP-PARKED/);
+  assert.match(skill, /irreducible business\/human-only residue OR HARD gate/);
+  assert.match(skill, /DELIVERY_DONE only[\s\S]*open or deferred spec/);
 });
 
 test("trusted-root mode rejects a canonical path escape", async () => {

--- a/skills/ooda-loop/tests/operator_profile_schema_test.py
+++ b/skills/ooda-loop/tests/operator_profile_schema_test.py
@@ -64,6 +64,7 @@ def test_operator_profile_negative_fixtures_are_rejected(mutate) -> None:
         lambda value: value["security"].update({"authority_claim": "authorized"}),
         lambda value: value["request"].update({"auto_merge": "authorized"}),
         lambda value: value["idempotency"].update({"replay_key": "not-a-digest"}),
+        lambda value: value["event"].update({"observed_at": "2026-08-01T12:00:00"}),
     ],
 )
 def test_trigger_envelope_negative_fixtures_are_rejected(mutate) -> None:


### PR DESCRIPTION
## Summary

- Routes ordinary technical inconclusiveness through bounded recon, deterministic evidence and one proportionate independent path before escalation.
- Parks unresolved technical residue with a checkpoint; reserves HITL for business rules, human-only acts and hard gates.
- Tightens accepted date-time values to explicit-offset ISO 8601 and adds negative coverage.

## Validation

- `node --test skills/ooda-loop/tests/operator-profile-contract.test.mjs`
- `pytest skills/ooda-loop/tests/operator_profile_schema_test.py -q`
- `openspec validate ooda-loop-operator-profile --strict`
- `gitleaks protect --staged --redact`

Co-Authored-By: Codex (OpenAI/GPT-5) <noreply+codex@openai.com>
