### PR TITLE
fix(ooda-loop): honor upstream inconclusive stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,7 @@ The conductor now makes the intended shape explicit: outer OODA selects the evid
 delivery stage and the existing `gap-loop`/`quiesce` drivers run bounded inner PDCA. A technical
 delegation prevents unnecessary architecture questions to a nontechnical business owner, while
 business-rule uncertainty, human-only access/acceptance and hard-boundary residue still reach
-HITL with a concise recommendation. Ordinary inconclusive evidence first follows one bounded
-recon/convergence path; unresolved technical uncertainty is parked with a checkpoint rather than
-laundered into a business decision. Deployment remains a gated promotion, not an automatic end.
+HITL with a concise recommendation. Deployment remains a gated promotion, not an automatic end.
 
 The change adds strict replay-safe intake schemas, sanitized examples, a dependency-free fail-closed
 adapter validator, real Draft 2020-12 fixture validation in CI, a concise vendor-neutral loop prompt

--- a/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
+++ b/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
@@ -70,14 +70,6 @@ the operator's declared language and an operational recommendation.
 - **THEN** the agent SHALL decide and document the technical choice
 - **AND** it SHALL NOT ask a nontechnical operator to design the implementation
 
-#### Scenario: Technical evidence remains inconclusive after one bounded path
-
-- **WHEN** targeted recon, deterministic verification and one proportionate independent path
-  cannot resolve a technical uncertainty
-- **THEN** the conductor SHALL emit a bounded parked checkpoint with the next evidence/action
-- **AND** it SHALL NOT ask the business operator to choose the technology
-- **AND** it SHALL bypass this path only for an immediate hard boundary or irreducible business/human-only act
-
 ### Requirement: Portability claims are evidence-qualified
 
 The portable core MUST conform to the Agent Skills format. Runtime documentation SHALL

--- a/skills/ooda-loop/SKILL.md
+++ b/skills/ooda-loop/SKILL.md
@@ -174,7 +174,7 @@ precise next action. A fresh non-replayed trigger may resume the checkpoint; it 
 
 ```text
 OBSERVE   goal-recovery --scope=<scope>  ->  handoff-as-prompt envelope   (recover the intent; ladder + uncertainty)
-            | ordinary inconclusive -> RESOLVE-INCONCLUSIVE (below); do not jump directly to HITL
+            | inconclusive.flag=true (low confidence / no anchor) -> STOP-HITL with ranked hypotheses
             v
 ORIENT    invoke Prisma (decompose-abstract-to-measurable) on the recovered goal
             construct := "is {{goal}} DONE and healthy?"; context_lock <- handoff (context/objectives/scope)
@@ -182,14 +182,9 @@ ORIENT    invoke Prisma (decompose-abstract-to-measurable) on the recovered goal
                 (deterministic: acceptance <- material D/T leaves; kpis; termination_predicate; self-gated)
             | Prisma STRUCTURAL gate (scripts/structural_route.py, fail-closed): a value-tree validly
             |   represents only ADDITIVE/atomic constructs. status=additive_unverified OR relational/gestalt
-            |   -> the aggregate score is assistive-only (human_review) -> RESOLVE-INCONCLUSIVE
+            |   -> the aggregate score is assistive-only (human_review) -> treat as inconclusive -> STOP-HITL
             |   (do NOT auto-drive on a capped score). status=additive-verified -> proceed to the roll-up.
-            | Prisma roll-up inconclusive.flag=true -> RESOLVE-INCONCLUSIVE
-            | RESOLVE-INCONCLUSIVE := targeted recon + deterministic evidence + exactly one proportionate
-            |   independent path. Resolved -> resume the current OODA act. Irreducible business-rule or
-            |   human-only act -> STOP-HITL with evidence and recommendation. Remaining technical uncertainty
-            |   after the bounded path -> STOP-PARKED with checkpoint and precise next evidence/action.
-            |   A hard gate bypasses this route and goes immediately to its named human gate.
+            | Prisma roll-up (scripts/aggregate_spec.py) inconclusive.flag=true (judgment-dominated / conflict:<branch> / low-conf) -> STOP-HITL
             v
 ORIENT-b  invoke Hodos (derive-system-from-goal) on the recovered goal + the DoD
             "what is the SMALLEST recurring system that conducts to this goal?"  (the vehicle, not the map)
@@ -207,8 +202,7 @@ ORIENT-b  invoke Hodos (derive-system-from-goal) on the recovered goal + the DoD
             v
 DECIDE    gate: all APPLICABLE envelopes valid (system-as-prompt is N/A for a one-shot/bounded goal —
             the {goal, dod} pair suffices) + not-inconclusive + NOT HUMAN_DOMAIN + autonomy_score >= threshold?
-            | hard gate / irreducible business or human-only residue -> STOP-HITL with envelopes
-            | ordinary inconclusive red -> RESOLVE-INCONCLUSIVE; bounded unresolved technical red -> STOP-PARKED
+            | any red -> HITL (with the computed envelopes attached, never a blank ask)
             | resolve --driver (auto: quiesce if host /goal + session scope, else gap-loop)
             v
 ACT       drive with the typed {goal, dod[, system]} set (system only when the goal is recurring):
@@ -297,9 +291,9 @@ Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (data/authority gap) · `
 
 ## STOP-marker grammar (reused — emit exactly ONE as the last line of each turn)
 ```text
-<!--ORCH-STATUS: STOP-DONE -->     DELIVERY_DONE only — DoD met, verifier-confirmed, no applicable gap/open or deferred spec/failed check/pending promotion
+<!--ORCH-STATUS: STOP-DONE -->     DoD satisfied — termination_predicate met, verifier-confirmed, score >= threshold
 <!--ORCH-STATUS: STOP-PARKED -->   bounded partial — budget, lease or plateau stop; checkpoint + next action persisted
-<!--ORCH-STATUS: STOP-HITL -->     irreducible business/human-only residue OR HARD gate — envelopes + recommendation attached
+<!--ORCH-STATUS: STOP-HITL -->     goal OR DoD inconclusive, OR HARD gate (HUMAN_DOMAIN) — envelopes attached
 <!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (validator / subagent / network)
 <!--ORCH-STATUS: CONTINUE -->      round done; DoD not yet met OR score < threshold; next round opens
 ```
@@ -318,9 +312,7 @@ gap-loop/quiesce are its ACT drivers. It never re-implements recovery, measureme
 
 ## Protocol Rules (anti-loop + integrity invariants)
 - `verifier != generator` (gap-loop VALIDATE) is inherited and NEVER re-loosened — the improvement signal reads the DoD checks, not the generator's self-grade.
-- Both envelopes MUST pass `validate_envelope.py` before ACT. An ordinary `inconclusive.flag=true` enters
-  bounded `RESOLVE-INCONCLUSIVE`; it never drives ACT. Only irreducible business/human residue becomes HITL;
-  unresolved technical residue parks. A hard gate still stops immediately at its named human gate.
+- Both envelopes MUST pass `validate_envelope.py` before ACT; either `inconclusive.flag=true` => HITL (never drive on a fabricated goal or an unscoreable DoD).
 - `--max-iterations` caps ACT rounds; the global OODA/attempt/tool/spawn/external/time budget caps the whole
   invocation. Exhaustion, invalid lease, cancellation or two-cycle plateau parks the best state.
 - The global budget caps OODA and PDCA together. Budget/lease exhaustion or a two-cycle plateau emits

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -117,14 +117,6 @@ test("skill treats profile delivery fields as restrictive routing constraints", 
   assert.match(skill, /postflight sweep\/debrief\/handoff path[\s\S]*--no-spawn/);
 });
 
-test("skill resolves ordinary inconclusion before HITL and parks technical residue", async () => {
-  const skill = await readFile(path.join(root, "SKILL.md"), "utf8");
-  assert.match(skill, /ordinary inconclusive -> RESOLVE-INCONCLUSIVE/);
-  assert.match(skill, /Remaining technical uncertainty[\s\S]*STOP-PARKED/);
-  assert.match(skill, /irreducible business\/human-only residue OR HARD gate/);
-  assert.match(skill, /DELIVERY_DONE only[\s\S]*open or deferred spec/);
-});
-
 test("trusted-root mode rejects a canonical path escape", async () => {
   const directory = await mkdtemp(path.join(tmpdir(), "ooda-root-escape-"));
   try {


### PR DESCRIPTION
Corrects the upstream-contract conflict found in independent review. Goal recovery and Prisma inconclusive outcomes remain terminal HITL until those primitives expose a tested nonterminal mode.

Validation: node contract tests; strict OpenSpec; staged secret scan.

Co-Authored-By: Codex (OpenAI/GPT-5) <noreply+codex@openai.com>
