### PR TITLE
fix(ooda-loop): make outward run state fail-closed

### DIFF
--- a/.github/workflows/ontology-validation.yml
+++ b/.github/workflows/ontology-validation.yml
@@ -20,6 +20,8 @@ on:
       - "skills/ooda-loop/templates/operator-profile.example.json"
       - "skills/ooda-loop/templates/trigger-envelope.schema.json"
       - "skills/ooda-loop/templates/trigger-envelope.example.json"
+      - "skills/ooda-loop/templates/run-envelope.schema.json"
+      - "skills/ooda-loop/templates/run-envelope.example.json"
       - "skills/ooda-loop/tests/operator_profile_schema_test.py"
       - ".github/workflows/ontology-validation.yml"
   pull_request:
@@ -32,6 +34,8 @@ on:
       - "skills/ooda-loop/templates/operator-profile.example.json"
       - "skills/ooda-loop/templates/trigger-envelope.schema.json"
       - "skills/ooda-loop/templates/trigger-envelope.example.json"
+      - "skills/ooda-loop/templates/run-envelope.schema.json"
+      - "skills/ooda-loop/templates/run-envelope.example.json"
       - "skills/ooda-loop/tests/operator_profile_schema_test.py"
       - ".github/workflows/ontology-validation.yml"
   workflow_dispatch: {}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ delegation prevents unnecessary architecture questions to a nontechnical busines
 business-rule uncertainty, human-only access/acceptance and hard-boundary residue still reach
 HITL with a concise recommendation. Deployment remains a gated promotion, not an automatic end.
 
-The change adds strict replay-safe intake schemas, sanitized examples, a dependency-free fail-closed
+The change adds strict replay-safe intake schemas plus a validated outward-run vocabulary, sanitized examples, a dependency-free fail-closed
 adapter validator, real Draft 2020-12 fixture validation in CI, a concise vendor-neutral loop prompt
 and runtime adapter guidance. It extends the existing conductor instead of creating a competing loop;
 its portable core is Agent Skills Markdown plus JSON, so a listed runtime is never represented as a

--- a/commands/ooda-loop.md
+++ b/commands/ooda-loop.md
@@ -22,7 +22,7 @@ The DoD envelope contract lives in `skills/ooda-loop/templates/dod-as-prompt.sch
            [--operator-profile=<trusted-path>]  (context claims/preferences; constrains, never grants)
            [--trigger-envelope=<trusted-path>]  (replay-safe sanitized event metadata)
            [--driver=auto|gap-loop|quiesce|<custom>]                (default auto)
-           [--conf-inconclusive=0.60]      (inconclusive-resolution threshold)
+           [--conf-inconclusive=0.60]      (upstream goal/DoD intent gate)
            [--autonomy-threshold=0.85]     (DECIDE gate + passed to driver)
            [--max-iterations=6]            (ACT loop cap)
            [--max-ooda-cycles=3] [--max-total-attempts=18]

--- a/commands/ooda-loop.md
+++ b/commands/ooda-loop.md
@@ -22,7 +22,7 @@ The DoD envelope contract lives in `skills/ooda-loop/templates/dod-as-prompt.sch
            [--operator-profile=<trusted-path>]  (context claims/preferences; constrains, never grants)
            [--trigger-envelope=<trusted-path>]  (replay-safe sanitized event metadata)
            [--driver=auto|gap-loop|quiesce|<custom>]                (default auto)
-           [--conf-inconclusive=0.60]      (goal-recovery HITL gate)
+           [--conf-inconclusive=0.60]      (inconclusive-resolution threshold)
            [--autonomy-threshold=0.85]     (DECIDE gate + passed to driver)
            [--max-iterations=6]            (ACT loop cap)
            [--max-ooda-cycles=3] [--max-total-attempts=18]
@@ -78,6 +78,8 @@ emit `STOP-PARKED`/`PARKED_PARTIAL` with a durable checkpoint. `STOP-DONE` is re
 finishing one stage while an applicable gap, deferred/open spec, failed check or promotion remains is not done.
 
 The vendor-neutral prompt contract is [`loop-contract.md`](../skills/ooda-loop/references/loop-contract.md).
+The outward JSON vocabulary is validated by
+[`run-envelope.schema.json`](../skills/ooda-loop/templates/run-envelope.schema.json).
 Portability is capability-based: the same Skill and JSON input can be consumed by an Agent Skills-capable host,
 but the host must explicitly map its own tools, identity and promotion gates. See
 [`runtime-adapters.md`](../skills/ooda-loop/references/runtime-adapters.md).

--- a/docs/adrs/ADR-014-operator-profile-intake.md
+++ b/docs/adrs/ADR-014-operator-profile-intake.md
@@ -77,6 +77,7 @@ until sanitized host dogfood is explicitly authorized and observed.
 - `skills/ooda-loop/SKILL.md`
 - `skills/ooda-loop/templates/operator-profile.schema.json`
 - `skills/ooda-loop/templates/trigger-envelope.schema.json`
+- `skills/ooda-loop/templates/run-envelope.schema.json`
 - `skills/ooda-loop/bin/validate_intake_contract.py`
 - `skills/ooda-loop/references/loop-contract.md`
 - `skills/ooda-loop/references/runtime-adapters.md`

--- a/docs/dogfood/2026-08-01-ooda-loop-operator-profile-static-eval.md
+++ b/docs/dogfood/2026-08-01-ooda-loop-operator-profile-static-eval.md
@@ -18,10 +18,10 @@
 ## Deterministic evidence
 
 - `node --test skills/ooda-loop/tests/operator-profile-contract.test.mjs`: static contract checks cover
-  both examples, missing required properties, extra fields, invalid lifecycle stage, duplicate baseline
+  all three contract examples, missing required properties, extra fields, invalid lifecycle/outcome vocabulary, duplicate baseline
   acknowledgement, control-plane injection and fail-closed schema evolution.
 - `pytest skills/ooda-loop/tests/operator_profile_schema_test.py -v`: runs the pinned real Draft 2020-12
-  validator against both examples and negative fixtures. The repository's small stdlib validator validates
+  validator with an explicit calendar-aware RFC3339 checker against all examples and negative fixtures. The repository's small stdlib validator validates
   the exact assertion-keyword subset used at adapter boundaries and refuses unsupported future assertions;
   it does not claim to be a general JSON Schema implementation.
 - `bash skills/goal-recovery/tests/run-tests.sh`: 20/20 passed.

--- a/openspec/changes/ooda-loop-operator-profile/design.md
+++ b/openspec/changes/ooda-loop-operator-profile/design.md
@@ -30,8 +30,9 @@ authentication proves transport origin only; it does not make payload content au
 ## Termination model
 
 Inner PDCA and outer OODA have separate ceilings. A stage may finish while delivery is
-still partial. The conductor therefore distinguishes stage-done, delivery-done, parked,
-partial, blocked, HITL and error states. Deferred work, accepted risk or an open
+still partial. The conductor therefore uses the exact run-envelope outcomes `STAGE_DONE`,
+`DELIVERY_DONE`, `PARKED_PARTIAL`, `BLOCKED_HITL`, `ERROR` and `CONTINUE`. Deferred work,
+accepted risk or an open
 specification cannot be relabeled as delivery-done.
 
 ## Validation boundary

--- a/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
+++ b/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
@@ -38,7 +38,7 @@ call budget, or sustained no-progress, preserving a resumable evidence-backed st
 #### Scenario: Stage keeps re-entering Observe without progress
 
 - **WHEN** the no-progress threshold or global OODA ceiling is reached
-- **THEN** the conductor SHALL stop as `PARKED` or `PARTIAL`
+- **THEN** the conductor SHALL stop as `PARKED_PARTIAL`
 - **AND** it SHALL preserve the binding gap and safe next action
 - **AND** it SHALL NOT continue indefinitely or report delivery done
 
@@ -53,8 +53,33 @@ SHALL prevent a `DELIVERY_DONE` result.
 - **WHEN** source checks and build pass
 - **AND** deployment remains gated or out of scope
 - **THEN** the conductor MAY report `STAGE_DONE`
-- **AND** it SHALL report the delivery as `PARTIAL`, `PARKED` or `BLOCKED` as applicable
+- **AND** it SHALL report `PARKED_PARTIAL` or `BLOCKED_HITL` as applicable
 - **AND** it SHALL NOT claim deployment or end-to-end delivery
+
+### Requirement: Child-driver markers are normalized once
+
+The conductor MUST capture the selected PDCA driver's terminal marker as an internal result and
+MUST emit exactly one outward marker. Soft driver exhaustion or unresolved technical residue SHALL
+be normalized to `PARKED_PARTIAL`; a driver-level done result SHALL NOT become `DELIVERY_DONE`
+unless the whole delivery contract is satisfied.
+
+#### Scenario: Driver exhausts its rounds on a technical gap
+
+- **WHEN** `gap-loop` or `quiesce` reaches its soft round limit without resolving a technical gap
+- **THEN** `ooda-loop` SHALL emit one `STOP-PARKED` outer marker with a durable checkpoint
+- **AND** it SHALL NOT leak a child `STOP-HITL` marker or ask the operator a technical question
+
+### Requirement: Outward states use one validated vocabulary
+
+The conductor MUST validate its outward JSON result against the versioned run-envelope schema.
+Documentation, tests and adapters SHALL use the schema's exact lifecycle, outcome, access and
+stop-marker enums rather than illustrative pipe-delimited aliases.
+
+#### Scenario: Adapter proposes a legacy partial state
+
+- **WHEN** an adapter attempts to emit `PARTIAL`, `PARKED` or an unstructured authority string
+- **THEN** run-envelope validation SHALL refuse the result
+- **AND** the adapter SHALL use `PARKED_PARTIAL` plus structured authority evidence as applicable
 
 ### Requirement: Escalation is proportional and business-readable
 

--- a/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
+++ b/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
@@ -85,7 +85,8 @@ stop-marker enums rather than illustrative pipe-delimited aliases.
 
 The conductor MUST resolve ordinary technical uncertainty through the least expensive
 applicable deterministic check or independent convergence path. It SHALL ask a human only
-for irreducible business rules or priorities, human-only acts, or hard boundaries, using
+when an upstream typed envelope cannot recover operator goal or acceptance intent, for
+irreducible business rules or priorities, for human-only acts, or for hard boundaries, using
 the operator's declared language and an operational recommendation.
 
 #### Scenario: Architecture choice is technically resolvable

--- a/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
+++ b/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
@@ -81,6 +81,13 @@ stop-marker enums rather than illustrative pipe-delimited aliases.
 - **THEN** run-envelope validation SHALL refuse the result
 - **AND** the adapter SHALL use `PARKED_PARTIAL` plus structured authority evidence as applicable
 
+#### Scenario: Adapter proposes an unauthorized continuation
+
+- **WHEN** an adapter emits a `CONTINUE` marker routed to ACT
+- **AND** the lease is not valid, cancellation is active, or continuation is not explicitly authorized
+- **THEN** run-envelope validation SHALL refuse the result
+- **AND** the conductor SHALL park or stop according to the validated terminal vocabulary
+
 ### Requirement: Escalation is proportional and business-readable
 
 The conductor MUST resolve ordinary technical uncertainty through the least expensive

--- a/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
+++ b/openspec/changes/ooda-loop-operator-profile/specs/ooda-loop/spec.md
@@ -96,6 +96,12 @@ the operator's declared language and an operational recommendation.
 - **THEN** the agent SHALL decide and document the technical choice
 - **AND** it SHALL NOT ask a nontechnical operator to design the implementation
 
+#### Scenario: Technical autonomy score remains below threshold
+
+- **WHEN** a bounded deterministic check and one proportionate independent uplift path leave the technical autonomy score below threshold
+- **THEN** the conductor SHALL emit `PARKED_PARTIAL` with a technical checkpoint and precise next action
+- **AND** it SHALL NOT emit `BLOCKED_HITL` or ask the operator to choose a technology
+
 ### Requirement: Portability claims are evidence-qualified
 
 The portable core MUST conform to the Agent Skills format. Runtime documentation SHALL

--- a/skills/ooda-loop/SKILL.md
+++ b/skills/ooda-loop/SKILL.md
@@ -291,7 +291,7 @@ Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (irreducible operator int
 <!--ORCH-STATUS: STOP-PARKED -->   bounded partial — budget, lease or plateau stop; checkpoint + next action persisted
 <!--ORCH-STATUS: STOP-HITL -->     operator goal/DoD intent inconclusive, OR HARD gate (HUMAN_DOMAIN) — envelopes attached
 <!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (validator / subagent / network)
-<!--ORCH-STATUS: CONTINUE -->      round done; DoD not yet met OR score < threshold; next round opens
+<!--ORCH-STATUS: CONTINUE -->      round done; DoD not met; another bounded OODA cycle is authorized and budgeted
 ```
 
 ## Relationship to siblings

--- a/skills/ooda-loop/SKILL.md
+++ b/skills/ooda-loop/SKILL.md
@@ -128,8 +128,9 @@ If that resolves a technical decision with independently proved execution author
 If a host lacks an armed/compatible council adapter, it stays consultative and grants no authority; use the
 independent evidence already available and retain the normal hard gates.
 
-Escalate only the irreducible residue: (1) a missing or conflicting business rule/priority owned by the
-operator; (2) a human-only access, approval, payment, acceptance, or physical action; or (3) a hard boundary
+Escalate only the irreducible residue: (0) unresolved operator goal or acceptance intent reported inconclusive
+by an upstream typed envelope; (1) a missing or conflicting business rule/priority owned by the operator;
+(2) a human-only access, approval, payment, acceptance, or physical action; or (3) a hard boundary
 whose named live gate requires a human. A council cannot open a hard gate; do not delay immediate containment
 or that gate for a council. The question must state the
 operational decision, the minimal options, current evidence, risk, and recommended option; never ask the
@@ -254,7 +255,7 @@ goal-movement-absent ⇒ the SYSTEM is wrong, never the driver)** is allowed —
 | `--operator-profile` | *(none)* | trusted control-plane path to a validated, fresh profile of context claims/preferences. It can constrain, never grant. |
 | `--trigger-envelope` | *(derived for direct invocation)* | trusted control-plane path to a validated replay-safe event envelope; adapters must create it before accepting external payloads. |
 | `--driver` | `auto` | `auto` (quiesce if host `/goal` + session scope, else gap-loop) \| `gap-loop` \| `quiesce` \| `<custom>` |
-| `--conf-inconclusive` | `0.60` | `0.0`-`1.0` — inconclusive-resolution threshold (below => `RESOLVE-INCONCLUSIVE` before ORIENT; only irreducible business/human residue becomes HITL) |
+| `--conf-inconclusive` | `0.60` | `0.0`-`1.0` — upstream goal/DoD intent gate (below => preserve the typed envelope's `STOP-HITL`; do not ask a technical-choice question) |
 | `--autonomy-threshold` | `0.85` | `0.0`-`1.0` — DECIDE gate + passed to the driver |
 | `--max-iterations` | `6` | int — ACT loop cap (passed to gap-loop `--max-iterations` / quiesce `--max-pdca`) |
 | `--max-ooda-cycles` | `3` | positive int — shared outer-cycle cap, including lifecycle re-observation. |
@@ -279,13 +280,13 @@ the vocabulary SSOT for lifecycle stages, outcomes, access, authority evidence, 
 `STOP-DONE`: the scoped delivery DoD is met and no applicable gap, deferred/open specification, failed check or
 pending promotion remains. `PARKED_PARTIAL` preserves bounded progress; `BLOCKED_HITL` names the irreducible gate.
 
-Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (irreducible business/human/hard gate) · `4` STOP-PARKED (bounded technical/partial).
+Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (irreducible operator intent/business/human/hard gate) · `4` STOP-PARKED (bounded technical/partial).
 
 ## STOP-marker grammar (reused — emit exactly ONE as the last line of each turn)
 ```text
 <!--ORCH-STATUS: STOP-DONE -->     DoD satisfied — termination_predicate met, verifier-confirmed, score >= threshold
 <!--ORCH-STATUS: STOP-PARKED -->   bounded partial — budget, lease or plateau stop; checkpoint + next action persisted
-<!--ORCH-STATUS: STOP-HITL -->     goal OR DoD inconclusive, OR HARD gate (HUMAN_DOMAIN) — envelopes attached
+<!--ORCH-STATUS: STOP-HITL -->     operator goal/DoD intent inconclusive, OR HARD gate (HUMAN_DOMAIN) — envelopes attached
 <!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (validator / subagent / network)
 <!--ORCH-STATUS: CONTINUE -->      round done; DoD not yet met OR score < threshold; next round opens
 ```
@@ -330,7 +331,7 @@ ooda-loop --scope=this.session                    # recover this session's goal 
 ooda-loop --dry-run                               # print the recovered {goal, dod} + driver + predicate; drive nothing
 ooda-loop --driver=quiesce --auto-merge=authorized --auto-merge-reason="nightly convergence, green CI"
 ooda-loop --scope=ticket:VKS-1234 --autonomy-threshold=0.9 --max-iterations=4
-ooda-loop --driver=gap-loop --conf-inconclusive=0.75   # stricter inconclusive-resolution threshold
+ooda-loop --driver=gap-loop --conf-inconclusive=0.75   # stricter upstream goal/DoD intent gate
 ooda-loop --only=orient --for-goal "ship the session-handoff spine"   # dod-recovery: derive+emit the measurable DoD only; drive nothing
 ooda-loop --operator-profile=./operator-profile.json --scope=ticket:ABC-42  # profile-aware intake -> OODA -> bounded PDCA
 ```

--- a/skills/ooda-loop/SKILL.md
+++ b/skills/ooda-loop/SKILL.md
@@ -203,7 +203,10 @@ ORIENT-b  invoke Hodos (derive-system-from-goal) on the recovered goal + the DoD
             v
 DECIDE    gate: all APPLICABLE envelopes valid (system-as-prompt is N/A for a one-shot/bounded goal —
             the {goal, dod} pair suffices) + not-inconclusive + NOT HUMAN_DOMAIN + autonomy_score >= threshold?
-            | any red -> HITL (with the computed envelopes attached, never a blank ask)
+            | structurally invalid envelope -> STOP-ERROR (fail closed; attach validation evidence)
+            | upstream goal/DoD intent inconclusive OR HUMAN_DOMAIN/hard gate -> STOP-HITL
+            | autonomy_score below threshold -> one proportionate independent uplift path;
+            |   still below threshold -> STOP-PARKED (technical checkpoint + precise next action; no operator ask)
             | resolve --driver (auto: quiesce if host /goal + session scope, else gap-loop)
             v
 ACT       drive with the typed {goal, dod[, system]} set (system only when the goal is recurring):
@@ -284,7 +287,7 @@ Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (irreducible operator int
 
 ## STOP-marker grammar (reused — emit exactly ONE as the last line of each turn)
 ```text
-<!--ORCH-STATUS: STOP-DONE -->     DoD satisfied — termination_predicate met, verifier-confirmed, score >= threshold
+<!--ORCH-STATUS: STOP-DONE -->     DELIVERY_DONE only — DoD met; no applicable gap/open SPEC/failed check/pending promotion
 <!--ORCH-STATUS: STOP-PARKED -->   bounded partial — budget, lease or plateau stop; checkpoint + next action persisted
 <!--ORCH-STATUS: STOP-HITL -->     operator goal/DoD intent inconclusive, OR HARD gate (HUMAN_DOMAIN) — envelopes attached
 <!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (validator / subagent / network)

--- a/skills/ooda-loop/SKILL.md
+++ b/skills/ooda-loop/SKILL.md
@@ -23,14 +23,9 @@ metadata:
 Thin **goal-loop conductor**. `ooda-loop` composes the three steps of the operator's recurring
 contract into one override-friendly preset; every step lands on a primitive that already exists.
 
-> **Provenance / lineage**: distills the operator's hand-invoked contract
-> `{ ooda --scope=this.session --goal==$(goal-recovery ... --type handoff-as-prompt) --dod==$(Prisma ...
-> --type dod-as-prompt); /quiesce --dod={{dod}} --goal={{goal}}; }` into a reusable tool. The operator
-> literally frames it as OODA — Observe/Orient/Decide/Act maps exactly onto recover/measure/gate/drive.
-> Named via `anima` (agent-register): `ooda-loop` (Boyd 1976; the operator's own `ooda` verb; cited SOTA
-> Raghavan & Schneier IEEE S&P 2025). Rejected `conductor` (near-collides with the family's `orchestrator`);
-> rejected `goal-loop` (`goal` vendor-reserved) / `goal-pilot` (collides `auto-pilot`). Authored by Claude
-> Opus 4.8 (1M) under operator `/enhance` directive 2026-07-12; reviewed by @ekson73.
+> **Lineage**: `anima` retained the existing name `ooda-loop`; this skill distills the operator's
+> recover → measurable DoD → converge contract. Naming rationale and prior art live in git history,
+> ADR-014 and the dated dogfood report rather than the hot execution context.
 
 ## §0 — BEING > Rules (foundational)
 Serves the operator's intent. Only a non-safety presentation nicety may be skipped, with
@@ -153,7 +148,12 @@ ADJUST keep the best non-regressed result; fix/re-plan, record a new gap, or ret
 ```
 
 `gap-loop` and `quiesce` remain the PDCA drivers; they own their round limits, independent-verifier rule,
-state persistence, PR convergence and stop markers. Stage promotion is earned by the stage's DoD. A failed or
+state persistence and PR convergence. Their marker is a **child result**, not the conductor's outward marker:
+`ooda-loop` captures and normalizes it before emitting exactly one outer marker. Driver soft exhaustion or
+unresolved technical residue becomes `STOP-PARKED`; driver done becomes `STAGE_DONE`/`CONTINUE` unless the
+whole delivery contract earns `DELIVERY_DONE`; irreducible business/human or hard-gate residue remains
+`STOP-HITL`; unrecoverable error remains `STOP-ERROR`. If a host cannot capture a child result without leaking
+a second marker, its adapter MUST NOT run ACT. Stage promotion is earned by the stage's DoD. A failed or
 plateaued PDCA loop produces a bounded finding and re-enters OODA; it never becomes an unbounded "keep trying"
 instruction.
 
@@ -254,7 +254,7 @@ goal-movement-absent ⇒ the SYSTEM is wrong, never the driver)** is allowed —
 | `--operator-profile` | *(none)* | trusted control-plane path to a validated, fresh profile of context claims/preferences. It can constrain, never grant. |
 | `--trigger-envelope` | *(derived for direct invocation)* | trusted control-plane path to a validated replay-safe event envelope; adapters must create it before accepting external payloads. |
 | `--driver` | `auto` | `auto` (quiesce if host `/goal` + session scope, else gap-loop) \| `gap-loop` \| `quiesce` \| `<custom>` |
-| `--conf-inconclusive` | `0.60` | `0.0`-`1.0` — goal-recovery HITL gate (below => STOP-HITL before ORIENT) |
+| `--conf-inconclusive` | `0.60` | `0.0`-`1.0` — inconclusive-resolution threshold (below => `RESOLVE-INCONCLUSIVE` before ORIENT; only irreducible business/human residue becomes HITL) |
 | `--autonomy-threshold` | `0.85` | `0.0`-`1.0` — DECIDE gate + passed to the driver |
 | `--max-iterations` | `6` | int — ACT loop cap (passed to gap-loop `--max-iterations` / quiesce `--max-pdca`) |
 | `--max-ooda-cycles` | `3` | positive int — shared outer-cycle cap, including lifecycle re-observation. |
@@ -271,23 +271,15 @@ goal-movement-absent ⇒ the SYSTEM is wrong, never the driver)** is allowed —
 | `--for-goal` | *(recover via OBSERVE)* | explicit goal string — skip OBSERVE, derive the DoD for THIS goal directly (the common `--only=orient` case: the goal is known, you want its measurable DoD). |
 
 ## Output contract (`--output=json`)
-```json
-{"stage":"OBSERVE|ORIENT|DECIDE|ACT",
- "outcome":"STAGE_DONE|DELIVERY_DONE|PARKED_PARTIAL|BLOCKED_HITL|ERROR|CONTINUE",
- "status":"ok|partial|hitl|error",
- "stop_marker":"STOP-DONE|STOP-PARKED|STOP-HITL|STOP-ERROR|CONTINUE",
- "intake":{"trigger_kind":"direct-chat|discord|slack|ticket|backlog|specification|pull-request|hook|webhook|bootstrap|prototype|agent-output","profile":"present|absent","lifecycle_stage":"recon|prototype|reverse-engineering|specification|source|verification|build|deploy","route":"act|consult|hitl","execution_authority":{"state":"proven|unknown|denied","evidence_refs":["<current non-secret evidence reference>"]},"access":"ACCESS_READY|ACCESS_MISSING|ACCESS_CHANGE_REQUIRED|ACCESS_FORBIDDEN"},
- "handoff":{"goal":"<...>","confidence":0.0,"inconclusive":{"flag":false}},
- "dod":{"for_goal":"<...>","termination_predicate":"<...>","evaluation":{"band":"HIGH|MEDIUM|LOW"}},
- "driver":"gap-loop|quiesce","autonomy_score":0.0,
- "budget":{"ooda_cycles":0,"attempts":0,"tool_calls":0,"spawns":0,"external_calls":0,"elapsed_minutes":0,"plateau_cycles":0,"lease":"valid|expired|unknown","cancelled":false},
- "postflight":"pending|done|deferred"}
-```
+Emit one instance validated against
+[`templates/run-envelope.schema.json`](templates/run-envelope.schema.json); use the sanitized
+[`run-envelope.example.json`](templates/run-envelope.example.json) as the shape reference. The schema is
+the vocabulary SSOT for lifecycle stages, outcomes, access, authority evidence, budgets and outer markers.
 `STAGE_DONE` means one stage passed and normally continues to OBSERVE. `DELIVERY_DONE` alone may emit
 `STOP-DONE`: the scoped delivery DoD is met and no applicable gap, deferred/open specification, failed check or
 pending promotion remains. `PARKED_PARTIAL` preserves bounded progress; `BLOCKED_HITL` names the irreducible gate.
 
-Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (data/authority gap) · `4` STOP-PARKED (bounded partial).
+Exit: `0` STOP-DONE · `1` STOP-ERROR · `2` STOP-HITL (irreducible business/human/hard gate) · `4` STOP-PARKED (bounded technical/partial).
 
 ## STOP-marker grammar (reused — emit exactly ONE as the last line of each turn)
 ```text
@@ -338,21 +330,16 @@ ooda-loop --scope=this.session                    # recover this session's goal 
 ooda-loop --dry-run                               # print the recovered {goal, dod} + driver + predicate; drive nothing
 ooda-loop --driver=quiesce --auto-merge=authorized --auto-merge-reason="nightly convergence, green CI"
 ooda-loop --scope=ticket:VKS-1234 --autonomy-threshold=0.9 --max-iterations=4
-ooda-loop --driver=gap-loop --conf-inconclusive=0.75   # stricter goal-recovery HITL gate, harness-agnostic driver
+ooda-loop --driver=gap-loop --conf-inconclusive=0.75   # stricter inconclusive-resolution threshold
 ooda-loop --only=orient --for-goal "ship the session-handoff spine"   # dod-recovery: derive+emit the measurable DoD only; drive nothing
 ooda-loop --operator-profile=./operator-profile.json --scope=ticket:ABC-42  # profile-aware intake -> OODA -> bounded PDCA
 ```
 
-## Quality Tests (6/6 static self-validity — behavioral extension not executed)
-1. **Self-Application** — the contract can represent its own creation goal and measurable DoD without requiring a second conductor. CONTRACT-COVERED; NOT EXECUTED in v0.3.0.
-2. **Non-Contradiction** — composes (not duplicates) goal-recovery/Prisma/gap-loop/quiesce; the OODA wiring + typed-pair are net-new; inherits `verifier != generator` without loosening it. PASS.
-3. **Survival** — applied to itself it advocates a recovered-goal + measurable-DoD + independent-verify loop; it is itself that. PASS.
-4. **Bounded-Responsibility** — inner+global budgets, cancellation/lease/no-progress stops, dual inconclusive
-   gates, authority/hard gates, STAGE_DONE vs DELIVERY_DONE vs PARKED_PARTIAL, and exactly one STOP marker. PASS.
-5. **Explicit-Exception** — When-not-to-use + HARD-gate HITL + §0 BEING>Rules + `--dry-run`. PASS.
-6. **Utility-Sunset** — §DUED below. PASS.
+## Quality evidence (progressive disclosure)
 
-`scope-discipline` 6Q: 6/6 (WHERE=multi-agent-os · DRY=~70% reused, composes 3 primitives · WHY=recurring hand-invoked contract, this session = a Triple-touch instance · WHO=operator+amnesic agents · FITS=orchestration-convergence sibling of gap-loop/quiesce/enhance-pipeline · MIN=1 thin conductor + 1 schema). `anti-theater` 8Q REALITY: 8/8.
+Static quality, schema and negative-fixture evidence is recorded in
+`docs/dogfood/2026-08-01-ooda-loop-operator-profile-static-eval.md`. Behavioral v0.3 ACT dogfood was
+explicitly **NOT EXECUTED**. Load that report only for audit or maintenance.
 
 ## §DUED Sunset (qualitative — not counter-based)
 Deprecate when ANY: a host ships a native recover->measure->converge primitive (E1) · gap-loop/quiesce absorb
@@ -364,7 +351,8 @@ preset never fires (E3) · operator retraction (E4) · >=3 false-positive runs (
 - `templates/operator-profile.schema.json` — portable intake and autonomy-profile contract; it is input to
   this conductor, not a new authority system
 - `templates/trigger-envelope.schema.json` — replay, freshness, sensitivity and injection-risk contract for
-  inbound signals; `bin/validate_intake_contract.py` fail-closes both intake schemas without dependencies
+  inbound signals; `bin/validate_intake_contract.py` fail-closes all three JSON contracts without dependencies
+- `templates/run-envelope.schema.json` — exact outward result vocabulary after child-driver normalization
 - `references/loop-contract.md` — concise, vendor-neutral execution prompt derived from this skill; the
   `SKILL.md` remains the normative instruction source
 - `references/runtime-adapters.md` — capability-based portability contract for Claude, Codex, Gemini,
@@ -399,7 +387,7 @@ preset never fires (E3) · operator retraction (E4) · >=3 false-positive runs (
 - v0.1.0 (2026-07-12) — bootstrap. Conductor for the operator's recover->measure->converge contract:
   OBSERVE (goal-recovery) -> ORIENT (Prisma DoD) -> DECIDE (dual inconclusive->HITL + autonomy gate) ->
   ACT (typed {goal,dod} pair into gap-loop/quiesce). Inherits verifier != generator, economic stop, idempotency,
-  STOP-marker from the drivers; adds only the OODA wiring + the typed-pair plumbing. Composes 3 primitives; reimplements nothing.
+  child-status semantics from the drivers and normalizes them into one outward STOP marker; adds only the OODA wiring + the typed-pair plumbing. Composes 3 primitives; reimplements nothing.
 
 ## License
 MIT (matches multi-agent-os repo `LICENSE`).

--- a/skills/ooda-loop/bin/validate_intake_contract.py
+++ b/skills/ooda-loop/bin/validate_intake_contract.py
@@ -2,7 +2,7 @@
 """Fail-closed stdlib validator for ooda-loop intake contracts.
 
 The repository intentionally does not require a JSON Schema package at runtime. This validator
-implements the exact Draft 2020-12 keyword subset used by the two intake schemas and refuses a
+implements the exact Draft 2020-12 keyword subset used by the intake/output schemas and refuses a
 schema containing an unsupported assertion keyword. It validates shape only; freshness, replay
 storage and effective authority still require live host evidence.
 
@@ -22,12 +22,13 @@ MAX_INPUT_BYTES = 1024 * 1024
 SCHEMAS = {
     "operator-profile": HERE / "templates" / "operator-profile.schema.json",
     "trigger-envelope": HERE / "templates" / "trigger-envelope.schema.json",
+    "run-envelope": HERE / "templates" / "run-envelope.schema.json",
 }
 ANNOTATIONS = {"$schema", "$id", "title", "description"}
 ASSERTIONS = {
     "type", "additionalProperties", "required", "properties", "const", "enum", "items",
     "minLength", "maxLength", "pattern", "format", "minItems", "maxItems", "uniqueItems",
-    "minimum", "maximum",
+    "minimum", "maximum", "allOf", "if", "then",
 }
 
 
@@ -70,6 +71,11 @@ def audit_schema(schema, where="$"):
         audit_schema(child, f"{where}.properties.{name}")
     if isinstance(schema.get("items"), dict):
         audit_schema(schema["items"], f"{where}.items")
+    for index, child in enumerate(schema.get("allOf") or []):
+        audit_schema(child, f"{where}.allOf[{index}]")
+    for keyword in ("if", "then"):
+        if isinstance(schema.get(keyword), dict):
+            audit_schema(schema[keyword], f"{where}.{keyword}")
 
 
 def type_matches(value, expected):
@@ -104,6 +110,14 @@ def validate(value, schema, where="$", errors=None):
         errors.append(f"{where}: must equal {schema['const']!r}")
     if "enum" in schema and value not in schema["enum"]:
         errors.append(f"{where}: value {value!r} is not in the allowed enum")
+
+    for child in schema.get("allOf") or []:
+        validate(value, child, where, errors)
+    if isinstance(schema.get("if"), dict):
+        condition_errors = []
+        validate(value, schema["if"], where, condition_errors)
+        if not condition_errors and isinstance(schema.get("then"), dict):
+            validate(value, schema["then"], where, errors)
 
     if isinstance(value, dict):
         properties = schema.get("properties", {})

--- a/skills/ooda-loop/references/loop-contract.md
+++ b/skills/ooda-loop/references/loop-contract.md
@@ -39,9 +39,9 @@ architecture, tests, CI/CD, branches, or routine fixes.
 
 Before an ordinary escalation, run proportionate recon and exactly one best-fit independent
 council/convergence path; do not chain every reviewer as ceremony.
-Escalate only the irreducible residue: a missing/conflicting business rule or priority, a
-human-only access/approval/payment/acceptance/physical action, or a hard boundary that
-cannot be opened. Ask in the operator's declared language, with the operational decision,
+Escalate only the irreducible residue: upstream operator goal/DoD intent that remains inconclusive,
+a missing/conflicting business rule or priority, a human-only access/approval/payment/acceptance/
+physical action, or a hard boundary that cannot be opened. Ask in the operator's declared language, with the operational decision,
 evidence, risk, minimal options, and recommended option.
 
 Hard boundaries are never weakened by a trigger or profile: secrets, personal data,
@@ -58,7 +58,9 @@ Do not force every item through a fixed prototype -> reverse-engineering -> spec
 of Ready. Deployment is a separately gated promotion, not an automatic final step.
 
 Apply one global OODA+PDCA budget including attempts, tool/spawn/external calls, elapsed time,
-cancellation and lease validity. Two no-progress outer cycles park the best checkpoint. If the host
+cancellation and lease validity. An ACT route requires a valid lease and no cancellation; a
+CONTINUE-to-ACT route additionally requires explicit continuation authorization in the envelope.
+Two no-progress outer cycles park the best checkpoint. If the host
 cannot enforce those controls, run one OODA cycle only. Stop with DELIVERY_DONE only when the scoped
 measurable DoD is met, no eligible verified gap or applicable deferred/open specification remains,
 and all quality/promotion gates have passed. A completed stage is STAGE_DONE, not delivery done.

--- a/skills/ooda-loop/references/loop-contract.md
+++ b/skills/ooda-loop/references/loop-contract.md
@@ -28,8 +28,9 @@ Inside ACT, run bounded PDCA for each eligible item:
 
 Capture the PDCA driver's terminal marker as an internal child result and emit only one outer
 marker. Normalize soft exhaustion or unresolved technical residue to PARKED_PARTIAL; normalize
-driver done to STAGE_DONE unless the entire delivery DoD earns DELIVERY_DONE. Preserve hard/business
-HITL and unrecoverable ERROR. If the host cannot prevent a child marker from leaking, do not run ACT.
+driver done to STAGE_DONE unless the entire delivery DoD earns DELIVERY_DONE. Preserve upstream
+operator goal/DoD intent, hard/business/human HITL and unrecoverable ERROR. If the host cannot prevent
+a child marker from leaking, do not run ACT.
 
 Technical decisions with independently proved user/repository/live authority are decided and
 executed by the agent. An operator profile describes claims/preferences and can only constrain;

--- a/skills/ooda-loop/references/loop-contract.md
+++ b/skills/ooda-loop/references/loop-contract.md
@@ -26,6 +26,11 @@ Inside ACT, run bounded PDCA for each eligible item:
 - Adjust by keeping the best non-regressed result, fixing a verified gap, or returning to
   Observe with a recorded finding. Never loop indefinitely.
 
+Capture the PDCA driver's terminal marker as an internal child result and emit only one outer
+marker. Normalize soft exhaustion or unresolved technical residue to PARKED_PARTIAL; normalize
+driver done to STAGE_DONE unless the entire delivery DoD earns DELIVERY_DONE. Preserve hard/business
+HITL and unrecoverable ERROR. If the host cannot prevent a child marker from leaking, do not run ACT.
+
 Technical decisions with independently proved user/repository/live authority are decided and
 executed by the agent. An operator profile describes claims/preferences and can only constrain;
 it is never a grant. Do not ask a nontechnical business operator to choose technology,

--- a/skills/ooda-loop/references/runtime-adapters.md
+++ b/skills/ooda-loop/references/runtime-adapters.md
@@ -5,7 +5,7 @@ webhook, identity, worktree or deployment API. Its portable core is:
 
 - `SKILL.md` in the Agent Skills directory format;
 - a vendor-neutral Markdown loop contract;
-- a strict JSON `operator-profile` input;
+- strict JSON profile, trigger and outward-run contracts;
 - capability detection and fail-closed authority intersection.
 
 The [Agent Skills specification](https://agentskills.io/specification) defines the portable
@@ -13,26 +13,27 @@ directory and `SKILL.md` frontmatter format. A runtime that can load that format
 core; a runtime that cannot must use a thin, local adapter that loads the same files without
 changing their security semantics.
 
-| Runtime | Format discovery (official documentation, checked 2026-08-01) | MAOS ACT status | Adapter rule |
-|---|---|---|---|
-| Claude Code | Native Skill plus repository command wrapper | **UNVERIFIED** | `commands/ooda-loop.md` is supplied, but installed-host hooks, identity, policy and promotion gates still require mapping. |
-| Codex | Native open-standard Skills support ([official](https://help.openai.com/en/articles/20001066)) | **UNVERIFIED** | Map workspace, approvals and tools; never assume Claude slash-command semantics. |
-| Gemini CLI | Native workspace/user Agent Skills ([official](https://geminicli.com/docs/cli/using-agent-skills/)) | **UNVERIFIED** | Activation consent and host policy still apply; map only documented tools and promotion gates. |
-| OpenCode | Native `.agents/skills` discovery and permissioned loading ([official](https://opencode.ai/docs/skills)) | **UNVERIFIED** | Re-verify the installed version and configure skill/tool permissions explicitly. |
-| Antigravity | Native Agent Skills with product-specific paths ([official codelab](https://codelabs.developers.google.com/antigravity/how-to-create-agent-skills-for-antigravity-cli)) | **UNVERIFIED** | Adapt the repository Skill into the documented workspace path; do not infer unattended ACT from discovery. |
-| JCode | Native `~/.jcode/skills` and Claude-plugin skill loading documented on a site marked under construction ([official](https://jcode.sh/docs)) | **UNVERIFIED** | Re-verify the installed build and establish project-scoped installation plus every ACT gate before mutation. |
+| Runtime | Format discovery (official documentation, checked 2026-08-01) | Route from this checkout | Command surface | MAOS ACT mapping/status |
+|---|---|---|---|---|
+| Claude Code | Native plugin Skills | Load the repository with `claude --plugin-dir <checkout>` or install the published `maos` plugin | Supplied wrapper: `/maos:ooda-loop` | Adapter mapping exists in the plugin but behavioral v0.3 dogfood is **UNVERIFIED**; live host gates still apply. |
+| Codex | Native open-standard Skills support ([official](https://help.openai.com/en/articles/20001066)) | Package/install `skills/ooda-loop` through the installed Codex Skill surface; a clone alone is not discovery | No MAOS slash-command claim; invoke by Skill intent/name | Adapter-required and **UNVERIFIED**: map workspace, approvals, tools, child-result capture and promotion. |
+| Gemini CLI | Native workspace/user Agent Skills ([official](https://geminicli.com/docs/cli/using-agent-skills/)) | `gemini skills link ./skills/ooda-loop --scope workspace` from this checkout, then verify `/skills list` | Native Skill activation; no MAOS command wrapper | Adapter-required and **UNVERIFIED**; activation consent and host policy remain in force. |
+| OpenCode | Native `.agents/skills` discovery and permissioned loading ([official](https://opencode.ai/docs/skills)) | Copy/link `skills/ooda-loop` to the consumer's `.agents/skills/ooda-loop` or configure an explicit Skill source | Native `skill` tool; no MAOS command wrapper | Adapter-required and **UNVERIFIED**; configure Skill/tool permissions and child-result capture. |
+| Antigravity | Native Agent Skills with product-specific paths ([official codelab](https://codelabs.developers.google.com/antigravity/how-to-create-agent-skills-for-antigravity-cli)) | Copy/link into the installed product's documented workspace Skill path; re-check singular/plural path for that product/version | Native semantic Skill activation; no MAOS command wrapper | Adapter-required and **UNVERIFIED**; discovery does not imply unattended ACT. |
+| JCode | Native `~/.jcode/skills` and Claude-plugin Skill loading documented on a site marked under construction ([official](https://jcode.sh/docs)) | Audited copy/link to `~/.jcode/skills/ooda-loop`; the checked page documents no project-local Skill path | `/ooda-loop` after installation is documented generically for skill names, not behavior-tested here | Adapter-required and **UNVERIFIED**; global installation expands scope and needs an explicit sovereignty review. |
 
 ## Adapter minimum
 
 An adapter must provide all of the following before it may run ACT:
 
 1. A way to read repository policy and the full Skill.
-2. A trusted-root path boundary plus a way to validate both intake contracts and keep them separate from raw trigger text.
+2. A trusted-root path boundary plus a way to validate all three JSON contracts and keep trigger data separate from control-plane configuration.
 3. A current identity/capability check for any mutation.
 4. An isolated change mechanism or an explicit reason it cannot mutate.
 5. A deterministic evidence channel for checks and promotion gates.
 6. A fail-closed mapping for missing capability, secrets, external integrations and hard boundaries.
 7. Project/tenant binding, connector-authentication evidence, replay storage, cancellation, lease and global budget enforcement.
+8. Child-driver result capture and normalization so exactly one outer marker is emitted.
 
 An adapter may receive Discord, Slack, Jira, Linear, chat or webhook data, but it must label it
 as signal-only unless an independent repository policy and live integration grant authority.

--- a/skills/ooda-loop/templates/run-envelope.example.json
+++ b/skills/ooda-loop/templates/run-envelope.example.json
@@ -28,7 +28,8 @@
     "elapsed_minutes": 4.5,
     "plateau_cycles": 0,
     "lease": "valid",
-    "cancelled": false
+    "cancelled": false,
+    "continuation_authorized": false
   },
   "postflight": "done",
   "next_action": "Verify the current repository authorization record before ACT."

--- a/skills/ooda-loop/templates/run-envelope.example.json
+++ b/skills/ooda-loop/templates/run-envelope.example.json
@@ -1,0 +1,35 @@
+{
+  "contract_version": "1.0",
+  "stage": "DECIDE",
+  "result": {
+    "outcome": "PARKED_PARTIAL",
+    "status": "partial",
+    "stop_marker": "STOP-PARKED",
+    "route": "park"
+  },
+  "intake": {
+    "trigger_kind": "ticket",
+    "profile": "present",
+    "lifecycle_stage": "specification",
+    "execution_authority": {
+      "state": "unknown",
+      "evidence_refs": []
+    },
+    "access": "ACCESS_READY"
+  },
+  "driver": "none",
+  "autonomy_score": 0.72,
+  "budget": {
+    "ooda_cycles": 1,
+    "attempts": 1,
+    "tool_calls": 8,
+    "spawns": 1,
+    "external_calls": 0,
+    "elapsed_minutes": 4.5,
+    "plateau_cycles": 0,
+    "lease": "valid",
+    "cancelled": false
+  },
+  "postflight": "done",
+  "next_action": "Verify the current repository authorization record before ACT."
+}

--- a/skills/ooda-loop/templates/run-envelope.schema.json
+++ b/skills/ooda-loop/templates/run-envelope.schema.json
@@ -95,7 +95,12 @@
         "properties": {
           "intake": {
             "properties": {
-              "execution_authority": {"properties": {"state": {"const": "proven"}}},
+              "execution_authority": {
+                "properties": {
+                  "state": {"const": "proven"},
+                  "evidence_refs": {"minItems": 1}
+                }
+              },
               "access": {"const": "ACCESS_READY"}
             }
           },

--- a/skills/ooda-loop/templates/run-envelope.schema.json
+++ b/skills/ooda-loop/templates/run-envelope.schema.json
@@ -67,7 +67,7 @@
     "budget": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["ooda_cycles", "attempts", "tool_calls", "spawns", "external_calls", "elapsed_minutes", "plateau_cycles", "lease", "cancelled"],
+      "required": ["ooda_cycles", "attempts", "tool_calls", "spawns", "external_calls", "elapsed_minutes", "plateau_cycles", "lease", "cancelled", "continuation_authorized"],
       "properties": {
         "ooda_cycles": {"type": "integer", "minimum": 0},
         "attempts": {"type": "integer", "minimum": 0},
@@ -77,7 +77,8 @@
         "elapsed_minutes": {"type": "number", "minimum": 0},
         "plateau_cycles": {"type": "integer", "minimum": 0},
         "lease": {"enum": ["valid", "expired", "unknown"]},
-        "cancelled": {"type": "boolean"}
+        "cancelled": {"type": "boolean"},
+        "continuation_authorized": {"type": "boolean"}
       }
     },
     "postflight": {"enum": ["pending", "done", "deferred"]},
@@ -96,6 +97,33 @@
             "properties": {
               "execution_authority": {"properties": {"state": {"const": "proven"}}},
               "access": {"const": "ACCESS_READY"}
+            }
+          },
+          "budget": {
+            "properties": {
+              "lease": {"const": "valid"},
+              "cancelled": {"const": false}
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "result": {
+            "properties": {
+              "stop_marker": {"const": "CONTINUE"},
+              "route": {"const": "act"}
+            }
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "budget": {
+            "properties": {
+              "continuation_authorized": {"const": true}
             }
           }
         }

--- a/skills/ooda-loop/templates/run-envelope.schema.json
+++ b/skills/ooda-loop/templates/run-envelope.schema.json
@@ -1,0 +1,105 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "urn:multi-agent-os:ooda-loop-run-envelope:1.0",
+  "title": "OODA-loop outward run envelope",
+  "description": "Validated vocabulary for the conductor's single outward result. Child-driver markers are normalized before this envelope is emitted.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["contract_version", "stage", "result", "intake", "budget", "postflight"],
+  "properties": {
+    "contract_version": {"const": "1.0"},
+    "stage": {"enum": ["OBSERVE", "ORIENT", "DECIDE", "ACT"]},
+    "result": {
+      "type": "object",
+      "description": "Atomic outward tuple. Keeping route with outcome/status/marker makes contradictory terminal states unrepresentable.",
+      "enum": [
+        {"outcome": "STAGE_DONE", "status": "ok", "stop_marker": "CONTINUE", "route": "act"},
+        {"outcome": "DELIVERY_DONE", "status": "ok", "stop_marker": "STOP-DONE", "route": "act"},
+        {"outcome": "PARKED_PARTIAL", "status": "partial", "stop_marker": "STOP-PARKED", "route": "park"},
+        {"outcome": "BLOCKED_HITL", "status": "hitl", "stop_marker": "STOP-HITL", "route": "hitl"},
+        {"outcome": "ERROR", "status": "error", "stop_marker": "STOP-ERROR", "route": "park"},
+        {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "act"},
+        {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "consult"}
+      ]
+    },
+    "intake": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["trigger_kind", "profile", "lifecycle_stage", "execution_authority", "access"],
+      "properties": {
+        "trigger_kind": {"enum": ["direct-chat", "discord", "slack", "ticket", "backlog", "specification", "pull-request", "hook", "webhook", "bootstrap", "prototype", "agent-output"]},
+        "profile": {"enum": ["present", "absent"]},
+        "lifecycle_stage": {"enum": ["recon", "prototype", "reverse-engineering", "specification", "source", "verification", "build", "deploy"]},
+        "execution_authority": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["state", "evidence_refs"],
+          "properties": {
+            "state": {"enum": ["proven", "unknown", "denied"]},
+            "evidence_refs": {"type": "array", "maxItems": 16, "uniqueItems": true, "items": {"type": "string", "minLength": 1, "maxLength": 160}}
+          }
+        },
+        "access": {"enum": ["ACCESS_READY", "ACCESS_MISSING", "ACCESS_CHANGE_REQUIRED", "ACCESS_FORBIDDEN"]}
+      }
+    },
+    "handoff": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["goal", "confidence", "inconclusive"],
+      "properties": {
+        "goal": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+        "inconclusive": {"type": "boolean"}
+      }
+    },
+    "dod": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["for_goal", "termination_predicate", "evaluation_band"],
+      "properties": {
+        "for_goal": {"type": "string", "minLength": 1, "maxLength": 1024},
+        "termination_predicate": {"type": "string", "minLength": 1, "maxLength": 2048},
+        "evaluation_band": {"enum": ["HIGH", "MEDIUM", "LOW"]}
+      }
+    },
+    "driver": {"enum": ["gap-loop", "quiesce", "none"]},
+    "autonomy_score": {"type": "number", "minimum": 0, "maximum": 1},
+    "budget": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["ooda_cycles", "attempts", "tool_calls", "spawns", "external_calls", "elapsed_minutes", "plateau_cycles", "lease", "cancelled"],
+      "properties": {
+        "ooda_cycles": {"type": "integer", "minimum": 0},
+        "attempts": {"type": "integer", "minimum": 0},
+        "tool_calls": {"type": "integer", "minimum": 0},
+        "spawns": {"type": "integer", "minimum": 0},
+        "external_calls": {"type": "integer", "minimum": 0},
+        "elapsed_minutes": {"type": "number", "minimum": 0},
+        "plateau_cycles": {"type": "integer", "minimum": 0},
+        "lease": {"enum": ["valid", "expired", "unknown"]},
+        "cancelled": {"type": "boolean"}
+      }
+    },
+    "postflight": {"enum": ["pending", "done", "deferred"]},
+    "next_action": {"type": "string", "maxLength": 512}
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "result": {"properties": {"route": {"const": "act"}}}
+        }
+      },
+      "then": {
+        "properties": {
+          "intake": {
+            "properties": {
+              "execution_authority": {"properties": {"state": {"const": "proven"}}},
+              "access": {"const": "ACCESS_READY"}
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -31,10 +31,11 @@ async function withMutation(sourceName, mutate, check) {
   }
 }
 
-test("stdlib validator accepts both complete examples", () => {
+test("stdlib validator accepts all complete contract examples", () => {
   for (const [kind, name] of [
     ["operator-profile", "operator-profile.example.json"],
-    ["trigger-envelope", "trigger-envelope.example.json"]
+    ["trigger-envelope", "trigger-envelope.example.json"],
+    ["run-envelope", "run-envelope.example.json"]
   ]) {
     const result = validate(kind, path.join(templates, name));
     assert.equal(result.status, 0, result.stderr);
@@ -68,6 +69,7 @@ test("trigger envelope refuses control-plane injection and unsafe raw payload me
     (value) => { value.idempotency.replay_key = "not-a-digest"; },
     (value) => { value.freshness.max_age_seconds = 0; },
     (value) => { value.event.observed_at = "2026-08-01T12:00:00"; },
+    (value) => { value.event.observed_at = "2026-99-99T99:99:99Z"; },
     (value) => { delete value.connector.authentication_state; },
     (value) => { value.binding.project_slug = "../escape"; }
   ];
@@ -101,12 +103,49 @@ test("validator fails closed if a future schema adds an unsupported assertion", 
 });
 
 test("skill output lifecycle stages match the intake contract", async () => {
-  const skill = await readFile(path.join(root, "SKILL.md"), "utf8");
   const profile = await json("operator-profile.schema.json");
-  const stages = profile.properties.delivery.properties.candidate_stages.items.enum;
-  const outputLine = skill.match(/"lifecycle_stage":"([^"]+)"/);
-  assert.ok(outputLine, "SKILL output contract must expose lifecycle stages");
-  assert.deepEqual(outputLine[1].split("|"), stages);
+  const run = await json("run-envelope.schema.json");
+  assert.deepEqual(
+    run.properties.intake.properties.lifecycle_stage.enum,
+    profile.properties.delivery.properties.candidate_stages.items.enum
+  );
+});
+
+test("run envelope refuses vocabulary drift and unstructured authority", async () => {
+  const cases = [
+    (value) => { value.result.outcome = "PARTIAL"; },
+    (value) => { value.result.stop_marker = "STOP-HITL-TECHNICAL"; },
+    (value) => { value.intake.lifecycle_stage = "reveng"; },
+    (value) => { value.intake.execution_authority = "proven"; },
+    (value) => { value.result = { outcome: "DELIVERY_DONE", status: "error", stop_marker: "STOP-HITL", route: "act" }; },
+    (value) => { value.result = { outcome: "PARKED_PARTIAL", status: "ok", stop_marker: "STOP-DONE", route: "park" }; },
+    (value) => { value.result = { outcome: "BLOCKED_HITL", status: "hitl", stop_marker: "STOP-ERROR", route: "act" }; },
+    (value) => { value.result = { outcome: "ERROR", status: "partial", stop_marker: "CONTINUE", route: "consult" }; },
+    (value) => {
+      value.result = { outcome: "CONTINUE", status: "partial", stop_marker: "CONTINUE", route: "act" };
+      value.intake.execution_authority.state = "denied";
+      value.intake.access = "ACCESS_FORBIDDEN";
+    },
+    (value) => { value.unexpected = true; }
+  ];
+  for (const mutate of cases) {
+    await withMutation("run-envelope.example.json", mutate, (file) => {
+      const result = validate("run-envelope", file);
+      assert.equal(result.status, 3, result.stdout + result.stderr);
+    });
+  }
+});
+
+test("run envelope permits ACT only with proven authority and ready access", async () => {
+  await withMutation("run-envelope.example.json", (value) => {
+    value.result = { outcome: "DELIVERY_DONE", status: "ok", stop_marker: "STOP-DONE", route: "act" };
+    value.intake.execution_authority.state = "proven";
+    value.intake.execution_authority.evidence_refs = ["repository-policy:accepted-decision-42"];
+    value.intake.access = "ACCESS_READY";
+  }, (file) => {
+    const result = validate("run-envelope", file);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  });
 });
 
 test("skill treats profile delivery fields as restrictive routing constraints", async () => {

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -162,6 +162,9 @@ test("skill separates unresolved operator intent from ordinary technical uncerta
   assert.match(skill, /unresolved operator goal or acceptance intent reported inconclusive/);
   assert.match(skill, /inconclusive\.flag=true[\s\S]*STOP-HITL/);
   assert.match(skill, /unresolved technical residue becomes `STOP-PARKED`/);
+  assert.doesNotMatch(skill, /any red\s*->\s*HITL/);
+  assert.match(skill, /autonomy_score below threshold[\s\S]*still below threshold -> STOP-PARKED/);
+  assert.match(skill, /STOP-DONE[\s\S]*DELIVERY_DONE only[\s\S]*no applicable gap\/open SPEC\/failed check\/pending promotion/);
 });
 
 test("trusted-root mode rejects a canonical path escape", async () => {

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -126,6 +126,26 @@ test("run envelope refuses vocabulary drift and unstructured authority", async (
       value.intake.execution_authority.state = "denied";
       value.intake.access = "ACCESS_FORBIDDEN";
     },
+    (value) => {
+      value.result = { outcome: "CONTINUE", status: "partial", stop_marker: "CONTINUE", route: "act" };
+      value.intake.execution_authority.state = "proven";
+      value.intake.access = "ACCESS_READY";
+      value.budget.lease = "expired";
+      value.budget.continuation_authorized = true;
+    },
+    (value) => {
+      value.result = { outcome: "CONTINUE", status: "partial", stop_marker: "CONTINUE", route: "act" };
+      value.intake.execution_authority.state = "proven";
+      value.intake.access = "ACCESS_READY";
+      value.budget.cancelled = true;
+      value.budget.continuation_authorized = true;
+    },
+    (value) => {
+      value.result = { outcome: "CONTINUE", status: "partial", stop_marker: "CONTINUE", route: "act" };
+      value.intake.execution_authority.state = "proven";
+      value.intake.access = "ACCESS_READY";
+      value.budget.continuation_authorized = false;
+    },
     (value) => { value.unexpected = true; }
   ];
   for (const mutate of cases) {
@@ -142,6 +162,21 @@ test("run envelope permits ACT only with proven authority and ready access", asy
     value.intake.execution_authority.state = "proven";
     value.intake.execution_authority.evidence_refs = ["repository-policy:accepted-decision-42"];
     value.intake.access = "ACCESS_READY";
+  }, (file) => {
+    const result = validate("run-envelope", file);
+    assert.equal(result.status, 0, result.stdout + result.stderr);
+  });
+});
+
+test("run envelope permits CONTINUE-to-ACT only with a live authorized budget", async () => {
+  await withMutation("run-envelope.example.json", (value) => {
+    value.result = { outcome: "CONTINUE", status: "partial", stop_marker: "CONTINUE", route: "act" };
+    value.intake.execution_authority.state = "proven";
+    value.intake.execution_authority.evidence_refs = ["repository-policy:accepted-decision-42"];
+    value.intake.access = "ACCESS_READY";
+    value.budget.lease = "valid";
+    value.budget.cancelled = false;
+    value.budget.continuation_authorized = true;
   }, (file) => {
     const result = validate("run-envelope", file);
     assert.equal(result.status, 0, result.stdout + result.stderr);

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -165,6 +165,7 @@ test("skill separates unresolved operator intent from ordinary technical uncerta
   assert.doesNotMatch(skill, /any red\s*->\s*HITL/);
   assert.match(skill, /autonomy_score below threshold[\s\S]*still below threshold -> STOP-PARKED/);
   assert.match(skill, /STOP-DONE[\s\S]*DELIVERY_DONE only[\s\S]*no applicable gap\/open SPEC\/failed check\/pending promotion/);
+  assert.doesNotMatch(skill, /CONTINUE[^\n]*score < threshold/);
 });
 
 test("trusted-root mode rejects a canonical path escape", async () => {

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -156,6 +156,14 @@ test("skill treats profile delivery fields as restrictive routing constraints", 
   assert.match(skill, /postflight sweep\/debrief\/handoff path[\s\S]*--no-spawn/);
 });
 
+test("skill separates unresolved operator intent from ordinary technical uncertainty", async () => {
+  const skill = await readFile(path.join(root, "SKILL.md"), "utf8");
+  assert.doesNotMatch(skill, /RESOLVE-INCONCLUSIVE/);
+  assert.match(skill, /unresolved operator goal or acceptance intent reported inconclusive/);
+  assert.match(skill, /inconclusive\.flag=true[\s\S]*STOP-HITL/);
+  assert.match(skill, /unresolved technical residue becomes `STOP-PARKED`/);
+});
+
 test("trusted-root mode rejects a canonical path escape", async () => {
   const directory = await mkdtemp(path.join(tmpdir(), "ooda-root-escape-"));
   try {

--- a/skills/ooda-loop/tests/operator-profile-contract.test.mjs
+++ b/skills/ooda-loop/tests/operator-profile-contract.test.mjs
@@ -102,7 +102,7 @@ test("validator fails closed if a future schema adds an unsupported assertion", 
   }
 });
 
-test("skill output lifecycle stages match the intake contract", async () => {
+test("run envelope lifecycle stages match operator profile candidate stages", async () => {
   const profile = await json("operator-profile.schema.json");
   const run = await json("run-envelope.schema.json");
   assert.deepEqual(
@@ -145,6 +145,13 @@ test("run envelope refuses vocabulary drift and unstructured authority", async (
       value.intake.execution_authority.state = "proven";
       value.intake.access = "ACCESS_READY";
       value.budget.continuation_authorized = false;
+    },
+    (value) => {
+      value.result = { outcome: "CONTINUE", status: "partial", stop_marker: "CONTINUE", route: "act" };
+      value.intake.execution_authority.state = "proven";
+      value.intake.execution_authority.evidence_refs = [];
+      value.intake.access = "ACCESS_READY";
+      value.budget.continuation_authorized = true;
     },
     (value) => { value.unexpected = true; }
   ];

--- a/skills/ooda-loop/tests/operator_profile_schema_test.py
+++ b/skills/ooda-loop/tests/operator_profile_schema_test.py
@@ -8,7 +8,9 @@ the assertion-keyword subset that these contracts use and fails closed on schema
 from __future__ import annotations
 
 import copy
+import datetime as dt
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -17,6 +19,22 @@ from jsonschema import Draft202012Validator, FormatChecker, ValidationError
 
 ROOT = Path(__file__).resolve().parent.parent
 TEMPLATES = ROOT / "templates"
+RFC3339 = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$"
+)
+FORMAT_CHECKER = FormatChecker()
+
+
+@FORMAT_CHECKER.checks("date-time")
+def valid_rfc3339_datetime(value: object) -> bool:
+    """Validate both RFC3339 shape/offset and real calendar/time values."""
+    if not isinstance(value, str) or RFC3339.fullmatch(value) is None:
+        return False
+    try:
+        parsed = dt.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None and parsed.utcoffset() is not None
 
 
 def load(name: str) -> dict:
@@ -26,7 +44,7 @@ def load(name: str) -> dict:
 def validator(kind: str) -> Draft202012Validator:
     schema = load(f"{kind}.schema.json")
     Draft202012Validator.check_schema(schema)
-    return Draft202012Validator(schema, format_checker=FormatChecker())
+    return Draft202012Validator(schema, format_checker=FORMAT_CHECKER)
 
 
 @pytest.mark.parametrize(
@@ -34,6 +52,7 @@ def validator(kind: str) -> Draft202012Validator:
     [
         ("operator-profile", "operator-profile.example.json"),
         ("trigger-envelope", "trigger-envelope.example.json"),
+        ("run-envelope", "run-envelope.example.json"),
     ],
 )
 def test_examples_are_valid_draft_2020_12(kind: str, example: str) -> None:
@@ -65,6 +84,7 @@ def test_operator_profile_negative_fixtures_are_rejected(mutate) -> None:
         lambda value: value["request"].update({"auto_merge": "authorized"}),
         lambda value: value["idempotency"].update({"replay_key": "not-a-digest"}),
         lambda value: value["event"].update({"observed_at": "2026-08-01T12:00:00"}),
+        lambda value: value["event"].update({"observed_at": "2026-99-99T99:99:99Z"}),
     ],
 )
 def test_trigger_envelope_negative_fixtures_are_rejected(mutate) -> None:
@@ -72,3 +92,44 @@ def test_trigger_envelope_negative_fixtures_are_rejected(mutate) -> None:
     mutate(instance)
     with pytest.raises(ValidationError):
         validator("trigger-envelope").validate(instance)
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda value: value["result"].update({"outcome": "PARTIAL"}),
+        lambda value: value["result"].update({"stop_marker": "STOP-HITL-TECHNICAL"}),
+        lambda value: value["intake"].update({"lifecycle_stage": "reveng"}),
+        lambda value: value["intake"].update({"execution_authority": "proven"}),
+        lambda value: value.update({"result": {"outcome": "DELIVERY_DONE", "status": "error", "stop_marker": "STOP-HITL", "route": "act"}}),
+        lambda value: value.update({"result": {"outcome": "PARKED_PARTIAL", "status": "ok", "stop_marker": "STOP-DONE", "route": "park"}}),
+        lambda value: value.update({"result": {"outcome": "BLOCKED_HITL", "status": "hitl", "stop_marker": "STOP-ERROR", "route": "act"}}),
+        lambda value: value.update({"result": {"outcome": "ERROR", "status": "partial", "stop_marker": "CONTINUE", "route": "consult"}}),
+        lambda value: (
+            value.update({"result": {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "act"}}),
+            value["intake"]["execution_authority"].update({"state": "denied"}),
+            value["intake"].update({"access": "ACCESS_FORBIDDEN"}),
+        ),
+    ],
+)
+def test_run_envelope_negative_fixtures_are_rejected(mutate) -> None:
+    instance = copy.deepcopy(load("run-envelope.example.json"))
+    mutate(instance)
+    with pytest.raises(ValidationError):
+        validator("run-envelope").validate(instance)
+
+
+def test_run_envelope_allows_act_with_proven_authority_and_ready_access() -> None:
+    instance = copy.deepcopy(load("run-envelope.example.json"))
+    instance["result"] = {
+        "outcome": "DELIVERY_DONE",
+        "status": "ok",
+        "stop_marker": "STOP-DONE",
+        "route": "act",
+    }
+    instance["intake"]["execution_authority"] = {
+        "state": "proven",
+        "evidence_refs": ["repository-policy:accepted-decision-42"],
+    }
+    instance["intake"]["access"] = "ACCESS_READY"
+    validator("run-envelope").validate(instance)

--- a/skills/ooda-loop/tests/operator_profile_schema_test.py
+++ b/skills/ooda-loop/tests/operator_profile_schema_test.py
@@ -128,6 +128,12 @@ def test_trigger_envelope_negative_fixtures_are_rejected(mutate) -> None:
             value["intake"].update({"access": "ACCESS_READY"}),
             value["budget"].update({"continuation_authorized": False}),
         ),
+        lambda value: (
+            value.update({"result": {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "act"}}),
+            value["intake"]["execution_authority"].update({"state": "proven", "evidence_refs": []}),
+            value["intake"].update({"access": "ACCESS_READY"}),
+            value["budget"].update({"continuation_authorized": True}),
+        ),
     ],
 )
 def test_run_envelope_negative_fixtures_are_rejected(mutate) -> None:

--- a/skills/ooda-loop/tests/operator_profile_schema_test.py
+++ b/skills/ooda-loop/tests/operator_profile_schema_test.py
@@ -110,6 +110,24 @@ def test_trigger_envelope_negative_fixtures_are_rejected(mutate) -> None:
             value["intake"]["execution_authority"].update({"state": "denied"}),
             value["intake"].update({"access": "ACCESS_FORBIDDEN"}),
         ),
+        lambda value: (
+            value.update({"result": {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "act"}}),
+            value["intake"]["execution_authority"].update({"state": "proven"}),
+            value["intake"].update({"access": "ACCESS_READY"}),
+            value["budget"].update({"lease": "expired", "continuation_authorized": True}),
+        ),
+        lambda value: (
+            value.update({"result": {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "act"}}),
+            value["intake"]["execution_authority"].update({"state": "proven"}),
+            value["intake"].update({"access": "ACCESS_READY"}),
+            value["budget"].update({"cancelled": True, "continuation_authorized": True}),
+        ),
+        lambda value: (
+            value.update({"result": {"outcome": "CONTINUE", "status": "partial", "stop_marker": "CONTINUE", "route": "act"}}),
+            value["intake"]["execution_authority"].update({"state": "proven"}),
+            value["intake"].update({"access": "ACCESS_READY"}),
+            value["budget"].update({"continuation_authorized": False}),
+        ),
     ],
 )
 def test_run_envelope_negative_fixtures_are_rejected(mutate) -> None:
@@ -132,4 +150,23 @@ def test_run_envelope_allows_act_with_proven_authority_and_ready_access() -> Non
         "evidence_refs": ["repository-policy:accepted-decision-42"],
     }
     instance["intake"]["access"] = "ACCESS_READY"
+    validator("run-envelope").validate(instance)
+
+
+def test_run_envelope_allows_continue_act_with_live_authorized_budget() -> None:
+    instance = copy.deepcopy(load("run-envelope.example.json"))
+    instance["result"] = {
+        "outcome": "CONTINUE",
+        "status": "partial",
+        "stop_marker": "CONTINUE",
+        "route": "act",
+    }
+    instance["intake"]["execution_authority"] = {
+        "state": "proven",
+        "evidence_refs": ["repository-policy:accepted-decision-42"],
+    }
+    instance["intake"]["access"] = "ACCESS_READY"
+    instance["budget"].update(
+        {"lease": "valid", "cancelled": False, "continuation_authorized": True}
+    )
     validator("run-envelope").validate(instance)


### PR DESCRIPTION
## Summary

- Adds an atomic run-envelope result vocabulary and rejects contradictory outcome/status/marker/route tuples.
- Requires independently proven authority plus ACCESS_READY before ACT, with fail-closed RFC3339 and schema validation.
- Separates irreducible operator goal/DoD intent from ordinary technical uncertainty: the former may reach STOP-HITL, while low technical autonomy is bounded and parked.
- Follows merged PRs #300, #301, and #302; the transformed delivery loop itself was not executed.

## Type

- [ ] feat (new functionality)
- [x] fix (bug fix)
- [x] docs
- [ ] refactor
- [ ] chore
- [x] security
- [x] governance
- [ ] release

## AI Involvement

- [ ] Human-authored
- [x] AI-assisted (human author used AI tools for parts of the change)
- [ ] AI-generated draft reviewed by human (named reviewer required)

All commits include a Codex Co-Authored-By footer. Anima retained the existing ooda-loop name; Forge and independent safety/portability councils reviewed the contract.

## Runtime / Surface Impact

- [x] Claude Code (plugin runtime, hooks, agents, commands, skills)
- [ ] GitHub Copilot (`.github/copilot-instructions.md`)
- [x] Generic AI agents (AGENTS.md contract)
- [ ] Plugin manifest (`.claude-plugin/plugin.json`) — requires downstream marketplace sync
- [x] CI / GitHub Actions (`.github/workflows/`)
- [x] Security / compliance posture

## Files requiring follow-up governance update

- [ ] `README.md`
- [ ] `AGENTS.md`
- [ ] `CLAUDE.md`
- [ ] `CONTRIBUTING.md`
- [ ] `SECURITY.md`
- [x] `CHANGELOG.md`
- [ ] `.github/CODEOWNERS`
- [ ] `.claude-plugin/plugin.json`
- [ ] Downstream marketplace pin (`ekson73/eko-claude-plugins`)

## Evidence

```bash
node --test skills/ooda-loop/tests/operator-profile-contract.test.mjs  # 11 passed
uvx --from pytest==8.3.3 --with jsonschema==4.23.0 pytest skills/ooda-loop/tests/operator_profile_schema_test.py -q  # 29 passed
bash skills/goal-recovery/tests/run-tests.sh  # 20 passed
bash tests/validate-plugin.sh  # 0 errors; 1 pre-existing warning
openspec validate ooda-loop-operator-profile --strict
npx --yes skills-ref@0.1.5 validate skills/ooda-loop
uvx check-jsonschema ...  # all 3 examples valid
gitleaks git . --log-opts=origin/main..HEAD --redact  # no leaks
```

Independent safety council final verdict: MERGE, no remaining P0-P2. Portability council final verdict: MERGE.

## Risks

Medium. This changes orchestration contracts and routing semantics, but does not execute the loop, deploy workloads, grant authority, or alter external systems. Remaining non-blocking debt: the ooda-loop Skill is large and should receive a future progressive-disclosure extraction; the repository has one pre-existing frontmatter warning in `agents/COWORK-AUTONOMY-POLICY.md`.

## Rollback

Revert this PR. The preceding profile-aware intake remains available from #300-#302. No migration or external state rollback is required.

## Checklist

- [x] Worktree + branch used (no direct-main commits)
- [x] Conventional Commits + `Co-Authored-By:` footer if AI involved
- [x] gitleaks clean (pre-commit + CI workflow)
- [x] Build / tests pass (`tests/validate-plugin.sh` or equivalent)
- [x] No secrets, no PII, no Vek-specific content
- [x] AGENTS.md / CONTRIBUTING.md / CLAUDE.md updated if contract changed
- [x] Version bump + CHANGELOG entry if `.claude-plugin/plugin.json` changed (not applicable; manifest unchanged)

Driven by `openspec/changes/ooda-loop-operator-profile/` and the `skills/ooda-loop/` Forge contract.
