### PR TITLE
feat(work-drain): add Antlia — level-triggered work-register drain conductor

### DIFF
--- a/commands/work-drain.md
+++ b/commands/work-drain.md
@@ -3,19 +3,24 @@ name: work-drain
 description: Drain a set of <object-targets> (sprint · backlog query · open PRs · tracker issues) item-by-item to quiescence — discover, derive an ordered register, and delegate each item to quiesce. Level-triggered and resumable. Soul-name: Antlia.
 ---
 
-# /work-drain Command
+# /maos:work-drain — Antlia
 
 Thin wrapper that invokes `skills/work-drain/SKILL.md`. The skill holds all logic
 (level-triggered register derivation, Eisenhower × dependency ordering, per-item
 delegation to `quiesce`, poison-item quarantine, bounds). This file is the command
 surface only.
 
+> **Invocation**: canonical form is `/maos:work-drain` (`plugin.json` sets
+> `command_namespace.prefix_required = true`, so plugin commands surface namespaced).
+> Bare `/work-drain` may work where the host does not implement the namespace layer,
+> but write the prefixed form everywhere.
+
 ## Usage
 
 ```text
-/work-drain <object-targets> [--owner=…] [--filter=…] [--sort=…] [--tracker=…] \
-            [--max-items=…] [--max-attempts=…] [--auto-merge=…] [--auto-merge-reason="…"] \
-            [--autonomy-threshold=…] [--max-pdca=…] [--dry-run]
+/maos:work-drain <object-targets> [--owner=…] [--filter=…] [--sort=…] [--tracker=…] \
+                 [--max-items=…] [--max-attempts=…] [--auto-merge=…] [--auto-merge-reason="…"] \
+                 [--autonomy-threshold=…] [--max-pdca=…] [--dry-run]
 ```
 
 `<object-targets>` is required. Everything else is optional and uses the skill's defaults.

--- a/commands/work-drain.md
+++ b/commands/work-drain.md
@@ -1,0 +1,64 @@
+---
+name: work-drain
+description: Drain a set of <object-targets> (sprint · backlog query · open PRs · tracker issues) item-by-item to quiescence — discover, derive an ordered register, and delegate each item to quiesce. Level-triggered and resumable. Soul-name: Antlia.
+---
+
+# /work-drain Command
+
+Thin wrapper that invokes `skills/work-drain/SKILL.md`. The skill holds all logic
+(level-triggered register derivation, Eisenhower × dependency ordering, per-item
+delegation to `quiesce`, poison-item quarantine, bounds). This file is the command
+surface only.
+
+## Usage
+
+```text
+/work-drain <object-targets> [--owner=…] [--filter=…] [--sort=…] [--tracker=…] \
+            [--max-items=…] [--max-attempts=…] [--auto-merge=…] [--auto-merge-reason="…"] \
+            [--autonomy-threshold=…] [--max-pdca=…] [--dry-run]
+```
+
+`<object-targets>` is required. Everything else is optional and uses the skill's defaults.
+
+## Object-targets
+
+| Form | Drains |
+|---|---|
+| `sprint:current` | the active sprint's open items for `--owner` |
+| `sprint:<name>` | a named sprint (use when `current` doesn't resolve) |
+| `jql:"<query>"` | an explicit tracker query |
+| `label:<x>` | items carrying a label |
+| `issues:<owner>/<repo>` | a repo's open issues |
+| `prs:open` | open PRs awaiting convergence |
+
+Comma-separate to combine.
+
+## What it does
+
+1. **DERIVE** — re-read the trackers and build the register (level-triggered: every pass
+   re-derives from source, never replays a stored queue).
+2. **ORDER** — Eisenhower quadrant × dependency-DAG topological sort.
+3. **SELECT** — the next item whose dependencies are satisfied, skipping quarantined ones.
+4. **DRAIN** — `/maos:quiesce --scope ticket:<id>` with the forwarded control flags.
+5. **VERIFY** — re-read the item; closed → continue, unchanged → count an attempt.
+6. **LOOP** — back to step 1 until the register derives empty.
+
+## Safety defaults
+
+- `--auto-merge` defaults to **`hold`** — draining N items with auto-merge on multiplies
+  blast-radius by N, so authorization is explicit and per-drain.
+- `--max-items` (20) bounds the register; overflow is **reported**, never silently dropped.
+- `--max-attempts` (2) quarantines a poison item instead of letting it block the drain.
+- If ≥half the register quarantines, the drain **stops and escalates** — systemic fault.
+
+## Anti-loop / autonomy bounds
+
+Inherited from the skill and from `quiesce` per item — `--max-pdca` (6), depth ≤ 2,
+Sentinel HIGH auto-blocks, 6-attempt escalation, HUMAN_DOMAIN + non-negotiable guardrails
+always halt → HITL. See `skills/work-drain/SKILL.md` (Bounds + Autonomy posture).
+
+## Related
+
+`skills/work-drain/SKILL.md` (logic) · `skills/quiesce/SKILL.md` (per-item driver) ·
+`skills/chief-of-staff/SKILL.md` (read-only twin) · `skills/gap-loop/SKILL.md` (sibling) ·
+`commands/quiesce.md` · `commands/chief-of-staff.md`.

--- a/skills/work-drain/SKILL.md
+++ b/skills/work-drain/SKILL.md
@@ -75,7 +75,7 @@ directly:
 
 | Flag | Default | Meaning |
 |---|---|---|
-| `<object-targets>` (positional) | *(required)* | What to drain: `sprint:current` · `sprint:<name>` · `jql:"<query>"` · `label:<x>` · `prs:open` · `issues:<repo>` · a comma-separated mix |
+| `<object-targets>` (positional) | *(required)* | What to drain: `sprint:current` · `sprint:<name>` · `jql:"<query>"` · `label:<x>` · `prs:open` · `issues:<owner>/<repo>` · a comma-separated mix |
 | `--owner` | `currentUser()` | Whose items; `any` widens (bounded by `--max-items`) |
 | `--filter` | `open` | `open` \| `pending` \| `all` — maps to the tracker's not-Done predicate |
 | `--sort` | `eisenhower` | `eisenhower` \| `dependency` \| `updated` \| `manual` (dependency-DAG always breaks ties) |
@@ -102,10 +102,17 @@ PASS (repeat until the register derives empty):
               cross-domain shape when unclear (delegate: work-compass)
   3. SELECT   the next item whose dependencies are all satisfied
               skip quarantined items (see Poison-item guard)
-  4. DRAIN    /maos:quiesce --scope ticket:<id> [forwarded flags]
+  4. DRAIN    /maos:quiesce --scope <scope-of(item)> [forwarded flags]
+              scope-of() maps the item's TYPE to quiesce's own scope grammar:
+                tracker item (Jira/Linear/GH issue) -> ticket:<id>
+                pull request                        -> pr:<n>
+              never hand a PR to ticket: — quiesce treats them as distinct scopes
   5. VERIFY   re-read the item; did it actually close?
               closed -> continue | unchanged -> count an attempt | error -> quarantine check
   6. LOOP     back to 1 — the register is re-derived, never popped
+              UNLESS the cumulative drained-count has reached --max-items:
+              then stop and report the remainder (see Bounds) — the cap binds the
+              INVOCATION, not one pass, or re-derivation would roll overflow past it
 ```
 
 Step 6 is the whole design. There is no "next item pointer" to lose.
@@ -116,7 +123,7 @@ Step 6 is the whole design. There is no "next item pointer" to lose.
 |---|---|
 | Cross-domain item discovery (ticket ↔ worktree ↔ branch ↔ PR) | `skills/work-compass` |
 | Eisenhower 2×2 prioritization | `skills/pulse` (via `chief-of-staff`'s established path) |
-| Actually finishing ONE item (goal-loop + PDCA + merge gate) | `skills/quiesce --scope ticket:<id>` |
+| Actually finishing ONE item (goal-loop + PDCA + merge gate) | `skills/quiesce --scope ticket:<id>` (a PR item → `--scope pr:<n>`) |
 | Abstract acceptance criterion → measurable | `skills/decompose-abstract-to-measurable` (Prisma) |
 | Adversarial verification on a hard-trigger | `skills/red-team` (Elenchus) |
 | Independent decision when score is short | `skills/council-gate` (Boule) → HITL residue only |
@@ -140,7 +147,14 @@ One item that always fails must never block the drain or burn the budget:
 
 ## Bounds (anti-runaway)
 
-- `--max-items` caps register size per drain; the overflow is **listed** in the briefing.
+- `--max-items` caps **items drained per invocation, cumulatively across passes** — not merely the
+  size of one derived register. Keep a per-invocation drained-count; when it reaches the cap, stop
+  and report, even if the register still derives non-empty. Without the cumulative reading, the
+  level-triggered re-derivation (step 6) would roll overflow into the next pass and work a
+  100-item backlog under a cap of 20 — the advertised blast-radius bound must hold for the
+  **invocation**, which is the unit the operator actually authorized.
+- The untouched remainder is **listed** in the briefing (`overflow beyond --max-items`), never
+  silently dropped. Re-invoke to continue — resumption is free (§ level-triggered).
 - `--max-attempts` caps per-item retries.
 - `quiesce`'s own bounds apply per item (`--max-pdca`, depth ≤ 2, 6-attempt escalation).
 - **No silent truncation, ever** — anything the drain declines to touch is named in the report.

--- a/skills/work-drain/SKILL.md
+++ b/skills/work-drain/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: work-drain
+version: "0.1.0"
 description: |
   Given one or more <object-targets> (a sprint, a backlog query, open PRs, tracker issues,
   a filter), DISCOVER every matching item across trackers, DERIVE a work-register from them,

--- a/skills/work-drain/SKILL.md
+++ b/skills/work-drain/SKILL.md
@@ -1,0 +1,243 @@
+---
+name: work-drain
+description: |
+  Given one or more <object-targets> (a sprint, a backlog query, open PRs, tracker issues,
+  a filter), DISCOVER every matching item across trackers, DERIVE a work-register from them,
+  ORDER it (Eisenhower x dependency-DAG), and DRAIN it item-by-item to quiescence —
+  autonomously, unattended, resumable. Level-triggered by design: every pass RE-DERIVES the
+  register from the trackers (the source of truth) instead of replaying a stored queue, so a
+  mid-drain interruption resumes correctly and a re-run is a no-op once empty. Thin conductor:
+  delegates discovery to work-compass, prioritization to pulse, and EACH item's actual work to
+  quiesce --scope ticket:<id> — reimplements no loop, no PDCA, no merge gate. Soul-name: Antlia
+  (the bilge-pump: drains a hold to empty, load by load).
+  Triggers: "work-drain", "drain the sprint", "drain the backlog", "work through my tickets",
+  "clear the sprint", "item by item until empty", "drenar o sprint", "drenar o backlog",
+  "trabalhe nos tickets um por um", "esvaziar a fila".
+allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, AskUserQuestion
+---
+
+# Work-Drain — *Antlia*
+
+> **Identity**: *Antlia* — Ancient Greek **ἀντλία**, a ship's bilge and by extension the pump
+> that empties it; Latinized by Lacaille (1752) as a constellation honoring the air-pump, and
+> shortened to one word by John Herschel (1844). A bilge-pump does exactly this skill's job:
+> it drains a hold **to empty**, **load by load**, and it is **safe to restart** — you re-read
+> the water level, you never replay a log of past strokes.
+> **Cross-link slug**: `[[work-drain]]`
+
+## Purpose
+
+Bridge the gap between a **tracker** (where work is declared) and the **loop family** (which
+knows how to finish one item). Nothing in the family builds a work-register from external
+sources: `gap-loop` drives a *self-derived* gap-register, `quiesce` drives *one* scope,
+`chief-of-staff` reports to a human read-only. `work-drain` is the conductor that turns
+"a sprint" into an ordered sequence of `quiesce` invocations and runs it to empty.
+
+## When to use
+
+- A sprint / backlog / label / filter has N open items and the operator wants them worked
+  through unattended, not triaged into a report.
+- Resuming an interrupted drain — re-invoke; it re-derives and continues.
+- Draining a set of open PRs awaiting convergence.
+
+## When **not** to use
+
+- **ONE** known item → `/maos:quiesce --scope ticket:<KEY>` directly (this skill would be ceremony).
+- Operator wants to *decide* what to focus on, not have it executed → `/maos:chief-of-staff` (read-only).
+- Gaps you derive yourself rather than read from a tracker → `/maos:gap-loop`.
+- Session-wide cleanup with no external register → `/maos:quiesce` bare.
+
+## Level-triggered by design (the load-bearing invariant)
+
+Kubernetes controllers are **level-triggered**: each reconciliation re-reads desired and actual
+state and computes the correction, rather than reacting to the event that woke it. A missed,
+duplicated, delayed or reordered event is therefore recoverable. `work-drain` adopts this
+directly:
+
+| Edge-triggered (rejected) | Level-triggered (this skill) |
+|---|---|
+| Build a queue once, pop items, trust the queue | **Re-derive the register from the trackers every pass** |
+| Interruption loses position | Interruption is free — the next pass re-reads the world |
+| Stale queue drifts from reality | Register cannot drift; the tracker *is* the state |
+| Needs a durable local queue file | Needs **no local queue** — no file to corrupt or desync |
+
+**Consequences (binding):**
+- The register is **derived, never stored** as the source of truth. A cached copy is a *hint*
+  for ordering within a pass; it is discarded at the start of the next pass.
+- **Idempotent-resume is inherent**, not bolted on: a re-run after a crash re-derives, sees the
+  already-closed items are gone from the query, and continues with what remains.
+- **Re-running on an empty sprint is a no-op** — the correct end state, not a failure.
+- Never trust the search index as authoritative: it lags. Confirm each item's real state with
+  a direct `get` before acting on it.
+
+## Parameters
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `<object-targets>` (positional) | *(required)* | What to drain: `sprint:current` · `sprint:<name>` · `jql:"<query>"` · `label:<x>` · `prs:open` · `issues:<repo>` · a comma-separated mix |
+| `--owner` | `currentUser()` | Whose items; `any` widens (bounded by `--max-items`) |
+| `--filter` | `open` | `open` \| `pending` \| `all` — maps to the tracker's not-Done predicate |
+| `--sort` | `eisenhower` | `eisenhower` \| `dependency` \| `updated` \| `manual` (dependency-DAG always breaks ties) |
+| `--tracker` | `auto` | `auto` \| `jira` \| `linear` \| `github` — `auto` probes which surfaces are live |
+| `--max-items` | `20` | Hard cap per drain (bounded blast-radius; the rest is reported, not silently dropped) |
+| `--max-attempts` | `2` | Per-item attempt cap before quarantine (poison-item guard) |
+| `--auto-merge` | `hold` | `authorized` \| `hold` \| `off` — forwarded to `quiesce` |
+| `--auto-merge-reason` | — | required-non-empty when `authorized`; passing it IS the authorization |
+| `--autonomy-threshold` | `0.85` | forwarded to `quiesce` |
+| `--max-pdca` | `6` | forwarded to `quiesce` |
+| `--dry-run` | off | Derive + order + print the register; drain nothing |
+
+> `--auto-merge` defaults to **`hold`**, not `authorized`. A conductor that merges by default
+> across N items multiplies blast-radius by N. The operator authorizes explicitly, per drain.
+
+## How it works
+
+```text
+PASS (repeat until the register derives empty):
+
+  1. DERIVE   re-read the trackers -> raw item set        (level-triggered; no stored queue)
+              confirm each item's real state via direct `get` (the index lags)
+  2. ORDER    Eisenhower quadrant (delegate: pulse) x dependency-DAG topological sort
+              cross-domain shape when unclear (delegate: work-compass)
+  3. SELECT   the next item whose dependencies are all satisfied
+              skip quarantined items (see Poison-item guard)
+  4. DRAIN    /maos:quiesce --scope ticket:<id> [forwarded flags]
+  5. VERIFY   re-read the item; did it actually close?
+              closed -> continue | unchanged -> count an attempt | error -> quarantine check
+  6. LOOP     back to 1 — the register is re-derived, never popped
+```
+
+Step 6 is the whole design. There is no "next item pointer" to lose.
+
+## Composition (what it delegates — it reimplements none of these)
+
+| Concern | Delegated to |
+|---|---|
+| Cross-domain item discovery (ticket ↔ worktree ↔ branch ↔ PR) | `skills/work-compass` |
+| Eisenhower 2×2 prioritization | `skills/pulse` (via `chief-of-staff`'s established path) |
+| Actually finishing ONE item (goal-loop + PDCA + merge gate) | `skills/quiesce --scope ticket:<id>` |
+| Abstract acceptance criterion → measurable | `skills/decompose-abstract-to-measurable` (Prisma) |
+| Adversarial verification on a hard-trigger | `skills/red-team` (Elenchus) |
+| Independent decision when score is short | `skills/council-gate` (Boule) → HITL residue only |
+| Workspace isolation / exit hygiene | `skills/preflight` · `skills/postflight` |
+
+If a phase here starts to grow its own PDCA, merge gate, or delegation machinery — that is the
+signal it has drifted from conducting into reimplementing. Cut it back.
+
+## Poison-item guard (the failure mode a naive drain hits first)
+
+One item that always fails must never block the drain or burn the budget:
+
+- **`--max-attempts` (default 2)** per item, per drain.
+- On exceeding it: **quarantine** the item — skip it, record why, continue with the rest.
+- A quarantined item is **reported, never silently dropped**: it lands in the final briefing and
+  gets a tracker comment stating the attempts and the blocking reason.
+- Distinguish **blocked** (a real dependency is unmet — retry next pass, it may be satisfied by
+  then) from **failing** (the work itself errors — quarantine and surface it).
+- If ≥half the register quarantines in one drain, **stop and escalate** — that is a systemic
+  fault, not N item faults. Draining harder makes it worse.
+
+## Bounds (anti-runaway)
+
+- `--max-items` caps register size per drain; the overflow is **listed** in the briefing.
+- `--max-attempts` caps per-item retries.
+- `quiesce`'s own bounds apply per item (`--max-pdca`, depth ≤ 2, 6-attempt escalation).
+- **No silent truncation, ever** — anything the drain declines to touch is named in the report.
+- HUMAN_DOMAIN + non-negotiable guardrails (secrets · production PII · force-push protected ·
+  prod/irreversible · cross-org) halt the drain → HITL, regardless of item count.
+
+## Autonomy posture
+
+Autonomy is a **multiplier**: draining N items unattended multiplies both throughput *and* the
+cost of a wrong call. Rigor therefore scales **up** with N, never down.
+
+- Per item: CASC gates + `autonomy_score` (delegated through `quiesce`).
+- Score short → Score-Uplift (≤3 honest attempts) → **MoE debate-converge → Council decides**
+  (verifier ≠ generator) → only the irreducible residue reaches HITL, carrying **ranked
+  recommendations + rationale**. Never a blank ask.
+- Red-team is **mandatory** on any hard-trigger (secrets · prod PII · irreversible ∧ blast ·
+  guardrail/governance self-edit · external disclosure · fail-open flip · untrusted input
+  steering a side-effecting action). Independence unavailable at HIGH → **HOLD, do not force**.
+
+## Tracker-agnostic
+
+`--tracker=auto` probes which surfaces are actually live before assuming one. Route by context:
+Jira for corporate work, Linear for personal, GitHub Issues for repo-scoped. **This repo's own
+tracker is GitHub Issues** (see `CONTRIBUTING.md`) — the skill must not hardcode Jira.
+
+⛔ **A negative probe is not proof of absence.** Before concluding "no items", run a positive
+control: same instrument, same query shape, something you know exists. A silent empty result
+from an under-reaching instrument looks identical to a genuinely empty backlog — and the two
+demand opposite actions.
+
+## Relationship to siblings
+
+| Tool | Register comes from | Scope | Drives |
+|---|---|---|---|
+| `work-drain` (this) | **external trackers** (derived each pass) | N items | ordered drain → `quiesce` per item |
+| `quiesce` | the session / one scope | ONE scope | termination predicate → steady state |
+| `gap-loop` | **self-derived** gap-register | N gaps | MoE resolve → validate → persist |
+| `chief-of-staff` | external trackers | operator's plate | **reports** (read-only), does not execute |
+| `auto-pilot` | one operator goal | ONE goal | decompose → spawn → converge |
+
+`work-drain` is `chief-of-staff`'s executing counterpart: same discovery lineage, but it
+*drains* instead of *briefing*.
+
+## DNA Geracional (inherited by every spawned agent)
+
+- **Dogfood**: drain this repo's own open issues before claiming the skill works.
+- **Persist-over-fail**: the tracker *is* the write-ahead log — update the item before and after,
+  so a collapse is recoverable from the tracker alone.
+- **DRY / KIS / YAGNI / SSOT** — compose primitives, never duplicate them.
+- **Boy-Scout** — leave every repo cleaner than found: no stale branches or worktrees, no loose
+  ends, no unanswered comments.
+- **No self-destructive decisions** — nothing that boomerangs onto a future session.
+
+## Examples
+
+```text
+/maos:work-drain sprint:current
+/maos:work-drain sprint:current --auto-merge=authorized --auto-merge-reason="sprint drain, operator-authorized"
+/maos:work-drain jql:"project = VKS AND assignee = currentUser() AND sprint IN openSprints() AND statusCategory != Done"
+/maos:work-drain issues:ekson73/multi-agent-os --tracker=github --max-items=5
+/maos:work-drain prs:open --dry-run
+```
+
+## Validation
+
+- `--dry-run` on a known sprint prints a register matching the tracker's own count.
+- Interrupting mid-drain and re-invoking resumes without redoing closed items (level-triggered).
+- Re-running on a drained sprint is a clean no-op.
+- A deliberately-failing item quarantines after `--max-attempts` and appears in the briefing.
+- Nothing the drain skipped is absent from the final report.
+
+## Reporting
+
+Per item and at the end — executive briefing ≤200 words: requested · executed · gaps · pending ·
+questions-not-asked · questions-unanswered · decisions-not-taken. Plus:
+
+```text
+STATUS CHECKLIST
+  🔴 not-started · 🟡 in-progress · 🟠 need-HITL · 🟢 agentic-done <NN%> · 🔵 human-done
+  quarantined: <n> (each with reason) · overflow beyond --max-items: <n>
+Autonomy pulse: X% green
+```
+
+⚠️ WIP ≤ 3 · ≤1 question per turn · deliver finished work, not question-batches · always name
+harness + repo + session in the handoff.
+
+## Related
+
+`skills/quiesce/SKILL.md` (per-item driver) · `skills/chief-of-staff/SKILL.md` (read-only twin) ·
+`skills/gap-loop/SKILL.md` (self-derived register sibling) · `skills/work-compass/SKILL.md`
+(discovery) · `skills/pulse/SKILL.md` (Eisenhower) · `skills/preflight`/`postflight` ·
+`commands/work-drain.md` (command surface).
+
+## Versioning
+
+v0.1.0 — initial. Named by the `anima` methodology (`[C-naming]`); soul-name *Antlia*
+(ἀντλία, the bilge-pump). Level-triggered design grounded in the Kubernetes controller pattern.
+
+## License
+
+MIT (inherits the plugin's license).


### PR DESCRIPTION
[PR-as-Documentation-Prompt]

## Summary

Adds **`work-drain`** (soul-name *Antlia*) — a conductor that bridges **external trackers** to
the existing loop family. Given `<object-targets>` (a sprint, a backlog query, open PRs, tracker
issues), it discovers matching items, derives an ordered work-register, and drains it
**item-by-item** by delegating each item to `quiesce --scope ticket:<id>`.

Two files: `skills/work-drain/SKILL.md` (logic) + `commands/work-drain.md` (thin surface).

## Type

Feature — new skill + command. No existing behavior changed.

## Why this is net-new (I checked before building)

The family has three near-neighbors and none covers this:

| Sibling | Register comes from | Why it isn't this |
|---|---|---|
| `gap-loop` | **self-derived** gap-register | never reads an external tracker |
| `chief-of-staff` | external trackers | **read-only** — reports, doesn't execute |
| `quiesce` | one scope | drives **ONE** item, not a set |

`work-drain` is `chief-of-staff`'s executing counterpart: same discovery lineage, but it
*drains* instead of *briefing*. It reimplements no loop, no PDCA, no merge gate.

> Full transparency: in a prior round I **declined** to build this, arguing Strata/YAGNI — that
> `quiesce` + `chief-of-staff` already covered ~90%. The operator overrode that. On closer
> inspection the operator was right: the remaining 10% (register-derivation from trackers) is
> exactly the part with no home, and it's where the interesting invariant lives.

## The load-bearing design decision: level-triggered

Modeled on the Kubernetes controller pattern. Every pass **re-derives** the register from the
trackers rather than popping a stored queue:

- **Idempotent-resume is inherent, not bolted on** — an interrupted drain resumes by re-reading
  the world; there is no "next item pointer" to lose.
- **Re-running on a drained sprint is a clean no-op** (the correct end state).
- **No local queue file** to corrupt, desync, or garbage-collect.

The alternative (build-queue-once, pop) needs a durable local queue *and* a resume protocol *and*
a drift-reconciler. Level-triggering makes all three unnecessary.

## Safety posture

- `--auto-merge` defaults to **`hold`**, not `authorized` — draining N items with auto-merge on
  multiplies blast-radius by N. Authorization is explicit and per-drain.
- **Poison-item quarantine** after `--max-attempts` (2): one always-failing item can't block the
  drain or burn budget. Quarantined items are **reported**, never silently dropped.
- **Systemic-fault circuit-breaker**: if ≥half the register quarantines, stop and escalate —
  that's one fault, not N.
- `--max-items` (20) bounds the register; overflow is listed in the briefing.
- HUMAN_DOMAIN + non-negotiable guardrails always halt → HITL.
- Tracker-agnostic (`--tracker=auto`) — deliberately **not** Jira-hardcoded, since this repo's
  own tracker is GitHub Issues per `CONTRIBUTING.md`.

## AI Involvement

Authored by Claude under operator direction. Naming ran the `anima` methodology per `[C-naming]`
(register gate → research → 12 correctness aspects → one sovereign name + rejected runner-up);
both the naming and creation decisions are recorded in `artifact-registry`, and a post-hoc
`lookup` now correctly returns **DUP-RISK** for this intent.

**Etymology (research-grounded)**: *Antlia* ← Ancient Greek **ἀντλία**, a ship's bilge and the
pump that empties it; Latinized by Lacaille (1752), shortened to one word by John Herschel
(1844). A bilge-pump drains a hold **to empty**, **load by load**, and is **safe to restart** —
you re-read the water level, you never replay a log of past strokes. That last property is
precisely the level-triggered invariant, which is why the name earned the slot.
Rejected runner-up: **`backlog-drain`** — accurate but too narrow; the skill also drains PRs and
arbitrary filters, so it would have been out-grown immediately (Anima aspect #11, scope).

## Evidence

- `gitleaks protect --staged` → `rc=0`, no leaks (exit code captured directly, not through a pipe).
- Frontmatter parses on both files; structure mirrors `quiesce`'s skill+command split.
- `artifact-registry lookup` before build → `CLEAR`; after recording → `DUP-RISK (2 matches)`,
  confirming future dedup fires.
- Built in an isolated worktree off `origin/main`; no commit to main.

## Risks

- **Unexercised**: this is a design landing, not a proven drain. The `## Validation` section
  lists the five checks that would prove it (dry-run register matches tracker count, interrupt →
  resume, re-run no-op, poison-item quarantine, nothing-skipped-unreported). Per the Dogfooding
  Mandate it should drain this repo's own open issues before being recommended anywhere.
- Delegation depth: `work-drain` → `quiesce` → `auto-pilot` sits at the depth-≤2 boundary. Worth
  a reviewer's eye.

## Rollback

Delete the two added files; nothing else references them yet.

## Checklist

- [x] Isolated worktree, conventional commit, signed-off
- [x] gitleaks clean (rc=0)
- [x] No existing file modified — purely additive
- [x] Composes siblings rather than duplicating them
- [x] Naming + creation recorded in artifact-registry
- [ ] Dogfood run (deferred — see Risks)
