### PR TITLE
fix(artifact-registry): parenthesize jq type-filter predicate

### DIFF
--- a/bin/artifact-registry
+++ b/bin/artifact-registry
@@ -129,7 +129,7 @@ if [ "$VERB" = "lookup" ]; then
           | ( ($qslug != "") and ($r.slug == $qslug) ) as $exact
           | ( $r + {overlap:$ov, exact:$exact} )
         )
-      | map(select( $hastype | not or (.type == $qtype) ))
+      | map(select( ($hastype | not) or (.type == $qtype) ))
       | map(select(.exact or .overlap >= 2))
       | sort_by(.exact, .overlap) | reverse
       | { verdict: (if any(.exact or .overlap >= 2) then "DUP-RISK" else "CLEAR" end),

--- a/tests/test-artifact-registry.sh
+++ b/tests/test-artifact-registry.sh
@@ -44,6 +44,29 @@ v=$("$BIN" lookup --purpose "generate a kubernetes helm chart for postgres" --js
 EMPTY="$(mktemp -d)"; v=$(ARTIFACT_REGISTRY_DIR="$EMPTY" "$BIN" lookup --purpose "anything" --json | jq -r '.verdict'); rm -rf "$EMPTY"
 [ "$v" = "CLEAR" ] && ok "empty registry -> CLEAR" || no "empty registry ($v)"
 
+# 6b. REGRESSION GUARD: lookup --type must FILTER, not crash (jq `|` vs `or` precedence).
+# Pre-fix, `$hastype | not or (.type == $qtype)` parsed as `$hastype | (not or (...))`,
+# piping a boolean into the disjunction -> "Cannot index boolean with string \"type\"".
+# Record a same-purpose sibling under a DIFFERENT type so the filter has to discriminate.
+"$BIN" record --kind create --slug praxis-audit-bin --type bin \
+  --purpose "self-referential session-method audit preset" >/dev/null 2>&1
+# control: no --type sees BOTH types
+n_all=$("$BIN" lookup --purpose "self-referential session-method audit preset" --json | jq -r '.matches | length')
+# --type skill admits only skill rows; --type bin only the bin row
+n_skill=$("$BIN" lookup --purpose "self-referential session-method audit preset" --type skill --json | jq -r '[.matches[] | select(.type=="skill")] | length')
+x_skill=$("$BIN" lookup --purpose "self-referential session-method audit preset" --type skill --json | jq -r '[.matches[] | select(.type!="skill")] | length')
+n_bin=$("$BIN" lookup --purpose "self-referential session-method audit preset" --type bin --json | jq -r '.matches | length')
+# a) it must not crash and must still find matches unfiltered
+[ "$n_all" -ge 2 ] && ok "lookup --type control: unfiltered sees >=2 ($n_all)" || no "lookup --type control ($n_all)"
+# b) --type skill must EXCLUDE every non-skill row (this is what the bug broke)
+[ "$x_skill" -eq 0 ] && ok "lookup --type skill excludes other types" || no "lookup --type skill leaked $x_skill non-skill row(s)"
+[ "$n_skill" -ge 1 ] && ok "lookup --type skill admits skill rows ($n_skill)" || no "lookup --type skill admitted none"
+# c) --type bin must admit exactly the bin sibling
+[ "$n_bin" -eq 1 ] && ok "lookup --type bin admits only the bin row" || no "lookup --type bin ($n_bin, want 1)"
+# d) a type present in NO row must yield CLEAR/0 (not a crash, not everything)
+v=$("$BIN" lookup --purpose "self-referential session-method audit preset" --type zzz-nonexistent --json | jq -r '.verdict')
+[ "$v" = "CLEAR" ] && ok "lookup --type <absent> -> CLEAR" || no "lookup --type <absent> ($v)"
+
 # 7. dry-run writes nothing
 before=$(wc -l < "$ARTIFACT_REGISTRY_DIR/artifact-registry.jsonl")
 "$BIN" record --kind name --slug foo-bar --dry-run >/dev/null 2>&1


### PR DESCRIPTION
**purpose-tag**: `PR-as-Correction-Prompt`

## Context

`artifact-registry lookup --type <t>` crashed instead of filtering:

```
$ ./bin/artifact-registry lookup --type skill
jq: error (at <stdin>:272): Cannot index boolean with string "type"
```

Root cause (bin/artifact-registry:132): in jq, `|` binds **looser** than `or`, so

```jq
$hastype | not or (.type == $qtype)
```

parses as `$hastype | (not or (.type == $qtype))` — the boolean is piped into the
*entire* disjunction, and `.type` is then evaluated against `true`/`false`.

## Objective

Restore `--type` filtering. This matters beyond cosmetics: `lookup` is the **dedup gate**
that Anima (naming) and Forge (creation) consult before minting a new artifact. A crashing
`--type` filter silently degrades that gate.

## Change

One line — explicit precedence:

```diff
-      | map(select( $hastype | not or (.type == $qtype) ))
+      | map(select( ($hastype | not) or (.type == $qtype) ))
```

## Acceptance / evidence

Verified with a **positive control** against the live 20-entry registry
(13 `skill` / 3 `bin` / 2 `adr` / 1 `script`), proving the filter *discriminates*
rather than merely no longer erroring:

| invocation | expected | actual |
|---|---|---|
| `--purpose "self-referential session-method audit"` | DUP-RISK | ✅ DUP-RISK, 2 matches |
| `… --type skill` | admits (same 2) | ✅ DUP-RISK, same 2 matches |
| `… --type bin` | excludes | ✅ CLEAR, 0 matches |

Pre-fix, the same invocations errored out entirely.

- `gitleaks protect --staged` → **rc=0**, no leaks (exit code captured directly, not through a pipe)

## Risks / rollback

Minimal — single-expression change in one jq filter, no interface or schema change.
Rollback: revert this commit.

## Cross-links

Closes #281
