### PR TITLE
fix(commands): valid YAML frontmatter for work-drain

### DIFF
--- a/commands/work-drain.md
+++ b/commands/work-drain.md
@@ -1,6 +1,7 @@
 ---
 name: work-drain
-description: Drain a set of <object-targets> (sprint · backlog query · open PRs · tracker issues) item-by-item to quiescence — discover, derive an ordered register, and delegate each item to quiesce. Level-triggered and resumable. Soul-name: Antlia.
+description: |
+  Drain a set of <object-targets> (sprint · backlog query · open PRs · tracker issues) item-by-item to quiescence — discover, derive an ordered register, and delegate each item to quiesce. Level-triggered and resumable. Soul-name: Antlia.
 ---
 
 # /maos:work-drain — Antlia


### PR DESCRIPTION
## Summary
- Quote/`|` the `work-drain` command description so `Soul-name: Antlia` does not break YAML parse.
- Restores command metadata at Claude Code load time (`claude plugin validate` now PASSes).

## Evidence
- `claude plugin validate` on worktree: **passed with warnings** (pre-fix: failed on work-drain YAML).

## Test plan
- [x] `claude plugin validate .` in worktree
- [ ] `/plugin update maos@a private plugin marketplace` after merge + restart session
- [ ] Confirm `/maos:work-drain` still discovers with description intact
