### PR TITLE
feat(packaging): Pi package + OpenCode thin plugin (#313 #314)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,26 @@ Plugin management runs **inside a Claude Code session** via the `/plugin` comman
 
 Then run `/plugin` (Installed tab) to confirm, and `/help` to see the `/maos:*` skills. Need to update later? `/plugin marketplace update eko-claude-plugins`.
 
+
+### Pi package
+
+```bash
+pi install git:github.com/ekson73/multi-agent-os@main
+```
+
+Loads MAOS `skills/` via the root `package.json` `pi` manifest. See [docs/multi-host-packaging.md](./docs/multi-host-packaging.md).
+
+### OpenCode plugin (thin entry)
+
+```bash
+mkdir -p ~/.config/opencode/plugins
+curl -fsSL -o ~/.config/opencode/plugins/maos.js \
+  https://raw.githubusercontent.com/ekson73/multi-agent-os/main/packaging/opencode-maos/index.js
+```
+
+Full skills: `npx skills add ekson73/multi-agent-os -g -a opencode`. Details: [packaging/opencode-maos](./packaging/opencode-maos/).
+
+
 ### From source (local dev / self-use)
 
 ```bash

--- a/docs/multi-host-packaging.md
+++ b/docs/multi-host-packaging.md
@@ -1,0 +1,10 @@
+# Multi-host packaging
+
+| Host | Entrypoint | Status |
+|---|---|---|
+| Claude Code | `.claude-plugin/plugin.json` + eko marketplace | ready |
+| Pi | root `package.json` (`pi.skills`) | ready for `pi install git:…` |
+| OpenCode | `packaging/opencode-maos/` | ready (thin plugin + skills via npx skills) |
+| Codex / others | Agent Skills via `npx skills add ekson73/multi-agent-os` | docs |
+
+Discovery hub: `ekson73/eko-claude-plugins` (target name **eko-plugin-marketplace**).

--- a/package.json
+++ b/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "maos",
+  "version": "1.22.0",
+  "description": "MAOS (Multi-Agent OS) — skills pack for multi-agent coordination. Claude plugin + Pi package + OpenCode plugin entrypoints.",
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ekson73/multi-agent-os.git"
+  },
+  "homepage": "https://github.com/ekson73/multi-agent-os",
+  "bugs": {
+    "url": "https://github.com/ekson73/multi-agent-os/issues"
+  },
+  "keywords": [
+    "pi-package",
+    "maos",
+    "multi-agent",
+    "agent-skills",
+    "orchestration",
+    "ai-agents"
+  ],
+  "files": [
+    "skills/**/SKILL.md",
+    "skills/**/*.md",
+    "packaging/**",
+    "README.md",
+    "LICENSE",
+    "AGENTS.md"
+  ],
+  "pi": {
+    "skills": ["./skills"]
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,9 @@
+# Packaging entrypoints (multi-host)
+
+| Path | Host | Install |
+|---|---|---|
+| Root [`package.json`](../package.json) | **Pi** | `pi install git:github.com/ekson73/multi-agent-os@main` |
+| [`opencode-maos/`](./opencode-maos/) | **OpenCode** | local plugin file or npm `opencode-maos` |
+| `.claude-plugin/` | **Claude Code** | via eko-plugin-marketplace / `maos@eko-claude-plugins` |
+
+Product content (skills, etc.) stays in-repo roots; these manifests only expose host loaders.

--- a/packaging/opencode-maos/README.md
+++ b/packaging/opencode-maos/README.md
@@ -1,0 +1,29 @@
+# opencode-maos
+
+Thin [OpenCode](https://opencode.ai/docs/plugins/) plugin entry for **MAOS** (`multi-agent-os`).
+
+## Install
+
+### A — Local plugin file (no npm publish)
+```bash
+mkdir -p ~/.config/opencode/plugins
+curl -fsSL -o ~/.config/opencode/plugins/maos.js \
+  https://raw.githubusercontent.com/ekson73/multi-agent-os/main/packaging/opencode-maos/index.js
+```
+Restart OpenCode.
+
+### B — npm package (when published)
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": ["opencode-maos"]
+}
+```
+
+### Skills (agentic-tools — not this package’s job)
+```bash
+npx skills add ekson73/multi-agent-os -g -a opencode
+```
+
+## Scope
+This package is a **runtime entrypoint**, not a dump of MAOS skills/agents/hooks.

--- a/packaging/opencode-maos/index.js
+++ b/packaging/opencode-maos/index.js
@@ -1,0 +1,35 @@
+/**
+ * opencode-maos — thin OpenCode plugin entry for MAOS.
+ *
+ * Does not vendor the full skill corpus into OpenCode hooks.
+ * Skills/agentic-tools remain in-repo and are consumed via:
+ *   - Claude: maos plugin / eko-plugin-marketplace
+ *   - Pi: `pi install git:github.com/ekson73/multi-agent-os@main`
+ *   - Skills CLI: `npx skills add ekson73/multi-agent-os`
+ *
+ * This module only registers a harmless lifecycle presence so the package
+ * is a valid OpenCode plugin and can be listed in opencode.json.
+ */
+
+/** @param {Record<string, unknown>} ctx */
+export const MaosPlugin = async (ctx) => {
+  try {
+    const log = ctx?.client?.app?.log
+    if (typeof log === "function") {
+      await log({
+        body: {
+          service: "opencode-maos",
+          level: "info",
+          message: "MAOS OpenCode plugin loaded (thin entry). Install skills via npx skills add ekson73/multi-agent-os",
+        },
+      })
+    }
+  } catch {
+    // logging optional — never block startup
+  }
+  return {
+    // Hook surface reserved for future non-skill integrations.
+  }
+}
+
+export default MaosPlugin

--- a/packaging/opencode-maos/package.json
+++ b/packaging/opencode-maos/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "opencode-maos",
+  "version": "1.22.0",
+  "description": "OpenCode plugin entry for MAOS (Multi-Agent OS). Thin runtime hook; full skills via npx skills add ekson73/multi-agent-os or Claude/Pi packaging.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js"
+  },
+  "files": [
+    "index.js",
+    "README.md"
+  ],
+  "keywords": [
+    "opencode",
+    "opencode-plugin",
+    "maos",
+    "multi-agent",
+    "ai-agents"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ekson73/multi-agent-os.git",
+    "directory": "packaging/opencode-maos"
+  },
+  "homepage": "https://github.com/ekson73/multi-agent-os/tree/main/packaging/opencode-maos",
+  "engines": {
+    "node": ">=20"
+  }
+}


### PR DESCRIPTION
Root package.json pi.skills + packaging/opencode-maos. Closes #313 #314. eko catalog can flip pi/opencode to ready after merge.