### PR TITLE
fix(skills): frontmatter for skills.sh multi-harness (1.22.1)

### DIFF
--- a/.agents/skills/multi-agent-os/SKILL.md
+++ b/.agents/skills/multi-agent-os/SKILL.md
@@ -1,99 +1,55 @@
-```markdown
-# multi-agent-os Development Patterns
+---
+name: multi-agent-os-repo
+description: >-
+  How to work on the multi-agent-os (MAOS) repository itself — layout (skills/,
+  agents/, commands/, packaging/), Agent Skills standard, Claude plugin + Pi
+  package + OpenCode thin plugin entrypoints, tests, and contribution norms.
+  Use when contributing to MAOS, packaging for multi-harness, or debugging
+  npx skills / marketplace installs of this repo.
+---
 
-> Auto-generated skill from repository analysis
+# Working on multi-agent-os (MAOS)
 
-## Overview
-This skill teaches the core development patterns and conventions used in the `multi-agent-os` TypeScript codebase. You'll learn about file naming, import/export styles, commit conventions, and how to write and run tests, as well as suggested commands for common workflows. This repository does not use a framework, focusing on clean TypeScript practices.
+## Domain
+This repository is the **product** (agentic-tools). Distribution index is
+`ekson73/eko-claude-plugins` (target name eko-plugin-marketplace) — do not
+vendor skills into eko.
 
-## Coding Conventions
+## Layout (high signal)
+| Path | Role |
+|---|---|
+| `skills/*/SKILL.md` | Agent Skills corpus (portable via `npx skills`) |
+| `agents/` | Subagent definitions |
+| `commands/` | Slash commands (Claude plugin) |
+| `.claude-plugin/plugin.json` | Claude marketplace plugin manifest (`maos`) |
+| `package.json` | Pi package (`pi.skills`) |
+| `packaging/opencode-maos/` | OpenCode thin plugin |
+| `docs/multi-host-packaging.md` | Multi-host install matrix |
 
-### File Naming
-- Use **PascalCase** for all file names.
-  - Example: `AgentManager.ts`, `UserSession.ts`
+## Install (consumers)
+```bash
+# Portable (many harnesses)
+npx skills add ekson73/multi-agent-os -g -a '*' -y
 
-### Import Style
-- Use **relative imports** for referencing other modules.
-  - Example:
-    ```typescript
-    import { Agent } from './Agent';
-    import { SessionManager } from '../Session/SessionManager';
-    ```
+# Claude
+# /plugin marketplace add ekson73/eko-claude-plugins
+# /plugin install maos@eko-claude-plugins
 
-### Export Style
-- Use **named exports** rather than default exports.
-  - Example:
-    ```typescript
-    // Agent.ts
-    export interface Agent { ... }
-    export function createAgent() { ... }
-    ```
-
-### Commit Messages
-- Follow **conventional commit** style.
-- Use prefixes such as `docs` to indicate documentation changes.
-  - Example:
-    ```
-    docs: update README with setup instructions
-    ```
-
-## Workflows
-
-### Documentation Updates
-**Trigger:** When updating or adding documentation.
-**Command:** `/update-docs`
-
-1. Make your documentation changes in the relevant files.
-2. Use a conventional commit message with the `docs` prefix.
-   - Example: `docs: add usage example to AgentManager`
-3. Push your changes and open a pull request if required.
-
-### Adding or Modifying Code
-**Trigger:** When implementing new features or updating existing code.
-**Command:** `/update-code`
-
-1. Create new files using PascalCase.
-2. Use relative imports and named exports.
-3. Write or update TypeScript code following the code style conventions.
-4. Add or update corresponding test files as needed.
-5. Commit changes with a descriptive, conventional commit message.
-6. Push your changes and open a pull request if required.
-
-### Running Tests
-**Trigger:** Before merging or after making code changes.
-**Command:** `/run-tests`
-
-1. Locate test files matching the `*.test.*` pattern.
-2. Run the test suite using your preferred TypeScript test runner (e.g., Jest, Mocha).
-   - Example command (if using Jest):
-     ```
-     npx jest
-     ```
-3. Ensure all tests pass before merging changes.
-
-## Testing Patterns
-
-- Test files are named with the `*.test.*` pattern (e.g., `AgentManager.test.ts`).
-- The specific test framework is not specified; use your team's preferred TypeScript test runner.
-- Place tests alongside the modules they test or in a dedicated `__tests__` directory.
-- Example test file:
-  ```typescript
-  // AgentManager.test.ts
-  import { createAgent } from './AgentManager';
-
-  describe('createAgent', () => {
-    it('should create a new agent with default properties', () => {
-      const agent = createAgent();
-      expect(agent).toBeDefined();
-      // more assertions...
-    });
-  });
-  ```
-
-## Commands
-| Command         | Purpose                                         |
-|-----------------|-------------------------------------------------|
-| /update-docs    | Update or add documentation                     |
-| /update-code    | Add or modify code following conventions        |
-| /run-tests      | Run all tests in the codebase                   |
+# Pi
+pi install git:github.com/ekson73/multi-agent-os@main
 ```
+
+## Skill authoring rules
+Every `SKILL.md` **must** start with YAML frontmatter containing at least:
+```yaml
+---
+name: my-skill-id
+description: When to use this skill (trigger-oriented, one paragraph).
+---
+```
+`npx skills` **skips** files missing `name` / `description`.
+
+## Tests / quality
+Follow repo `AGENTS.md` / `CONTRIBUTING.md`. Run project test-runner before commit.
+Do not invent marketplace formats for hosts eko marks `n/a`.
+

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "_comment": "MAOS plugin manifest. Edit version on release; see CHANGELOG.md. Namespacing + vendor-reserved details below.",
   "name": "maos",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "MAOS (Multi-Agent OS) - Coordination Framework for AI Agents with Orchestration, Sentinel Protocol, Worktree Governance, Status Maps, Forge Meta-Agent, Governance Protocols",
   "author": {
     "name": "MAOS Community",
@@ -29,21 +29,51 @@
     "playbook"
   ],
   "command_namespace": {
-    "_comment": "Sandwich Namespacing Layer 2 — manifest-declared namespace prefix for plugin commands. Forward-compat: if host runtime supports `command_namespace` declaration, commands surface as /maos:<name> (preventing cross-plugin collision). If host does not support, fallback to function-specific filename (Layer 3) handles disambiguation. See AGENTS.md §34 and sister-PR ekson73/vek-dot-claude#54 (vendor-reserved-words audit list, Layer 4).",
+    "_comment": "Sandwich Namespacing Layer 2 \u2014 manifest-declared namespace prefix for plugin commands. Forward-compat: if host runtime supports `command_namespace` declaration, commands surface as /maos:<name> (preventing cross-plugin collision). If host does not support, fallback to function-specific filename (Layer 3) handles disambiguation. See AGENTS.md \u00a734 and sister-PR ekson73/vek-dot-claude#54 (vendor-reserved-words audit list, Layer 4).",
     "prefix": "maos",
     "separator": ":",
     "prefix_required": true,
     "fallback": "permit_unprefixed_if_no_collision"
   },
   "vendor_reserved_audit": {
-    "_comment": "Sandwich Namespacing Layer 4 reference — list of vendor-native command names plugins should NEVER override at filename level. Authoritative cross-vendor catalog: ekson73/vek-dot-claude:docs/vendor-reserved-words.md v1.0.0 (36+ Claude Code built-ins + Cursor/Copilot/Aider/Gemini/Goose).",
+    "_comment": "Sandwich Namespacing Layer 4 reference \u2014 list of vendor-native command names plugins should NEVER override at filename level. Authoritative cross-vendor catalog: ekson73/vek-dot-claude:docs/vendor-reserved-words.md v1.0.0 (36+ Claude Code built-ins + Cursor/Copilot/Aider/Gemini/Goose).",
     "source_of_truth": "https://github.com/ekson73/vek-dot-claude/blob/main/docs/vendor-reserved-words.md",
     "claude_code_builtins_sample": [
-      "help", "clear", "status", "compact", "cost", "exit", "quit", "resume",
-      "login", "logout", "model", "init", "memory", "context", "review",
-      "permissions", "hooks", "mcp", "agents", "plugin", "config", "ide",
-      "color", "vim", "goal", "loop", "schedule", "enhance", "bug", "doctor",
-      "output-style", "output-styles", "terminal-setup", "upgrade", "install-github-app"
+      "help",
+      "clear",
+      "status",
+      "compact",
+      "cost",
+      "exit",
+      "quit",
+      "resume",
+      "login",
+      "logout",
+      "model",
+      "init",
+      "memory",
+      "context",
+      "review",
+      "permissions",
+      "hooks",
+      "mcp",
+      "agents",
+      "plugin",
+      "config",
+      "ide",
+      "color",
+      "vim",
+      "goal",
+      "loop",
+      "schedule",
+      "enhance",
+      "bug",
+      "doctor",
+      "output-style",
+      "output-styles",
+      "terminal-setup",
+      "upgrade",
+      "install-github-app"
     ]
   }
 }

--- a/.claude/skills/multi-agent-os/SKILL.md
+++ b/.claude/skills/multi-agent-os/SKILL.md
@@ -1,99 +1,55 @@
-```markdown
-# multi-agent-os Development Patterns
+---
+name: multi-agent-os-repo
+description: >-
+  How to work on the multi-agent-os (MAOS) repository itself — layout (skills/,
+  agents/, commands/, packaging/), Agent Skills standard, Claude plugin + Pi
+  package + OpenCode thin plugin entrypoints, tests, and contribution norms.
+  Use when contributing to MAOS, packaging for multi-harness, or debugging
+  npx skills / marketplace installs of this repo.
+---
 
-> Auto-generated skill from repository analysis
+# Working on multi-agent-os (MAOS)
 
-## Overview
-This skill teaches the core development patterns and conventions used in the `multi-agent-os` TypeScript codebase. You'll learn about file naming, import/export styles, commit conventions, and how to write and run tests, as well as suggested commands for common workflows. This repository does not use a framework, focusing on clean TypeScript practices.
+## Domain
+This repository is the **product** (agentic-tools). Distribution index is
+`ekson73/eko-claude-plugins` (target name eko-plugin-marketplace) — do not
+vendor skills into eko.
 
-## Coding Conventions
+## Layout (high signal)
+| Path | Role |
+|---|---|
+| `skills/*/SKILL.md` | Agent Skills corpus (portable via `npx skills`) |
+| `agents/` | Subagent definitions |
+| `commands/` | Slash commands (Claude plugin) |
+| `.claude-plugin/plugin.json` | Claude marketplace plugin manifest (`maos`) |
+| `package.json` | Pi package (`pi.skills`) |
+| `packaging/opencode-maos/` | OpenCode thin plugin |
+| `docs/multi-host-packaging.md` | Multi-host install matrix |
 
-### File Naming
-- Use **PascalCase** for all file names.
-  - Example: `AgentManager.ts`, `UserSession.ts`
+## Install (consumers)
+```bash
+# Portable (many harnesses)
+npx skills add ekson73/multi-agent-os -g -a '*' -y
 
-### Import Style
-- Use **relative imports** for referencing other modules.
-  - Example:
-    ```typescript
-    import { Agent } from './Agent';
-    import { SessionManager } from '../Session/SessionManager';
-    ```
+# Claude
+# /plugin marketplace add ekson73/eko-claude-plugins
+# /plugin install maos@eko-claude-plugins
 
-### Export Style
-- Use **named exports** rather than default exports.
-  - Example:
-    ```typescript
-    // Agent.ts
-    export interface Agent { ... }
-    export function createAgent() { ... }
-    ```
-
-### Commit Messages
-- Follow **conventional commit** style.
-- Use prefixes such as `docs` to indicate documentation changes.
-  - Example:
-    ```
-    docs: update README with setup instructions
-    ```
-
-## Workflows
-
-### Documentation Updates
-**Trigger:** When updating or adding documentation.
-**Command:** `/update-docs`
-
-1. Make your documentation changes in the relevant files.
-2. Use a conventional commit message with the `docs` prefix.
-   - Example: `docs: add usage example to AgentManager`
-3. Push your changes and open a pull request if required.
-
-### Adding or Modifying Code
-**Trigger:** When implementing new features or updating existing code.
-**Command:** `/update-code`
-
-1. Create new files using PascalCase.
-2. Use relative imports and named exports.
-3. Write or update TypeScript code following the code style conventions.
-4. Add or update corresponding test files as needed.
-5. Commit changes with a descriptive, conventional commit message.
-6. Push your changes and open a pull request if required.
-
-### Running Tests
-**Trigger:** Before merging or after making code changes.
-**Command:** `/run-tests`
-
-1. Locate test files matching the `*.test.*` pattern.
-2. Run the test suite using your preferred TypeScript test runner (e.g., Jest, Mocha).
-   - Example command (if using Jest):
-     ```
-     npx jest
-     ```
-3. Ensure all tests pass before merging changes.
-
-## Testing Patterns
-
-- Test files are named with the `*.test.*` pattern (e.g., `AgentManager.test.ts`).
-- The specific test framework is not specified; use your team's preferred TypeScript test runner.
-- Place tests alongside the modules they test or in a dedicated `__tests__` directory.
-- Example test file:
-  ```typescript
-  // AgentManager.test.ts
-  import { createAgent } from './AgentManager';
-
-  describe('createAgent', () => {
-    it('should create a new agent with default properties', () => {
-      const agent = createAgent();
-      expect(agent).toBeDefined();
-      // more assertions...
-    });
-  });
-  ```
-
-## Commands
-| Command         | Purpose                                         |
-|-----------------|-------------------------------------------------|
-| /update-docs    | Update or add documentation                     |
-| /update-code    | Add or modify code following conventions        |
-| /run-tests      | Run all tests in the codebase                   |
+# Pi
+pi install git:github.com/ekson73/multi-agent-os@main
 ```
+
+## Skill authoring rules
+Every `SKILL.md` **must** start with YAML frontmatter containing at least:
+```yaml
+---
+name: my-skill-id
+description: When to use this skill (trigger-oriented, one paragraph).
+---
+```
+`npx skills` **skips** files missing `name` / `description`.
+
+## Tests / quality
+Follow repo `AGENTS.md` / `CONTRIBUTING.md`. Run project test-runner before commit.
+Do not invent marketplace formats for hosts eko marks `n/a`.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.22.1] - 2026-08-10
+
+### Fixed
+- `.agents/skills/multi-agent-os/SKILL.md` + `.claude/skills/multi-agent-os/SKILL.md`: add Agent Skills frontmatter (`name`/`description`) so `npx skills` no longer skips them
+- Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
+
+### Added
+- `scripts/validate-skill-frontmatter.sh` + `npm run validate:skills`
+- `docs/multi-host-packaging.md` install matrix + agent id notes
+
+
 All notable changes to the Multi-Agent OS plugin will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/docs/multi-host-packaging.md
+++ b/docs/multi-host-packaging.md
@@ -3,13 +3,52 @@
 | Host | Entrypoint | Status |
 |---|---|---|
 | Claude Code | `.claude-plugin/plugin.json` + eko marketplace | ready |
-| Pi | root `package.json` (`pi.skills`) | ready for `pi install git:…` |
-| OpenCode | `packaging/opencode-maos/` | ready (thin plugin + skills via npx skills) |
-| Codex / others | Agent Skills via `npx skills add ekson73/multi-agent-os` | docs |
+| Pi | root `package.json` (`pi.skills`) | ready (`pi install git:…`) |
+| OpenCode | `packaging/opencode-maos/` | ready (thin plugin + skills) |
+| Codex / Copilot / Kiro / Gemini / Warp / … | [Agent Skills](https://agentskills.io) via `npx skills` | docs |
 
-Discovery hub: `ekson73/eko-claude-plugins` (target name **eko-plugin-marketplace**).
+## Domain
+| Repo | Role |
+|---|---|
+| **multi-agent-os** (this) | **Product** — skills, agents, commands, packaging |
+| **eko-claude-plugins** | **Index** — catalog + host docs only |
 
-## Discovery index (eko) — research 2026-08
-- https://github.com/ekson73/eko-claude-plugins/blob/main/docs/research/HOST-RESEARCH-2026-08.md
-- Compat: MULTI-HARNESS-COMPAT.md in eko
-- Portable: `npx skills add ekson73/multi-agent-os -g -a '*' -y`
+Discovery / research council (2026-08):  
+https://github.com/ekson73/eko-claude-plugins/blob/main/docs/research/HOST-RESEARCH-2026-08.md
+
+## Install matrix
+
+### Portable (recommended multi-harness bridge)
+```bash
+npx skills add ekson73/multi-agent-os -g -a '*' -y
+```
+Requires each `SKILL.md` to have YAML `name` + `description` (see `scripts/validate-skill-frontmatter.sh`).
+
+### Native
+| Host | Command |
+|---|---|
+| Claude | `/plugin marketplace add ekson73/eko-claude-plugins` then `/plugin install maos@eko-claude-plugins` |
+| Pi | `pi install git:github.com/ekson73/multi-agent-os@main` |
+| OpenCode | copy/curl `packaging/opencode-maos/index.js` → `~/.config/opencode/plugins/maos.js` **and/or** skills CLI |
+
+### Explicit skills agent ids (when known)
+```bash
+npx skills add ekson73/multi-agent-os -g -a codex
+npx skills add ekson73/multi-agent-os -g -a opencode
+npx skills add ekson73/multi-agent-os -g -a claude-code
+npx skills add ekson73/multi-agent-os -g -a gemini-cli
+npx skills add ekson73/multi-agent-os -g -a github-copilot
+npx skills add ekson73/multi-agent-os -g -a kiro
+```
+If an id is rejected by your `skills` CLI version, use `-a '*'`.
+
+## Not in this repo’s job
+- Publishing ChatGPT store / VS Code VSIX / Open VSX / Grok packs as MAOS core
+- Hosting a multi-vendor “app store” UI (that’s eko’s index role, Claude-only mall)
+
+## Validate
+```bash
+npm run validate:skills
+# or
+bash scripts/validate-skill-frontmatter.sh
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maos",
-  "version": "1.22.0",
-  "description": "MAOS (Multi-Agent OS) — skills pack for multi-agent coordination. Claude plugin + Pi package + OpenCode plugin entrypoints.",
+  "version": "1.22.1",
+  "description": "MAOS (Multi-Agent OS) \u2014 skills pack for multi-agent coordination. Claude plugin + Pi package + OpenCode plugin entrypoints.",
   "license": "MIT",
   "private": false,
   "type": "module",
@@ -14,12 +14,14 @@
     "url": "https://github.com/ekson73/multi-agent-os/issues"
   },
   "keywords": [
-    "pi-package",
+    "agent-skills",
+    "agentskills",
+    "ai-agents",
     "maos",
     "multi-agent",
-    "agent-skills",
     "orchestration",
-    "ai-agents"
+    "pi-package",
+    "skills-sh"
   ],
   "files": [
     "skills/**/SKILL.md",
@@ -30,9 +32,14 @@
     "AGENTS.md"
   ],
   "pi": {
-    "skills": ["./skills"]
+    "skills": [
+      "./skills"
+    ]
   },
   "engines": {
     "node": ">=20"
+  },
+  "scripts": {
+    "validate:skills": "bash scripts/validate-skill-frontmatter.sh"
   }
 }

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -7,3 +7,5 @@
 | `.claude-plugin/` | **Claude Code** | via eko-plugin-marketplace / `maos@eko-claude-plugins` |
 
 Product content (skills, etc.) stays in-repo roots; these manifests only expose host loaders.
+
+Skills frontmatter gate: `npm run validate:skills` (Agent Skills / skills.sh compatibility).

--- a/scripts/validate-skill-frontmatter.sh
+++ b/scripts/validate-skill-frontmatter.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Fail if any SKILL.md under the repo lacks Agent Skills required frontmatter.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+python3 <<'PY'
+from pathlib import Path
+import re, sys
+root = Path(".")
+bad = []
+good = 0
+skip_parts = {".git", ".worktrees", "node_modules"}
+for p in root.rglob("SKILL.md"):
+    if any(part in skip_parts for part in p.parts):
+        continue
+    text = p.read_text(encoding="utf-8", errors="replace")
+    m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n", text, re.S)
+    if not m:
+        bad.append(f"{p}: missing YAML frontmatter")
+        continue
+    fm = m.group(1)
+    # allow name/description with optional quotes / multiline >
+    has_name = re.search(r"(?m)^name:\s*\S", fm) is not None
+    has_desc = re.search(r"(?m)^description:\s*\S", fm) is not None
+    if not (has_name and has_desc):
+        bad.append(f"{p}: frontmatter needs name + description")
+    else:
+        good += 1
+if bad:
+    print("FAIL skill frontmatter:")
+    print("\n".join(bad))
+    sys.exit(1)
+print(f"OK {good} SKILL.md files have name+description frontmatter")
+PY


### PR DESCRIPTION
## PDCA
**Plan:** Dogfood `npx skills add ekson73/multi-agent-os -l` → found 2 SKILL.md skipped (no frontmatter).  
**Do:** Fix `.agents` + `.claude` skills; add `validate:skills`; multi-host docs.  
**Check:** `npm run validate:skills` / script OK; 0 bad SKILL.md.  
**Act:** Merge; eko research notes dogfood result.

## Domain
MAOS product fix (skills quality). eko remains index-only.

Closes portable-path friction for multi-harness council 2026-08.