### PR TITLE
chore(packaging): OpenCode version sync + skills gate in validate-plugin

### DIFF
--- a/.github/workflows/version-sync.yml
+++ b/.github/workflows/version-sync.yml
@@ -1,10 +1,6 @@
 # Version Sync Workflow
-# Ensures version consistency between plugin.json (SSOT) and documentation files
-#
 # SSOT: .claude-plugin/plugin.json
-# Synced files: README.md (badge + footer), CLAUDE.md (footer)
-#
-# Trigger: On push to main when plugin.json changes, or manual dispatch
+# Synced: README.md, CLAUDE.md, package.json, packaging/opencode-maos/package.json
 
 name: Version Sync
 
@@ -26,7 +22,6 @@ permissions:
 jobs:
   sync-version:
     runs-on: ubuntu-latest
-    # Prevent infinite loop from our own commits
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     steps:
@@ -46,34 +41,41 @@ jobs:
       - name: Sync README.md badge
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # Update version badge
           sed -i "s/Version-[0-9]*\.[0-9]*\.[0-9]*-blue/Version-${VERSION}-blue/g" README.md
           echo "✅ README.md badge updated"
 
       - name: Sync README.md footer
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # Update footer version
           sed -i "s/Multi-Agent OS v[0-9]*\.[0-9]*\.[0-9]*/Multi-Agent OS v${VERSION}/g" README.md
           echo "✅ README.md footer updated"
 
       - name: Sync CLAUDE.md footer
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          # Update CLAUDE.md footer
           sed -i "s/Multi-Agent OS v[0-9]*\.[0-9]*\.[0-9]*/Multi-Agent OS v${VERSION}/g" CLAUDE.md
           echo "✅ CLAUDE.md footer updated"
+
+      - name: Sync package.json + OpenCode packaging version
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          jq --arg v "$VERSION" '.version = $v' package.json > package.json.tmp && mv package.json.tmp package.json
+          if [ -f packaging/opencode-maos/package.json ]; then
+            jq --arg v "$VERSION" '.version = $v' packaging/opencode-maos/package.json > /tmp/oc.json && mv /tmp/oc.json packaging/opencode-maos/package.json
+          fi
+          echo "✅ package.json + packaging/opencode-maos version → $VERSION"
 
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet README.md CLAUDE.md; then
+          FILES=(README.md CLAUDE.md package.json packaging/opencode-maos/package.json)
+          if git diff --quiet -- "${FILES[@]}"; then
             echo "changed=false" >> $GITHUB_OUTPUT
             echo "ℹ️ No version changes needed"
           else
             echo "changed=true" >> $GITHUB_OUTPUT
             echo "📝 Version changes detected:"
-            git diff --stat README.md CLAUDE.md
+            git diff --stat -- "${FILES[@]}"
           fi
 
       - name: Commit and push changes
@@ -82,7 +84,7 @@ jobs:
           VERSION="${{ steps.version.outputs.version }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add README.md CLAUDE.md
+          git add README.md CLAUDE.md package.json packaging/opencode-maos/package.json
           git commit -m "chore: sync version to v${VERSION} [skip ci]"
           git push
           echo "🚀 Version synced to v${VERSION}"
@@ -95,6 +97,6 @@ jobs:
           echo "| File | Status |" >> $GITHUB_STEP_SUMMARY
           echo "|------|--------|" >> $GITHUB_STEP_SUMMARY
           echo "| \`.claude-plugin/plugin.json\` | v${VERSION} (SSOT) |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`README.md\` badge | Synced |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`README.md\` footer | Synced |" >> $GITHUB_STEP_SUMMARY
-          echo "| \`CLAUDE.md\` footer | Synced |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`package.json\` | Synced |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`packaging/opencode-maos/package.json\` | Synced |" >> $GITHUB_STEP_SUMMARY
+          echo "| \`README.md\` / \`CLAUDE.md\` | Synced |" >> $GITHUB_STEP_SUMMARY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [1.22.1] - 2026-08-10
 
 ### Fixed
+- Sync `packaging/opencode-maos` version to plugin SSOT; wire `validate-skill-frontmatter` into `tests/validate-plugin.sh`; extend `version-sync.yml` to package manifests
+
+
+### Fixed
 - `.agents/skills/multi-agent-os/SKILL.md` + `.claude/skills/multi-agent-os/SKILL.md`: add Agent Skills frontmatter (`name`/`description`) so `npx skills` no longer skips them
 - Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
 

--- a/packaging/opencode-maos/package.json
+++ b/packaging/opencode-maos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-maos",
-  "version": "1.22.0",
+  "version": "1.22.1",
   "description": "OpenCode plugin entry for MAOS (Multi-Agent OS). Thin runtime hook; full skills via npx skills add ekson73/multi-agent-os or Claude/Pi packaging.",
   "license": "MIT",
   "type": "module",

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -420,6 +420,19 @@ else
 fi
 echo ""
 
+# Agent Skills frontmatter (skills.sh / multi-harness portable path)
+echo "Checking Agent Skills frontmatter..."
+if [ -x "$PLUGIN_ROOT/scripts/validate-skill-frontmatter.sh" ] || [ -f "$PLUGIN_ROOT/scripts/validate-skill-frontmatter.sh" ]; then
+    if bash "$PLUGIN_ROOT/scripts/validate-skill-frontmatter.sh"; then
+        pass "scripts/validate-skill-frontmatter.sh passes"
+    else
+        fail "scripts/validate-skill-frontmatter.sh FAILED (SKILL.md needs name+description YAML frontmatter)"
+    fi
+else
+    fail "scripts/validate-skill-frontmatter.sh missing"
+fi
+echo ""
+
 # Summary
 echo "========================================"
 echo "  Validation Summary"


### PR DESCRIPTION
## PDCA
**Plan:** Next logical multi-harness hygiene after skills frontmatter fix.  
**Do:** Recon found `packaging/opencode-maos` @1.22.0 vs SSOT 1.22.1; validate-plugin not calling skill frontmatter gate; version-sync ignored package.json.  
**Check:** `bash tests/validate-plugin.sh $PWD` → PASSED; opencode version 1.22.1.  
**Act:** Merge; prevents future drift for Pi/OpenCode/skills.sh path.

No plugin SemVer bump (still 1.22.1).