### PR TITLE
fix(governance): rescue #321 unpushed root-cause — YAML-parse frontmatter validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ re-eval the report itself asked for. Result: **3 of 5 claims held, 2 disproved, 
 document does not make for a cold agent.** The floor repair is confirmed on both methods (a reader
 enumerating termination passages, and a run that exited REFINE at 3 rounds where an unconditional
 floor needs ≥6). Disproved: the referent halt site is assigned to two different phases by two
-passages of the same section; and 13 of 29 stop points carry no terminal marker, against the
+passages of the same section; and 13 of 29 stop/refuse/escalate points carry no terminal marker, against the
 document's own assertion that a halt without one is an unfinished rule — 11 of those 13 outside the
 section that makes the assertion. Three inputs of three classes produced three halts and zero
 rendered prompts. The verdict stands at FAIL, but the failure is now located: **specification, not

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: refine-braindump-to-prompt
 version: "0.3.0"
-description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases: RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses; economic stop by default, floor only where the profile licenses the long loop) -> RED-TEAM (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope + multi-sink emission). Use when a dump must become executable work rather than a ledger, an envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop) and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool). Composes in-repo primitives; reimplements nothing.
+description: >-
+  Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases:
+  RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list
+  with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses;
+  economic stop by default, floor only where the profile licenses the long loop) -> RED-TEAM
+  (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope +
+  multi-sink emission). Use when a dump must become executable work rather than a ledger, an
+  envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop)
+  and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool).
+  Composes in-repo primitives; reimplements nothing.
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ---
 
@@ -23,7 +32,7 @@ Take ONE raw, unstructured operator braindump — mixed directives, cartesian re
 session-meta wrappers — and lapidate it into ONE prompt that an agent (or a team) can execute
 end-to-end with minimum human-in-the-loop. The distinctive act is **REFINE**: a bounded loop whose
 *object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating on
-the economic stop (`n* ≤ 3-4`) by default — and, **only where a profile licenses the long loop**, on
+the economic stop (`n* (typically 3 or 4)`) by default — and, **only where a profile licenses the long loop**, on
 a two-part condition (a floor AND a dryness test) rather than a single clean pass.
 
 ## When to use
@@ -77,7 +86,7 @@ DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
              if long_loop_licensed: until (revisions >= min_revisions)
                                       AND (clean_rounds >= clean_rounds_required)
-             else:                  until the economic stop (n* <= 3-4), floor OFF
+             else:                  until the economic stop (n* (typically 3 or 4)), floor OFF
 RED-TEAM  := independent adversarial refutation of the DRAFT (verifier != generator)
              REFUTED -> classify: craft-defect => back to REFINE (<= max_redteam_cycles)
                                   missing-fact => STOP-HITL now (rounds cannot invent facts)
@@ -308,7 +317,7 @@ Three sources disagree about when an agentic loop may stop, and the disagreement
 |---|---|
 | Shumer's aim-prompt (and skills derived from it) | *"loop until utterly perfect — you are the brake"* → **none** |
 | Osmani, *Loop Engineering* | clear stopping rules are the **5th mandatory component** (cost · attempts · wall-clock · gain-stagnation) |
-| `skills/convergence-engine` (this repo) | economic stop `n* ≤ 3-4`; floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
+| `skills/convergence-engine` (this repo) | economic stop at `n*`, the closed form `n* = 1 + ⌈ln((1−ρ)·g₀·V/C) / ln(1/ρ)⌉` (ρ=retained-gap fraction · g₀=initial gap · V=value/correct-unit · C=round cost). It grows only **logarithmically** in `V/C`, so it evaluates to **3 or 4** across realistic inputs — a computed bound, not a magic literal. Floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
 
 **The synthesis this skill encodes — the Verifiability Gate:**
 
@@ -318,7 +327,7 @@ long_loop_licensed := bar_is_machine_verifiable
                     AND evidence_is_directly_inspectable
 
 if long_loop_licensed -> cap = profile budget (attempts | cost | wall-clock | stagnation delta)
-else                  -> cap = convergence-engine economic stop (n* <= 3-4)
+else                  -> cap = convergence-engine economic stop (n* (typically 3 or 4))
 NEVER                 -> unbounded, on work that is irreversible, costly, or unobservable
 ```
 
@@ -344,12 +353,12 @@ stop_refine := (rounds <= --max-rounds)                    # hard cap; exceeded 
                    (revisions    >= --min-revisions)       # floor   — profile-supplied
                    AND (clean_rounds >= --clean-rounds)    # dryness — profile-supplied
                else:
-                   economic stop governs ALONE (n* <= 3-4) # no floor, no dryness counter
+                   economic stop governs ALONE (n* (typically 3 or 4)) # no floor, no dryness counter
 ```
 
 **The floor is licensed, not global — and that is load-bearing.** A round either produces a
 revision or is clean, never both, so a `min-revisions=3 AND clean-rounds=3` floor requires **≥6
-rounds**. When the loop is *unlicensed* the cap is `n* ≤ 3-4`. **A global floor would therefore
+rounds**. When the loop is *unlicensed* the cap is `n* (typically 3 or 4)`. **A global floor would therefore
 exceed its own cap on every unlicensed run** — and `profiles/default.md` states the gate normally
 evaluates false for that profile, so that is the common path, not an edge case. The floor belongs to
 the profile that licenses it (`gauntlet-loop`, whose `≥3 revisions AND ≥3 consecutive clean rounds`
@@ -552,7 +561,7 @@ the prompt itself (the operator names the target).
 
 ## Protocol Rules (anti-loop invariants + bounds)
 
-- REFINE stops on the economic stop (`n* <= 3-4`) by DEFAULT. The **two-part** floor (min-revisions
+- REFINE stops on the economic stop (`n* (typically 3 or 4)`) by DEFAULT. The **two-part** floor (min-revisions
   AND consecutive-clean-rounds) applies ONLY where the Verifiability Gate licenses the long loop —
   asserting it unconditionally makes the floor exceed its own cap on every unlicensed run.
 - `--max-rounds` (default 12) is a hard cap → `STOP-HITL` on exhaustion.
@@ -596,7 +605,7 @@ the prompt itself (the operator names the target).
   tolerance) → **`STOP-HITL` immediately**: no number of refine rounds can manufacture a fact the
   dump does not contain. **Precedence**: this outranks the economic stop — the stop caps iteration
   *within* REFINE and never governs the RED-TEAM return path. Without that precedence the two
-  collide structurally on any unlicensed run (stop caps REFINE at `n* ≤ 3-4`; a refutation at round
+  collide structurally on any unlicensed run (stop caps REFINE at `n* (typically 3 or 4)`; a refutation at round
   4 demands a round 5 that is over-cap by construction).
 - **`--max-redteam-cycles` exhausted while still REFUTED** → `STOP-HITL` carrying the standing
   findings as the escalation payload.

--- a/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
+++ b/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
@@ -322,3 +322,7 @@ yet tell a cold agent enough to run it the same way twice.
 
 **Verdict: FAIL — 3 claims held, 2 disproved, 22 decisions undelegated.** The failure is
 specification, not mechanism. The next cycle should close Q15's 22 before adding capability.
+
+---
+
+*Signed: Claude-Eval-ef60-321 | 2026-08-14T17:47:00-03:00*

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -262,6 +262,46 @@ else
     fail "plugin-scripts/gaac/delegate.sh missing or not executable"
 fi
 
+# ─── Frontmatter must actually PARSE as YAML ─────────────────────────────────
+# Root-cause fix (2026-08-14): every frontmatter check above greps for a LINE
+# (`^name: x$`) and therefore reports PASS on a file whose YAML the loader
+# rejects. A skill shipped with an unquoted plain scalar containing ': ' —
+# structurally unloadable — while this script printed "✓ PASSED". A grep answers
+# "does the text contain?", never "does the parser accept?"; the second question
+# is the one that decides whether the artifact loads at all.
+# Capability-detected: PyYAML absent → WARN, never a red build for a missing dep.
+echo "Validating frontmatter parses as YAML..."
+if python3 -c "import yaml" 2>/dev/null; then
+    YAML_BAD=$(python3 - "$PLUGIN_ROOT" <<'PYEOF'
+import glob, io, os, sys, yaml
+root = sys.argv[1]
+bad = []
+for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
+    for p in sorted(glob.glob(os.path.join(root, pat))):
+        if os.path.basename(p) == "README.md":
+            continue                      # docs, not artifacts (same rule as above)
+        try:
+            t = io.open(p, encoding="utf-8").read()
+            if not t.startswith("---\n"):
+                continue                  # 'missing frontmatter' is already warned above
+            yaml.safe_load(t.split("---\n", 2)[1])
+        except yaml.YAMLError as e:
+            bad.append(f"{os.path.relpath(p, root)} :: {str(e).splitlines()[0]}")
+        except Exception as e:
+            bad.append(f"{os.path.relpath(p, root)} :: {type(e).__name__}: {e}")
+print("\n".join(bad))
+PYEOF
+)
+    if [ -z "$YAML_BAD" ]; then
+        pass "all artifact frontmatter parses as YAML"
+    else
+        while IFS= read -r line; do [ -n "$line" ] && fail "unparseable frontmatter: $line"; done <<< "$YAML_BAD"
+    fi
+else
+    warn "PyYAML absent — frontmatter parse check SKIPPED (grep-only checks cannot catch a broken loader)"
+fi
+echo ""
+
 # Skill frontmatter
 SKILL_FILE="$PLUGIN_ROOT/skills/delegate-governance/SKILL.md"
 if [ -f "$SKILL_FILE" ] && grep -q "^name: delegate-governance$" "$SKILL_FILE"; then


### PR DESCRIPTION
The merge of #321 (755ca20) captured the pushed head; four files of
post-push work remained uncommitted in the feature worktree. Rescued,
not dropped (NO-LOOSE-ENDINGS):

- tests/validate-plugin.sh: root-cause fix — frontmatter must PARSE as
  YAML, not merely grep-match. A grep answers 'does the text contain?',
  never 'does the parser accept?'. Capability-detected: PyYAML absent
  => WARN, never a red build for a missing dep.
- skills/refine-braindump-to-prompt/SKILL.md: its own frontmatter was
  the instance of the bug class (plain scalar with ': ') — now a
  folded block; n* notation normalized.
- CHANGELOG/EVAL-REPORT: precision wording + eval signature line.

Local run: validate-plugin.sh EXIT=0, new check PASSED with PyYAML
present (not skipped). Unsigned per [C19] §6.1 (signing agent down).

Co-Authored-By: Codex Opus <noreply@anthropic.com>
