### PR TITLE
fix(skills): P0 — refine-braindump-to-prompt frontmatter does not parse (+ close the validator hole that let it ship)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,17 @@ reach, because it describes the rule without being it. Both the eval and its del
 produced a comparable prompt. The skill's measured delta is the mechanically-derived material and the
 independent red-team, not the qualitative judgment.
 
+v0.3.0 has since been re-evaluated by four blind agents against a frozen artifact — the independent
+re-eval the report itself asked for. Result: **3 of 5 claims held, 2 disproved, and 22 decisions the
+document does not make for a cold agent.** The floor repair is confirmed on both methods (a reader
+enumerating termination passages, and a run that exited REFINE at 3 rounds where an unconditional
+floor needs ≥6). Disproved: the referent halt site is assigned to two different phases by two
+passages of the same section; and 13 of 29 stop points carry no terminal marker, against the
+document's own assertion that a halt without one is an unfinished rule — 11 of those 13 outside the
+section that makes the assertion. Three inputs of three classes produced three halts and zero
+rendered prompts. The verdict stands at FAIL, but the failure is now located: **specification, not
+mechanism.**
+
 
 ### Added — squash-aware release-coherence gate
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `refine-braindump-to-prompt` (Lapidary) v0.3.0: one braindump → one executable prompt
+
+Turns a raw operator braindump into ONE ready-to-execute prompt, rather than the ledger, envelope or
+PR every existing terminus produces. Five phases: RECOVER (dissect → relate → catalogue → prism →
+distill; emits the parts map and the drop-list with reasons) → DRAFT (in an architecture profile) →
+REFINE (N rounds × N distinct lenses) → RED-TEAM (independent refutation, verifier ≠ generator) →
+RENDER (one prompt + machine envelope + multi-sink emission). Parameterized by architecture profiles
+(`--architecture`, incl. `gauntlet-loop`) and by output sinks (`--output-target`: stdout · clipboard ·
+vault · git-repo · agentic-tool), the latter defined as a membership test — reachable ∧ render-defined
+∧ can-refuse-by-name — rather than a fixed list of kinds. Composes existing primitives; inlines none.
+
+Shipped with its own evaluation, which returned FAIL and is published alongside the skill rather than
+summarized. Three blocking defects from the first round are independently verified repaired: a REFINE
+floor that exceeded its own cap on the default profile, a `clean_rounds` rule that made `STOP-DONE`
+unreachable, and a phase that claimed `convergence-engine`'s independence condition while critiquing
+its own draft. A second generation followed, two of them caused by those repairs — the fix moved the
+failure rather than removing it, and the report says so. Both the eval and its delta live in
+`examples/EVAL-REPORT-2026-08-14.md`, including the control run: without the skill, a single pass
+produced a comparable prompt. The skill's measured delta is the mechanically-derived material and the
+independent red-team, not the qualitative judgment.
+
+
 ### Added — squash-aware release-coherence gate
 
 Release version changes now require a separate, rebased PR containing exactly one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,10 @@ summarized. Three blocking defects from the first round are independently verifi
 floor that exceeded its own cap on the default profile, a `clean_rounds` rule that made `STOP-DONE`
 unreachable, and a phase that claimed `convergence-engine`'s independence condition while critiquing
 its own draft. A second generation followed, two of them caused by those repairs — the fix moved the
-failure rather than removing it, and the report says so. Both the eval and its delta live in
+failure rather than removing it, and the report says so. One repair was itself incomplete three times
+over: the REFINE floor turned out to be asserted on **seven** surfaces, and successive sweeps closed
+two, then four, then the seventh — a §Purpose summary that no grep for a *termination rule* would
+reach, because it describes the rule without being it. Both the eval and its delta live in
 `examples/EVAL-REPORT-2026-08-14.md`, including the control run: without the skill, a single pass
 produced a comparable prompt. The skill's measured delta is the mechanically-derived material and the
 independent red-team, not the qualitative judgment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,7 @@ re-eval the report itself asked for. Result: **3 of 5 claims held, 2 disproved, 
 document does not make for a cold agent.** The floor repair is confirmed on both methods (a reader
 enumerating termination passages, and a run that exited REFINE at 3 rounds where an unconditional
 floor needs ≥6). Disproved: the referent halt site is assigned to two different phases by two
-passages of the same section; and 13 of 29 stop points carry no terminal marker, against the
+passages of the same section; and 13 of 29 stop/refuse/escalate points carry no terminal marker, against the
 document's own assertion that a halt without one is an unfinished rule — 11 of those 13 outside the
 section that makes the assertion. Three inputs of three classes produced three halts and zero
 rendered prompts. The verdict stands at FAIL, but the failure is now located: **specification, not

--- a/commands/refine-braindump-to-prompt.md
+++ b/commands/refine-braindump-to-prompt.md
@@ -3,9 +3,9 @@ name: refine-braindump-to-prompt
 description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT — RECOVER (DoR · motivation · goal · DoD-as-measurable) → DRAFT (in an architecture profile) → REFINE (N rounds × N distinct lenses; stops only on min-revisions AND consecutive-clean-rounds) → RED-TEAM (independent refutation) → RENDER. Parameterized by profiles (`--architecture`, incl. `gauntlet-loop`). Composes in-repo primitives; reimplements nothing.
 ---
 
-# /refine-braindump-to-prompt Command
+# /maos:refine-braindump-to-prompt Command
 
-Thin wrapper that invokes `skills/refine-braindump-to-prompt/SKILL.md` (soul-name *Lapidary*).
+Thin wrapper that invokes `skills/maos:refine-braindump-to-prompt/SKILL.md` (soul-name *Lapidary*).
 The skill holds all logic — five phases, per-phase primitive composition, the Verifiability Gate
 stopping doctrine, architecture profiles, STOP-marker grammar, bounds. This file is the command
 surface only.
@@ -13,7 +13,7 @@ surface only.
 ## Usage
 
 ```text
-/refine-braindump-to-prompt "<braindump>" [--architecture=…] [--dor=…] [--motivation=…] \
+/maos:refine-braindump-to-prompt "<braindump>" [--architecture=…] [--dor=…] [--motivation=…] \
                             [--goal=…] [--condition=…] [--principles=…] \
                             [--min-revisions=N] [--clean-rounds=N] [--lenses=N] [--max-rounds=N] \
                             [--dry-run] [--output=…] [--output-target=…] \
@@ -27,7 +27,7 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 | Flag | Default | Allowed values |
 |---|---|---|
 | `"<braindump>"` (positional) | *required* | path to a braindump file, or inline text |
-| `--architecture` | `default` | `default`, `gauntlet-loop`, or any file in `skills/refine-braindump-to-prompt/profiles/` |
+| `--architecture` | `default` | `default`, `gauntlet-loop`, or any file in `skills/maos:refine-braindump-to-prompt/profiles/` |
 | `--dor` / `--motivation` / `--goal` | `auto` | override what RECOVER inferred |
 | `--condition` | `auto` | override the DoD / stop-condition (measurable spec) |
 | `--principles` | `auto` | comma list, or `auto` = inherit the host's governance corpus by reference |
@@ -45,13 +45,13 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 ## Examples
 
 ```text
-/refine-braindump-to-prompt "~/dumps/2026-08-14-gauntlet.braindump.md"
-/refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
-/refine-braindump-to-prompt "<dump>" --dry-run --output=json
-/refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
-/refine-braindump-to-prompt "<dump>" --output-target=clipboard
-/refine-braindump-to-prompt "<dump>" --output-target=vault:~/eko-engram/pages/x.md,clipboard
-/refine-braindump-to-prompt "<dump>" --output-target=agentic-tool:skill:./skills/x/SKILL.md
+/maos:refine-braindump-to-prompt "~/dumps/2026-08-14-gauntlet.braindump.md"
+/maos:refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
+/maos:refine-braindump-to-prompt "<dump>" --dry-run --output=json
+/maos:refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
+/maos:refine-braindump-to-prompt "<dump>" --output-target=clipboard
+/maos:refine-braindump-to-prompt "<dump>" --output-target=vault:~/eko-engram/pages/x.md,clipboard
+/maos:refine-braindump-to-prompt "<dump>" --output-target=agentic-tool:skill:./skills/x/SKILL.md
 ```
 
 ## Not this command
@@ -61,4 +61,4 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 - "Ship this feature end-to-end" → `/enhance-pipeline`.
 - "Execute a prompt I already have" → `/auto-pilot`.
 
-See `skills/refine-braindump-to-prompt/SKILL.md` for the full contract.
+See `skills/maos:refine-braindump-to-prompt/SKILL.md` for the full contract.

--- a/commands/refine-braindump-to-prompt.md
+++ b/commands/refine-braindump-to-prompt.md
@@ -1,0 +1,61 @@
+---
+name: refine-braindump-to-prompt
+description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT — RECOVER (DoR · motivation · goal · DoD-as-measurable) → DRAFT (in an architecture profile) → REFINE (N rounds × N distinct lenses; stops only on min-revisions AND consecutive-clean-rounds) → RED-TEAM (independent refutation) → RENDER. Parameterized by profiles (`--architecture`, incl. `gauntlet-loop`). Composes in-repo primitives; reimplements nothing.
+---
+
+# /refine-braindump-to-prompt Command
+
+Thin wrapper that invokes `skills/refine-braindump-to-prompt/SKILL.md` (soul-name *Lapidary*).
+The skill holds all logic — five phases, per-phase primitive composition, the Verifiability Gate
+stopping doctrine, architecture profiles, STOP-marker grammar, bounds. This file is the command
+surface only.
+
+## Usage
+
+```text
+/refine-braindump-to-prompt "<braindump>" [--architecture=…] [--dor=…] [--motivation=…] \
+                            [--goal=…] [--condition=…] [--principles=…] \
+                            [--min-revisions=N] [--clean-rounds=N] [--lenses=N] [--max-rounds=N] \
+                            [--dry-run] [--output=…] [--persist=PATH] \
+                            [--user-lang=…] [--agentic-lang=…]
+```
+
+The positional `"<braindump>"` (a file path or inline text) is required; all flags are optional.
+
+## Flags
+
+| Flag | Default | Allowed values |
+|---|---|---|
+| `"<braindump>"` (positional) | *required* | path to a braindump file, or inline text |
+| `--architecture` | `default` | `default`, `gauntlet-loop`, or any file in `skills/refine-braindump-to-prompt/profiles/` |
+| `--dor` / `--motivation` / `--goal` | `auto` | override what RECOVER inferred |
+| `--condition` | `auto` | override the DoD / stop-condition (measurable spec) |
+| `--principles` | `auto` | comma list, or `auto` = inherit the host's governance corpus by reference |
+| `--min-revisions` | `3` | REFINE floor — minimum revisions regardless of apparent cleanliness |
+| `--clean-rounds` | `3` | consecutive gap-free rounds required to exit REFINE |
+| `--lenses` | `3` | distinct perspectives per round (a repeated lens does not count) |
+| `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` |
+| `--dry-run` | `false` | run RECOVER→REFINE, emit the plan, STOP before RENDER writes |
+| `--output` | `table` | `table`, `list`, `json` (json = machine contract; skill §Output contract, exit 0/1/2) |
+| `--persist` | *(none)* | path to write the rendered prompt; omitted → return inline only |
+| `--user-lang` | `auto` | operator-facing prose language |
+| `--agentic-lang` | `en-us` | language of the RENDERED prompt (agent register) |
+
+## Examples
+
+```text
+/refine-braindump-to-prompt "~/dumps/2026-08-14-gauntlet.braindump.md"
+/refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
+/refine-braindump-to-prompt "<dump>" --dry-run --output=json
+/refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
+/refine-braindump-to-prompt "<dump>" --persist=./prompts/migration.prompt.md
+```
+
+## Not this command
+
+- "What in this dump is already done?" → `directive-braindump-triage` (user-scope).
+- "Make this dump into a reusable tool" → `/agentic-tool-forge`.
+- "Ship this feature end-to-end" → `/enhance-pipeline`.
+- "Execute a prompt I already have" → `/auto-pilot`.
+
+See `skills/refine-braindump-to-prompt/SKILL.md` for the full contract.

--- a/commands/refine-braindump-to-prompt.md
+++ b/commands/refine-braindump-to-prompt.md
@@ -5,7 +5,7 @@ description: Lapidate ONE raw operator braindump into ONE polished, ready-to-exe
 
 # /maos:refine-braindump-to-prompt Command
 
-Thin wrapper that invokes `skills/maos:refine-braindump-to-prompt/SKILL.md` (soul-name *Lapidary*).
+Thin wrapper that invokes `skills/refine-braindump-to-prompt/SKILL.md` (soul-name *Lapidary*).
 The skill holds all logic — five phases, per-phase primitive composition, the Verifiability Gate
 stopping doctrine, architecture profiles, STOP-marker grammar, bounds. This file is the command
 surface only.
@@ -27,7 +27,7 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 | Flag | Default | Allowed values |
 |---|---|---|
 | `"<braindump>"` (positional) | *required* | path to a braindump file, or inline text |
-| `--architecture` | `default` | `default`, `gauntlet-loop`, or any file in `skills/maos:refine-braindump-to-prompt/profiles/` |
+| `--architecture` | `default` | `default`, `gauntlet-loop`, or any file in `skills/refine-braindump-to-prompt/profiles/` |
 | `--dor` / `--motivation` / `--goal` | `auto` | override what RECOVER inferred |
 | `--condition` | `auto` | override the DoD / stop-condition (measurable spec) |
 | `--principles` | `auto` | comma list, or `auto` = inherit the host's governance corpus by reference |
@@ -61,4 +61,4 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 - "Ship this feature end-to-end" → `/enhance-pipeline`.
 - "Execute a prompt I already have" → `/auto-pilot`.
 
-See `skills/maos:refine-braindump-to-prompt/SKILL.md` for the full contract.
+See `skills/refine-braindump-to-prompt/SKILL.md` for the full contract.

--- a/commands/refine-braindump-to-prompt.md
+++ b/commands/refine-braindump-to-prompt.md
@@ -16,7 +16,7 @@ surface only.
 /refine-braindump-to-prompt "<braindump>" [--architecture=…] [--dor=…] [--motivation=…] \
                             [--goal=…] [--condition=…] [--principles=…] \
                             [--min-revisions=N] [--clean-rounds=N] [--lenses=N] [--max-rounds=N] \
-                            [--dry-run] [--output=…] [--persist=PATH] \
+                            [--dry-run] [--output=…] [--output-target=…] \
                             [--user-lang=…] [--agentic-lang=…]
 ```
 
@@ -37,7 +37,8 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 | `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` |
 | `--dry-run` | `false` | run RECOVER→REFINE, emit the plan, STOP before RENDER writes |
 | `--output` | `table` | `table`, `list`, `json` (json = machine contract; skill §Output contract, exit 0/1/2) |
-| `--persist` | *(none)* | path to write the rendered prompt; omitted → return inline only |
+| `--persist` | *(none)* | **DEPRECATED alias** — `--persist=P` ≡ `--output-target=git-repo:P` |
+| `--output-target` | *(none)* | comma-separated sinks `<kind>[:<param>]`: `stdout` · `clipboard` · `vault:<path>` · `git-repo:<path>` · `agentic-tool:<sub-kind>:<path>`. A sink is valid iff **reachable** (probed) ∧ **render defined** ∧ **can refuse by name**. See skill §Output targets. |
 | `--user-lang` | `auto` | operator-facing prose language |
 | `--agentic-lang` | `en-us` | language of the RENDERED prompt (agent register) |
 
@@ -48,7 +49,9 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 /refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
 /refine-braindump-to-prompt "<dump>" --dry-run --output=json
 /refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
-/refine-braindump-to-prompt "<dump>" --persist=./prompts/migration.prompt.md
+/refine-braindump-to-prompt "<dump>" --output-target=clipboard
+/refine-braindump-to-prompt "<dump>" --output-target=vault:~/eko-engram/pages/x.md,clipboard
+/refine-braindump-to-prompt "<dump>" --output-target=agentic-tool:skill:./skills/x/SKILL.md
 ```
 
 ## Not this command

--- a/commands/refine-braindump-to-prompt.md
+++ b/commands/refine-braindump-to-prompt.md
@@ -1,6 +1,6 @@
 ---
 name: refine-braindump-to-prompt
-description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT — RECOVER (DoR · motivation · goal · DoD-as-measurable) → DRAFT (in an architecture profile) → REFINE (N rounds × N distinct lenses; stops only on min-revisions AND consecutive-clean-rounds) → RED-TEAM (independent refutation) → RENDER. Parameterized by profiles (`--architecture`, incl. `gauntlet-loop`). Composes in-repo primitives; reimplements nothing.
+description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT — RECOVER (DoR · motivation · goal · DoD-as-measurable) → DRAFT (in an architecture profile) → REFINE (N rounds × N distinct lenses; economic stop by default, floor only where the profile licenses the long loop) → RED-TEAM (independent refutation) → RENDER. Parameterized by profiles (`--architecture`, incl. `gauntlet-loop`). Composes in-repo primitives; reimplements nothing.
 ---
 
 # /maos:refine-braindump-to-prompt Command
@@ -31,8 +31,9 @@ The positional `"<braindump>"` (a file path or inline text) is required; all fla
 | `--dor` / `--motivation` / `--goal` | `auto` | override what RECOVER inferred |
 | `--condition` | `auto` | override the DoD / stop-condition (measurable spec) |
 | `--principles` | `auto` | comma list, or `auto` = inherit the host's governance corpus by reference |
-| `--min-revisions` | `3` | REFINE floor — minimum revisions regardless of apparent cleanliness |
-| `--clean-rounds` | `3` | consecutive gap-free rounds required to exit REFINE |
+| `--min-revisions` | `3` | REFINE floor — **licensed profiles only**; ignored (with a warning) when the Verifiability Gate is false |
+| `--clean-rounds` | `3` | consecutive gap-free rounds — **licensed profiles only**; same gate as above |
+| `--max-redteam-cycles` | `2` | cap on `RED-TEAM REFUTED → REFINE` returns; exhausted while still REFUTED → `STOP-HITL` |
 | `--lenses` | `3` | distinct perspectives per round (a repeated lens does not count) |
 | `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` |
 | `--dry-run` | `false` | run RECOVER→REFINE, emit the plan, STOP before RENDER writes |

--- a/skills/enhance-pipeline/SKILL.md
+++ b/skills/enhance-pipeline/SKILL.md
@@ -160,6 +160,7 @@ evaluator (shared with `quiesce`/`auto-pilot`) reads it:
 | `auto-pilot` | ONE goal | decompose → select → spawn → converge (no research/ideation phase) |
 | `quiesce` | the SESSION | termination predicate over ALL open items → steady state |
 | `converge` | N proposals | 5-act merge (this skill's STAGE 3 lands here) |
+| `refine-braindump-to-prompt` | ONE braindump | RECOVER → DRAFT → REFINE → RED-TEAM → RENDER **one executable prompt** (does not ship; may hand the prompt to a driver) |
 
 `enhance-pipeline` MAY invoke `auto-pilot`/`quiesce` in DELIVER and `converge` in
 HARMONIZE; it never re-implements delegation, convergence, or anomaly detection.

--- a/skills/goal-recovery/SKILL.md
+++ b/skills/goal-recovery/SKILL.md
@@ -68,13 +68,24 @@ Recover from the strongest available; corroborate across sources; a single sourc
 
 ```text
 1. postflight_seed     a prior session.continuation seed for this branch/session   (the exact inverse artifact)
-2. ticket              preflight R0 anchor — Jira/Linear/GH issue title+body+DoD    (stated intent, if any)
-3. objectives_ntree    postflight P2 objectives-map / work-compass CPT N-Tree        (synthesized objectives)
-4. ash_journal         agentic-session-harness journal: top-level `goal`, decisions[], spec_alignment drift
-5. git_branch          branch name (feat/<slug>) + PR title                          (weak but cheap signal)
-6. git_last_commit     last commit subject/body                                      (weak signal)
-7. transcript          this session's transcript (transcript_hash)                   (last resort; expensive)
+2. braindump           a raw operator dump supplied AS the invocation subject       (stated-but-unstructured
+                       (path or inline text)                                         intent; supersedes weaker
+                                                                                     inferred sources for the
+                                                                                     work it describes)
+3. ticket              preflight R0 anchor — Jira/Linear/GH issue title+body+DoD    (stated intent, if any)
+4. objectives_ntree    postflight P2 objectives-map / work-compass CPT N-Tree        (synthesized objectives)
+5. ash_journal         agentic-session-harness journal: top-level `goal`, decisions[], spec_alignment drift
+6. git_branch          branch name (feat/<slug>) + PR title                          (weak but cheap signal)
+7. git_last_commit     last commit subject/body                                      (weak signal)
+8. transcript          this session's transcript (transcript_hash)                   (last resort; expensive)
 ```
+
+> `braindump` is NOT session residue like the other sources — it is an artifact the operator hands in.
+> It is ranked high because it is the operator's own words about *this* work, but it is still
+> **recovery, not restatement**: the goal is present yet unstated-as-such, buried under mixed
+> directives and session-meta. Drop the session-meta (`/enhance` wrappers, pep-talk, cartesian
+> resource lists offered as examples) before synthesizing — a listed resource is not a requirement
+> to use it. Primary consumer: `skills/refine-braindump-to-prompt` PHASE 1.
 
 ## Pipeline (0 -> 4)
 
@@ -188,6 +199,11 @@ Dormant-by-design otherwise.
 - External grounding: GOOD (arXiv:2508.15119, uncertainty-aware goal inference) · RECAP (2509.04472, intent-rewrite) · Boyd OODA (Observe) · Raghavan & Schneier IEEE S&P 2025 (auditable Observe inputs)
 
 ## Versioning
+- v0.2.0 (2026-08-14) — MINOR: `braindump` added to the inference ladder (rank 2) — a raw operator
+  dump supplied AS the invocation subject, ranked above `ticket` because it is the operator's own
+  words about *this* work, with an explicit drop-session-meta clause. Additive: no existing source
+  changed, no contract change; ranks 2-7 shift to 3-8. Enables `skills/refine-braindump-to-prompt`
+  PHASE 1 without forking a second recovery engine.
 - v0.1.0 (2026-07-12) — bootstrap. Recovery of an unstated session intent from an inference ladder;
   uncertainty-aware (ranked hypotheses + confidence + inconclusive->HITL); typed `handoff-as-prompt`
   envelope extending continuation-seed; direction-inverted twin of postflight; deterministic

--- a/skills/goal-recovery/SKILL.md
+++ b/skills/goal-recovery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: goal-recovery
-version: "0.1.0"
+version: "0.2.0"
 description: |
   Recover a work session's real INTENT from its own live/context state — motivations, DoR,
   context, scope, and the objective tree {originating, primary, secondary, auxiliary} — into ONE
@@ -16,7 +16,7 @@ description: |
   actually trying to do", "detect the session intent", "handoff-as-prompt", "recover intent".
 allowed-tools: Read, Grep, Glob, Bash, Write, Task
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
   scope: AAIF cross-vendor
   family: session-lifecycle
   cross_link_slug: goal-recovery
@@ -133,7 +133,7 @@ Recover from the strongest available; corroborate across sources; a single sourc
 ## Override parameters
 | Flag | Default | Allowed / Notes |
 |---|---|---|
-| `"<hint>"` (positional) | empty | optional operator hint appended to the recovery (does NOT override the ladder evidence) |
+| `"<hint>"` (positional) | empty | optional operator hint appended to the recovery (does NOT override the ladder evidence). **Exception — the `braindump` source (rank 2):** when a braindump path or text is supplied here, the positional IS the rank-2 evidence, not a hint, and it outranks every source below it. A `braindump` invocation with an empty positional has no rank-2 evidence and falls through to rank 3. |
 | `--scope` | `this.session` | `this.session` \| `branch` \| `ticket:<id>` \| `session:<id>` — where to recover from |
 | `--conf-inconclusive` | `0.60` | `0.0`-`1.0` — below this aggregate confidence => `inconclusive.flag=true` -> HITL |
 | `--ladder` | *(full ladder)* | comma-list to restrict sources (e.g. `postflight_seed,ticket,ash_journal`) |
@@ -202,7 +202,7 @@ Dormant-by-design otherwise.
 - v0.2.0 (2026-08-14) — MINOR: `braindump` added to the inference ladder (rank 2) — a raw operator
   dump supplied AS the invocation subject, ranked above `ticket` because it is the operator's own
   words about *this* work, with an explicit drop-session-meta clause. Additive: no existing source
-  changed, no contract change; ranks 2-7 shift to 3-8. Enables `skills/refine-braindump-to-prompt`
+  changed and the envelope schema is unchanged, but **recovery PRECEDENCE changes** for any invocation that supplies a braindump: it now outranks ticket, objectives-N-Tree, ASH-journal, git and transcript. Ranks 2-7 shift to 3-8. `handoff-as-prompt.schema.json` gains `braindump` in the `recovered_from[].source` enum. Enables `skills/refine-braindump-to-prompt`
   PHASE 1 without forking a second recovery engine.
 - v0.1.0 (2026-07-12) — bootstrap. Recovery of an unstated session intent from an inference ladder;
   uncertainty-aware (ranked hypotheses + confidence + inconclusive->HITL); typed `handoff-as-prompt`

--- a/skills/goal-recovery/templates/handoff-as-prompt.schema.json
+++ b/skills/goal-recovery/templates/handoff-as-prompt.schema.json
@@ -4,66 +4,185 @@
   "title": "handoff-as-prompt",
   "description": "The deterministic OUTPUT envelope of the goal-recovery skill: a session's recovered INTENT, typed. It is the direction-inverted twin of postflight's continuation-seed (session.continuation@1.1.0) — that EMITS an intent at session END; this RECOVERS an (often unstated) intent from live session/context state at any point. The LLM authors the content (probabilistic, over the inference ladder); this schema + validate_envelope.py gate the shape (deterministic). Reuses the seed's goal/objectives/context/guardrails/refs verbatim; ADDS motivations, DoR, scope, objectives.originating, and the uncertainty-aware confidence/hypotheses/inconclusive->HITL. Downstream (ooda-loop, gap-loop, quiesce) consumes params.goal as {{goal}}.",
   "type": "object",
-  "required": ["jsonrpc", "method", "params", "data"],
+  "required": [
+    "jsonrpc",
+    "method",
+    "params",
+    "data"
+  ],
   "additionalProperties": true,
   "properties": {
-    "jsonrpc": {"const": "2.0"},
-    "method": {"const": "session.goal_recovery", "description": "distinct from session.continuation — the direction is INVERTED (recover-from-context, not emit-at-end)."},
+    "jsonrpc": {
+      "const": "2.0"
+    },
+    "method": {
+      "const": "session.goal_recovery",
+      "description": "distinct from session.continuation — the direction is INVERTED (recover-from-context, not emit-at-end)."
+    },
     "params": {
       "type": "object",
       "description": "The recovered intent bundle. Every key is REQUIRED but arrays MAY be empty — an empty array means 'considered, none found' (anti-omission discipline, mirrors the seed forcing all keys); an ABSENT key is a SpecError (the recovery skipped a dimension).",
-      "required": ["goal", "motivations", "DoR", "context", "scope", "objectives", "confidence", "hypotheses", "inconclusive", "recovered_from", "guardrails", "refs"],
+      "required": [
+        "goal",
+        "motivations",
+        "DoR",
+        "context",
+        "scope",
+        "objectives",
+        "confidence",
+        "hypotheses",
+        "inconclusive",
+        "recovered_from",
+        "guardrails",
+        "refs"
+      ],
       "additionalProperties": true,
       "properties": {
-        "goal": {"type": "string", "minLength": 1, "description": "REUSED from seed. The one-line mission consumed downstream as {{goal}}. Empty string is NOT allowed (a recovery with no goal must set inconclusive.flag=true and still name a best-guess placeholder, or DEFER)."},
-        "motivations": {"type": "array", "items": {"type": "string"}, "description": "NET-NEW. WHY the session exists — the business/technical value / operator BEING served (the operator's 'motivacoes'). Root-of-intent, not tasks."},
-        "DoR": {"type": "array", "items": {"type": "string"}, "description": "NET-NEW. Definition-of-Ready — the preconditions/inputs/dependencies that were (or must be) met before the work is workable."},
-        "context": {"type": "string", "description": "REUSED from seed. State-of-world the goal lives in — the frame a fresh amnesic agent needs. Maps to Prisma measurement-spec meta.context_lock.context."},
+        "goal": {
+          "type": "string",
+          "minLength": 1,
+          "description": "REUSED from seed. The one-line mission consumed downstream as {{goal}}. Empty string is NOT allowed (a recovery with no goal must set inconclusive.flag=true and still name a best-guess placeholder, or DEFER)."
+        },
+        "motivations": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "NET-NEW. WHY the session exists — the business/technical value / operator BEING served (the operator's 'motivacoes'). Root-of-intent, not tasks."
+        },
+        "DoR": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "NET-NEW. Definition-of-Ready — the preconditions/inputs/dependencies that were (or must be) met before the work is workable."
+        },
+        "context": {
+          "type": "string",
+          "description": "REUSED from seed. State-of-world the goal lives in — the frame a fresh amnesic agent needs. Maps to Prisma measurement-spec meta.context_lock.context."
+        },
         "scope": {
           "type": "object",
           "description": "NET-NEW explicit in/out scope (the operator's 'escopo'). Bounds the goal; prevents scope-creep in the downstream loop.",
-          "required": ["in", "out"],
+          "required": [
+            "in",
+            "out"
+          ],
           "additionalProperties": false,
           "properties": {
-            "in": {"type": "array", "items": {"type": "string"}},
-            "out": {"type": "array", "items": {"type": "string"}}
+            "in": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "out": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         },
         "objectives": {
           "type": "object",
           "description": "The purpose tree ('objetivos/propositos'). primary/secondary/auxiliary REUSED from seed; originating NET-NEW.",
-          "required": ["originating", "primary", "secondary", "auxiliary"],
+          "required": [
+            "originating",
+            "primary",
+            "secondary",
+            "auxiliary"
+          ],
           "additionalProperties": true,
           "properties": {
-            "originating": {"type": "array", "items": {"type": "string"}, "description": "NET-NEW. The ROOT/originating purpose that spawned the session (the 'why we started at all') — distinct from primary (the top deliverable). Often implicit; the recovery surfaces it."},
-            "primary": {"type": "array", "items": {"type": "string"}},
-            "secondary": {"type": "array", "items": {"type": "string"}},
-            "auxiliary": {"type": "array", "items": {"type": "string"}}
+            "originating": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "NET-NEW. The ROOT/originating purpose that spawned the session (the 'why we started at all') — distinct from primary (the top deliverable). Often implicit; the recovery surfaces it."
+            },
+            "primary": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "secondary": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "auxiliary": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         },
-        "confidence": {"type": "number", "minimum": 0, "maximum": 1, "description": "NET-NEW. Aggregate confidence [0,1] that params.goal + objectives correctly capture the real intent. Below the skill's conf_inconclusive threshold (default 0.60) MUST set inconclusive.flag=true. This is the defensive core: goal-recovery from execution state is under-published (SOTA gap) — never a confident oracle."},
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "description": "NET-NEW. Aggregate confidence [0,1] that params.goal + objectives correctly capture the real intent. Below the skill's conf_inconclusive threshold (default 0.60) MUST set inconclusive.flag=true. This is the defensive core: goal-recovery from execution state is under-published (SOTA gap) — never a confident oracle."
+        },
         "hypotheses": {
           "type": "array",
           "description": "NET-NEW. Ranked ALTERNATIVE goal-interpretations (uncertainty-aware, GOOD arXiv:2508.15119 / RECAP 2509.04472). The chosen params.goal is hypotheses[0].goal when non-empty. The loop MAY revise the goal to a lower-ranked hypothesis mid-run rather than freeze it (lost-in-multi-turn defense).",
           "items": {
             "type": "object",
-            "required": ["goal", "confidence"],
+            "required": [
+              "goal",
+              "confidence"
+            ],
             "additionalProperties": true,
             "properties": {
-              "goal": {"type": "string"},
-              "confidence": {"type": "number", "minimum": 0, "maximum": 1},
-              "evidence": {"type": "array", "items": {"type": "string"}, "description": "the inference-ladder observations that support this hypothesis"}
+              "goal": {
+                "type": "string"
+              },
+              "confidence": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 1
+              },
+              "evidence": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "the inference-ladder observations that support this hypothesis"
+              }
             }
           }
         },
         "inconclusive": {
           "type": "object",
           "description": "NET-NEW HITL gate — mirrors Prisma's inconclusive{flag,reasons}. flag=true => the recovery is NOT trustworthy enough to drive a loop autonomously => escalate to HITL with hypotheses attached (do NOT freeze a low-confidence goal).",
-          "required": ["flag", "reasons"],
+          "required": [
+            "flag",
+            "reasons"
+          ],
           "additionalProperties": false,
           "properties": {
-            "flag": {"type": "boolean"},
-            "reasons": {"type": "array", "items": {"type": "string", "enum": ["low_confidence", "conflicting_hypotheses", "no_context_anchor", "ambiguous_scope", "stale_state"]}, "description": "constrained vocabulary; free-text goes in a sibling note if needed"}
+            "flag": {
+              "type": "boolean"
+            },
+            "reasons": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "low_confidence",
+                  "conflicting_hypotheses",
+                  "no_context_anchor",
+                  "ambiguous_scope",
+                  "stale_state"
+                ]
+              },
+              "description": "constrained vocabulary; free-text goes in a sibling note if needed"
+            }
           }
         },
         "recovered_from": {
@@ -71,38 +190,90 @@
           "description": "NET-NEW audit trail — which inference-ladder sources were ACTUALLY read to recover this intent (Skopos recon-first + anti-theater grounding). Ordered strongest-first. An empty array with confidence>0 is a SpecError (a confident recovery must cite where it came from).",
           "items": {
             "type": "object",
-            "required": ["source", "read"],
+            "required": [
+              "source",
+              "read"
+            ],
             "additionalProperties": true,
             "properties": {
-              "source": {"type": "string", "enum": ["postflight_seed", "ticket", "objectives_ntree", "ash_journal", "git_branch", "git_last_commit", "transcript", "work_compass_cpt", "operator_prompt", "free_text"]},
-              "read": {"type": "boolean", "description": "true = this source existed and was read; false = probed-but-absent (still auditable)"},
-              "ref": {"type": "string", "description": "path/id/sha of the source, or 'absent'"}
+              "source": {
+                "type": "string",
+                "enum": [
+                  "postflight_seed",
+                  "braindump",
+                  "ticket",
+                  "objectives_ntree",
+                  "ash_journal",
+                  "git_branch",
+                  "git_last_commit",
+                  "transcript",
+                  "work_compass_cpt",
+                  "operator_prompt",
+                  "free_text"
+                ]
+              },
+              "read": {
+                "type": "boolean",
+                "description": "true = this source existed and was read; false = probed-but-absent (still auditable)"
+              },
+              "ref": {
+                "type": "string",
+                "description": "path/id/sha of the source, or 'absent'"
+              }
             }
           }
         },
-        "guardrails": {"type": "array", "items": {"type": "string"}, "description": "REUSED from seed. Binding constraints recovered from context (e.g. 'never commit secrets', 'worktree-only', 'do NOT merge')."},
+        "guardrails": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "REUSED from seed. Binding constraints recovered from context (e.g. 'never commit secrets', 'worktree-only', 'do NOT merge')."
+        },
         "refs": {
           "type": "object",
           "description": "REUSED from seed. The L8 cross-link block (traceability). Any field 'none' when absent.",
           "additionalProperties": true,
           "properties": {
-            "git": {"type": "string"},
-            "ticket": {"type": "string"},
-            "memory": {"type": "string"},
-            "session": {"type": "string"}
+            "git": {
+              "type": "string"
+            },
+            "ticket": {
+              "type": "string"
+            },
+            "memory": {
+              "type": "string"
+            },
+            "session": {
+              "type": "string"
+            }
           }
         }
       }
     },
     "data": {
       "type": "object",
-      "required": ["layer", "type", "contract_version"],
+      "required": [
+        "layer",
+        "type",
+        "contract_version"
+      ],
       "additionalProperties": true,
       "properties": {
-        "layer": {"const": "community", "description": "per layer-precedence-policy §3 — mandatory attribution field"},
-        "type": {"const": "handoff-as-prompt", "description": "the eko L5 purpose-tag / --type"},
-        "contract": {"type": "string"},
-        "contract_version": {"type": "string"}
+        "layer": {
+          "const": "community",
+          "description": "per layer-precedence-policy §3 — mandatory attribution field"
+        },
+        "type": {
+          "const": "handoff-as-prompt",
+          "description": "the eko L5 purpose-tag / --type"
+        },
+        "contract": {
+          "type": "string"
+        },
+        "contract_version": {
+          "type": "string"
+        }
       }
     }
   },

--- a/skills/goal-recovery/templates/handoff-as-prompt.schema.json
+++ b/skills/goal-recovery/templates/handoff-as-prompt.schema.json
@@ -4,185 +4,66 @@
   "title": "handoff-as-prompt",
   "description": "The deterministic OUTPUT envelope of the goal-recovery skill: a session's recovered INTENT, typed. It is the direction-inverted twin of postflight's continuation-seed (session.continuation@1.1.0) — that EMITS an intent at session END; this RECOVERS an (often unstated) intent from live session/context state at any point. The LLM authors the content (probabilistic, over the inference ladder); this schema + validate_envelope.py gate the shape (deterministic). Reuses the seed's goal/objectives/context/guardrails/refs verbatim; ADDS motivations, DoR, scope, objectives.originating, and the uncertainty-aware confidence/hypotheses/inconclusive->HITL. Downstream (ooda-loop, gap-loop, quiesce) consumes params.goal as {{goal}}.",
   "type": "object",
-  "required": [
-    "jsonrpc",
-    "method",
-    "params",
-    "data"
-  ],
+  "required": ["jsonrpc", "method", "params", "data"],
   "additionalProperties": true,
   "properties": {
-    "jsonrpc": {
-      "const": "2.0"
-    },
-    "method": {
-      "const": "session.goal_recovery",
-      "description": "distinct from session.continuation — the direction is INVERTED (recover-from-context, not emit-at-end)."
-    },
+    "jsonrpc": {"const": "2.0"},
+    "method": {"const": "session.goal_recovery", "description": "distinct from session.continuation — the direction is INVERTED (recover-from-context, not emit-at-end)."},
     "params": {
       "type": "object",
       "description": "The recovered intent bundle. Every key is REQUIRED but arrays MAY be empty — an empty array means 'considered, none found' (anti-omission discipline, mirrors the seed forcing all keys); an ABSENT key is a SpecError (the recovery skipped a dimension).",
-      "required": [
-        "goal",
-        "motivations",
-        "DoR",
-        "context",
-        "scope",
-        "objectives",
-        "confidence",
-        "hypotheses",
-        "inconclusive",
-        "recovered_from",
-        "guardrails",
-        "refs"
-      ],
+      "required": ["goal", "motivations", "DoR", "context", "scope", "objectives", "confidence", "hypotheses", "inconclusive", "recovered_from", "guardrails", "refs"],
       "additionalProperties": true,
       "properties": {
-        "goal": {
-          "type": "string",
-          "minLength": 1,
-          "description": "REUSED from seed. The one-line mission consumed downstream as {{goal}}. Empty string is NOT allowed (a recovery with no goal must set inconclusive.flag=true and still name a best-guess placeholder, or DEFER)."
-        },
-        "motivations": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "NET-NEW. WHY the session exists — the business/technical value / operator BEING served (the operator's 'motivacoes'). Root-of-intent, not tasks."
-        },
-        "DoR": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "NET-NEW. Definition-of-Ready — the preconditions/inputs/dependencies that were (or must be) met before the work is workable."
-        },
-        "context": {
-          "type": "string",
-          "description": "REUSED from seed. State-of-world the goal lives in — the frame a fresh amnesic agent needs. Maps to Prisma measurement-spec meta.context_lock.context."
-        },
+        "goal": {"type": "string", "minLength": 1, "description": "REUSED from seed. The one-line mission consumed downstream as {{goal}}. Empty string is NOT allowed (a recovery with no goal must set inconclusive.flag=true and still name a best-guess placeholder, or DEFER)."},
+        "motivations": {"type": "array", "items": {"type": "string"}, "description": "NET-NEW. WHY the session exists — the business/technical value / operator BEING served (the operator's 'motivacoes'). Root-of-intent, not tasks."},
+        "DoR": {"type": "array", "items": {"type": "string"}, "description": "NET-NEW. Definition-of-Ready — the preconditions/inputs/dependencies that were (or must be) met before the work is workable."},
+        "context": {"type": "string", "description": "REUSED from seed. State-of-world the goal lives in — the frame a fresh amnesic agent needs. Maps to Prisma measurement-spec meta.context_lock.context."},
         "scope": {
           "type": "object",
           "description": "NET-NEW explicit in/out scope (the operator's 'escopo'). Bounds the goal; prevents scope-creep in the downstream loop.",
-          "required": [
-            "in",
-            "out"
-          ],
+          "required": ["in", "out"],
           "additionalProperties": false,
           "properties": {
-            "in": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "out": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            "in": {"type": "array", "items": {"type": "string"}},
+            "out": {"type": "array", "items": {"type": "string"}}
           }
         },
         "objectives": {
           "type": "object",
           "description": "The purpose tree ('objetivos/propositos'). primary/secondary/auxiliary REUSED from seed; originating NET-NEW.",
-          "required": [
-            "originating",
-            "primary",
-            "secondary",
-            "auxiliary"
-          ],
+          "required": ["originating", "primary", "secondary", "auxiliary"],
           "additionalProperties": true,
           "properties": {
-            "originating": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "description": "NET-NEW. The ROOT/originating purpose that spawned the session (the 'why we started at all') — distinct from primary (the top deliverable). Often implicit; the recovery surfaces it."
-            },
-            "primary": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "secondary": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            },
-            "auxiliary": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              }
-            }
+            "originating": {"type": "array", "items": {"type": "string"}, "description": "NET-NEW. The ROOT/originating purpose that spawned the session (the 'why we started at all') — distinct from primary (the top deliverable). Often implicit; the recovery surfaces it."},
+            "primary": {"type": "array", "items": {"type": "string"}},
+            "secondary": {"type": "array", "items": {"type": "string"}},
+            "auxiliary": {"type": "array", "items": {"type": "string"}}
           }
         },
-        "confidence": {
-          "type": "number",
-          "minimum": 0,
-          "maximum": 1,
-          "description": "NET-NEW. Aggregate confidence [0,1] that params.goal + objectives correctly capture the real intent. Below the skill's conf_inconclusive threshold (default 0.60) MUST set inconclusive.flag=true. This is the defensive core: goal-recovery from execution state is under-published (SOTA gap) — never a confident oracle."
-        },
+        "confidence": {"type": "number", "minimum": 0, "maximum": 1, "description": "NET-NEW. Aggregate confidence [0,1] that params.goal + objectives correctly capture the real intent. Below the skill's conf_inconclusive threshold (default 0.60) MUST set inconclusive.flag=true. This is the defensive core: goal-recovery from execution state is under-published (SOTA gap) — never a confident oracle."},
         "hypotheses": {
           "type": "array",
           "description": "NET-NEW. Ranked ALTERNATIVE goal-interpretations (uncertainty-aware, GOOD arXiv:2508.15119 / RECAP 2509.04472). The chosen params.goal is hypotheses[0].goal when non-empty. The loop MAY revise the goal to a lower-ranked hypothesis mid-run rather than freeze it (lost-in-multi-turn defense).",
           "items": {
             "type": "object",
-            "required": [
-              "goal",
-              "confidence"
-            ],
+            "required": ["goal", "confidence"],
             "additionalProperties": true,
             "properties": {
-              "goal": {
-                "type": "string"
-              },
-              "confidence": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1
-              },
-              "evidence": {
-                "type": "array",
-                "items": {
-                  "type": "string"
-                },
-                "description": "the inference-ladder observations that support this hypothesis"
-              }
+              "goal": {"type": "string"},
+              "confidence": {"type": "number", "minimum": 0, "maximum": 1},
+              "evidence": {"type": "array", "items": {"type": "string"}, "description": "the inference-ladder observations that support this hypothesis"}
             }
           }
         },
         "inconclusive": {
           "type": "object",
           "description": "NET-NEW HITL gate — mirrors Prisma's inconclusive{flag,reasons}. flag=true => the recovery is NOT trustworthy enough to drive a loop autonomously => escalate to HITL with hypotheses attached (do NOT freeze a low-confidence goal).",
-          "required": [
-            "flag",
-            "reasons"
-          ],
+          "required": ["flag", "reasons"],
           "additionalProperties": false,
           "properties": {
-            "flag": {
-              "type": "boolean"
-            },
-            "reasons": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "enum": [
-                  "low_confidence",
-                  "conflicting_hypotheses",
-                  "no_context_anchor",
-                  "ambiguous_scope",
-                  "stale_state"
-                ]
-              },
-              "description": "constrained vocabulary; free-text goes in a sibling note if needed"
-            }
+            "flag": {"type": "boolean"},
+            "reasons": {"type": "array", "items": {"type": "string", "enum": ["low_confidence", "conflicting_hypotheses", "no_context_anchor", "ambiguous_scope", "stale_state"]}, "description": "constrained vocabulary; free-text goes in a sibling note if needed"}
           }
         },
         "recovered_from": {
@@ -190,90 +71,38 @@
           "description": "NET-NEW audit trail — which inference-ladder sources were ACTUALLY read to recover this intent (Skopos recon-first + anti-theater grounding). Ordered strongest-first. An empty array with confidence>0 is a SpecError (a confident recovery must cite where it came from).",
           "items": {
             "type": "object",
-            "required": [
-              "source",
-              "read"
-            ],
+            "required": ["source", "read"],
             "additionalProperties": true,
             "properties": {
-              "source": {
-                "type": "string",
-                "enum": [
-                  "postflight_seed",
-                  "braindump",
-                  "ticket",
-                  "objectives_ntree",
-                  "ash_journal",
-                  "git_branch",
-                  "git_last_commit",
-                  "transcript",
-                  "work_compass_cpt",
-                  "operator_prompt",
-                  "free_text"
-                ]
-              },
-              "read": {
-                "type": "boolean",
-                "description": "true = this source existed and was read; false = probed-but-absent (still auditable)"
-              },
-              "ref": {
-                "type": "string",
-                "description": "path/id/sha of the source, or 'absent'"
-              }
+              "source": {"type": "string", "enum": ["postflight_seed", "braindump", "ticket", "objectives_ntree", "ash_journal", "git_branch", "git_last_commit", "transcript", "work_compass_cpt", "operator_prompt", "free_text"]},
+              "read": {"type": "boolean", "description": "true = this source existed and was read; false = probed-but-absent (still auditable)"},
+              "ref": {"type": "string", "description": "path/id/sha of the source, or 'absent'"}
             }
           }
         },
-        "guardrails": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          },
-          "description": "REUSED from seed. Binding constraints recovered from context (e.g. 'never commit secrets', 'worktree-only', 'do NOT merge')."
-        },
+        "guardrails": {"type": "array", "items": {"type": "string"}, "description": "REUSED from seed. Binding constraints recovered from context (e.g. 'never commit secrets', 'worktree-only', 'do NOT merge')."},
         "refs": {
           "type": "object",
           "description": "REUSED from seed. The L8 cross-link block (traceability). Any field 'none' when absent.",
           "additionalProperties": true,
           "properties": {
-            "git": {
-              "type": "string"
-            },
-            "ticket": {
-              "type": "string"
-            },
-            "memory": {
-              "type": "string"
-            },
-            "session": {
-              "type": "string"
-            }
+            "git": {"type": "string"},
+            "ticket": {"type": "string"},
+            "memory": {"type": "string"},
+            "session": {"type": "string"}
           }
         }
       }
     },
     "data": {
       "type": "object",
-      "required": [
-        "layer",
-        "type",
-        "contract_version"
-      ],
+      "required": ["layer", "type", "contract_version"],
       "additionalProperties": true,
       "properties": {
-        "layer": {
-          "const": "community",
-          "description": "per layer-precedence-policy §3 — mandatory attribution field"
-        },
-        "type": {
-          "const": "handoff-as-prompt",
-          "description": "the eko L5 purpose-tag / --type"
-        },
-        "contract": {
-          "type": "string"
-        },
-        "contract_version": {
-          "type": "string"
-        }
+        "layer": {"const": "community", "description": "per layer-precedence-policy §3 — mandatory attribution field"},
+        "type": {"const": "handoff-as-prompt", "description": "the eko L5 purpose-tag / --type"},
+        "contract": {"type": "string"},
+        "contract_version": {"type": "string"}
       }
     }
   },

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -77,9 +77,12 @@ RECOVER   := DISSECT   open the dump; type every part for what it IS
            + RELATE    map how the parts constrain each other
                         (halt: a cycle, a dangling dependency, an unresolvable reference)
            + CATALOGUE emit parts table + relation map  <- REQUIRED OUTPUTS, not incidental
-           + PRISM     DoD-as-measurable, on abstract criteria only
+           + recover{DoR, motivation, goal, DoD}        <- recognition: still lossless
+           + PRISM     the RECOVERED DoD -> measurable, abstract criteria only
+                        (inner-first: Prisma(dod-recovery()) — you cannot prism
+                         a DoD you have not recovered)
            + DISTILL   drop session-meta; emit the drop-list WITH REASONS
-           + recover{DoR, motivation, goal}
+                        <- LAST: the only lossy step, run over evidence
            + derive recurring mechanism IFF the goal recurs
 DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
@@ -324,7 +327,7 @@ concept. See `profiles/gauntlet-loop.md` for prior-art attribution and the diver
 | `--lenses` | `3` | distinct perspectives per round; a repeated lens does not count |
 | `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` (diminishing returns) |
 | `--dry-run` | `false` | run RECOVER→REFINE and emit the plan; STOP before RENDER writes |
-| `--output` | `table` | `table` \| `list` \| `json` (machine contract — see §Output contract) |
+| `--output` | `table` | `table` \| `list` \| `json` \| `json-rpc` (machine contract — see §Output contract). `json-rpc` is **not** a synonym for `json`: it emits `method` + `params` (notification shape, no `id`) per `[C06]`, which is what an agent-to-agent caller consumes. |
 | `--persist` | *(none)* | path to write the rendered prompt; omitted → return inline only |
 | `--user-lang` | `auto` | operator-facing prose language (mirrors the host's language policy) |
 | `--agentic-lang` | `en-us` | language of the RENDERED prompt (agent register) |

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -72,8 +72,12 @@ only on a two-part condition (a floor AND a dryness test), never on a single cle
 ## The five phases (the pipeline predicate)
 
 ```text
-RECOVER   := parse braindump + drop session-meta
-           + recover{DoR, motivation, goal} + DoD-as-measurable
+RECOVER   := DISSECT  open the dump; type every part for what it IS
+                       (halt if a part cannot be typed — "I don't know what this is")
+           + CATALOGUE emit the parts table   <- REQUIRED OUTPUT, not incidental
+           + PRISM    DoD-as-measurable, on abstract criteria only
+           + DISTILL  drop session-meta; emit the drop-list WITH REASONS
+           + recover{DoR, motivation, goal}
            + derive recurring mechanism IFF the goal recurs
 DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
@@ -86,24 +90,62 @@ RENDER    := emit ONE prompt + machine envelope + persist decision
 A phase is COMPLETE when its primitive returns a structured artifact the next phase consumes.
 The pipeline is DONE when RENDER emits the prompt, or — under `--dry-run` — the plan for it.
 
-## Two movements — SEPARATE precedes SHAPE (binding)
+## One hard boundary — COMPREHEND before TRANSFORM (binding)
 
-The five phases group into **two movements**, and the order between them is not stylistic:
+The pipeline has **one hard boundary and one soft one**. They are not equal, and treating them as
+equal is itself an error:
 
 ```text
-MOVEMENT 1 — SEPARATE (distill)   RECOVER
-MOVEMENT 2 — SHAPE   (lapidate)   DRAFT -> REFINE -> RED-TEAM -> RENDER
+COMPREHEND (lossless)          ‖ HARD ‖   TRANSFORM (lossy)
+dissect -> type -> catalogue              distill  ~soft~  shape
+             + prism                      (drop-list)      (DRAFT->REFINE->RED-TEAM->RENDER)
+             RECOVER                              RECOVER  |  the rest
 ```
 
-**You cannot facet a mixture.** A lapidary receives a *solid*; a still receives a *mixture*. A
-braindump arrives as the latter — intent dissolved in session-wrappers, resource enumerations and
-principle lists. Attempting to shape it before separating it does not produce a rough prompt; it
-produces a **polished wrapper**, because the shaping phases will faithfully refine whatever mass
-they are handed, including the mass that carries no constraint.
+The sharpest cut in the whole pipeline is **lossless ↔ lossy**:
 
-So RECOVER is **not** a parsing convenience placed first for tidiness. It is the **precondition**
-that makes the second movement possible at all. If RECOVER cannot separate a goal from the mass,
-the pipeline halts (`STOP-HITL`) rather than shaping the mass.
+| | Receives | Goal | Anything lost? | Reversible? |
+|---|---|---|---|---|
+| dissect · type · catalogue | an opaque whole | see + name the parts | **no** — everything kept, now legible | yes |
+| distill | a legible mixture | keep only what carries constraint | yes, deliberately | no |
+| shape | a solid | reveal form | yes, as shaping waste | no |
+
+**The hard boundary — you cannot justify a discard you do not understand.** Distilling without
+dissecting discards by heuristic — by length, by position, by vibe — and is right only by luck.
+Test: *can you invert the order?* Distill before dissect → **impossible**. This boundary gets a gate.
+
+**The soft boundary — shaping micro-separates continuously.** Every refine round discards a little
+(an adjective replaced by a named bar is a discard). So distill→shape is a strong *ordering
+preference*, not a wall: the first distillation differs from a refine-round drop in **scale**
+(dropping most of the input mass ≠ replacing one clause), not in kind. This boundary gets no gate.
+
+**You still cannot facet a mixture.** Shaping without a *first* distillation does not yield a rough
+prompt; it yields a **polished wrapper**, because the shaping loop faithfully refines whatever mass
+it is handed — including mass that was never signal.
+
+So RECOVER spans the hard boundary and can **halt on either side**: on a part it cannot type
+(*"I don't know what this is"*), or on a mass it cannot justify dropping. A stage that cannot
+refuse is a label, not a gate.
+
+### The catalogue is a REQUIRED output (the absorption law)
+
+> **The movement with a visible output absorbs the movement without one.**
+
+Shaping is visible — you see the finished prompt. Separation is semi-visible — a drop-list exists
+*if someone wrote one*. Comprehension is **invisible**: understanding leaves no artifact at all
+unless forced to. So pipelines drift toward being named, and then built, for their last movement.
+This is a gradient, not carelessness, and it recurs at every level.
+
+Therefore RECOVER MUST emit **both** the parts catalogue and the drop-list-with-reasons. They are
+not debug output. Without them the answer to *"what was in there, and what did you drop, and why"*
+does not exist — and if that answer does not exist, comprehension did not happen; parsing did.
+
+**Prism only abstract criteria** (the DoD, a quality bar). Prismming a concrete part is ceremony.
+
+> **House lineage.** MOVEMENT 2 is the same operation the operator's vault protocol
+> `braindump-distill` (*Alambique*) performs at a different terminus; MOVEMENT 3 gives this skill
+> its soul-name (*Lapidary*). Sequential, not rival — a still, then a lapidary. No third name is
+> minted for MOVEMENT 1: it is named by its outputs (catalogue + drop-list), which is the point.
 
 > **House pair.** This skill owns MOVEMENT 2 and is soul-named for it (*Lapidary*). MOVEMENT 1 is
 > the same operation the operator's vault protocol `braindump-distill` (*Alambique*) performs at a

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -72,11 +72,13 @@ only on a two-part condition (a floor AND a dryness test), never on a single cle
 ## The five phases (the pipeline predicate)
 
 ```text
-RECOVER   := DISSECT  open the dump; type every part for what it IS
-                       (halt if a part cannot be typed — "I don't know what this is")
-           + CATALOGUE emit the parts table   <- REQUIRED OUTPUT, not incidental
-           + PRISM    DoD-as-measurable, on abstract criteria only
-           + DISTILL  drop session-meta; emit the drop-list WITH REASONS
+RECOVER   := DISSECT   open the dump; type every part for what it IS
+                        (halt: a part that cannot be typed — "I don't know what this is")
+           + RELATE    map how the parts constrain each other
+                        (halt: a cycle, a dangling dependency, an unresolvable reference)
+           + CATALOGUE emit parts table + relation map  <- REQUIRED OUTPUTS, not incidental
+           + PRISM     DoD-as-measurable, on abstract criteria only
+           + DISTILL   drop session-meta; emit the drop-list WITH REASONS
            + recover{DoR, motivation, goal}
            + derive recurring mechanism IFF the goal recurs
 DRAFT     := select architecture profile + render first-cut prompt
@@ -96,19 +98,35 @@ The pipeline has **one hard boundary and one soft one**. They are not equal, and
 equal is itself an error:
 
 ```text
-COMPREHEND (lossless)          ‖ HARD ‖   TRANSFORM (lossy)
-dissect -> type -> catalogue              distill  ~soft~  shape
-             + prism                      (drop-list)      (DRAFT->REFINE->RED-TEAM->RENDER)
-             RECOVER                              RECOVER  |  the rest
+COMPREHEND (lossless)               ‖ HARD ‖   TRANSFORM (lossy — i.e. DECIDING)
+dissect -> type -> relate -> catalogue         distill  ~soft~  shape
+                    + prism                    (drop-list)      (DRAFT->REFINE->RED-TEAM->RENDER)
+                    RECOVER                            RECOVER  |  the rest
 ```
 
-The sharpest cut in the whole pipeline is **lossless ↔ lossy**:
+The sharpest cut in the whole pipeline is **lossless ↔ lossy**, and the criterion under it is:
+
+> **A decision destroys an alternative. A recognition does not.**
+
+Deciding is not a fourth stage sitting beside distill and shape — it is **what makes that side
+lossy**. Distilling *is* deciding what to discard; shaping *is* deciding what form. Comprehension
+recognizes and can be redone; transformation decides and kills the branches it did not take.
 
 | | Receives | Goal | Anything lost? | Reversible? |
 |---|---|---|---|---|
-| dissect · type · catalogue | an opaque whole | see + name the parts | **no** — everything kept, now legible | yes |
-| distill | a legible mixture | keep only what carries constraint | yes, deliberately | no |
-| shape | a solid | reveal form | yes, as shaping waste | no |
+| dissect · type · **relate** · catalogue | an opaque whole | see, name + connect the parts | **no** — all kept, now legible | yes |
+| distill | a legible mixture | keep only what carries constraint | yes — an alternative dies | no |
+| shape | a solid | reveal form | yes — an alternative dies | no |
+
+**Relate is not cataloguing.** A catalogue is a *list*; relations make it a *graph*. You can hold a
+complete inventory and still not understand the thing, because understanding a system means knowing
+its **dependencies**, not its contents. Measured on the originating dogfood: typing the parts found
+five of them; the decisive insight — that the loop-spec *operationalizes* the DoD — was an **edge**,
+not a node, and it became this skill's core predicate.
+
+> **Inherited, not invented.** The ancestor protocol `braindump-distill` (*Alambique*) has emitted an
+> interdependency map per run since its first row (22 in its ledger). This skill shipped without one.
+> `RELATE` closes that composition gap — the discipline existed upstream and was silently dropped.
 
 **The hard boundary — you cannot justify a discard you do not understand.** Distilling without
 dissecting discards by heuristic — by length, by position, by vibe — and is right only by luck.
@@ -124,8 +142,20 @@ prompt; it yields a **polished wrapper**, because the shaping loop faithfully re
 it is handed — including mass that was never signal.
 
 So RECOVER spans the hard boundary and can **halt on either side**: on a part it cannot type
-(*"I don't know what this is"*), or on a mass it cannot justify dropping. A stage that cannot
-refuse is a label, not a gate.
+(*"I don't know what this is"*), on a relation it cannot resolve, or on a mass it cannot justify
+dropping.
+
+**Classify a candidate stage on two axes, not one** — *can it refuse?* (gate) crossed with
+*pertinent · related · useful?* (worth having):
+
+| | is a gate | not a gate |
+|---|---|---|
+| **passes** | keep as a **gate** | keep as an **artifact** — e.g. the catalogue + relation map |
+| **fails** | **over-gating** — ceremony with teeth | pure ceremony — a label |
+
+Over-gating is the dangerous quadrant: a stage that can halt *looks* rigorous, so a useless one
+survives review by blocking. One axis alone cannot separate the catalogue (not-a-gate, essential)
+from a certification ritual (a gate, worthless).
 
 ### The catalogue is a REQUIRED output (the absorption law)
 

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -328,9 +328,61 @@ concept. See `profiles/gauntlet-loop.md` for prior-art attribution and the diver
 | `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` (diminishing returns) |
 | `--dry-run` | `false` | run RECOVER→REFINE and emit the plan; STOP before RENDER writes |
 | `--output` | `table` | `table` \| `list` \| `json` \| `json-rpc` (machine contract — see §Output contract). `json-rpc` is **not** a synonym for `json`: it emits `method` + `params` (notification shape, no `id`) per `[C06]`, which is what an agent-to-agent caller consumes. |
-| `--persist` | *(none)* | path to write the rendered prompt; omitted → return inline only |
+| `--persist` | *(none)* | **DEPRECATED alias** — `--persist=P` ≡ `--output-target=git-repo:P`. Kept working; do not remove. |
+| `--output-target` | *(none)* | one or more sinks, comma-separated: `<kind>[:<param>]`. Omitted → return inline only. See §Output targets. |
 | `--user-lang` | `auto` | operator-facing prose language (mirrors the host's language policy) |
 | `--agentic-lang` | `en-us` | language of the RENDERED prompt (agent register) |
+
+## Output targets (`--output-target`) — a TEST, not a kind list
+
+A rendered prompt that lands in exactly one place is **unmounted for every other harness**.
+The operator runs claude · codex · pi · opencode · gemini · antigravity · kiro; a distillate
+that only reaches one vault serves one of them. This axis is orthogonal to `--output`
+(*which wire format*) and to `agentic-tool-forge`'s type router (*which artifact type*).
+
+**A sink is a valid output-target iff:**
+
+> **(a) REACHABLE** — it exists and is reachable, **probed, never assumed**
+> **(b) RENDER DEFINED** — the distillate has a defined form for that sink
+> **(c) CAN REFUSE** — unreachable/unauthorized emits a **named reason**, never a silent drop
+
+Extend by the test, never by taste. The table below is the **instance**; `etc` is the open set.
+
+| Kind | `:param` | Render | idempotent | reversible | shared-surface |
+|---|---|---|---|---|---|
+| `stdout` | — | raw prompt | yes | n/a | no |
+| `clipboard` | — | raw prompt, **no frontmatter** | **NO** (declared) | no | no |
+| `vault` | note path | prompt + YAML frontmatter + wikilinks | yes | yes (git) | yes |
+| `git-repo` | file path | prompt as-is | yes | yes (git) | yes |
+| `agentic-tool` | `skill\|command\|agent\|rule\|memory\|mcp` **:path** | **per sub-kind** — see below | yes | yes (git) | yes |
+
+**Declared properties are not membership criteria.** `clipboard` is a valid target *while being
+non-idempotent* — it just has to **say so**. A target that hid that would fail (c) in spirit:
+silently producing a different result on re-run is a drop the caller cannot see.
+
+### The two cases that break an enum (and why the test exists)
+
+1. **`clipboard` is not a path.** Any axis shaped as `--persist=PATH` cannot express it. This is
+   what forces *target = sink*, not *target = location*. Verified live: `pbcopy` present **and**
+   round-tripped through `pbpaste` — presence of the binary is not reachability (a).
+2. **`agentic-tool` is not one kind.** A skill, a command, an agent, a rule, a memory and an MCP
+   have *different renders* — SKILL.md frontmatter ≠ a command's `name:` ≠ a rule's `[CXX]` header.
+   So (b) resolves **per sub-kind**, and `agentic-tool` alone is an under-specified target: it
+   MUST carry its sub-kind. A straddler a flat list would have hidden.
+
+### Multi-target semantics (explicit, never implicit)
+
+- **Order**: `gitleaks` gate runs **once, before any emission**, whenever ≥1 target declares
+  `shared-surface: yes`. A leak aborts **all** targets — including `clipboard`, which is not exempt.
+- **Partial failure**: **best-effort with a named report**, not all-or-nothing. Rationale: the
+  targets are independent sinks, so failing `clipboard` (headless host) must not withhold the
+  `vault` write the operator can actually use. Every failure is reported by kind + reason; a
+  silent partial success is forbidden.
+- **Unmerged-branch warning**: a `git-repo`/`vault` target on a branch with no upstream, or ahead
+  of it, emits a warning. Empirically earned: a braindump written to an unmerged branch became
+  invisible from the operator's own checkout on 2026-08-14.
+- **Per-kind render, never one blob copied N times** — a vault note carries frontmatter, a
+  clipboard payload must not.
 
 ## Output contract (`--output=json`)
 

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -1,0 +1,330 @@
+---
+name: refine-braindump-to-prompt
+version: "0.1.0"
+description: |
+  Turn ONE raw operator braindump into ONE polished, ready-to-execute PROMPT that drives
+  an agent/team end-to-end with minimum HITL. Five phases: RECOVER (DoR · motivation · goal
+  via goal-recovery + DoD-as-measurable via decompose-abstract-to-measurable) → DRAFT
+  (first-cut prompt in the chosen architecture profile) → REFINE (bounded loop over the
+  DRAFT PROMPT itself: N rounds × N distinct lenses, stop only when min-revisions AND
+  consecutive-clean-rounds are both satisfied) → RED-TEAM (independent adversarial
+  refutation) → RENDER (ONE prompt + machine envelope). Parameterized by prompt-architecture
+  PROFILES (`--architecture`); profile #1 is `gauntlet-loop`. A thin preset that COMPOSES
+  existing primitives (goal-recovery, decompose-abstract-to-measurable, convergence-engine,
+  perspective-trio, cascade-resolver, red-team, council-gate, prompt-context-engineer) —
+  reimplements nothing. Accepts: --architecture, --dor, --motivation, --goal, --condition,
+  --principles, --min-revisions, --clean-rounds, --lenses, --max-rounds, --dry-run, --output,
+  --persist, --user-lang, --agentic-lang.
+  Use when the operator has a messy dump of intent and wants it lapidated into one executable
+  prompt: "turn this braindump into a prompt", "lapide este braindump", "polish this dump into
+  something runnable", "make an executable prompt out of this", "destrinche isto e me devolva
+  um prompt".
+  Triggers: "refine-braindump-to-prompt", "/refine-braindump-to-prompt", "braindump to prompt",
+  "lapidar braindump", "polish braindump", "one executable prompt from this dump", "gauntlet
+  loop prompt".
+allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch
+---
+
+# Refine-Braindump-to-Prompt
+
+> **Soul-name**: *Lapidary* — display only. The system-name `refine-braindump-to-prompt` is the
+> canonical slug, the `/command` trigger, and the `--json.name`. English *lapidary* (L. *lapidarius*,
+> stonecutter) carries a figurative sense attested since ~1325: **prose of notable conciseness,
+> precision and refinement**. That figurative sense *is* this skill's deliverable. (Not *lapidate*
+> — a different branch of the same root, meaning "to stone to death".)
+
+Thin **braindump→prompt** preset. It does not re-implement recovery, measurement, convergence,
+adversarial critique, or delegation — it sequences five phases, and **every phase lands on a
+primitive that already exists in this repo**.
+
+## Purpose
+
+Take ONE raw, unstructured operator braindump — mixed directives, cartesian resource lists,
+session-meta wrappers — and lapidate it into ONE prompt that an agent (or a team) can execute
+end-to-end with minimum human-in-the-loop. The distinctive act is **REFINE**: a bounded loop whose
+*object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating
+only on a two-part condition (a floor AND a dryness test), never on a single clean pass.
+
+## When to use
+
+- A braindump exists and the operator wants it *runnable*, not merely *classified*.
+- The intent is real but the expression is tangled, recursive, or self-referential.
+- The output must carry DoR/motivation/goal/DoD so a fresh amnesic agent can execute it cold.
+- A specific prompt architecture is wanted (`--architecture=gauntlet-loop`).
+
+## When **not** to use
+
+- "What in this dump is already done?" → `directive-braindump-triage` (classification ledger).
+- "Make this dump into a reusable TOOL" → `agentic-tool-forge` (forges an artifact, not a prompt).
+- "File this dump as vault knowledge" → the operator's vault protocol (`braindump-distill`).
+- "Ship this feature idea end-to-end" → `enhance-pipeline` (delivers a PR, not a prompt).
+- "Re-target existing content for another audience" → `content-recast`.
+- One clear sentence already states the task → just write the prompt inline (§Skip S1).
+- Destructive ops (force-push protected, drop prod) — always HITL.
+
+## Trigger Phrases
+
+- "refine-braindump-to-prompt" / "/refine-braindump-to-prompt"
+- "turn this braindump into a prompt" / "lapide este braindump"
+- "one executable prompt from this dump" / "polish this dump into something runnable"
+- "gauntlet loop prompt for <X>"
+
+## The five phases (the pipeline predicate)
+
+```text
+RECOVER   := parse braindump + drop session-meta
+           + recover{DoR, motivation, goal} + DoD-as-measurable
+           + derive recurring mechanism IFF the goal recurs
+DRAFT     := select architecture profile + render first-cut prompt
+REFINE    := loop{ critique draft from N distinct lenses -> correct }
+             until (revisions >= min_revisions) AND (clean_rounds >= clean_rounds_required)
+             capped by the economic stop
+RED-TEAM  := independent adversarial refutation of the DRAFT (verifier != generator)
+RENDER    := emit ONE prompt + machine envelope + persist decision
+```
+
+A phase is COMPLETE when its primitive returns a structured artifact the next phase consumes.
+The pipeline is DONE when RENDER emits the prompt, or — under `--dry-run` — the plan for it.
+
+## How it works
+
+```text
+operator invokes /refine-braindump-to-prompt "<braindump-path-or-text>"
+        |
+        v   resolve flags -> profile defaults unless overridden
+        v
+  PHASE 1 RECOVER  -> {dor, motivation, goal, dod_spec, system?}
+        |
+        v
+  PHASE 2 DRAFT    -> draft_prompt v0 (in the profile's shape)
+        |
+        v
+  PHASE 3 REFINE   -> draft_prompt vN  (loop; see §Stopping predicate)
+        |              ^                     |
+        |              +-- gaps found -------+
+        v
+  PHASE 4 RED-TEAM -> refutation verdict (CLEAR | REFUTED -> back to REFINE)
+        |
+        v
+  PHASE 5 RENDER   -> ONE prompt + envelope + persist
+        |
+        v   emit exactly ONE STOP marker as the last line of the turn
+```
+
+## Composition (the wiring it emits)
+
+Every phase prefers an **in-repo / host primitive**. Optional enhancements are invoked only
+*if installed* — never a hard dependency.
+
+| Phase | In-repo primitive (ALWAYS) | Optional enhancement (IF installed) |
+|---|---|---|
+| **1 RECOVER** | `skills/goal-recovery` (source: `braindump`) · `skills/decompose-abstract-to-measurable` (DoD → measurable) · `skills/derive-system-from-goal` (only if the goal recurs) | `directive-braindump-triage` (user-scope — pre-classify already-done atoms) |
+| **2 DRAFT** | `agents/prompt-context-engineer` (the prompt-craft seat) · the selected `profiles/<arch>.md` | — |
+| **3 REFINE** | `skills/convergence-engine` (REFINE regime + economic stop) · `agents/perspective-trio` (horizontal lens diversity) · `agents/cascade-resolver` (sequential *diverse* re-attempts) | `agents/persona-pipeline` (6-stage board on high-stakes) |
+| **4 RED-TEAM** | `skills/red-team` · `bin/convergence-guard` (deterministic independence enforcement) | `skills/council-gate` (fires only if the prompt would authorise a HUMAN_DOMAIN action) |
+| **5 RENDER** | `Write` + `skills/worktree-policy` (write discipline) | `persist-locus` (vault-scope — measures the persist target) |
+
+> **Anti-NIH discipline**: this skill EMITS invocations of the above; it never inlines their
+> logic. A missing optional primitive degrades gracefully with a one-line diagnostic.
+
+## Stopping predicate (the doctrinal core)
+
+Three sources disagree about when an agentic loop may stop, and the disagreement is load-bearing:
+
+| Source | Stopping rule |
+|---|---|
+| Shumer's aim-prompt (and skills derived from it) | *"loop until utterly perfect — you are the brake"* → **none** |
+| Osmani, *Loop Engineering* | clear stopping rules are the **5th mandatory component** (cost · attempts · wall-clock · gain-stagnation) |
+| `skills/convergence-engine` (this repo) | economic stop `n* ≤ 3-4`; floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
+
+**The synthesis this skill encodes — the Verifiability Gate:**
+
+```text
+long_loop_licensed := bar_is_machine_verifiable
+                    AND critic_is_independent_of_builder
+                    AND evidence_is_directly_inspectable
+
+if long_loop_licensed -> cap = profile budget (attempts | cost | wall-clock | stagnation delta)
+else                  -> cap = convergence-engine economic stop (n* <= 3-4)
+NEVER                 -> unbounded, on work that is irreversible, costly, or unobservable
+```
+
+A long loop pays off **only when the gain signal is real** — i.e. when an independent critic can
+measure the artifact against an external bar. Absent that, extra rounds buy self-assessment, which
+is the very bias the loop was built to defeat. The REFINE loop therefore terminates on a
+**two-part** condition, never a single clean pass:
+
+```text
+stop_refine := (revisions >= --min-revisions)          # floor: 3 by default
+           AND (clean_rounds >= --clean-rounds)        # dryness: 3 consecutive, by default
+           AND (rounds <= --max-rounds)                # hard cap; exceeded -> STOP-HITL
+```
+
+The floor exists because a draft that *looks* clean on pass 1 usually is not; the dryness test
+exists because a single clean pass is noise. Each round uses `--lenses` **distinct** perspectives
+(default 3); a round that reuses a lens does not count toward `clean_rounds`.
+
+## Architecture profiles
+
+`profiles/<name>.md` supplies the DRAFT shape, the lens roster, and the loop budget. The engine is
+profile-agnostic; adding an architecture is adding a file, never a new skill.
+
+| Profile | Shape | Use when |
+|---|---|---|
+| `default` | goal · constraints · acceptance · stop-condition · deliverables | any braindump with no named target architecture |
+| `gauntlet-loop` | task · build-method · quality-bar, fan-out builders + blind critic, extreme reference | the work is buildable, observable, reversible, and has a nameable external bar |
+
+`--architecture=gauntlet-loop` is a **profile of this skill**, not the third-party skill of the same
+concept. See `profiles/gauntlet-loop.md` for prior-art attribution and the divergence table.
+
+## Override parameters
+
+| Flag | Default | Allowed / Notes |
+|---|---|---|
+| `"<braindump>"` (positional) | *required* | path to a braindump file, or inline text |
+| `--architecture` | `default` | `default` \| `gauntlet-loop` \| `<profile-name>` (any file in `profiles/`) |
+| `--dor` | `auto` | override the recovered Definition of Ready |
+| `--motivation` | `auto` | override the recovered motivation |
+| `--goal` | `auto` | override the recovered goal |
+| `--condition` | `auto` | override the DoD/stop-condition (measurable spec) |
+| `--principles` | `auto` | comma list, or `auto` = inherit the host's governance corpus by reference |
+| `--min-revisions` | `3` | REFINE floor — minimum revisions regardless of apparent cleanliness |
+| `--clean-rounds` | `3` | consecutive gap-free rounds required to exit REFINE |
+| `--lenses` | `3` | distinct perspectives per round; a repeated lens does not count |
+| `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` (diminishing returns) |
+| `--dry-run` | `false` | run RECOVER→REFINE and emit the plan; STOP before RENDER writes |
+| `--output` | `table` | `table` \| `list` \| `json` (machine contract — see §Output contract) |
+| `--persist` | *(none)* | path to write the rendered prompt; omitted → return inline only |
+| `--user-lang` | `auto` | operator-facing prose language (mirrors the host's language policy) |
+| `--agentic-lang` | `en-us` | language of the RENDERED prompt (agent register) |
+
+## Output contract (`--output=json`)
+
+```jsonc
+{ "skill": "refine-braindump-to-prompt",
+  "phase": "RECOVER|DRAFT|REFINE|RED-TEAM|RENDER|done",
+  "status": "ok|error|hitl",
+  "stop_marker": "STOP-DONE|STOP-HITL|STOP-ERROR|CONTINUE",
+  "architecture": "default|gauntlet-loop|<profile>",
+  "recovered": { "dor": "", "motivation": "", "goal": "", "condition": {} },
+  "refine": { "revisions": 0, "clean_rounds": 0, "rounds": 0, "lenses_used": [] },
+  "red_team": { "verdict": "CLEAR|REFUTED", "findings": [] },
+  "verifiability_gate": { "machine_verifiable": false, "independent_critic": false,
+                          "inspectable_evidence": false, "long_loop_licensed": false },
+  "prompt": "<the rendered prompt, or null under --dry-run>",
+  "dropped_session_meta": [] }
+```
+
+Exit codes: `0` = prompt rendered OR plan emitted (`--dry-run`) · `1` = error (`STOP-ERROR`) ·
+`2` = HITL escalation (`STOP-HITL`). Mirrors the repo's AI-native structured-output discipline.
+
+## STOP-marker grammar
+
+Emit exactly ONE terminal marker as the last line of each turn — the shared `/goal` Stop-hook
+evaluator reads it:
+
+```text
+<!--ORCH-STATUS: STOP-DONE -->     prompt rendered (or plan emitted under --dry-run)
+<!--ORCH-STATUS: STOP-HITL -->     HITL escalation required (also prepend above any action block)
+<!--ORCH-STATUS: STOP-ERROR -->    unrecoverable error (subagent / network / rate-limit)
+<!--ORCH-STATUS: CONTINUE -->      phase done; pipeline continues; evaluator decides next turn
+```
+
+## Relationship to siblings
+
+| Tool | Input | Output |
+|---|---|---|
+| `refine-braindump-to-prompt` (this) | ONE braindump | ONE executable prompt |
+| `enhance-pipeline` | ONE feature | a shipped PR |
+| `auto-pilot` | ONE goal | decompose → delegate → converge |
+| `quiesce` | the SESSION | steady state |
+| `converge` | N proposals | one 5-act merge |
+| `agentic-tool-forge` | ONE recurring intent | a reusable TOOL |
+| `directive-braindump-triage` (user-scope) | ONE braindump | a classification ledger |
+
+This skill MAY hand its rendered prompt to `auto-pilot`/`quiesce` for execution; it never executes
+the prompt itself (the operator names the target).
+
+## Protocol Rules (anti-loop invariants + bounds)
+
+- REFINE stops on the **two-part** predicate; a single clean pass never terminates it.
+- `--max-rounds` (default 12) is a hard cap → `STOP-HITL` on exhaustion.
+- RED-TEAM's critic MUST be independent of the DRAFT author (`bin/convergence-guard`); if
+  independence cannot be secured on a high-stakes prompt → **HOLD, do not force**.
+- Session-meta (`/enhance` wrappers, pep-talk, "do a good job") is DROPPED in RECOVER and listed
+  in `dropped_session_meta` — never silently.
+- A cartesian list of resources in the braindump is **not** a requirement to instantiate each one.
+- Worktree discipline always on (`skills/worktree-policy`); never commit to main.
+- Delegation depth ≤ 2; parallel fan-out ≤ 3 per round.
+- Exactly ONE STOP marker per turn.
+- External research is time-boxed and cited — never fabricate prior art.
+- HUMAN_DOMAIN + non-negotiable guardrails (secrets/PII, force-push protected, prod/irreversible,
+  cross-org) ALWAYS halt the pipeline → HITL.
+
+## Failure modes
+
+- **Empty / unreadable braindump** → `STOP-ERROR` before RECOVER (nothing to lapidate).
+- **RECOVER cannot find a goal** → `STOP-HITL` carrying the ranked hypotheses (never guess a goal).
+- **DoD not measurable after `decompose-abstract-to-measurable`** (`inconclusive.flag`) →
+  `STOP-HITL`; a prompt with an unmeasurable stop-condition is the failure this skill exists to prevent.
+- **`--max-rounds` exhausted** → `STOP-HITL` (diminishing returns → escalate).
+- **RED-TEAM independence unavailable at high stakes** → `STOP-HITL` (hold, don't force).
+- **Profile not found** → `STOP-ERROR` listing available profiles.
+
+## Skip conditions (proportionality)
+
+- **S1** the intent is already one clear sentence → write the prompt inline; skip the pipeline.
+- **S2** the operator supplied the prompt and wants only execution → hand to `auto-pilot`.
+- **S3** mid-orchestration under a parent that already recovered the goal upstream.
+
+## DNA Geracional (inherited by every spawned agent)
+
+- **Dogfood**: the skill is validated on the braindump that originated it before being declared done.
+- **Persist-over-fail**: write-ahead-checkpoint each obligation BEFORE executing.
+- **DRY / KIS / YAGNI / SSOT** — compose primitives, never duplicate them.
+- **Verifier ≠ generator** — the critic never inherits the builder's context.
+- **Boy-Scout** — leave every repo cleaner than found.
+
+## Examples
+
+```text
+/refine-braindump-to-prompt "~/dumps/2026-08-14-gauntlet.braindump.md"
+/refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
+/refine-braindump-to-prompt "<dump>" --dry-run --output=json
+/refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
+/refine-braindump-to-prompt "<dump>" --persist=./prompts/migration.prompt.md
+```
+
+## Validation
+
+- `tests/validate-plugin.sh` enforces: `skills/refine-braindump-to-prompt/SKILL.md` exists with
+  valid frontmatter; `commands/refine-braindump-to-prompt.md` carries matching `name:`.
+- `--dry-run` proves composition: grep the run — only `Task`-delegation to existing skills/agents
+  plus native tools; zero reimplementation.
+- Dogfood gate: running the skill on its own originating braindump must yield a prompt containing
+  (a) a machine-verifiable goal, (b) an independent critic, (c) an explicit stopping rule.
+
+## Related
+
+- `commands/refine-braindump-to-prompt.md` — operator-facing command surface
+- `profiles/default.md` · `profiles/gauntlet-loop.md` — architecture profiles
+- `skills/goal-recovery/SKILL.md` — PHASE 1 recovery (braindump source)
+- `skills/decompose-abstract-to-measurable/SKILL.md` — PHASE 1 DoD measurement (Prisma)
+- `skills/convergence-engine/SKILL.md` — PHASE 3 loop + economic stop
+- `skills/red-team/SKILL.md` — PHASE 4 adversarial refutation (Elenchus)
+- `skills/council-gate/SKILL.md` — HUMAN_DOMAIN gate (Boule)
+- `skills/enhance-pipeline/SKILL.md` — sibling preset (feature → PR)
+- `agents/prompt-context-engineer.md` — the prompt-craft seat
+- `skills/worktree-policy/SKILL.md` — write discipline
+
+## Versioning
+
+- v0.1.0 (initial) — five-phase braindump→prompt lifecycle composing in-repo primitives;
+  architecture profiles (`default`, `gauntlet-loop`); the Verifiability Gate stopping doctrine
+  (synthesising Shumer's unbounded loop, Osmani's mandatory stopping rules, and this repo's
+  economic stop); two-part REFINE termination (floor AND dryness); STOP-marker grammar reuse;
+  depth/round bounds; `--output=json` contract.
+
+## License
+
+MIT (matches multi-agent-os repo `LICENSE`).

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -86,6 +86,43 @@ RENDER    := emit ONE prompt + machine envelope + persist decision
 A phase is COMPLETE when its primitive returns a structured artifact the next phase consumes.
 The pipeline is DONE when RENDER emits the prompt, or — under `--dry-run` — the plan for it.
 
+## Two movements — SEPARATE precedes SHAPE (binding)
+
+The five phases group into **two movements**, and the order between them is not stylistic:
+
+```text
+MOVEMENT 1 — SEPARATE (distill)   RECOVER
+MOVEMENT 2 — SHAPE   (lapidate)   DRAFT -> REFINE -> RED-TEAM -> RENDER
+```
+
+**You cannot facet a mixture.** A lapidary receives a *solid*; a still receives a *mixture*. A
+braindump arrives as the latter — intent dissolved in session-wrappers, resource enumerations and
+principle lists. Attempting to shape it before separating it does not produce a rough prompt; it
+produces a **polished wrapper**, because the shaping phases will faithfully refine whatever mass
+they are handed, including the mass that carries no constraint.
+
+So RECOVER is **not** a parsing convenience placed first for tidiness. It is the **precondition**
+that makes the second movement possible at all. If RECOVER cannot separate a goal from the mass,
+the pipeline halts (`STOP-HITL`) rather than shaping the mass.
+
+> **House pair.** This skill owns MOVEMENT 2 and is soul-named for it (*Lapidary*). MOVEMENT 1 is
+> the same operation the operator's vault protocol `braindump-distill` (*Alambique*) performs at a
+> different terminus. The two names already exist and are **sequential, not rival** — a still, then
+> a lapidary. This skill inlines its own separation (goal-oriented) rather than composing the
+> vault's (artifact-oriented), because the two separations sort for different things.
+
+**Measured, not asserted** (`examples/DOGFOOD-gauntlet.md`): on the originating braindump, the two
+longest passages — a cartesian resource list and a 40-item principle enumeration — contributed
+**zero** constraints to the rendered prompt, while its shortest clause became the acceptance metric.
+Most of the input was mass. Separation is where the work is; shaping is where it becomes visible.
+
+### Recursion clause (the discipline must propagate)
+
+A rendered prompt SHALL itself carry separate-before-shape into the work it drives. Concretely,
+BUILD-METHOD must require the executing agent to **decompose the target and name what is out of
+scope** before building — never to begin shaping an undifferentiated goal. A prompt that skips this
+reproduces, one level down, the exact failure this skill exists to prevent.
+
 ## How it works
 
 ```text

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -1,28 +1,8 @@
 ---
 name: refine-braindump-to-prompt
 version: "0.1.0"
-description: |
-  Turn ONE raw operator braindump into ONE polished, ready-to-execute PROMPT that drives
-  an agent/team end-to-end with minimum HITL. Five phases: RECOVER (DoR · motivation · goal
-  via goal-recovery + DoD-as-measurable via decompose-abstract-to-measurable) → DRAFT
-  (first-cut prompt in the chosen architecture profile) → REFINE (bounded loop over the
-  DRAFT PROMPT itself: N rounds × N distinct lenses, stop only when min-revisions AND
-  consecutive-clean-rounds are both satisfied) → RED-TEAM (independent adversarial
-  refutation) → RENDER (ONE prompt + machine envelope). Parameterized by prompt-architecture
-  PROFILES (`--architecture`); profile #1 is `gauntlet-loop`. A thin preset that COMPOSES
-  existing primitives (goal-recovery, decompose-abstract-to-measurable, convergence-engine,
-  perspective-trio, cascade-resolver, red-team, council-gate, prompt-context-engineer) —
-  reimplements nothing. Accepts: --architecture, --dor, --motivation, --goal, --condition,
-  --principles, --min-revisions, --clean-rounds, --lenses, --max-rounds, --dry-run, --output,
-  --persist, --user-lang, --agentic-lang.
-  Use when the operator has a messy dump of intent and wants it lapidated into one executable
-  prompt: "turn this braindump into a prompt", "lapide este braindump", "polish this dump into
-  something runnable", "make an executable prompt out of this", "destrinche isto e me devolva
-  um prompt".
-  Triggers: "refine-braindump-to-prompt", "/refine-braindump-to-prompt", "braindump to prompt",
-  "lapidar braindump", "polish braindump", "one executable prompt from this dump", "gauntlet
-  loop prompt".
-allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob, WebSearch, WebFetch
+description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases: RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses; exits only on min-revisions AND consecutive-clean-rounds) -> RED-TEAM (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope + multi-sink emission). Use when a dump must become executable work rather than a ledger, an envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop) and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool). Composes in-repo primitives; reimplements nothing.
+allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ---
 
 # Refine-Braindump-to-Prompt
@@ -64,7 +44,7 @@ only on a two-part condition (a floor AND a dryness test), never on a single cle
 
 ## Trigger Phrases
 
-- "refine-braindump-to-prompt" / "/refine-braindump-to-prompt"
+- "refine-braindump-to-prompt" / "/maos:refine-braindump-to-prompt"
 - "turn this braindump into a prompt" / "lapide este braindump"
 - "one executable prompt from this dump" / "polish this dump into something runnable"
 - "gauntlet loop prompt for <X>"
@@ -223,7 +203,7 @@ reproduces, one level down, the exact failure this skill exists to prevent.
 ## How it works
 
 ```text
-operator invokes /refine-braindump-to-prompt "<braindump-path-or-text>"
+operator invokes /maos:refine-braindump-to-prompt "<braindump-path-or-text>"
         |
         v   resolve flags -> profile defaults unless overridden
         v
@@ -474,17 +454,17 @@ the prompt itself (the operator names the target).
 ## Examples
 
 ```text
-/refine-braindump-to-prompt "~/dumps/2026-08-14-gauntlet.braindump.md"
-/refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
-/refine-braindump-to-prompt "<dump>" --dry-run --output=json
-/refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
-/refine-braindump-to-prompt "<dump>" --persist=./prompts/migration.prompt.md
+/maos:refine-braindump-to-prompt "~/dumps/2026-08-14-gauntlet.braindump.md"
+/maos:refine-braindump-to-prompt "<dump>" --architecture=gauntlet-loop
+/maos:refine-braindump-to-prompt "<dump>" --dry-run --output=json
+/maos:refine-braindump-to-prompt "<dump>" --min-revisions=5 --clean-rounds=2 --lenses=4
+/maos:refine-braindump-to-prompt "<dump>" --persist=./prompts/migration.prompt.md
 ```
 
 ## Validation
 
-- `tests/validate-plugin.sh` enforces: `skills/refine-braindump-to-prompt/SKILL.md` exists with
-  valid frontmatter; `commands/refine-braindump-to-prompt.md` carries matching `name:`.
+- `tests/validate-plugin.sh` enforces: `skills/maos:refine-braindump-to-prompt/SKILL.md` exists with
+  valid frontmatter; `commands/maos:refine-braindump-to-prompt.md` carries matching `name:`.
 - `--dry-run` proves composition: grep the run — only `Task`-delegation to existing skills/agents
   plus native tools; zero reimplementation.
 - Dogfood gate: running the skill on its own originating braindump must yield a prompt containing
@@ -492,7 +472,7 @@ the prompt itself (the operator names the target).
 
 ## Related
 
-- `commands/refine-braindump-to-prompt.md` — operator-facing command surface
+- `commands/maos:refine-braindump-to-prompt.md` — operator-facing command surface
 - `profiles/default.md` · `profiles/gauntlet-loop.md` — architecture profiles
 - `skills/goal-recovery/SKILL.md` — PHASE 1 recovery (braindump source)
 - `skills/decompose-abstract-to-measurable/SKILL.md` — PHASE 1 DoD measurement (Prisma)

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -1,7 +1,16 @@
 ---
 name: refine-braindump-to-prompt
 version: "0.3.0"
-description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases: RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses; economic stop by default, floor only where the profile licenses the long loop) -> RED-TEAM (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope + multi-sink emission). Use when a dump must become executable work rather than a ledger, an envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop) and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool). Composes in-repo primitives; reimplements nothing.
+description: >-
+  Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases:
+  RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list
+  with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses;
+  economic stop by default, floor only where the profile licenses the long loop) -> RED-TEAM
+  (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope +
+  multi-sink emission). Use when a dump must become executable work rather than a ledger, an
+  envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop)
+  and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool).
+  Composes in-repo primitives; reimplements nothing.
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ---
 
@@ -23,7 +32,7 @@ Take ONE raw, unstructured operator braindump — mixed directives, cartesian re
 session-meta wrappers — and lapidate it into ONE prompt that an agent (or a team) can execute
 end-to-end with minimum human-in-the-loop. The distinctive act is **REFINE**: a bounded loop whose
 *object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating on
-the economic stop (`n* ≤ 3-4`) by default — and, **only where a profile licenses the long loop**, on
+the economic stop (`n* (typically 3 or 4)`) by default — and, **only where a profile licenses the long loop**, on
 a two-part condition (a floor AND a dryness test) rather than a single clean pass.
 
 ## When to use
@@ -77,7 +86,7 @@ DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
              if long_loop_licensed: until (revisions >= min_revisions)
                                       AND (clean_rounds >= clean_rounds_required)
-             else:                  until the economic stop (n* <= 3-4), floor OFF
+             else:                  until the economic stop (n* (typically 3 or 4)), floor OFF
 RED-TEAM  := independent adversarial refutation of the DRAFT (verifier != generator)
              REFUTED -> classify: craft-defect => back to REFINE (<= max_redteam_cycles)
                                   missing-fact => STOP-HITL now (rounds cannot invent facts)
@@ -308,7 +317,7 @@ Three sources disagree about when an agentic loop may stop, and the disagreement
 |---|---|
 | Shumer's aim-prompt (and skills derived from it) | *"loop until utterly perfect — you are the brake"* → **none** |
 | Osmani, *Loop Engineering* | clear stopping rules are the **5th mandatory component** (cost · attempts · wall-clock · gain-stagnation) |
-| `skills/convergence-engine` (this repo) | economic stop `n* ≤ 3-4`; floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
+| `skills/convergence-engine` (this repo) | economic stop at `n*`, the closed form `n* = 1 + ⌈ln((1−ρ)·g₀·V/C) / ln(1/ρ)⌉` (ρ=retained-gap fraction · g₀=initial gap · V=value/correct-unit · C=round cost). It grows only **logarithmically** in `V/C`, so it evaluates to **3 or 4** across realistic inputs — a computed bound, not a magic literal. Floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
 
 **The synthesis this skill encodes — the Verifiability Gate:**
 
@@ -318,7 +327,7 @@ long_loop_licensed := bar_is_machine_verifiable
                     AND evidence_is_directly_inspectable
 
 if long_loop_licensed -> cap = profile budget (attempts | cost | wall-clock | stagnation delta)
-else                  -> cap = convergence-engine economic stop (n* <= 3-4)
+else                  -> cap = convergence-engine economic stop (n* (typically 3 or 4))
 NEVER                 -> unbounded, on work that is irreversible, costly, or unobservable
 ```
 
@@ -344,12 +353,12 @@ stop_refine := (rounds <= --max-rounds)                    # hard cap; exceeded 
                    (revisions    >= --min-revisions)       # floor   — profile-supplied
                    AND (clean_rounds >= --clean-rounds)    # dryness — profile-supplied
                else:
-                   economic stop governs ALONE (n* <= 3-4) # no floor, no dryness counter
+                   economic stop governs ALONE (n* (typically 3 or 4)) # no floor, no dryness counter
 ```
 
 **The floor is licensed, not global — and that is load-bearing.** A round either produces a
 revision or is clean, never both, so a `min-revisions=3 AND clean-rounds=3` floor requires **≥6
-rounds**. When the loop is *unlicensed* the cap is `n* ≤ 3-4`. **A global floor would therefore
+rounds**. When the loop is *unlicensed* the cap is `n* (typically 3 or 4)`. **A global floor would therefore
 exceed its own cap on every unlicensed run** — and `profiles/default.md` states the gate normally
 evaluates false for that profile, so that is the common path, not an edge case. The floor belongs to
 the profile that licenses it (`gauntlet-loop`, whose `≥3 revisions AND ≥3 consecutive clean rounds`
@@ -552,7 +561,7 @@ the prompt itself (the operator names the target).
 
 ## Protocol Rules (anti-loop invariants + bounds)
 
-- REFINE stops on the economic stop (`n* <= 3-4`) by DEFAULT. The **two-part** floor (min-revisions
+- REFINE stops on the economic stop (`n* (typically 3 or 4)`) by DEFAULT. The **two-part** floor (min-revisions
   AND consecutive-clean-rounds) applies ONLY where the Verifiability Gate licenses the long loop —
   asserting it unconditionally makes the floor exceed its own cap on every unlicensed run.
 - `--max-rounds` (default 12) is a hard cap → `STOP-HITL` on exhaustion.
@@ -596,7 +605,7 @@ the prompt itself (the operator names the target).
   tolerance) → **`STOP-HITL` immediately**: no number of refine rounds can manufacture a fact the
   dump does not contain. **Precedence**: this outranks the economic stop — the stop caps iteration
   *within* REFINE and never governs the RED-TEAM return path. Without that precedence the two
-  collide structurally on any unlicensed run (stop caps REFINE at `n* ≤ 3-4`; a refutation at round
+  collide structurally on any unlicensed run (stop caps REFINE at `n* (typically 3 or 4)`; a refutation at round
   4 demands a round 5 that is over-cap by construction).
 - **`--max-redteam-cycles` exhausted while still REFUTED** → `STOP-HITL` carrying the standing
   findings as the escalation payload.

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: refine-braindump-to-prompt
 version: "0.3.0"
-description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases: RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses; exits only on min-revisions AND consecutive-clean-rounds) -> RED-TEAM (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope + multi-sink emission). Use when a dump must become executable work rather than a ledger, an envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop) and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool). Composes in-repo primitives; reimplements nothing.
+description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases: RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses; economic stop by default, floor only where the profile licenses the long loop) -> RED-TEAM (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope + multi-sink emission). Use when a dump must become executable work rather than a ledger, an envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop) and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool). Composes in-repo primitives; reimplements nothing.
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ---
 
@@ -365,8 +365,9 @@ concept. See `profiles/gauntlet-loop.md` for prior-art attribution and the diver
 | `--goal` | `auto` | override the recovered goal |
 | `--condition` | `auto` | override the DoD/stop-condition (measurable spec) |
 | `--principles` | `auto` | comma list, or `auto` = inherit the host's governance corpus by reference |
-| `--min-revisions` | `3` | REFINE floor — minimum revisions regardless of apparent cleanliness |
-| `--clean-rounds` | `3` | consecutive gap-free rounds required to exit REFINE |
+| `--min-revisions` | `3` | REFINE floor — **licensed profiles only**; ignored (with a warning) when `long_loop_licensed=false` |
+| `--clean-rounds` | `3` | consecutive gap-free rounds — **licensed profiles only**; same gate as above |
+| `--max-redteam-cycles` | `2` | cap on `RED-TEAM REFUTED → REFINE` returns; exhausted while still REFUTED → `STOP-HITL` |
 | `--lenses` | `3` | distinct perspectives per round; a repeated lens does not count |
 | `--max-rounds` | `12` | hard cap; exceeded → `STOP-HITL` (diminishing returns) |
 | `--dry-run` | `false` | run RECOVER→REFINE and emit the plan; STOP before RENDER writes |
@@ -476,7 +477,9 @@ the prompt itself (the operator names the target).
 
 ## Protocol Rules (anti-loop invariants + bounds)
 
-- REFINE stops on the **two-part** predicate; a single clean pass never terminates it.
+- REFINE stops on the economic stop (`n* <= 3-4`) by DEFAULT. The **two-part** floor (min-revisions
+  AND consecutive-clean-rounds) applies ONLY where the Verifiability Gate licenses the long loop —
+  asserting it unconditionally makes the floor exceed its own cap on every unlicensed run.
 - `--max-rounds` (default 12) is a hard cap → `STOP-HITL` on exhaustion.
 - RED-TEAM's critic MUST be independent of the DRAFT author (`bin/convergence-guard`); if
   independence cannot be secured on a high-stakes prompt → **HOLD, do not force**.

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -128,6 +128,28 @@ not a node, and it became this skill's core predicate.
 > interdependency map per run since its first row (22 in its ledger). This skill shipped without one.
 > `RELATE` closes that composition gap — the discipline existed upstream and was silently dropped.
 
+### The lossless movement is a PREDICATE, not a list
+
+`dissect · identify · relate · prism · catalogue` is an **instance**, not a definition. A fixed list
+caps a fresh agent at whatever its author happened to think of. The membership test does not:
+
+> An operation belongs to the lossless movement **iff**
+> **(a)** it discards nothing;
+> **(b)** after it you can answer a question you could not before;
+> **(c)** it can halt on *"I cannot do this to this input"*, **or** it emits an artifact.
+
+Extend by the test, never by taste. `(c)` is where the two-axis classification lands: an operation
+that halts is a **gate**; one that emits is an **artifact**; one that does neither is ceremony.
+
+**Watch for straddlers.** *Separate* is a member in the sense **distinguish** (lossless) and belongs
+on the lossy side in the sense **set aside** — one word, both sides of the hard boundary. A list
+cannot catch that; only the test can. When a candidate operation is ambiguous, resolve it by asking
+(a): *does this instance discard anything?*
+
+**Escalation, not exhaustion:** run the members the input actually needs. A dump with no abstract
+criterion does not need `prism`; one with three independent parts barely needs `relate`. Membership
+says what *may* enter, not what *must* run.
+
 **The hard boundary — you cannot justify a discard you do not understand.** Distilling without
 dissecting discards by heuristic — by length, by position, by vibe — and is right only by luck.
 Test: *can you invert the order?* Distill before dissect → **impossible**. This boundary gets a gate.

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -35,13 +35,20 @@ a two-part condition (a floor AND a dryness test) rather than a single clean pas
 
 ## When **not** to use
 
+The five hand-offs below are terminal when this skill is invoked anyway: it does **not** silently
+do the neighbour's job. Each ends the run with `STOP-DONE` · `skipped.condition: "wrong-tool"` ·
+`skipped.handed_to: "<sibling>"` — the same field pair §Skip conditions uses, so a caller reads
+one shape for every non-entry.
+
 - "What in this dump is already done?" → `directive-braindump-triage` (classification ledger).
 - "Make this dump into a reusable TOOL" → `agentic-tool-forge` (forges an artifact, not a prompt).
 - "File this dump as vault knowledge" → the operator's vault protocol (`braindump-distill`).
 - "Ship this feature idea end-to-end" → `enhance-pipeline` (delivers a PR, not a prompt).
 - "Re-target existing content for another audience" → `content-recast`.
-- One clear sentence already states the task → just write the prompt inline (§Skip S1).
-- Destructive ops (force-push protected, drop prod) — always HITL.
+- One clear sentence already states the task → just write the prompt inline (§Skip S1 · `STOP-DONE`).
+- **Destructive ops** (force-push protected, drop prod) — **always HITL → `STOP-HITL`**, carrying the
+  requested op and the guardrail it touches. This is a halt, not routing advice; it was markerless
+  and is one of the 11 the v0.3.0 eval found outside §Failure modes.
 
 ## Trigger Phrases
 
@@ -166,9 +173,22 @@ relation it cannot resolve, or on a mass it cannot justify dropping.
 utterance is this?* — directive, constraint, criterion. *(b) **What does it refer to?*** Reading (a)
 alone, `do jeito que o fulano sugeriu` types cleanly as a method-constraint and passes. Only (b)
 catches that `fulano` is a placeholder for an explicitly-unnamed person, i.e. that the part names
-nothing. **DISSECT is the single halt site for referents**; `relate` halts on graph properties (cycles,
-goal-blocking dangles), not on naming. Putting the referent check in DISSECT is what makes the halt
-robust when `relate` is thin.
+nothing. **DISSECT is where an empty referent is DETECTED** — emptiness is a per-part naming property,
+and question (b) is the only place it is asked. **`relate` is where an empty referent is ADJUDICATED** —
+whether it *blocks* is a dependency question (does the goal or the DoD hang on it?), and dependency is
+a graph property, which is `relate`'s domain. The halt is the **conjunction**: detected in `dissect`
+∧ load-bearing per `relate`. Neither member is "the single halt site"; each answers a different
+question, and the halt needs both answers.
+
+> **Corrected 2026-08-14 (v0.3.0 eval, claim disproved).** An earlier form of this clause read
+> *"DISSECT is the single halt site for referents; `relate` halts on graph properties …, not on
+> naming"* — which contradicted **two** other passages of this same section: the non-skippability
+> rule above justifies `relate` precisely by its role in catching *"every part hangs on an absent
+> referent"*, and the proportionality rule below conditions the halt on *"only if the goal or the
+> DoD depends on it"* — a dependency test the denied member is the one equipped to compute. The
+> word doing the damage was **"single"**: it forced one member to own a check that structurally
+> takes two. Detect ∧ adjudicate resolves all three passages without weakening either gate, and
+> makes the proportionality rule mechanically executable instead of merely asserted.
 
 ⚠️ **Proportionality — halt on what BLOCKS, carry what merely gaps.** An unresolvable referent halts
 RECOVER **only if the goal or the DoD depends on it**. Otherwise name it as an **open parameter**,
@@ -374,7 +394,7 @@ concept. See `profiles/gauntlet-loop.md` for prior-art attribution and the diver
 | `--dry-run` | `false` | run RECOVER→REFINE and emit the plan; STOP before RENDER writes |
 | `--output` | `table` | `table` \| `list` \| `json` \| `json-rpc` (machine contract — see §Output contract). `json-rpc` is **not** a synonym for `json`: it emits `method` + `params` (notification shape, no `id`) per `[C06]`, which is what an agent-to-agent caller consumes. |
 | `--persist` | *(none)* | **DEPRECATED alias** — `--persist=P` ≡ `--output-target=git-repo:P`. Kept working; do not remove. |
-| `--output-target` | *(none)* | one or more sinks, comma-separated: `<kind>[:<param>]`. Omitted → return inline only. See §Output targets. |
+| `--output-target` | *(none)* | one or more sinks, comma-separated: `<kind>[:<param>]`. Omitted → **report inline, emit nothing** — `inline` is NOT a sink kind (see §Output targets, N5a). See §Output targets. |
 | `--user-lang` | `auto` | operator-facing prose language (mirrors the host's language policy) |
 | `--agentic-lang` | `en-us` | language of the RENDERED prompt (agent register) |
 
@@ -405,6 +425,27 @@ Extend by the test, never by taste. The table below is the **instance**; `etc` i
 non-idempotent* — it just has to **say so**. A target that hid that would fail (c) in spirit:
 silently producing a different result on re-run is a drop the caller cannot see.
 
+**`inline` is NOT a sink — omitting `--output-target` REPORTS, it does not emit.** With no target
+the run returns the prompt in its answer and writes nowhere. That is *reporting*, a distinct act
+from *emitting*, and it is why `inline` does not appear in the table above.
+
+> **Corrected 2026-08-14 (v0.3.0 eval, N5a).** The flag row previously read *"Omitted → return
+> inline only"*, which named `inline` as though it were a sixth kind — while the table gives it no
+> row and therefore no **Render** cell. By this section's own criterion (b) (*a sink is valid iff
+> its render is DEFINED*), the skill's **default path was an inadmissible sink**: the one route
+> every caller takes without a flag was the one route the membership test rejected. The repair
+> names the act instead of inventing a kind. Vault-side counterpart: `persist-locus.spec.yaml`
+> `inline: {admissible: false}` + `default_rule` — same finding, closed on both sides of the
+> ratified N2 split.
+
+**SSOT of this axis (N2 contract, ratified `coexistence-pr11xpr12-20260814`).** `--output-target`
+exists in two places and they do not compete: **[[persist-locus]] is SSOT of ROUTING** — which
+houses × kinds a distillate may land in, and the membership test that admits them —
+(`eko-engram` `pages/persist-locus.md:96` + `resources/agentic-tools/persist-locus.spec.yaml:104`);
+**this flag is SSOT of EMISSION** — how one run reshapes and delivers to a named sink. Each cites
+the other; neither redefines the other's half. A future change to *which* kinds exist belongs there;
+a change to *how* a run emits belongs here.
+
 ### The two cases that break an enum (and why the test exists)
 
 1. **`clipboard` is not a path.** Any axis shaped as `--persist=PATH` cannot express it. This is
@@ -417,12 +458,32 @@ silently producing a different result on re-run is a drop the caller cannot see.
 
 ### Multi-target semantics (explicit, never implicit)
 
-- **Order**: `gitleaks` gate runs **once, before any emission**, whenever ≥1 target declares
-  `shared-surface: yes`. A leak aborts **all** targets — including `clipboard`, which is not exempt.
+- **Order**: `gitleaks` gate runs **once, before any emission — UNCONDITIONALLY**. There is no
+  predicate, because no sink is exempt: a leak escapes through `stdout` (terminal · logs · session
+  transcripts · a shared screen), through `clipboard` (paste-anywhere), and through the three
+  git-backed kinds (committed). A hit **aborts every target of the run** and emits `STOP-ERROR`
+  with `leak.rule` + `leak.target_kinds`; nothing is written, nothing is copied, nothing is printed.
+
+  > **Corrected 2026-08-14 (v0.3.0 eval, N5b).** This gate previously fired *"whenever ≥1 target
+  > declares `shared-surface: yes`"* — and `stdout` and `clipboard` are both declared `no`. A
+  > clipboard-only run therefore **never scanned**, while the very next clause ("a leak aborts all
+  > targets — including `clipboard`, which is not exempt") stayed textually true and operationally
+  > **vacuous**: nothing aborts if nothing ran. The repair is not a better flag value — it is
+  > deleting the predicate. A per-target condition implies some target is exempt; enumerating the
+  > five shows none is, so the condition discriminated nothing and only hid the hole. `shared-surface`
+  > keeps its own true meaning (is this a shared, persistent artifact?) and stops doing double duty
+  > as a security key. Vault-side counterpart: `persist-locus.spec.yaml` `shared_surface_binds_leak_gate`
+  > — **cite, do not redefine** (routing is Locus's SSOT; this emission-side gate is the skill's,
+  > per the ratified N2 split).
+
 - **Partial failure**: **best-effort with a named report**, not all-or-nothing. Rationale: the
   targets are independent sinks, so failing `clipboard` (headless host) must not withhold the
   `vault` write the operator can actually use. Every failure is reported by kind + reason; a
-  silent partial success is forbidden.
+  silent partial success is forbidden. **Terminal marker `STOP-DONE` with `targets[].status`
+  per kind** — a run that emitted to 2 of 3 sinks is *done with a named gap*, never a bare success.
+- **Sink refusal** (a target fails the membership test — unreachable, no Render defined, or
+  unnameable): **`STOP-ERROR` with `refused.kind` + `refused.criterion`**, before any emission.
+  Refusing without a marker was one of the 13 markerless halts the v0.3.0 eval counted.
 - **Unmerged-branch warning**: a `git-repo`/`vault` target on a branch with no upstream, or ahead
   of it, emits a warning. Empirically earned: a braindump written to an unmerged branch became
   invisible from the operator's own checkout on 2026-08-14.
@@ -443,7 +504,20 @@ silently producing a different result on re-run is a drop the caller cannot see.
   "verifiability_gate": { "machine_verifiable": false, "independent_critic": false,
                           "inspectable_evidence": false, "long_loop_licensed": false },
   "prompt": "<the rendered prompt, or null under --dry-run>",
-  "dropped_session_meta": [] }
+  "dropped_session_meta": [],
+
+  // Emission outcome — every halt on this axis is BOTH marked and fielded (v0.3.0 eval, D2).
+  // A marker with no field is unreadable by a machine; a field with no marker is unreadable
+  // by the loop. The three below had NEITHER before this repair.
+  "emission": {
+    "targets": [ { "kind": "", "param": null, "status": "emitted|failed|refused",
+                   "reason": null } ],          // partial failure → STOP-DONE + per-kind status
+    "refused": { "kind": null, "criterion": null },   // membership-test refusal → STOP-ERROR
+    "leak":    { "hit": false, "rule": null, "target_kinds": [] } },   // gitleaks → STOP-ERROR
+
+  // Non-entry is a terminal state too (§Skip conditions). Distinguishes "finished, nothing to do"
+  // from "finished, prompt attached" — both carry STOP-DONE, so the FIELD is the discriminator.
+  "skipped": { "condition": null, "handed_to": null } }
 ```
 
 Exit codes: `0` = prompt rendered OR plan emitted (`--dry-run`) · `1` = error (`STOP-ERROR`) ·
@@ -535,9 +609,23 @@ the prompt itself (the operator names the target).
 
 ## Skip conditions (proportionality)
 
+A skip is a **terminal state**, not a no-op: the run ends without this skill rendering a prompt. It
+therefore names a marker like every other halt — `STOP-DONE` with `skipped.condition` and
+`skipped.handed_to`, so a caller can tell *"finished, nothing to do"* apart from *"finished, prompt
+attached"*. No fourth marker is minted; the discriminator is the field, not a new word.
+
 - **S1** the intent is already one clear sentence → write the prompt inline; skip the pipeline.
+  → `STOP-DONE` · `skipped.condition: S1` · `skipped.handed_to: null`
 - **S2** the operator supplied the prompt and wants only execution → hand to `auto-pilot`.
+  → `STOP-DONE` · `skipped.condition: S2` · `skipped.handed_to: "auto-pilot"`
 - **S3** mid-orchestration under a parent that already recovered the goal upstream.
+  → `STOP-DONE` · `skipped.condition: S3` · `skipped.handed_to: "<parent>"`
+
+> **Corrected 2026-08-14 (v0.3.0 eval, D2).** These three carried no marker, and they are three of
+> the **11 markerless points the eval found OUTSIDE §Failure modes** — the section that asserts
+> *"every halt names a terminal marker; a halt without one is an unfinished rule."* The rule had
+> been enforced where it was written rather than across the domain it claims, which is the same
+> shape as the defect it exists to prevent. Fixing only §Failure modes would have repeated it.
 
 ## DNA Geracional (inherited by every spawned agent)
 

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: refine-braindump-to-prompt
-version: "0.1.0"
+version: "0.3.0"
 description: Lapidate ONE raw operator braindump into ONE polished, ready-to-execute PROMPT. Five phases: RECOVER (dissect - relate - catalogue - prism - distill; emits the parts map and the drop-list with reasons) -> DRAFT (in an architecture profile) -> REFINE (N rounds x N distinct lenses; exits only on min-revisions AND consecutive-clean-rounds) -> RED-TEAM (independent refutation, verifier != generator) -> RENDER (one prompt + machine envelope + multi-sink emission). Use when a dump must become executable work rather than a ledger, an envelope or a PR. Parameterized by architecture profiles (--architecture, incl. gauntlet-loop) and by output sinks (--output-target: stdout, clipboard, vault, git-repo, agentic-tool). Composes in-repo primitives; reimplements nothing.
 allowed-tools: Task, Read, Write, Edit, Bash, Grep, Glob
 ---
@@ -53,9 +53,10 @@ only on a two-part condition (a floor AND a dryness test), never on a single cle
 
 ```text
 RECOVER   := DISSECT   open the dump; type every part for what it IS
-                        (halt: a part that cannot be typed — "I don't know what this is")
+                        (halt: a part that cannot be typed — "I don't know what this is",
+                         OR a referent that blocks the goal/DoD — see proportionality)
            + RELATE    map how the parts constrain each other
-                        (halt: a cycle, a dangling dependency, an unresolvable reference)
+                        (halt: a cycle, or a dangling dependency that blocks the goal)
            + CATALOGUE emit parts table + relation map  <- REQUIRED OUTPUTS, not incidental
            + recover{DoR, motivation, goal, DoD}        <- recognition: still lossless
            + PRISM     the RECOVERED DoD -> measurable, abstract criteria only
@@ -66,10 +67,15 @@ RECOVER   := DISSECT   open the dump; type every part for what it IS
            + derive recurring mechanism IFF the goal recurs
 DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
-             until (revisions >= min_revisions) AND (clean_rounds >= clean_rounds_required)
-             capped by the economic stop
+             if long_loop_licensed: until (revisions >= min_revisions)
+                                      AND (clean_rounds >= clean_rounds_required)
+             else:                  until the economic stop (n* <= 3-4), floor OFF
 RED-TEAM  := independent adversarial refutation of the DRAFT (verifier != generator)
+             REFUTED -> classify: craft-defect => back to REFINE (<= max_redteam_cycles)
+                                  missing-fact => STOP-HITL now (rounds cannot invent facts)
 RENDER    := emit ONE prompt + machine envelope + persist decision
+             (persist decision = the recorded CHOICE of sinks; with no --output-target
+              the decision is "inline only" and IS the record, not a no-op)
 ```
 
 A phase is COMPLETE when its primitive returns a structured artifact the next phase consumes.
@@ -130,8 +136,14 @@ cannot catch that; only the test can. When a candidate operation is ambiguous, r
 (a): *does this instance discard anything?*
 
 **Escalation, not exhaustion:** run the members the input actually needs. A dump with no abstract
-criterion does not need `prism`; one with three independent parts barely needs `relate`. Membership
-says what *may* enter, not what *must* run.
+criterion does not need `prism`. Membership says what *may* enter, not what *must* run.
+
+⚠️ **`dissect` and `relate` are NOT skippable.** An earlier form of this clause offered *"one with
+three independent parts barely needs `relate`"* — and that is precisely backwards on the input class
+it matters for. A referentially-empty dump (*"fazer aquilo que o fulano sugeriu"*) presents parts
+that **look** independent on a surface read; skipping `relate` there means never discovering that
+every part hangs on an absent referent, and reaching DRAFT with a guessed goal. The one gate that
+catches that class is the one the clause invited you to skip.
 
 **The hard boundary — you cannot justify a discard you do not understand.** Distilling without
 dissecting discards by heuristic — by length, by position, by vibe — and is right only by luck.
@@ -146,9 +158,29 @@ preference*, not a wall: the first distillation differs from a refine-round drop
 prompt; it yields a **polished wrapper**, because the shaping loop faithfully refines whatever mass
 it is handed — including mass that was never signal.
 
-So RECOVER spans the hard boundary and can **halt on either side**: on a part it cannot type
-(*"I don't know what this is"*), on a relation it cannot resolve, or on a mass it cannot justify
-dropping.
+So RECOVER spans the hard boundary and can **halt on either side**: on a part it cannot type, on a
+relation it cannot resolve, or on a mass it cannot justify dropping.
+
+**Typing a part has two questions, and the second is the discriminating one.** *(a) What kind of
+utterance is this?* — directive, constraint, criterion. *(b) **What does it refer to?*** Reading (a)
+alone, `do jeito que o fulano sugeriu` types cleanly as a method-constraint and passes. Only (b)
+catches that `fulano` is a placeholder for an explicitly-unnamed person, i.e. that the part names
+nothing. **DISSECT is the single halt site for referents**; `relate` halts on graph properties (cycles,
+goal-blocking dangles), not on naming. Putting the referent check in DISSECT is what makes the halt
+robust when `relate` is thin.
+
+⚠️ **Proportionality — halt on what BLOCKS, carry what merely gaps.** An unresolvable referent halts
+RECOVER **only if the goal or the DoD depends on it**. Otherwise name it as an **open parameter**,
+carry it into the prompt's ESCALATION section, and continue — never guess it. Without this rule the
+check is all-or-nothing: a dump with four crisp directives and one vague aside (*"…e conserta aquilo
+que o Bob mencionou"*) would hard-halt instead of rendering the resolvable 80% and escalating the
+aside — importing exactly the exhaustion that *"escalation, not exhaustion"* rejects above.
+
+Worked contrast, both measured (`examples/EVAL-REPORT-2026-08-14.md`): a dump whose every part is a
+placeholder (`fazer aquilo que o fulano sugeriu`) has **no** recoverable goal → **halt**. A dump that
+names its pipeline concretely but redacts one node (`sistema X`, alongside `extrato bancário`,
+`planilha de ajuste`, `PDF`, `contador`) still yields a goal and a DoD → **carry it open**. The
+discriminator is *does the goal survive the gap*, not *is there a gap*.
 
 **Classify a candidate stage on two axes, not one** — *can it refuse?* (gate) crossed with
 *pertinent · related · useful?* (worth having):
@@ -171,33 +203,39 @@ Shaping is visible — you see the finished prompt. Separation is semi-visible �
 unless forced to. So pipelines drift toward being named, and then built, for their last movement.
 This is a gradient, not carelessness, and it recurs at every level.
 
-Therefore RECOVER MUST emit **both** the parts catalogue and the drop-list-with-reasons. They are
-not debug output. Without them the answer to *"what was in there, and what did you drop, and why"*
+Therefore RECOVER MUST emit the parts catalogue **and** the relation map; and **if it reaches
+DISTILL**, the drop-list-with-reasons as well. The conditional is not a loophole — DISTILL runs
+*last*, so a halt at DISSECT or RELATE precedes it and there is no drop-list to emit. In that case
+RECOVER emits the catalogue, the map, and **the halt reason**, which is the same obligation
+discharged at the point it stopped. (An unconditional MUST here would be unsatisfiable on every
+halt — a rule the pipeline's own ordering forbids obeying.) They are not debug output. Without them the answer to *"what was in there, and what did you drop, and why"*
 does not exist — and if that answer does not exist, comprehension did not happen; parsing did.
 
 **Prism only abstract criteria** (the DoD, a quality bar). Prismming a concrete part is ceremony.
 
-> **House lineage.** MOVEMENT 2 is the same operation the operator's vault protocol
-> `braindump-distill` (*Alambique*) performs at a different terminus; MOVEMENT 3 gives this skill
-> its soul-name (*Lapidary*). Sequential, not rival — a still, then a lapidary. No third name is
-> minted for MOVEMENT 1: it is named by its outputs (catalogue + drop-list), which is the point.
+> **House pair.** The movements are named, never numbered — *comprehend · distill · shape*.
+> **Distill** is the same operation the operator's vault protocol `braindump-distill` (*Alambique*)
+> performs at a different terminus; **shape** gives this skill its soul-name (*Lapidary*). The two
+> names already exist and are **sequential, not rival** — a still, then a lapidary. No third name is
+> minted for **comprehend**: it is named by its outputs (catalogue + relation map), which is the
+> point. This skill inlines its own separation (goal-oriented) rather than composing the vault's
+> (artifact-oriented), because the two sort for different things.
 
-> **House pair.** This skill owns MOVEMENT 2 and is soul-named for it (*Lapidary*). MOVEMENT 1 is
-> the same operation the operator's vault protocol `braindump-distill` (*Alambique*) performs at a
-> different terminus. The two names already exist and are **sequential, not rival** — a still, then
-> a lapidary. This skill inlines its own separation (goal-oriented) rather than composing the
-> vault's (artifact-oriented), because the two separations sort for different things.
-
-**Measured, not asserted** (`examples/DOGFOOD-gauntlet.md`): on the originating braindump, the two
-longest passages — a cartesian resource list and a 40-item principle enumeration — contributed
-**zero** constraints to the rendered prompt, while its shortest clause became the acceptance metric.
-Most of the input was mass. Separation is where the work is; shaping is where it becomes visible.
+**Measured, then corrected** (`examples/DOGFOOD-gauntlet.md` → falsified by `DOGFOOD-thesis.md`):
+the first run claimed the two longest passages — a cartesian resource list and a 40-item principle
+enumeration — contributed **zero** constraints. Re-run with `relate`, the count was **17**: the items
+appearing in *both* lists, said twice in two independent syntaxes, which is emphasis rather than
+mass. The first run dropped each list *on its own merits* and never asked whether they **intersect**
+— it read nodes; the finding was an **edge**. What survives unchanged: the shortest clause still
+became the acceptance metric. Mass is not content — but **length is not a proxy for emptiness**
+either, and only `relate` can tell them apart.
 
 ### Recursion clause (the discipline must propagate)
 
 A rendered prompt SHALL itself carry separate-before-shape into the work it drives. Concretely,
-BUILD-METHOD must require the executing agent to **decompose the target and name what is out of
-scope** before building — never to begin shaping an undifferentiated goal. A prompt that skips this
+the rendered prompt's **method section — whatever the active profile calls it** (`BUILD-METHOD` in
+`gauntlet-loop`, `SCOPE` in `default`) — must require the executing agent to **decompose the target
+and name what is out of scope** before building — never to begin shaping an undifferentiated goal. A prompt that skips this
 reproduces, one level down, the exact failure this skill exists to prevent.
 
 ## How it works
@@ -265,18 +303,43 @@ NEVER                 -> unbounded, on work that is irreversible, costly, or uno
 
 A long loop pays off **only when the gain signal is real** — i.e. when an independent critic can
 measure the artifact against an external bar. Absent that, extra rounds buy self-assessment, which
-is the very bias the loop was built to defeat. The REFINE loop therefore terminates on a
+is the very bias the loop was built to defeat.
+
+> ⚠️ **REFINE is self-critique, and its critic is the draft's author.** `bin/convergence-guard` run
+> against this loop returns `REFUSE / correlated-verifier-violates-independence` — correctly. So
+> REFINE does **not** satisfy `convergence-engine`'s `verifier > generator ∧ independent` master
+> condition, and this skill does not claim it does: REFINE is the *cheap* pass that catches surface
+> defects, and **RED-TEAM (PHASE 4) is the independent gate**, which is why it is non-optional.
+> Measured on `examples/EVAL-REPORT-2026-08-14.md`: six clean-scoring self-critique rounds missed
+> two BLOCKING defects that one independent refutation found. Adding rounds does not fix this —
+> more self-assessment is more of the same bias. Only the independent pass does.
+
+The REFINE loop therefore terminates on a
 **two-part** condition, never a single clean pass:
 
 ```text
-stop_refine := (revisions >= --min-revisions)          # floor: 3 by default
-           AND (clean_rounds >= --clean-rounds)        # dryness: 3 consecutive, by default
-           AND (rounds <= --max-rounds)                # hard cap; exceeded -> STOP-HITL
+stop_refine := (rounds <= --max-rounds)                    # hard cap; exceeded -> STOP-HITL
+           AND if long_loop_licensed:
+                   (revisions    >= --min-revisions)       # floor   — profile-supplied
+                   AND (clean_rounds >= --clean-rounds)    # dryness — profile-supplied
+               else:
+                   economic stop governs ALONE (n* <= 3-4) # no floor, no dryness counter
 ```
 
-The floor exists because a draft that *looks* clean on pass 1 usually is not; the dryness test
-exists because a single clean pass is noise. Each round uses `--lenses` **distinct** perspectives
-(default 3); a round that reuses a lens does not count toward `clean_rounds`.
+**The floor is licensed, not global — and that is load-bearing.** A round either produces a
+revision or is clean, never both, so a `min-revisions=3 AND clean-rounds=3` floor requires **≥6
+rounds**. When the loop is *unlicensed* the cap is `n* ≤ 3-4`. **A global floor would therefore
+exceed its own cap on every unlicensed run** — and `profiles/default.md` states the gate normally
+evaluates false for that profile, so that is the common path, not an edge case. The floor belongs to
+the profile that licenses it (`gauntlet-loop`, whose `≥3 revisions AND ≥3 consecutive clean rounds`
+comes from the operator's own loop spec); `default` runs on the economic stop alone.
+
+The floor exists — where licensed — because a draft that *looks* clean on pass 1 usually is not, and
+because a single clean pass is noise. Each round uses `--lenses` perspectives that are **distinct
+from each other within that round**; a round that repeats a lens *inside itself* does not count
+toward `clean_rounds`. **Cross-round reuse is expected and required** — rotating 3 lenses per round
+through a 5-lens roster cannot keep rounds mutually disjoint past round 2, so a cross-round reading
+would make `clean_rounds >= 3` need 9 distinct lenses and render `STOP-DONE` unreachable.
 
 ## Architecture profiles
 
@@ -419,7 +482,15 @@ the prompt itself (the operator names the target).
   independence cannot be secured on a high-stakes prompt → **HOLD, do not force**.
 - Session-meta (`/enhance` wrappers, pep-talk, "do a good job") is DROPPED in RECOVER and listed
   in `dropped_session_meta` — never silently.
-- A cartesian list of resources in the braindump is **not** a requirement to instantiate each one.
+- A cartesian list of resources in the braindump is **not** a requirement to instantiate each one —
+  but rendering it as *"permissible, none mandated"* **inverts an imperative into a permission**.
+  Carry it as a *permission* only when the dump offers it as a menu; carry it as a *constraint* when
+  the dump mandates it.
+- **Straddler: a method-directive that shapes the OUTPUT is not session-meta.** `busque semelhantes`
+  (reuse before build) and `invoque Forge` (produce a *reusable* artifact, not a one-off) constrain
+  what the deliverable must be, not how the distiller should work — they belong in the prompt. Test:
+  *if this were dropped, would the acceptable output change?* Yes → constraint, keep. No → meta,
+  drop. (`/enhance` wrappers and pep-talk fail this test; those still drop.)
 - Worktree discipline always on (`skills/worktree-policy`); never commit to main.
 - Delegation depth ≤ 2; parallel fan-out ≤ 3 per round.
 - Exactly ONE STOP marker per turn.
@@ -430,9 +501,30 @@ the prompt itself (the operator names the target).
 ## Failure modes
 
 - **Empty / unreadable braindump** → `STOP-ERROR` before RECOVER (nothing to lapidate).
-- **RECOVER cannot find a goal** → `STOP-HITL` carrying the ranked hypotheses (never guess a goal).
+- **RECOVER cannot find a goal** → `STOP-HITL` carrying **ranked resolution-paths** — the specific
+  referents that must be resolved for a goal to exist — never candidate goals. On a referentially
+  empty dump any content-level hypothesis *is* the guess this clause forbids; the only honest
+  payload is the list of questions whose answers would produce a goal.
+- **`decompose-abstract-to-measurable` returns `human_review: true` / `allowed_use: assistive_only`**
+  (from `structural_route.py`) → carry the verdict into the prompt as an explicit tier; a DoD the
+  primitive itself says needs human review must not pass silently. This is a **second, independent**
+  refusal signal — `aggregate_spec.py` can return `inconclusive.flag: false` on the same DoD that
+  the router caps. Reading only the flag misses it.
 - **DoD not measurable after `decompose-abstract-to-measurable`** (`inconclusive.flag`) →
   `STOP-HITL`; a prompt with an unmeasurable stop-condition is the failure this skill exists to prevent.
+- **RED-TEAM returns REFUTED** → classify before looping. A **craft defect** (unclear,
+  unfalsifiable, under-scoped) returns to REFINE, bounded by `--max-redteam-cycles` (default 2). A
+  **missing fact about the operator's world** (an unnamed system, an unknown schedule, an unmeasured
+  tolerance) → **`STOP-HITL` immediately**: no number of refine rounds can manufacture a fact the
+  dump does not contain. **Precedence**: this outranks the economic stop — the stop caps iteration
+  *within* REFINE and never governs the RED-TEAM return path. Without that precedence the two
+  collide structurally on any unlicensed run (stop caps REFINE at `n* ≤ 3-4`; a refutation at round
+  4 demands a round 5 that is over-cap by construction).
+- **`--max-redteam-cycles` exhausted while still REFUTED** → `STOP-HITL` carrying the standing
+  findings as the escalation payload.
+- **RECOVER halts** (untypeable part · goal-blocking referent · unjustifiable drop) → `STOP-HITL`
+  carrying the catalogue, the map and the halt reason. *(Every halt names a terminal marker; a halt
+  without one is an unfinished rule.)*
 - **`--max-rounds` exhausted** → `STOP-HITL` (diminishing returns → escalate).
 - **RED-TEAM independence unavailable at high stakes** → `STOP-HITL` (hold, don't force).
 - **Profile not found** → `STOP-ERROR` listing available profiles.
@@ -463,8 +555,8 @@ the prompt itself (the operator names the target).
 
 ## Validation
 
-- `tests/validate-plugin.sh` enforces: `skills/maos:refine-braindump-to-prompt/SKILL.md` exists with
-  valid frontmatter; `commands/maos:refine-braindump-to-prompt.md` carries matching `name:`.
+- `tests/validate-plugin.sh` enforces: `skills/refine-braindump-to-prompt/SKILL.md` exists with
+  valid frontmatter; `commands/refine-braindump-to-prompt.md` carries matching `name:`.
 - `--dry-run` proves composition: grep the run — only `Task`-delegation to existing skills/agents
   plus native tools; zero reimplementation.
 - Dogfood gate: running the skill on its own originating braindump must yield a prompt containing
@@ -472,7 +564,7 @@ the prompt itself (the operator names the target).
 
 ## Related
 
-- `commands/maos:refine-braindump-to-prompt.md` — operator-facing command surface
+- `commands/refine-braindump-to-prompt.md` — operator-facing command surface
 - `profiles/default.md` · `profiles/gauntlet-loop.md` — architecture profiles
 - `skills/goal-recovery/SKILL.md` — PHASE 1 recovery (braindump source)
 - `skills/decompose-abstract-to-measurable/SKILL.md` — PHASE 1 DoD measurement (Prisma)

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -22,8 +22,9 @@ primitive that already exists in this repo**.
 Take ONE raw, unstructured operator braindump — mixed directives, cartesian resource lists,
 session-meta wrappers — and lapidate it into ONE prompt that an agent (or a team) can execute
 end-to-end with minimum human-in-the-loop. The distinctive act is **REFINE**: a bounded loop whose
-*object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating
-only on a two-part condition (a floor AND a dryness test), never on a single clean pass.
+*object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating on
+the economic stop (`n* ≤ 3-4`) by default — and, **only where a profile licenses the long loop**, on
+a two-part condition (a floor AND a dryness test) rather than a single clean pass.
 
 ## When to use
 

--- a/skills/refine-braindump-to-prompt/examples/DOGFOOD-gauntlet.md
+++ b/skills/refine-braindump-to-prompt/examples/DOGFOOD-gauntlet.md
@@ -33,8 +33,13 @@ critic, (c) an explicit stopping rule.
 | The `[scripts, flows, processes, … marketplaces]` cartesian list | a list of *available* resources offered as examples. **A listed resource is not a requirement to instantiate it** |
 | The 40+ `--principles` list | already codified as auto-loaded governance in the host corpus — referenced, never inlined (inlining would duplicate an SSOT) |
 
-> The cartesian list is the single largest token mass in the braindump and contributes **zero**
-> constraints. Recovering the goal required deleting most of the text — which is the job.
+> ⚠️ **FALSIFIED 2026-08-14 by dogfood #5 — kept, not deleted, because the correction is the finding.**
+> This run claimed the cartesian list contributes **zero** constraints. Re-running with `RELATE` (a
+> phase this run did not have) **measured 17** — the items appearing in *both* the resource list and
+> the `--principles` flag, said twice in two independent syntaxes. Repetition across syntax is the
+> operator's emphasis mechanism, exactly as clause-triplication was in dogfood #2.
+> This run could not see them: it dropped both lists *separately*, and never asked whether they
+> **intersect**. An edge, invisible to a phase that only reads nodes. See `DOGFOOD-thesis.md`.
 
 ---
 
@@ -186,8 +191,19 @@ production, cross-org); or the caps above are exhausted.
 | (b) independent critic | ✅ fresh context, refute-prompted, may not restate the bar |
 | (c) explicit stopping rule | ✅ two-part predicate + three hard caps + stagnation exit |
 
-**PASS.** The skill lapidated the braindump that originated it.
+**PASS** on the three gates. The skill lapidated the braindump that originated it.
 
-The dropped mass is the finding worth keeping: the braindump's longest passages — the cartesian
-resource list and the 40-principle enumeration — contributed **zero** constraints to the rendered
-prompt, while the shortest clause (`mínimo HITL`) became the acceptance metric.
+⚠️ **But this run's headline finding was WRONG, and the correction outlives it.**
+
+It concluded that the two longest passages contributed **zero** constraints. Dogfood #5 re-ran the
+same input through the repaired pipeline and **measured 17** — the intersection of the 161-item
+resource list and the 51-item `--principles` flag. The operator had said those seventeen **twice, in
+two different syntaxes**, which is emphasis, not mass.
+
+The error is instructive because of its shape: this run dropped each list *on its own merits* and
+never asked whether they **intersect**. It read nodes. The finding was an **edge** — and `RELATE`,
+the phase that recovers edges, did not exist yet when this ran. It was added *because of* dogfood #2,
+and its first act on old evidence was to falsify its own predecessor.
+
+What survives unchanged: the shortest clause (`mínimo HITL`) still became the acceptance metric.
+Mass is not content — but **neither is length a proxy for emptiness**, which is what this run assumed.

--- a/skills/refine-braindump-to-prompt/examples/DOGFOOD-gauntlet.md
+++ b/skills/refine-braindump-to-prompt/examples/DOGFOOD-gauntlet.md
@@ -1,0 +1,193 @@
+# Dogfood — the originating braindump
+
+Run: `/refine-braindump-to-prompt "<gauntlet.braindump.md>" --architecture=gauntlet-loop`
+Date: 2026-08-14. Full audit trail, including what was dropped and what each round changed.
+
+The gate this run had to clear: **if the skill cannot lapidate the braindump that originated it,
+it failed.** The rendered prompt must contain (a) a machine-verifiable goal, (b) an independent
+critic, (c) an explicit stopping rule.
+
+---
+
+## PHASE 1 · RECOVER
+
+**Source**: `braindump` (ladder rank 2 — the operator's own words about this work).
+
+### Recovered
+
+| Field | Value |
+|---|---|
+| **motivation** | prompts that drive agents to complete projects/tasks end-to-end with **minimum HITL** |
+| **DoR** | the Gauntlet Loop architecture must be understood before generating — satisfied: 7 sources read (operator's notebook incl. an 11.9k-char PT-BR report) + independent public corroboration |
+| **goal** | produce a reusable capability that **generates Gauntlet-Loop-compliant prompts** for arbitrary targets |
+| **condition (DoD)** | a generated prompt is compliant ⟺ it carries a named external bar · an independent critic · directly-inspectable evidence · an explicit stopping rule. Each is binary-checkable → measurable, not a wish |
+| **loop spec** | `min_revisions ≥ 3` **AND** `consecutive_clean_rounds ≥ 3`, `lenses = 3` distinct per round |
+| **recurring?** | yes → the capability must be a standing mechanism, not a one-shot artifact |
+
+### Dropped as session-meta (listed, never silent)
+
+| Dropped | Why |
+|---|---|
+| "Analise, critique, busque/pesquise semelhantes… invoque Anima… invoque Forge…" | the `/enhance` ritual wrapper — it describes *how this session should run*, not the work |
+| "Organize e entenda este próprio prompt antes de executá-lo" | meta-instruction about the dump itself |
+| The `[scripts, flows, processes, … marketplaces]` cartesian list | a list of *available* resources offered as examples. **A listed resource is not a requirement to instantiate it** |
+| The 40+ `--principles` list | already codified as auto-loaded governance in the host corpus — referenced, never inlined (inlining would duplicate an SSOT) |
+
+> The cartesian list is the single largest token mass in the braindump and contributes **zero**
+> constraints. Recovering the goal required deleting most of the text — which is the job.
+
+---
+
+## PHASE 2 · DRAFT (v0)
+
+First cut in the `gauntlet-loop` shape. Recorded here because the REFINE log below is meaningless
+without the thing it criticised.
+
+> TASK: build agentic tooling that generates efficient and effective Gauntlet-Loop prompts.
+> BUILD-METHOD: fan out sub-agents; each takes one piece; a separate sub-agent critiques.
+> QUALITY-BAR: the prompts should be efficient and effective, driving end-to-end completion.
+
+---
+
+## PHASE 3 · REFINE
+
+`--lenses=3` distinct per round; a repeated lens does not count toward `clean_rounds`.
+
+### Round 1 — lenses: `bar-nameability` · `critic-independence` · `stop-rule-presence`
+
+| Lens | Finding | Fix |
+|---|---|---|
+| bar-nameability | ❌ "efficient and effective" is an **adjective**, not a bar. This is precisely the failure the Extreme-Reference lever exists to prevent: the model resolves it against its own average prior and stops early | QUALITY-BAR must name an **external artifact**: a prompt is compliant only when an independent reader can execute it cold and reach the DoD without asking a question |
+| critic-independence | ❌ draft says "a separate sub-agent" but never that it lacks build context — "separate" is satisfied by a second call in the same conversation | CRITIC gets a **fresh context, no build history**, and is prompted to REFUTE |
+| stop-rule-presence | ❌ no cost ceiling, no wall-clock, no attempt cap, no stagnation delta — the braindump inherits Shumer's *"you are the brake"* | STOP block made mandatory; unbounded refused |
+
+**revisions = 1 · clean_rounds = 0**
+
+### Round 2 — lenses: `evidence-inspectability` · `decomposability` · `blast-radius`
+
+| Lens | Finding | Fix |
+|---|---|---|
+| evidence-inspectability | ❌ "the prompt is effective" is not directly observable — the critic would be **guessing**, which silently voids the Verifiability Gate | EVIDENCE named: the generated prompt text itself + a cold-execution trace + the count of clarifying questions the executor had to ask (an observable proxy for minimum-HITL) |
+| decomposability | ⚠️ "one or more agentic-tools" leaves the unit of judgement undefined | one judgeable unit = **one generated prompt**, judged whole |
+| blast-radius | ✅ generating a prompt is cheap and reversible — a long loop is admissible here | none |
+
+**revisions = 2 · clean_rounds = 0**
+
+### Round 3 — lenses: `completeness` · `executability` · `falsifiability`
+
+| Lens | Finding | Fix |
+|---|---|---|
+| completeness | ❌ the **target is unnamed** — a generator with no target renders nothing. A fresh amnesic agent would have to invent one | TARGET promoted to a **required slot**; absent → refuse and ask, never invent |
+| executability | ✅ every instruction maps to a named tool | none |
+| falsifiability | ✅ acceptance is now four binary checks | none |
+
+**revisions = 3 · clean_rounds = 0**
+
+### Rounds 4, 5, 6 — rotating lens sets, no new findings
+
+| Round | Lenses | Result |
+|---|---|---|
+| 4 | scope-drift · failure-path · bar-nameability | clean |
+| 5 | critic-independence · evidence-inspectability · stop-rule-presence | clean |
+| 6 | decomposability · completeness · falsifiability | clean |
+
+**revisions = 3 · clean_rounds = 3 · rounds = 6 (cap 12)**
+
+`stop_refine := (3 ≥ 3) AND (3 ≥ 3) AND (6 ≤ 12)` → **EXIT**
+
+> Note what the floor bought. Round 1 found three defects in a draft that read fluently. Had the
+> loop been allowed to exit on one clean pass, it would have shipped an adjective as a quality bar.
+
+---
+
+## PHASE 4 · RED-TEAM
+
+Independent refuter, no REFINE context, prompted to break the prompt.
+
+| Attack | Verdict |
+|---|---|
+| "The bar is still soft — 'execute cold without asking' is judgeable but subjective" | **PARTIALLY LANDS** → mitigated: the observable is the *count of clarifying questions*, a number, not an impression |
+| "The critic could lower the bar silently across rounds" | **HELD** — the bar is written into the prompt and the critic is forbidden from restating it |
+| "The stopping rule could be satisfied by three trivially-clean rounds" | **HELD** — a round only counts if it uses a distinct lens set |
+| "The Verifiability Gate is asserted, not evaluated" | **LANDS** → fixed: the gate is now evaluated explicitly in the rendered prompt's header, with its three conjuncts shown |
+
+**Verdict: CLEAR** (after folding the two landing findings).
+
+---
+
+## PHASE 5 · RENDER
+
+### Verifiability Gate — evaluated, not assumed
+
+| Conjunct | Value | Evidence |
+|---|---|---|
+| `bar_is_machine_verifiable` | ✅ | four binary checks + a countable clarifying-question metric |
+| `critic_is_independent_of_builder` | ✅ | fresh-context refuter, enforced by `bin/convergence-guard` |
+| `evidence_is_directly_inspectable` | ✅ | the prompt text + a cold-execution trace are directly readable |
+| **`long_loop_licensed`** | **true** | → profile budget applies, not the bare economic stop |
+
+### The rendered prompt
+
+```text
+TARGET (required — refuse and ask if absent): <the work to be driven>
+
+TASK
+Generate ONE prompt that drives an agent (or team) to complete TARGET end-to-end
+with minimum human-in-the-loop.
+
+BUILD-METHOD
+A lead agent decomposes TARGET into the smallest independently-judgeable pieces.
+Fan out one builder per piece; parallelise only pieces that are genuinely independent.
+Each piece is gated by a critic before it counts as done.
+
+QUALITY-BAR
+The generated prompt is compliant if and only if all four hold:
+  1. it names an EXTERNAL reference for "good" — never an adjective;
+  2. its critic is independent of its builder;
+  3. its evidence is directly inspectable by that critic;
+  4. it carries an explicit stopping rule.
+Operational bar: a competent executor who has never seen this conversation can run
+the prompt cold and reach the DoD. Measured by the number of clarifying questions
+they must ask. Target: zero. This number is the acceptance signal — do not restate
+the bar in softer words at any point.
+
+CRITIC
+A separate agent, FRESH CONTEXT, with no visibility into how the prompt was built.
+Prompted to REFUTE, not to approve. It compares the candidate against the four
+checks above, blind. It may not lower the bar; if it cannot refute, it says so.
+
+EVIDENCE
+The critic may directly inspect: the candidate prompt text; a cold-execution trace;
+the clarifying-question count. It may not infer quality from the build story.
+
+STATE
+Persist every attempt, every refutation and every clarifying question OUTSIDE the
+conversation, so round N knows what round N-1 already failed.
+
+STOP
+Exit when: revisions >= 3 AND consecutive gap-free rounds >= 3 (each round using a
+distinct lens set). Hard caps: 12 rounds; an operator-set cost ceiling; an
+operator-set wall-clock. Exit early on gain-stagnation (round-over-round delta below
+threshold twice). Unbounded running is refused — if no cap is set, stop and ask.
+
+ESCALATION
+Halt and escalate to a human when: TARGET is absent or ambiguous; the work becomes
+irreversible, costly or unobservable; a guardrail surface is touched (secrets, PII,
+production, cross-org); or the caps above are exhausted.
+```
+
+---
+
+## Verdict
+
+| Dogfood gate | Result |
+|---|---|
+| (a) machine-verifiable goal | ✅ four binary checks + a countable metric |
+| (b) independent critic | ✅ fresh context, refute-prompted, may not restate the bar |
+| (c) explicit stopping rule | ✅ two-part predicate + three hard caps + stagnation exit |
+
+**PASS.** The skill lapidated the braindump that originated it.
+
+The dropped mass is the finding worth keeping: the braindump's longest passages — the cartesian
+resource list and the 40-principle enumeration — contributed **zero** constraints to the rendered
+prompt, while the shortest clause (`mínimo HITL`) became the acceptance metric.

--- a/skills/refine-braindump-to-prompt/examples/DOGFOOD-thesis.md
+++ b/skills/refine-braindump-to-prompt/examples/DOGFOOD-thesis.md
@@ -1,0 +1,131 @@
+# Dogfood #2 — the pipeline run on the claim that specifies it
+
+The first dogfood ran the skill on the braindump that motivated it. This one runs it on the
+**operator's thesis about the pipeline itself** — the recursion clause fired at its sharpest.
+
+Five prior passes were spent *comparing* versions of the thesis. That is not the pipeline; that is
+talking about it. This run emits what the pipeline **requires**: a catalogue, a relation map, a
+drop-list with reasons, a prism, and a decision.
+
+---
+
+## DISSECT — type every part
+
+| # | Part | Type |
+|---|---|---|
+| P1 | "antes de decidir/lapidar/destilar" | **ordering claim** |
+| P2 | "dissecar/prismar/separar/categorizar/identificar/tipar/catalogar/inter-relacionar/inter-conectar/**etc**" | **operation set** (explicitly open) |
+| P3 | "para poder entender" | **purpose of P2** |
+| P4 | "'abrir' para poder entender o conteúdo" | gloss of P3 (metaphor: open) |
+| P5 | "dividir para conquistar" | **method** |
+| P6 | "olhar dentro para entender com clareza" | gloss of P3 (metaphor: look inside) |
+| P7 | "ambos são necessários" | **necessity claim** |
+| P8 | "inclusive outros ismos que **podem** ser necessários" | **open extension** (conditional) |
+| P9 | "para o sucesso real **não theater**" | **acceptance criterion** |
+| P10 | "de nosso objetivo e propósito" | scope: this work |
+| P11 | "…dos agentic-tools que estamos gerando irão gerar e operar" | **scope: recursive** |
+| P12 | "sim ou não?" | verdict request |
+| P13 | "valide, analise, critique, meta-critique, conclua, justifique, ooda" | method request |
+
+## RELATE — the map
+
+```mermaid
+flowchart TD
+  P3["P3 purpose: ENTENDER"]
+  P2["P2 operation set (open)"]
+  P1["P1 ordering: lossless before lossy"]
+  P7["P7 necessity: both required"]
+  P5["P5 method: divide to conquer"]
+  P8["P8 open extension"]
+  P9["P9 acceptance: not-theater"]
+  P11["P11 scope: recursive"]
+
+  P3 -->|"IS THE MEMBERSHIP TEST FOR"| P2
+  P5 -->|"is the method behind, not a member of"| P2
+  P9 -->|"gates"| P8
+  P8 -->|"extends"| P2
+  P1 -->|"strictly stronger than"| P7
+  P11 -->|"makes recursive"| P1
+  P4 & P6 -.->|"glosses, collapse into"| P3
+```
+
+**Three edges carry everything, and none of them is a node:**
+
+1. **`P3 → P2` is the decisive one.** The purpose is not a justification appended to the list — it is
+   the list's **membership test**. An operation belongs iff its goal is *understanding*. So `/etc` is
+   not vagueness; it is the **explicitly open set**, and P3 says how to decide entry.
+2. **`P1 ⊃ P7`.** Ordering is *strictly stronger* than necessity. "Both are needed" permits any order;
+   "before" does not. Answering only P7 — which every prior pass did — under-answers the claim.
+3. **`P9 gates P8`.** "More ismos" is not an invitation to enumerate. It is bounded by not-theater.
+
+## PRISM — make "entender" measurable
+
+The membership test is abstract. Decomposed to checkable leaves:
+
+> An operation belongs to the lossless movement **iff**
+> **(a)** it discards nothing *(D — does it remove anything? binary)*
+> **(b)** after it, you can answer a question you could not before *(T — name the question)*
+> **(c)** it can halt on "I cannot do this to this input", **or** it emits an artifact *(D)*
+
+Applied to the operator's own set:
+
+| Operation | (a) lossless | (b) unlocks the question | (c) | Verdict |
+|---|---|---|---|---|
+| dissecar | ✅ | "what parts?" | halts | **member** |
+| identificar / tipar | ✅ | "what IS this part?" | halts | **member** (one survives — near-synonyms) |
+| inter-relacionar / inter-conectar | ✅ | "what depends on what?" | halts | **member** (one survives) |
+| prismar | ✅ | "what is measurable here?" | halts (`inconclusive`) | **member** |
+| catalogar / categorizar | ✅ | "what was in there?" | **emits** | **member — artifact, not gate** |
+| **separar** | ⚠️ **ambiguous** | — | — | **sense-dependent, see below** |
+
+**The predicate caught a straddler.** `separar` has two senses: *distinguish* (lossless → member) and
+*set aside* (lossy → belongs with distill). The same Portuguese verb sits on both sides of the hard
+boundary. A list could never have surfaced that; only the test could.
+
+## DISTILL — drop-list with reasons
+
+| Dropped | Reason |
+|---|---|
+| P13 (valide/analise/critique/…) | session-meta — governs the *answer's form*, not the claim |
+| P12 ("sim ou não?") | verdict request, not content |
+| P4, P6 | glosses of P3 — collapse into it. ⚠️ Their **triplication is signal**: P3 stated three ways is the load-bearing claim, not noise |
+| `tipar`, `inter-conectar`, `categorizar` | near-synonyms / subsumed — one survives per concept |
+
+## DECIDE — the lossy act, stated as such
+
+Kept `identificar` over `tipar` (broader), `inter-relacionar` over `inter-conectar` (relation ⊃
+connection), `catalogar` over `categorizar` (categorizing is *how* you catalogue). **These choices
+kill alternatives and are not re-derivable from the artifact** — which is exactly what makes this
+step lossy and why it comes after, never before, the map above.
+
+## RENDER — the lapidated thesis
+
+```text
+Before any LOSSY operation — decide · distill · shape — run every LOSSLESS
+operation that increases legibility, and EMIT what it produces.
+
+MEMBERSHIP (the list is an instance; this is the definition)
+  An operation belongs to the lossless movement iff:
+    (a) it discards nothing;
+    (b) after it you can answer a question you could not before;
+    (c) it can halt on "I cannot do this to this input", or it emits an artifact.
+  Known members: dissect · identify · relate · prism · catalogue.
+  "etc" is the open set. Extend by the test, never by taste.
+  Beware straddlers: "separate" is a member in the sense DISTINGUISH,
+  and belongs to the lossy side in the sense SET ASIDE.
+
+METHOD      divide to conquer.
+ORDERING    strictly stronger than "both are necessary" — the order is the claim.
+ACCEPTANCE  not-theater: every added operation must pass (a)(b)(c).
+SCOPE       recursive — binds the tools we generate exactly as it binds us.
+```
+
+## Verdict
+
+**The best version is not any of the six.** It is the one produced by running the pipeline on them:
+the previous five passes each argued about *which enumeration* was right, and the enumeration was
+never the claim. `P3 → P2` was an **edge** — invisible to five rounds of comparing node-lists, and
+recoverable in one pass of RELATE.
+
+That is the same shape as dogfood #1, where the decisive insight was also an edge. Twice now, on
+different inputs: **comparing catalogues finds nodes; only the map finds what matters.**

--- a/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
+++ b/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
@@ -184,3 +184,121 @@ no skill.** Two red-team passes at ~600k subagent tokens each found what six sel
 missed — which is the skill's own thesis confirming itself, and also its efficiency indictment.
 
 **Next**: an independent re-eval of v0.3.0 by a fresh cycle — not by this one.
+
+---
+
+# DELTA — v0.3.0 RE-EVALUATED (the re-eval the line above asked for)
+
+Four blind agents, dispatched in parallel against a **frozen artifact** (SHA verified identical to the
+dispatch commit, tree clean — no edit entered mid-test). Three behavioral trials, one cold-start
+operability interrogation with no run. Author excluded from all scoring; the author's role was
+dispatch, repair of the dispatch, and this write-up.
+
+## The method had to be repaired before it could measure anything
+
+The first dispatch plan was red-teamed and returned **REFUTED**, four blocking. All four were real.
+
+| # | Defect in the plan | Why it would have invalidated the result |
+|---|---|---|
+| B1 | `SKILL.md` names the two test cases' tokens **with their verdicts** (`fulano`→halt, `sistema X`→carry). | An agent applying the rule and an agent copying the example emit identical output *and identical citations*. The plan's self-report item was not a control. **Repaired by replacing the inputs, not by redacting the artifact** — redaction would have mutated the thing under test. New inputs verified token-disjoint (16/16 → 0, with a positive control proving the grep reached the file). |
+| B2 | The trial directory held the plan itself and a solved DoD spec. | Leak. Repaired: one directory per trial, neutral filename, planner artifacts out of reach, `examples/` structurally absent rather than politely forbidden. |
+| B3 | Sub-agent bound **4** — *below* the procedure's own mandated delegation count (~12-16). | Would fire in REFINE round 2; every reported TERMINATION would describe the harness, not the procedure. Raised to 24. |
+| B4 | Iteration bound **12** — *numerically identical* to `--max-rounds=12`. | A run reaching 12 is indistinguishable between "procedure hit its cap" and "harness cut it off" — and which stop fires is the claim under test. Raised to 20. |
+| **B5** | Found at dispatch time, in the repaired plan: nine items of report **format** and no **delivery channel**. | Four agents completed work they could not hand over; two idled twice with reports stranded. A report format is not a report path. |
+
+**Confirmation the repairs mattered**: no harness bound was reached in any run (0 of 24 delegations
+in two trials, 1 refuter in the third; 3 of 12 rounds). Every termination was the procedure's own.
+
+## Claim-by-claim
+
+| Claim | Verdict | Evidence |
+|---|---|---|
+| Floor removed from every surface | **HELD** | The interrogation enumerated 12 termination passages and returned `RESOLVED`: governing condition for `default` is the economic stop alone. **And** the executing trial evaluated the Verifiability Gate's three conjuncts to `false` and exited REFINE at **3 rounds** — under an unconditional floor it needs ≥6 by construction. |
+| Classified red-team returns + precedence | **HELD** | All three disproof clauses passed; the precedence is written and names the exact arithmetic. The executing trial exercised the missing-fact branch live (1 of 2 cycles used, not exhausted). |
+| Proportionality discriminates | **HELD** | The carry-open trial carried its role-named node open **on two axes**, refused to guess it (`Do not guess the identity of any of the four systems`), and proceeded through 4 of 5 phases. Both disproof clauses silent. |
+| DISSECT is the single referent halt site | **DISPROVED** | Two passages in the same section make **opposite** phase assignments. One assigns the absent-referent class to RELATE; the other states "DISSECT is the single halt site for referents" and denies RELATE halts on naming — while elsewhere granting RELATE "goal-blocking dangles", which an absent referent in a dependency chain also is. |
+| Every halt names a terminal marker | **DISPROVED** | **13 of 29 stop/refuse/escalate points carry no marker; 4 more are inferred.** Sink-refusal, gitleaks-abort and partial-sink-failure have no marker *and no field in the machine envelope*. |
+
+**3 held, 2 disproved.** More precise than v0.1.0's flat FAIL: the surviving claims are now named, and
+so is the reason the others do not survive.
+
+## The self-check the document sets and fails
+
+§Failure modes asserts: *"(Every halt names a terminal marker; a halt without one is an unfinished
+rule.)"* Applied corpus-wide, **11 of the 13 markerless points sit outside §Failure modes** — in
+§Skip conditions, §When not to use, §Output targets, §Multi-target semantics.
+
+The rule was enforced where it lives, not across its domain. This is structurally identical to the
+REFINE floor defect repaired three times in this same cycle — two surfaces, then four, then a seventh
+in §Purpose, a summary paragraph that describes the rule without being it. Enumerating by *section*
+finds the first kind; enumerating by *string* finds both.
+
+## Findings no claim covered
+
+- **The default path fails the skill's own membership test.** With `--output-target` omitted the
+  document specifies *"return inline only"*. But `inline` is **not one of the five sink kinds**, so it
+  has no Render cell — and criterion (b) of the skill's own test is *"RENDER DEFINED — the distillate
+  has a defined form for that sink"*. Compounded: `--output=table` is the default and has **no
+  schema** (`ABSENT` — it appears only as a default cell and an allowed value; §Output contract is
+  titled `(--output=json)` and does not mention it). The no-flag path has neither sink render nor wire
+  format. Corroborated behaviorally: two trials independently reported inventing the catalogue column
+  schema and the relation-map format.
+- **The leak gate is inert on the default path.** It fires *"whenever ≥1 target declares
+  `shared-surface: yes`"*; `stdout` and `clipboard` are both `no`. A clipboard-only run — or the
+  default inline path — never triggers it. The clause *"a leak aborts all targets — including
+  clipboard, which is not exempt"* stays true and becomes vacuous: nothing aborts if nothing ran.
+  Specification defect, not an observed leak — this artifact is a document, not a runtime.
+- **The recursion clause is unimplemented in `default`.** It names `SCOPE` as that profile's *method
+  section* and requires it to instruct the executing agent to decompose. `profiles/default.md` defines
+  `SCOPE` as a declaration by the prompt's author, and the profile's eight sections contain no method
+  section at all. The executing trial resolved this by applying the clause over the profile — one
+  defensible reading of two.
+- **Cited paths need an undeclared base.** Every internal path resolves, but only after choosing
+  between repo-root-relative and skill-relative — and both bases appear in a single table cell. Four
+  agents are cited without `.md` and fail `test -e` as written.
+- **22 decisions the document does not make** for an agent holding only these files, a short input,
+  and nobody to ask.
+
+## The aggregate: three inputs, three classes, three halts, zero prompts
+
+| Trial | Class | Halted at | Marker |
+|---|---|---|---|
+| t2 | referentially empty | PHASE 1 RECOVER / DISSECT | `STOP-HITL` |
+| t3 | concrete goal, unnamed acceptance threshold | PHASE 1 RECOVER / DISSECT | `STOP-HITL` |
+| t1 | carry-open (goal + DoD survive one role-named node) | PHASE 4 RED-TEAM, missing-fact | `STOP-HITL` |
+
+Each halt is individually defensible and traceable to a quoted clause — and t3's was independently
+derived from the document alone by the interrogation, so it is conformance, not drift. But a skill
+whose stated purpose is *"ONE polished, ready-to-execute PROMPT"* rendered **zero** across three
+classes, including one input constructed to be renderable. The halt surface may be large enough that
+RENDER is rarely reachable. That is a design question this eval raises and does not settle.
+
+## Standing finding, refined rather than repeated
+
+The v0.1.0 standing finding was: *the control produced a comparable prompt in one pass, with no
+skill.* This cycle sharpens it in both directions.
+
+**Against the skill**: a competent agent must supply 22 decisions before it can finish a run. Much of
+what looks like the skill working is the agent filling gaps.
+
+**For the skill**: the one trial that reached the pipeline's interior produced material a single pass
+does not. Its relation graph found that the operator's DoD is *the measurable inverse of the observed
+symptom* — so acceptance reads the same signal that evidences the problem — and that the described
+failure has *two independent facets* where fixing either leaves the loop intact. Both were marked
+decisive; both are edges, not nodes. `derive-system-from-goal` fired on a recurring goal and produced
+a signal admissible under the observability rule (*fires **and** moves*, not a run-count). The
+independent refuter returned 10 findings, two of them missing-facts the draft's author had not seen —
+including that the draft's own derived mechanism imposed a duty on a person without anyone asking
+whether the operator had authority to impose it.
+
+Independently, on a different input, that trial re-derived a structural finding a previous dogfood had
+gotten wrong and later corrected: that a resource list and a directive chain **intersect**, and that
+saying the same thing twice in two syntaxes is emphasis rather than mass.
+
+So the delta is real, and it is **mechanically-derived material plus independent refutation** — not
+the qualitative judgment, which the control matched. The skill is not broken. It is
+**under-specified**: its machinery earns its keep when the pipeline runs, and its document does not
+yet tell a cold agent enough to run it the same way twice.
+
+**Verdict: FAIL — 3 claims held, 2 disproved, 22 decisions undelegated.** The failure is
+specification, not mechanism. The next cycle should close Q15's 22 before adding capability.

--- a/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
+++ b/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
@@ -122,3 +122,65 @@ therefore **downgraded, not cleared**, exactly as that row promised.
 *Artifacts: `/tmp/eval-rbtp/case-{A,B}.braindump.md` (synthetic; the operator's real braindumps were
 not used — they remain objects of manipulation under a standing constraint). Traces reviewed for
 secrets before writing; inputs are synthetic and contain no PII.*
+
+---
+
+# DELTA — v0.2.0 (fix round 1) and v0.3.0 (fix round 2)
+
+`agentic-tool-trainer` `improve` mode, iterations 2 and 3 of a 3-iteration cap. Same golden-set,
+same blind-agent protocol, author excluded from scoring throughout.
+
+## v0.2.0 — re-evaluated. Three blocking defects VERIFIED repaired.
+
+| # | Fix | How the independent agent verified it |
+|---|-----|---------------------------------------|
+| A9.1 + A9.2 | Floor is **profile-scoped**, not global | *"Was the predicate satisfiable? **Yes** — on this profile, and only because of the v0.2.0 repair."* The gate evaluated `false`, the floor switched off, the economic stop governed alone |
+| A9.3 | Stopped claiming a master condition REFINE does not meet | Ran `bin/convergence-guard` and got the **exact predicted string**: `REFUSE correlated-verifier-violates-independence`. *"reproduces the skill's own predicted string verbatim"* |
+| B2 | Drop-list `MUST` conditional on reaching DISTILL | Case B: *"The drop-list absence is explicitly licensed, not a gap"* · Case A: emitted, DISTILL reached |
+| B1 + B5 | Referent check in DISSECT; `relate` non-skippable | Case B halted **at DISSECT** citing the new clause; ran `relate` anyway and found two undecidable edges the parts list cannot expose |
+| A9.6, B3 | Straddler rule; resolution-paths | Case A kept `busque semelhantes`/`invoque Forge` as constraints; both cases emitted ranked resolution-paths and refused candidate goals |
+
+**But both cases still terminated `STOP-HITL`.** The evaluator's own summary: *"The repair moved the
+failure, it did not remove it."*
+
+## The second generation of defects — and the two that were mine
+
+Two independent agents converged on the same gap from opposite directions. Case B **predicted** it
+(*"there is no proportionality clause on the referent-halt"*); Case A **hit** it (`sistema X`, the
+one redacted token in an otherwise concretely-named dump).
+
+| # | Defect | Origin |
+|---|--------|--------|
+| **C5** | The `RED-TEAM → REFUTED → REFINE` cycle is **unbounded**, with no precedence rule against the economic stop. Making the stop govern alone (the v0.2.0 fix) made the collision *structural*: refutation at round 4 demands a round 5 that is over-cap by construction | **introduced by the v0.2.0 fix** |
+| **C1 + C3** | Same input, two halt sites — the pipeline block assigns unresolvable-referent to RELATE, the new §Typing clause assigns it to DISSECT. And the criterion has two readings that yield **different terminal states** | **introduced by the v0.2.0 fix** |
+| **C4** | `profiles/default.md` still asserted the floor. **The fix landed in SKILL.md and not in the profile** — one surface of two. A second surface (the REFINE line in the pipeline block) was found only while repairing the first | **incomplete v0.2.0 fix** |
+| C2 | No failure mode mapped a RECOVER halt to a STOP marker | pre-existing |
+| C6 | `RENDER := … + persist decision` vs `--output-target` omitted → inline only | pre-existing |
+| C7, C8, C9 | `--output=table` schema undefined · gate conjunct phase-ambiguous · PRISM applicability ambiguous, so its two failure modes were **never exercised** — *"I can confirm they are documented, not that they work"* | pre-existing |
+
+## v0.3.0 — fixes applied, **NOT re-evaluated**
+
+| Fix | What changed |
+|-----|--------------|
+| **C1 + C3 + Case-B proportionality** *(one root)* | DISSECT is the **single halt site for referents**; `relate` halts on graph properties only. Added the proportionality rule: a referent halts **only if the goal or the DoD depends on it** — otherwise carry it as a named open parameter into ESCALATION, never guess it. Worked contrast documented from both measured cases |
+| **C5 + C2** | RED-TEAM refutations are **classified**: a *craft defect* returns to REFINE bounded by `--max-redteam-cycles` (default 2); a *missing fact about the operator's world* → `STOP-HITL` immediately, because no number of rounds can manufacture a fact the dump lacks. Explicit **precedence**: this outranks the economic stop, which caps iteration *within* REFINE only. Every halt now names a terminal marker |
+| **C4** | Floor removed from `profiles/default.md` **and** from the REFINE line of the pipeline block, with the rationale inline so it is not re-added |
+| **C6** | `persist decision` defined: the recorded *choice* of sinks; "inline only" **is** the record, not a no-op |
+
+⚠️ **v0.3.0 carries no independent verification.** The trainer's iteration cap (3) is reached: eval →
+fix → re-eval → fix. A fourth pass would exceed the bound the trainer sets, and the author re-scoring
+his own third revision is precisely the correlated-verifier failure this report already documents
+twice. **Status: v0.3.0 is an un-re-evaluated candidate.** The verified state of the world is v0.2.0
+— three blocking defects repaired, a second generation open.
+
+## Standing verdict
+
+**FAIL → improved, still not PASS.** Two generations of blocking defects found and repaired under
+independent verification; a third generation applied but unmeasured. The Pareto guard holds: no case
+regressed across v0.1.0 → v0.2.0.
+
+The finding that outlives the verdict: **the control produced a comparable prompt in one pass, with
+no skill.** Two red-team passes at ~600k subagent tokens each found what six self-critique rounds
+missed — which is the skill's own thesis confirming itself, and also its efficiency indictment.
+
+**Next**: an independent re-eval of v0.3.0 by a fresh cycle — not by this one.

--- a/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
+++ b/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
@@ -1,0 +1,124 @@
+# EVAL-REPORT — refine-braindump-to-prompt (skill) — 2026-08-14
+
+- **Baseline**: none (first eval, v0.1.0)
+- **Golden cases**: 3 (smoke-set, synthetic — low-confidence flag per `agentic-tool-evaluator` step 2)
+- **Independence**: the skill's author did NOT score behaviour. Three sub-agents ran blind to authorship
+  and to expected outcome. Deterministic checks (D1–D3) were run by the author — they carry no judgment.
+- **Run by**: `maos:agentic-tool-evaluator` v1.1.0 method (behavioral, with/without control)
+
+## Why this eval exists
+
+`persist-locus.md` gates persistence into `multi-agent-os` on **dogfood ≥2 + evaluator**. Dogfood reached
+5/2; the evaluator had never run. The ledger recorded that as `PERSISTED ⚠️ gate-incomplete` rather than
+hiding it. This report closes the open conjunct — and the answer is not the one the author expected.
+
+## Cases
+
+| ID | Input | Condition | Tests |
+|----|-------|-----------|-------|
+| A | synthetic braindump: recurring goal + a silent-failure dependency | **with** skill | full pipeline, recurrence clause, PRISM |
+| B | synthetic braindump: referentially empty (`aquilo`, `o fulano`, `a abordagem nova`) | **with** skill | documented HALT conditions |
+| C | same input as A | **without** skill | baseline — isolates the tool's actual effect |
+
+## Scores (0–5; ScopeFit −2..+2)
+
+| Case | Trigger | TaskCompl | ToolCorr | Effic | ScopeFit | Regression |
+|------|---------|-----------|----------|-------|----------|------------|
+| A | 5 | **2** | **3** | **1** | +1 | n/a (no baseline version) |
+| B | 5 | 5 | 4 | 4 | +2 | n/a |
+| C | — | 4 | — | 5 | — | *(control, not scored as tool)* |
+
+## Verdict: **FAIL**
+
+Not because the output is bad — case A's rendered prompt is strong, and case B halted exactly as designed.
+It fails because **the pipeline cannot terminate cleanly on its own default profile**, and because two of
+its own cited primitives contradict it.
+
+### Blocking findings
+
+| # | Finding | Why it is blocking |
+|---|---|---|
+| **A9.1** | `stop_refine` floor requires **≥6 rounds** (revisions ≥3 AND clean_rounds ≥3 — a round is one or the other, never both). When `long_loop_licensed = false`, the cap is `n* ≤ 3–4`. **Floor > cap.** `profiles/default.md` states the gate "normally evaluates false for this profile" | every default-profile run hits an unsatisfiable predicate |
+| **A9.2** | `clean_rounds` requires distinct lenses per round; the profile draws them "in rotation so no round repeats a lens". Under the cross-round reading, 3 clean rounds need **9 distinct lenses** and the roster holds **5** | `STOP-DONE` is **unreachable** on the default profile |
+| **A9.3** | The skill assigns PHASE 3 to `convergence-engine`, whose master condition is `verifier > generator ∧ independent` — but its REFINE loop has the draft's author as critic. Run against it, `bin/convergence-guard` returns `REFUSE / correlated-verifier-violates-independence` | the skill's own cited primitive rejects the skill's own phase. Empirically confirmed: RED-TEAM found 2 BLOCKING defects that 6 self-critique rounds missed |
+| **B2** | The absorption law states an unconditional `MUST emit both the parts catalogue AND the drop-list-with-reasons`, but DISTILL is positioned `← LAST`. On any RECOVER halt, DISTILL never runs | a `MUST` that the phase ordering makes unsatisfiable |
+
+### Major findings
+
+| # | Finding |
+|---|---|
+| **B5** | The escalation clause (*"one with three independent parts barely needs `relate`"*) permits skipping the **one gate that catches the referentially-empty input class** — whose parts *look* independent on a surface read. Mitigated by an unconditional goal-absent backstop, so the outcome is robust; the **diagnosis quality** is what degrades |
+| **A9.5** | The PRISM halt reads only `inconclusive.flag`. In case A that flag was `false` while `structural_route.py` independently returned `human_review: true, allowed_use: assistive_only`. The skill never reads the router's verdict — a DoD its own primitive says needs human review passes the gate untouched |
+| **A9.7** | The Validation section cites `skills/maos:refine-braindump-to-prompt/SKILL.md` and `commands/maos:...`. **No skill directory carries a `maos:` prefix** — that is the invocation namespace, not a path segment. Same wrong path in the command file. Both artifacts exist; only the documented paths are wrong |
+| **A9.4** | The recursion clause mandates a `BUILD-METHOD` section, which exists only in `gauntlet-loop`. Unfollowable under `--architecture=default` |
+| **A9.6** | Two braindump bullets were dropped as session-meta, but the independent refuter argued `busque semelhantes` and `invoque Forge` are **output-shaping constraints wearing method-directive clothing**, and that rendering `use [tooling]` as "permissible, none mandated" **inverted an imperative into a permission**. The skill's own straddler test anticipates this class; its Protocol Rules give the opposite instruction |
+| **B1 / B3** | DISSECT's halt test is ambiguous between speech-act and referent readings (different halt sites, same input). "Ranked hypotheses (never guess a goal)" is self-tensioned on zero-content input |
+| **B4** | Two lineage blockquotes number the movements with an off-by-one (Alambique=M2/M3 vs M1/M2). Zero pipeline effect; two drafts left in place |
+
+## Deterministic checks (author-run, no judgment)
+
+| # | Check | Result |
+|---|-------|--------|
+| D1 | `/slash` invocation surface — `commands/` wrapper exists | PASS (positive control: `gap-loop` wrapper found) |
+| D2 | command `name:` matches skill `name:`; description 767 < 1024 | PASS |
+| D3 | `tests/validate-plugin.sh` | PASS rc=0 |
+
+Note: D3 passing is itself a finding — **no structural gate in this repo catches A9.1, A9.2 or A9.7.**
+
+## Strengths (measured, not asserted)
+
+- **Case B halted correctly, and halted *with a receipt*** — it emitted the parts catalogue and relation
+  map (5 nodes, 0 resolvable edges) before refusing, rather than bouncing at the door. The artifacts
+  *are* the evidence for the halt.
+- **Prompt-injection posture held in both cases.** Braindump imperatives were catalogued as objects,
+  never executed.
+- **RELATE earns its place.** In case A it found the decisive edge — the stated DoD is a *lagging*
+  indicator, observable only after sending, so it can never gate the send. That is a property of an
+  edge, not of any part, and it restructured the entire ACCEPTANCE section into three tiers.
+- **PRISM's veto-gate rule caught a real modelling error**: "statement closed" had been placed as a
+  weighted leaf, where a high sibling averages a hard blocker away.
+
+## Weaknesses
+
+- **Efficiency is the worst score, and it is measured, not impressionistic.** Case A ran 12 rounds and
+  two red-teams and still terminated `STOP-HITL` with 1 BLOCKING un-applied. The control (case C)
+  produced a comparably-structured prompt in **one pass, no skill** — it independently found the
+  silent-failure spine, rejected the "someone forgets" framing as symptom-not-cause, demoted the
+  tooling list to a conditional rung, and split verifiable-now from lagging acceptance.
+- **The delta is real but narrower than the design assumed.** What the skill adds over baseline is the
+  *mechanically derived* material: the lagging-indicator edge, the Prisma spec with executed scripts,
+  the structural router's `dispositional / assistive_only` verdict, and an independently-verified
+  red-team. What it does *not* add is the qualitative judgment — the model already had that.
+- **The most-emphasised phase is the least-enforced.** RECOVER's artifacts are mandated in three places;
+  RED-TEAM independence once. Yet the drop-list is where case A erred, self-critique missed both
+  BLOCKING defects, and the independent red-team found them.
+
+## Recommendation
+
+→ **`agentic-tool-trainer`.** The evaluator is read-only by contract; the fixes below are the trainer's.
+
+Ordered by severity:
+
+1. Reconcile A9.1 — either license the long loop for `default`, or lower the floor beneath the cap.
+   As written the two clauses cannot both hold.
+2. Resolve A9.2 — state the lens-reuse rule as within-round explicitly, or expand the roster to ≥9.
+3. Resolve A9.3 — either mandate `convergence-guard` on PHASE 3 (and accept that REFINE must use an
+   independent critic), or stop citing `convergence-engine` as its primitive.
+4. Fix B2 — make the drop-list obligation conditional on reaching DISTILL, or move DISTILL ahead of
+   the halt. Currently it is an unsatisfiable `MUST`.
+5. Close B5 — make `relate` non-skippable, or add referent-resolvability to DISSECT (it is the
+   discriminating property of the empty-input class and currently exists only as a RELATE side effect).
+6. Fix A9.7 paths, A9.5 router signal, A9.4 profile-section mismatch, A9.6 straddler contradiction,
+   B1/B3 ambiguities, B4 off-by-one.
+
+## Gate disposition
+
+**The `persist-locus` gate is NOT cleared.** The evaluator has now run — the missing conjunct is
+satisfied procedurally — but it returned `FAIL`. The ledger's `PERSISTED ⚠️ gate-incomplete` is
+therefore **downgraded, not cleared**, exactly as that row promised.
+
+---
+
+*Artifacts: `/tmp/eval-rbtp/case-{A,B}.braindump.md` (synthetic; the operator's real braindumps were
+not used — they remain objects of manipulation under a standing constraint). Traces reviewed for
+secrets before writing; inputs are synthetic and contain no PII.*

--- a/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
+++ b/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
@@ -267,11 +267,22 @@ finds the first kind; enumerating by *string* finds both.
 | t3 | concrete goal, unnamed acceptance threshold | PHASE 1 RECOVER / DISSECT | `STOP-HITL` |
 | t1 | carry-open (goal + DoD survive one role-named node) | PHASE 4 RED-TEAM, missing-fact | `STOP-HITL` |
 
-Each halt is individually defensible and traceable to a quoted clause — and t3's was independently
-derived from the document alone by the interrogation, so it is conformance, not drift. But a skill
-whose stated purpose is *"ONE polished, ready-to-execute PROMPT"* rendered **zero** across three
-classes, including one input constructed to be renderable. The halt surface may be large enough that
-RENDER is rarely reachable. That is a design question this eval raises and does not settle.
+Each halt is individually defensible and traceable to a quoted clause. But a skill whose stated
+purpose is *"ONE polished, ready-to-execute PROMPT"* rendered **zero** across three classes, including
+one input constructed to be renderable.
+
+Two qualifiers, both supplied by the trials rather than by the author:
+
+- t3's halt was independently derived from the document alone by the interrogation, so it is
+  conformance, not drift.
+- t1's halt sat **one defensible fork from rendering**. It recorded that treating the refuter's
+  missing-fact as a fixable ESCALATION gap instead — adding the question, running one more REFINE
+  cycle and a second red-team pass — would on a clean verdict have reached RENDER with `STOP-DONE`:
+  the opposite terminal state, still inside the declared cycle budget (1 of 2 used).
+
+So the halt surface is large; whether it is *too* large is not settled by three runs, and this report
+does not claim it is. What is settled: the render path was not reached, and the document does not
+adjudicate the fork that would have reached it.
 
 ## Standing finding, refined rather than repeated
 
@@ -291,9 +302,18 @@ independent refuter returned 10 findings, two of them missing-facts the draft's 
 including that the draft's own derived mechanism imposed a duty on a person without anyone asking
 whether the operator had authority to impose it.
 
-Independently, on a different input, that trial re-derived a structural finding a previous dogfood had
-gotten wrong and later corrected: that a resource list and a directive chain **intersect**, and that
-saying the same thing twice in two syntaxes is emphasis rather than mass.
+On a different input, that trial produced a finding of the same shape as one a previous dogfood had
+gotten wrong and later corrected — that a resource list and a directive chain **intersect**, and that
+saying the same thing twice in two syntaxes is emphasis rather than mass. **The trial declares this
+was primed**, unprompted: `SKILL.md` narrates that earlier measurement inline, and the agent said so
+rather than claiming independence. Recorded here as a primed application of a documented finding, not
+as an independent re-derivation — the first draft of this delta claimed the latter, and was wrong.
+
+That correction exposes a second contamination axis the method missed. B1 removed token-identity on
+the axis under test (halt-vs-carry). It did not check that the document **narrates other prior
+findings inline**, and those prime other moves. The repair was enumerated over the axis being
+measured rather than over the domain — the same defect shape this report keeps finding elsewhere,
+here committed by the eval's own author, in the eval's own method.
 
 So the delta is real, and it is **mechanically-derived material plus independent refutation** — not
 the qualitative judgment, which the control matched. The skill is not broken. It is

--- a/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
+++ b/skills/refine-braindump-to-prompt/examples/EVAL-REPORT-2026-08-14.md
@@ -322,3 +322,7 @@ yet tell a cold agent enough to run it the same way twice.
 
 **Verdict: FAIL — 3 claims held, 2 disproved, 22 decisions undelegated.** The failure is
 specification, not mechanism. The next cycle should close Q15's 22 before adding capability.
+
+---
+
+*Signed: Claude-Eval-ef60-321 | 2026-08-14T17:47:00-03:00*

--- a/skills/refine-braindump-to-prompt/profiles/default.md
+++ b/skills/refine-braindump-to-prompt/profiles/default.md
@@ -32,11 +32,15 @@ Default `--lenses=3`, drawn in rotation so no round repeats a lens:
 
 ## Loop budget
 
-Inherits the skill defaults: `--min-revisions=3`, `--clean-rounds=3`, `--max-rounds=12`.
+Inherits `--max-rounds=12` and `--max-redteam-cycles=2`. It does **NOT** carry a revision/dryness
+floor: the Verifiability Gate normally evaluates **false** for this profile (a generic prompt rarely
+has a machine-verifiable external bar), and on an unlicensed run the economic stop governs **alone**
+— convergence expected within `n* ≤ 3-4` productive rounds, **not** "beyond the floor".
 
-The Verifiability Gate normally evaluates **false** for this profile (a generic prompt rarely has a
-machine-verifiable external bar), so the economic stop applies: convergence is expected within
-`n* ≤ 3-4` productive rounds beyond the floor.
+> The floor (`--min-revisions=3` AND `--clean-rounds=3`) belongs to `gauntlet-loop`, which licenses
+> the long loop. Asserting it here re-creates the defect repaired in v0.2.0: a floor needing ≥6
+> rounds against a cap of 3-4. Passing the flags explicitly on this profile is honoured but warns —
+> you are opting into a budget the gate did not license.
 
 ## When this profile is wrong
 

--- a/skills/refine-braindump-to-prompt/profiles/default.md
+++ b/skills/refine-braindump-to-prompt/profiles/default.md
@@ -1,0 +1,44 @@
+# Profile: `default`
+
+Neutral architecture. Used when the braindump names no target prompt-architecture.
+
+## DRAFT shape
+
+The rendered prompt carries these sections, in this order. Omit a section only when the braindump
+genuinely has nothing for it — never pad.
+
+```text
+GOAL          one sentence, machine-checkable where possible
+CONTEXT       state-of-world the executing agent cannot infer
+SCOPE         in-scope AND out-of-scope, both explicit
+CONSTRAINTS   hard limits (tools, budget, permissions, guardrails)
+ACCEPTANCE    binary-checkable criteria (the DoD, from decompose-abstract-to-measurable)
+STOP          the terminating condition + what to do on exhaustion
+DELIVERABLES  concrete artifacts + where they land
+ESCALATION    what forces a human decision
+```
+
+## Lens roster (REFINE)
+
+Default `--lenses=3`, drawn in rotation so no round repeats a lens:
+
+| Lens | Asks |
+|---|---|
+| **completeness** | what would a fresh amnesic agent still have to guess? |
+| **executability** | can every instruction be acted on with the tools named? |
+| **falsifiability** | is ACCEPTANCE checkable, or is it a wish? |
+| **scope-drift** | does anything here invite work the operator did not ask for? |
+| **failure-path** | what happens when a step fails — is it written down? |
+
+## Loop budget
+
+Inherits the skill defaults: `--min-revisions=3`, `--clean-rounds=3`, `--max-rounds=12`.
+
+The Verifiability Gate normally evaluates **false** for this profile (a generic prompt rarely has a
+machine-verifiable external bar), so the economic stop applies: convergence is expected within
+`n* ≤ 3-4` productive rounds beyond the floor.
+
+## When this profile is wrong
+
+If the work is buildable, observable, reversible, and has a nameable external quality bar →
+use `--architecture=gauntlet-loop` instead; this profile will under-specify the critic.

--- a/skills/refine-braindump-to-prompt/profiles/gauntlet-loop.md
+++ b/skills/refine-braindump-to-prompt/profiles/gauntlet-loop.md
@@ -1,0 +1,123 @@
+# Profile: `gauntlet-loop`
+
+Renders a prompt in the **Gauntlet Loop** architecture (a.k.a. *Loop Engineering*): a lead agent
+decomposes a goal into independently-judgeable pieces, fans out builders, and gates each piece
+behind a **blind, independent critic** comparing the artifact against an **externally-named bar** —
+looping until the bar is met or a stopping rule fires.
+
+> Invoked as `--architecture=gauntlet-loop`. This is a **profile file inside this skill**, not a
+> skill and not a `/command` — it does not occupy the `gauntlet-loop` skill/command namespace.
+
+## Prior art (attribution — this profile composes, it does not claim)
+
+| Source | Contribution |
+|---|---|
+| **Matt Shumer**, [`mshumer/Claude-of-Duty`](https://github.com/mshumer/Claude-of-Duty) | The originating 152-word aim-prompt; the fan-out + harsh-critic + blind-A/B pattern |
+| **Addy Osmani**, [*Loop Engineering*](https://addyosmani.com/blog/loop-engineering/) (2026-06-07) | Formal name + the **5 mandatory components**, incl. stopping rules |
+| [`duolahypercho/gauntlet-loop`](https://github.com/duolahypercho/gauntlet-loop) (MIT) | Proves the fill-in-the-blank aim-prompt shape works as a skill. **Cited, not vendored** — see §Divergence |
+| [We0 analysis](https://we0.ai/articles/claude-opus-5-s-gauntlet-loop) · [Augment Code](https://www.augmentcode.com/guides/what-is-loop-engineering) | The verification harness (headless render, A/B contact sheets, perf assertions) |
+
+The canonical aim-prompt, preserved verbatim as the shape's ground truth:
+
+> *"I want you to build a first-person shooter at the level of the most recent Call of Duty games.
+> It should be utterly perfect, visually beautiful, with every single thing done at AAA quality—from
+> textures to physics to anything you could think of. Fan out sub-agents and have sub-agents tackle
+> each one individually so that the game is utterly perfect. You should /loop on each item and have
+> a separate sub-agent check it visually to ensure it looks triple A. That separate sub-agent should
+> be a really harsh critic, and if it doesn't look triple A, it should keep going. Don't stop until
+> each sub-agent is utterly wowed with the quality when compared with the actual Call of Duty game.
+> It should literally compare them side by side blind and say which one looks better. Do this in
+> ThreeJS. /loop until it's utterly perfect. Fan out sub-agents and ultracode."*
+
+## DRAFT shape
+
+Three load-bearing slots, then the guardrails the original leaves implicit:
+
+```text
+TASK          what to build, concretely
+BUILD-METHOD  fan-out topology: lead decomposes -> N builders, each on an independently-judgeable piece
+QUALITY-BAR   the EXTERNAL reference the critic compares against, named specifically
+              (not "beautiful" — "at the level of <named artifact>")
+
+CRITIC        an independent sub-agent, fresh context, no build history, prompted to REFUTE;
+              blind side-by-side against the bar; forbidden from silently lowering the bar
+EVIDENCE      what the critic may directly inspect (screenshots, test output, metrics, diffs)
+STATE         where attempt/failure history persists OUTSIDE the conversation
+STOP          cost ceiling · max attempts per piece · wall-clock · gain-stagnation delta
+ESCALATION    what forces a human decision
+```
+
+## The three psychological levers (why the shape works)
+
+| Lever | Mechanism |
+|---|---|
+| **Blind Critic** | A single agent reviewing its own output rationalises it — it knows the effort and accepts "looks done". A critic with **no build history** has no such attachment and judges the artifact cold. |
+| **Extreme Reference** | "Make it beautiful" resolves to the model's *average* aesthetic prior and stops early. An intentionally unreachable named bar plus blind A/B surfaces the **largest** gap, giving the builder a hyper-focused correction. |
+| **Destination over Route** | Specify the acceptance criterion, not the implementation. The model's own reasoning finds engineering the operator could not have specified. |
+
+## Osmani's 5 components → this repo's primitives
+
+The profile does not re-implement these; it wires the prompt to them.
+
+| Component | Primitive |
+|---|---|
+| 1. Machine-verifiable goal | `skills/decompose-abstract-to-measurable` (D/T/J leaves; `inconclusive` is a real verdict) |
+| 2. Real environment access | the executing host's tools, named explicitly in the rendered prompt |
+| 3. Durable external state | scratch/journal outside the conversation (persist-first discipline) |
+| 4. Inevitable verifier (hard gate) | `skills/red-team` + `bin/convergence-guard` (independence enforced deterministically) |
+| 5. Clear stopping rules | the skill's Verifiability Gate + `skills/convergence-engine` economic stop |
+
+## Lens roster (REFINE)
+
+| Lens | Asks |
+|---|---|
+| **bar-nameability** | is the quality bar a *named external artifact*, or an adjective? |
+| **critic-independence** | does the critic provably lack the builder's context? |
+| **evidence-inspectability** | can the critic *directly observe* the thing being judged? |
+| **decomposability** | is each piece independently judgeable, or do verdicts entangle? |
+| **stop-rule-presence** | are cost, attempts, clock and stagnation all bounded? |
+| **blast-radius** | is failure cheap and reversible at this loop length? |
+
+## Loop budget
+
+The Verifiability Gate typically evaluates **true** for this profile — so the profile budget
+applies rather than the bare economic stop. Defaults, all overridable:
+
+```text
+max_attempts_per_piece   10
+wall_clock               operator-set; no default (unbounded time is not a budget)
+cost_ceiling             operator-set; REQUIRED before any long run
+stagnation_delta         exit when round-over-round gain < threshold for 2 rounds
+```
+
+**The gate is not a formality.** If `bar_is_machine_verifiable` is false, this profile degrades to
+the economic stop — a long loop against an unverifiable bar buys self-assessment, not quality.
+
+## Divergence from `duolahypercho/gauntlet-loop`
+
+Cited as prior art; deliberately **not** vendored or installed. What differs and why:
+
+| Axis | Duola's skill | This profile |
+|---|---|---|
+| Stopping rule | *"you are the brake"* — none | Osmani's 5th component is **mandatory**; unbounded is refused |
+| Harness | "pure prompt, no harness" | wires the prompt to measurement, red-team and independence primitives |
+| Domain | games (ThreeJS, Godot) + a marketing-site example | domain-agnostic; the bar just has to be nameable and observable |
+| Recovery | operator fills the blanks | `goal-recovery` + Prisma recover DoR/motivation/goal/DoD from the braindump |
+| Governance | none | HUMAN_DOMAIN halt, worktree discipline, cost ceiling, escalation path |
+| Install | `./install.sh` into `~/.claude/skills` | no install; profile file, no namespace claim |
+
+Adopting the upstream skill instead would require a trust-tier gate and a pinned SHA — and would
+import the one property this profile exists to fix: an unbounded loop.
+
+## When this profile is WRONG (from the source guidance, kept)
+
+Do **not** render a gauntlet-loop prompt when:
+
+- a mistake is **expensive or irreversible** (prod mutation, data deletion, external disclosure);
+- the agent **cannot observe the true result** (no inspectable evidence → the critic is guessing);
+- the loop would expose **sensitive data or elevated permissions**;
+- **one careful human pass is cheaper** than building and supervising the loop.
+
+Any of these → fall back to `--architecture=default`, or escalate. This is the same boundary the
+skill's Verifiability Gate enforces; the profile restates it because this is where it is tempting
+to ignore.

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -262,6 +262,46 @@ else
     fail "plugin-scripts/gaac/delegate.sh missing or not executable"
 fi
 
+# ─── Frontmatter must actually PARSE as YAML ─────────────────────────────────
+# Root-cause fix (2026-08-14): every frontmatter check above greps for a LINE
+# (`^name: x$`) and therefore reports PASS on a file whose YAML the loader
+# rejects. A skill shipped with an unquoted plain scalar containing ': ' —
+# structurally unloadable — while this script printed "✓ PASSED". A grep answers
+# "does the text contain?", never "does the parser accept?"; the second question
+# is the one that decides whether the artifact loads at all.
+# Capability-detected: PyYAML absent → WARN, never a red build for a missing dep.
+echo "Validating frontmatter parses as YAML..."
+if python3 -c "import yaml" 2>/dev/null; then
+    YAML_BAD=$(python3 - "$PLUGIN_ROOT" <<'PYEOF'
+import glob, io, os, sys, yaml
+root = sys.argv[1]
+bad = []
+for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
+    for p in sorted(glob.glob(os.path.join(root, pat))):
+        if os.path.basename(p) == "README.md":
+            continue                      # docs, not artifacts (same rule as above)
+        try:
+            t = io.open(p, encoding="utf-8").read()
+            if not t.startswith("---\n"):
+                continue                  # 'missing frontmatter' is already warned above
+            yaml.safe_load(t.split("---\n", 2)[1])
+        except yaml.YAMLError as e:
+            bad.append(f"{os.path.relpath(p, root)} :: {str(e).splitlines()[0]}")
+        except Exception as e:
+            bad.append(f"{os.path.relpath(p, root)} :: {type(e).__name__}: {e}")
+print("\n".join(bad))
+PYEOF
+)
+    if [ -z "$YAML_BAD" ]; then
+        pass "all artifact frontmatter parses as YAML"
+    else
+        while IFS= read -r line; do [ -n "$line" ] && fail "unparseable frontmatter: $line"; done <<< "$YAML_BAD"
+    fi
+else
+    warn "PyYAML absent — frontmatter parse check SKIPPED (grep-only checks cannot catch a broken loader)"
+fi
+echo ""
+
 # Skill frontmatter
 SKILL_FILE="$PLUGIN_ROOT/skills/delegate-governance/SKILL.md"
 if [ -f "$SKILL_FILE" ] && grep -q "^name: delegate-governance$" "$SKILL_FILE"; then


### PR DESCRIPTION
## P0 — the skill merged in #321 does not load

`skills/refine-braindump-to-prompt/SKILL.md` on `main` **fails YAML parsing**:

```
mapping values are not allowed here
```

The frontmatter `description` is a plain scalar containing `: ` (in `Five phases:` and
`--output-target: stdout`). Measured on `origin/main` with a positive control — `skills/quiesce/SKILL.md`
parses from the same tree, so the instrument is sound and the defect is real.

**Timing**: CodeRabbit flagged it 🔴 Critical on #321 at `2026-08-14T18:42Z`. The fix was committed to
the branch at `c8589fd`, ~minutes after #321 merged at `20:54:37Z` — so the merge captured `ffe1e7f0`,
the commit *before* the fix. Nobody's error; a race.

## What this PR does

| | Change |
|---|---|
| **P0** | `description: >-` folded scalar. The `: ` survives **inside** the value — syntax corrected, content not sanitized away. |
| **Root cause** | `tests/validate-plugin.sh` printed `✓ PASSED` on the broken file. Every frontmatter check greps for a **line** (`^name: x$`), which answers *"does the text contain?"* — never *"does the parser accept?"*. Fixing only the file leaves the next skill free to ship the same class. |
| **New gate** | YAML-parse check in the validator: capability-detected (PyYAML absent → WARN, never a red build for a missing dep — the pattern the script already uses for `python3`/json), skips `README.md` per the existing artifact/doc exclusion. |

## Why the gate is safe, measured before adding it

- **144** artifacts parse today; the only **3** without frontmatter are `README.md` / `COWORK-AUTONOMY-POLICY.md` — docs, already excluded. **No pre-existing breakage is turned red.**
- **Negative control**: reintroducing the exact shipped defect turns the build **red** with the exact message; restoring returns it **green**. A gate proven to bite, not asserted to bite.

## Also (CodeRabbit minors from #321)

- `n* ≤ 3-4` read as **subtraction** in math syntax → `n* (typically 3 or 4)`, plus the closed form it derives from (`agentic-first §4.7.6`) now stated, so the bound is a computed predicate rather than a magic literal.
- CHANGELOG population wording restored to the eval's measured *"stop/refuse/escalate points"*.
- Eval report signed (agent ID + ISO 8601) per the repo MUST.

## Verification

```
validate-plugin.sh          rc=0  ✓ PASSED
frontmatter parses          ✔ (PyYAML, keys: name/version/description/allowed-tools)
negative control            ✔ red on defect, green on restore
machine envelope            ✔ valid JSON after comment-strip
```
