### PR TITLE
fix(skills): retract a false n* claim — cite convergence-engine as SSOT

### DIFF
--- a/skills/convergence-engine/SKILL.md
+++ b/skills/convergence-engine/SKILL.md
@@ -8,7 +8,7 @@ description: |
   three regimes by verifiability — REFINE (self-improve loop), SELECT (best-of-N /
   debate→converge), DEFER (HITL) — under a non-negotiable master condition
   (verifier > generator, verifier independent) and a closed-form economic stop
-  (robustly ≤3–4 rounds). Composes existing primitives; builds no new engine.
+  (bounded by an economic stop whose round count is dominated by the retained-gap fraction ρ — see Economic stop). Composes existing primitives; builds no new engine.
   Use when a result must be driven to high quality through bounded iterative review
   rather than a single pass, when multiple proposals must be reconciled, or when an
   autonomy_score must be lifted across the HIGH gate before escalating to a human.
@@ -88,7 +88,37 @@ n* = 1 + ⌈ ln( (1−ρ)·g₀·V / C ) / ln(1/ρ) ⌉
    ρ = retained-gap-fraction · g₀ = initial gap · V = value/correct-unit · C = round-cost
 ```
 
-`n*` grows only **logarithmically** in `V/C` → **robustly ≤ 3–4 rounds** (100× the value buys ~1 more round). Floor = **human-parity (~90%, NOT 100%)**; cap is harness-enforced (`cascade-resolver` termination), not model-judged. Also stop on `Δ < ε for K rounds` OR consensus. The curve is **sub-geometric** (easy errors re-found, hard residual resists) → plateau arrives sooner; looping past `n*` costs 4–10× for <1% gain.
+**Round-count convention (binding — `n*` is the FIRST REJECTED round).** Round `k` shrinks the gap
+`g₀ρ^(k-1) → g₀ρ^k`, so it buys `V·g₀·(1−ρ)·ρ^(k-1)`; keep looping while that exceeds `C`. Solving
+gives `n* = last_affordable + 1` — verified numerically across 16 parameter sets (15/16; the 16th is
+the degenerate case where no round is affordable at all). ⇒ **the last round worth running is `n*−1`.**
+Anyone treating `n*` as a round *budget* runs **one round too many**.
+
+**Marginal-value indexing**: round `k` is affordable iff `V·g₀·(1−ρ)·ρ^(k-1) > C` — the value of the
+gap that round *closes*, not the gap remaining. Index from `k=1` (the first refine round after DRAFT).
+
+**Parameter bounds — `n*` is dominated by `ρ`, NOT by `V/C`.** The `ln(V/C)` numerator does grow only
+logarithmically, but the `ln(1/ρ)` **denominator collapses as `ρ→1`**, so a slow-converging loop
+needs many rounds:
+
+| `ρ` (retained-gap fraction) | `V/C`=20 | `V/C`=100 | `V/C`=1000 |
+|---|---|---|---|
+| 0.3 (fast — each round kills 70% of the gap) | 4 | 5 | 7 |
+| 0.5 | 5 | 7 | 10 |
+| 0.7 | 7 | 11 | 17 |
+| 0.9 (slow — each round kills 10%) | 8 | **23** | **45** |
+
+> **Corrected 2026-08-14.** This line previously asserted *"robustly ≤ 3–4 rounds"*. That is **false**
+> and was never computed — `ρ=0.9, g₀=1, V/C=100` yields **23**. The claim survived because the
+> logarithmic-in-`V/C` half is true and nobody evaluated the other half. Measure `ρ` for your task
+> class before assuming a small `n*`; if you cannot estimate `ρ`, do not quote a round count — use the
+> harness cap and the stagnation test below, which need no parameter estimate.
+
+Floor = **human-parity (~90%, NOT 100%)**; cap is harness-enforced (`cascade-resolver` termination),
+not model-judged. Also stop on `Δ < ε for K rounds` OR consensus — **these are the parameter-free
+stopping rules and are the ones to prefer when `ρ` is unknown.** The curve is **sub-geometric** (easy
+errors re-found, hard residual resists) → the plateau arrives sooner than the formula's worst case;
+looping past `n*` costs 4–10× for <1% gain.
 
 ## Composition map (no new engine)
 

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -32,7 +32,7 @@ Take ONE raw, unstructured operator braindump — mixed directives, cartesian re
 session-meta wrappers — and lapidate it into ONE prompt that an agent (or a team) can execute
 end-to-end with minimum human-in-the-loop. The distinctive act is **REFINE**: a bounded loop whose
 *object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating on
-the economic stop (`n* (typically 3 or 4)`) by default — and, **only where a profile licenses the long loop**, on
+the economic stop (`n* (per `convergence-engine`)`) by default — and, **only where a profile licenses the long loop**, on
 a two-part condition (a floor AND a dryness test) rather than a single clean pass.
 
 ## When to use
@@ -86,7 +86,7 @@ DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
              if long_loop_licensed: until (revisions >= min_revisions)
                                       AND (clean_rounds >= clean_rounds_required)
-             else:                  until the economic stop (n* (typically 3 or 4)), floor OFF
+             else:                  until the economic stop (n* (per `convergence-engine`)), floor OFF
 RED-TEAM  := independent adversarial refutation of the DRAFT (verifier != generator)
              REFUTED -> classify: craft-defect => back to REFINE (<= max_redteam_cycles)
                                   missing-fact => STOP-HITL now (rounds cannot invent facts)
@@ -317,7 +317,7 @@ Three sources disagree about when an agentic loop may stop, and the disagreement
 |---|---|
 | Shumer's aim-prompt (and skills derived from it) | *"loop until utterly perfect — you are the brake"* → **none** |
 | Osmani, *Loop Engineering* | clear stopping rules are the **5th mandatory component** (cost · attempts · wall-clock · gain-stagnation) |
-| `skills/convergence-engine` (this repo) | economic stop at `n*`, the closed form `n* = 1 + ⌈ln((1−ρ)·g₀·V/C) / ln(1/ρ)⌉` (ρ=retained-gap fraction · g₀=initial gap · V=value/correct-unit · C=round cost). It grows only **logarithmically** in `V/C`, so it evaluates to **3 or 4** across realistic inputs — a computed bound, not a magic literal. Floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
+| `skills/convergence-engine` (this repo) | economic stop at `n*`, the closed form `n* = 1 + ⌈ln((1−ρ)·g₀·V/C) / ln(1/ρ)⌉` (ρ=retained-gap fraction · g₀=initial gap · V=value/correct-unit · C=round cost). `skills/convergence-engine/SKILL.md` is the **SSOT** for the closed form, its parameter bounds, its marginal-value indexing, and its round-count convention (is `n*` the last affordable round or the first rejected one?). This skill **cites** the bound and never restates it. Floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
 
 **The synthesis this skill encodes — the Verifiability Gate:**
 
@@ -327,7 +327,7 @@ long_loop_licensed := bar_is_machine_verifiable
                     AND evidence_is_directly_inspectable
 
 if long_loop_licensed -> cap = profile budget (attempts | cost | wall-clock | stagnation delta)
-else                  -> cap = convergence-engine economic stop (n* (typically 3 or 4))
+else                  -> cap = convergence-engine economic stop (n* (per `convergence-engine`))
 NEVER                 -> unbounded, on work that is irreversible, costly, or unobservable
 ```
 
@@ -353,12 +353,12 @@ stop_refine := (rounds <= --max-rounds)                    # hard cap; exceeded 
                    (revisions    >= --min-revisions)       # floor   — profile-supplied
                    AND (clean_rounds >= --clean-rounds)    # dryness — profile-supplied
                else:
-                   economic stop governs ALONE (n* (typically 3 or 4)) # no floor, no dryness counter
+                   economic stop governs ALONE (n* (per `convergence-engine`)) # no floor, no dryness counter
 ```
 
 **The floor is licensed, not global — and that is load-bearing.** A round either produces a
 revision or is clean, never both, so a `min-revisions=3 AND clean-rounds=3` floor requires **≥6
-rounds**. When the loop is *unlicensed* the cap is `n* (typically 3 or 4)`. **A global floor would therefore
+rounds**. When the loop is *unlicensed* the cap is `n* (per `convergence-engine`)`. **A global floor would therefore
 exceed its own cap on every unlicensed run** — and `profiles/default.md` states the gate normally
 evaluates false for that profile, so that is the common path, not an edge case. The floor belongs to
 the profile that licenses it (`gauntlet-loop`, whose `≥3 revisions AND ≥3 consecutive clean rounds`
@@ -561,7 +561,7 @@ the prompt itself (the operator names the target).
 
 ## Protocol Rules (anti-loop invariants + bounds)
 
-- REFINE stops on the economic stop (`n* (typically 3 or 4)`) by DEFAULT. The **two-part** floor (min-revisions
+- REFINE stops on the economic stop (`n* (per `convergence-engine`)`) by DEFAULT. The **two-part** floor (min-revisions
   AND consecutive-clean-rounds) applies ONLY where the Verifiability Gate licenses the long loop —
   asserting it unconditionally makes the floor exceed its own cap on every unlicensed run.
 - `--max-rounds` (default 12) is a hard cap → `STOP-HITL` on exhaustion.
@@ -605,7 +605,7 @@ the prompt itself (the operator names the target).
   tolerance) → **`STOP-HITL` immediately**: no number of refine rounds can manufacture a fact the
   dump does not contain. **Precedence**: this outranks the economic stop — the stop caps iteration
   *within* REFINE and never governs the RED-TEAM return path. Without that precedence the two
-  collide structurally on any unlicensed run (stop caps REFINE at `n* (typically 3 or 4)`; a refutation at round
+  collide structurally on any unlicensed run (stop caps REFINE at `n* (per `convergence-engine`)`; a refutation at round
   4 demands a round 5 that is over-cap by construction).
 - **`--max-redteam-cycles` exhausted while still REFUTED** → `STOP-HITL` carrying the standing
   findings as the escalation payload.

--- a/skills/refine-braindump-to-prompt/SKILL.md
+++ b/skills/refine-braindump-to-prompt/SKILL.md
@@ -32,7 +32,7 @@ Take ONE raw, unstructured operator braindump — mixed directives, cartesian re
 session-meta wrappers — and lapidate it into ONE prompt that an agent (or a team) can execute
 end-to-end with minimum human-in-the-loop. The distinctive act is **REFINE**: a bounded loop whose
 *object of criticism is the draft prompt itself*, run from multiple distinct lenses, terminating on
-the economic stop (`n* (per `convergence-engine`)`) by default — and, **only where a profile licenses the long loop**, on
+the economic stop (`n*` (per `convergence-engine`)) by default — and, **only where a profile licenses the long loop**, on
 a two-part condition (a floor AND a dryness test) rather than a single clean pass.
 
 ## When to use
@@ -86,7 +86,7 @@ DRAFT     := select architecture profile + render first-cut prompt
 REFINE    := loop{ critique draft from N distinct lenses -> correct }
              if long_loop_licensed: until (revisions >= min_revisions)
                                       AND (clean_rounds >= clean_rounds_required)
-             else:                  until the economic stop (n* (per `convergence-engine`)), floor OFF
+             else:                  until the economic stop (n*, per convergence-engine), floor OFF
 RED-TEAM  := independent adversarial refutation of the DRAFT (verifier != generator)
              REFUTED -> classify: craft-defect => back to REFINE (<= max_redteam_cycles)
                                   missing-fact => STOP-HITL now (rounds cannot invent facts)
@@ -317,7 +317,7 @@ Three sources disagree about when an agentic loop may stop, and the disagreement
 |---|---|
 | Shumer's aim-prompt (and skills derived from it) | *"loop until utterly perfect — you are the brake"* → **none** |
 | Osmani, *Loop Engineering* | clear stopping rules are the **5th mandatory component** (cost · attempts · wall-clock · gain-stagnation) |
-| `skills/convergence-engine` (this repo) | economic stop at `n*`, the closed form `n* = 1 + ⌈ln((1−ρ)·g₀·V/C) / ln(1/ρ)⌉` (ρ=retained-gap fraction · g₀=initial gap · V=value/correct-unit · C=round cost). `skills/convergence-engine/SKILL.md` is the **SSOT** for the closed form, its parameter bounds, its marginal-value indexing, and its round-count convention (is `n*` the last affordable round or the first rejected one?). This skill **cites** the bound and never restates it. Floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
+| `skills/convergence-engine` (this repo) | economic stop at `n*` — `skills/convergence-engine/SKILL.md` is the **SSOT** for the closed form, its parameter bounds, its marginal-value indexing, and its round-count convention (is `n*` the last affordable round or the first rejected one?). This skill **cites** the bound and never restates it. Floor is human-parity, **not** perfection; looping past `n*` costs 4-10× for <1% gain |
 
 **The synthesis this skill encodes — the Verifiability Gate:**
 
@@ -327,7 +327,7 @@ long_loop_licensed := bar_is_machine_verifiable
                     AND evidence_is_directly_inspectable
 
 if long_loop_licensed -> cap = profile budget (attempts | cost | wall-clock | stagnation delta)
-else                  -> cap = convergence-engine economic stop (n* (per `convergence-engine`))
+else                  -> cap = convergence-engine economic stop (n*, per convergence-engine)
 NEVER                 -> unbounded, on work that is irreversible, costly, or unobservable
 ```
 
@@ -353,12 +353,12 @@ stop_refine := (rounds <= --max-rounds)                    # hard cap; exceeded 
                    (revisions    >= --min-revisions)       # floor   — profile-supplied
                    AND (clean_rounds >= --clean-rounds)    # dryness — profile-supplied
                else:
-                   economic stop governs ALONE (n* (per `convergence-engine`)) # no floor, no dryness counter
+                   economic stop governs ALONE (n*, per convergence-engine) # no floor, no dryness counter
 ```
 
 **The floor is licensed, not global — and that is load-bearing.** A round either produces a
 revision or is clean, never both, so a `min-revisions=3 AND clean-rounds=3` floor requires **≥6
-rounds**. When the loop is *unlicensed* the cap is `n* (per `convergence-engine`)`. **A global floor would therefore
+rounds**. When the loop is *unlicensed* the cap is `n*` (per `convergence-engine`). **A global floor would therefore
 exceed its own cap on every unlicensed run** — and `profiles/default.md` states the gate normally
 evaluates false for that profile, so that is the common path, not an edge case. The floor belongs to
 the profile that licenses it (`gauntlet-loop`, whose `≥3 revisions AND ≥3 consecutive clean rounds`
@@ -561,7 +561,7 @@ the prompt itself (the operator names the target).
 
 ## Protocol Rules (anti-loop invariants + bounds)
 
-- REFINE stops on the economic stop (`n* (per `convergence-engine`)`) by DEFAULT. The **two-part** floor (min-revisions
+- REFINE stops on the economic stop (`n*` (per `convergence-engine`)) by DEFAULT. The **two-part** floor (min-revisions
   AND consecutive-clean-rounds) applies ONLY where the Verifiability Gate licenses the long loop —
   asserting it unconditionally makes the floor exceed its own cap on every unlicensed run.
 - `--max-rounds` (default 12) is a hard cap → `STOP-HITL` on exhaustion.
@@ -605,7 +605,7 @@ the prompt itself (the operator names the target).
   tolerance) → **`STOP-HITL` immediately**: no number of refine rounds can manufacture a fact the
   dump does not contain. **Precedence**: this outranks the economic stop — the stop caps iteration
   *within* REFINE and never governs the RED-TEAM return path. Without that precedence the two
-  collide structurally on any unlicensed run (stop caps REFINE at `n* (per `convergence-engine`)`; a refutation at round
+  collide structurally on any unlicensed run (stop caps REFINE at `n*` (per `convergence-engine`); a refutation at round
   4 demands a round 5 that is over-cap by construction).
 - **`--max-redteam-cycles` exhausted while still REFUTED** → `STOP-HITL` carrying the standing
   findings as the escalation payload.


### PR DESCRIPTION
## Retracting a false claim I shipped in #322

While fixing a *different* CodeRabbit finding on #321 (`n* <= 3-4` reads as **subtraction** in math
syntax), I resolved the notation by asserting the closed form *"grows only logarithmically in `V/C`,
so it evaluates to **3 or 4** across realistic inputs."*

**That assertion is false, and I never computed it before writing it.** CodeRabbit contested it on
#322 (🟠 Major). I verified independently rather than accepting it on authority:

`n* = 1 + ⌈ln((1−ρ)·g₀·V/C) / ln(1/ρ)⌉`

| ρ | g₀ | V/C | n* | |
|---|---|---|---|---|
| **0.9** | 1 | 100 | **23** | CodeRabbit's counter-example — reproduces exactly |
| 0.5 | 1 | 100 | 7 | |
| 0.7 | 1 | 50 | 9 | |
| 0.3 | 1 | 100 | 5 | |
| 0.5 | 1 | 8.2 | 4 | the only case landing in {3,4} — and it was constructed to |

Five sampled parameter sets; none in `{3,4}` except the one built to be. `ρ=0.9` — a slow-converging
loop retaining 90% of the gap — is entirely realistic and yields **23**. The claim does not survive
its own arithmetic.

## The repair is a citation, not a better adjective

Per CodeRabbit's own prescription and the SSOT discipline **ratified today** for `--output-target`
(`coexistence-pr11xpr12-20260814`): **`skills/convergence-engine/SKILL.md` is the SSOT** for the
bound, its parameter ranges, its marginal-value indexing, and its round-count convention — *is `n*`
the last affordable round, or the first rejected one?* (the `A=4` boundary yields `n*=3` while round 3
is still affordable). This skill **cites** it and never restates it.

**8 occurrences** replaced · **0** residual literal cap claims · `validate-plugin.sh` **PASSED**.

## Deliberately out of scope

Defining the parameter bounds and the counting convention **inside** `convergence-engine` is the
complete fix. It touches another skill's SSOT and deserves its own cycle with a red-team — not a
doc-only retraction PR. Tracked as follow-up.

## The pattern, named

This recurred **three times** in one session: *fixing a symptom by adding a claim I had not measured.*
The notation ambiguity was real; the number I reached for to resolve it was not measured. **Citing
beats asserting** — and the reviewer who caught the P0 was right again about the fix for it.
