### PR TITLE
docs(skills): transmute v0.1.3 — cross-harness SSOT consolidation (Alambique cross-link)

### DIFF
--- a/skills/transmute/SKILL.md
+++ b/skills/transmute/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: transmute
-version: "0.1.2"
+version: "0.1.3"
 description: >-
   Transmute ONE source of ANY kind (text · prompt · draft · braindump · doc · code ·
   agentic-tool · report) through a menu of transformations (comprehend · analyze ·
@@ -61,6 +61,7 @@ every non-entry, per `refine-braindump-to-prompt`'s convention):
 | "braindump → ONE executable prompt" | `refine-braindump-to-prompt` |
 | "recurring intent → reusable tool" | `agentic-tool-forge` |
 | "re-target content for an audience" | `content-recast` |
+| "braindump → durable VAULT artifacts (PARA placement)" | `braindump-distill` (eko-engram *Alambique* — vault-side SSOT; routing per `persist-locus`) |
 | "what in this dump is already done?" | `directive-braindump-triage` |
 | "ship this feature end-to-end (PR)" | `enhance-pipeline` |
 | "improve an EXISTING tool" | `agentic-tool-trainer` |
@@ -111,6 +112,7 @@ consumes. DONE when EMIT reports (or, under `--dry-run`, when the plan is emitte
 | `audience-recast` | `content-recast` | faithfulness guard lives there |
 | `artifact:{md\|html\|pdf\|slides\|diagram}` | renderers (`document-generate` · `archify` · `make-pdf` · host-native) | never re-implement a renderer |
 | `ledger` | `directive-braindump-triage` | provenance ledger |
+| `vault-artifact` | `braindump-distill` (eko-engram *Alambique*, user-scope IF vault mounted) | vault-side standing protocol — PARA placement + ledger + `persist-locus` routing; transmute routes there, never reimplements placement |
 | `ticket` | `ticket-as-prompt` (user-scope, IF installed) | Jira/Linear render |
 
 The router EMITS invocations (anti-NIH); a missing optional primitive degrades to the
@@ -262,6 +264,16 @@ router added no routing). Dormant-by-design otherwise.
 
 ## Versioning
 
+- v0.1.3 — **cross-harness SSOT consolidation** (round n+5 recon): recon of the
+  eko-engram ledger revealed the vault family (2026-08-14) reached the OPPOSITE
+  verdict on the same directive-class ("dropped: new generic enhancer skill —
+  compose-not-fork") — resolved as different denominators (vault: mint-in-
+  ~/.agents? NO · repo: N×M-router gap? YES). Division ratified (extends the N2
+  split): WHERE=persist-locus · HOW=Lapidary `--output-target` · WHICH=transmute
+  · vault-protocol=Alambique. This patch cross-links: cast-router row
+  `vault-artifact` → Alambique + hand-off row. **Eval C3 caveat recorded**: DRY
+  score was measured intra-maos only; cross-harness audit now complete — no
+  overlap (Alambique = vault placement SSOT; transmute = repo routing SSOT).
 - v0.1.2 — **dogfood cycle 2 COMPLETE → eval C5 re-scored 2→5 = PASS** (full pipeline
   INTAKE→COMPREHEND→TRANSFORM→CAST→EMIT on a real source: the operator's recurring
   `/enhance` round template, 4 live traces). Emitted `prompts/transmute-round.md`

--- a/skills/transmute/examples/EVAL-REPORT-2026-08-15.md
+++ b/skills/transmute/examples/EVAL-REPORT-2026-08-15.md
@@ -9,6 +9,13 @@
 | C1 placeholder-empty input class (4 real occurrences: n+1–n+4) | 5 (router catches + names placeholder + emits fill-snippet since n+3) | 4 (correct STOP-ERROR; snippet DX added) | 5 | 5 (no wasted pipeline) | 5 | 0 |
 | C2 invocation surface `/transmute` (commands wrapper exists, name matches) | 5 | 5 | 5 | 5 | 5 | 0 |
 | C3 DRY routing (routes to siblings; no restatement — 15.5KB vs 45KB Lapidary; SSOTs cited in-line) | n/a (inspection) | 5 | 5 | 5 | 5 | 0 |
+
+> **C3 caveat (recorded 2026-08-15, round n+5)**: this 5/5 was measured **intra-maos only**.
+ Cross-harness recon (eko-engram ledger) found the vault family had independently
+ evaluated the same directive-class and dropped minting a generic enhancer
+ (compose-not-fork). Post-audit: **no overlap** — Alambique is the vault-side
+ placement SSOT (PARA + ledger + persist-locus routing); transmute is the repo-side
+ invocation router. Cross-links added in v0.1.3. Score stands.
 | C4 safe-by-default (dry-run default; leak gate unconditional; worktree on git sinks) | n/a (spec inspection) | 4 (spec'd; untested on a dirty source — no real dirty-source run yet) | 4 | 5 | 5 | 0 |
 | C5 real source → cast → emit (a genuine filled braindump through COMPREHEND→…→EMIT) | 3 (trigger table + wrappers present) | **2 — NOT YET EXERCISED** | n/a | n/a | n/a | n/a |
 


### PR DESCRIPTION
Round n+5 recon of a private downstream repository's ledger found the vault family's opposite verdict on the same directive-class. Converged: different denominators, no overlap — Alambique (vault placement SSOT) × transmute (repo routing SSOT). Adds cast-router row `vault-artifact` → braindump-distill, hand-off row, changelog, and the honest eval C3 cross-harness caveat (DRY was measured intra-maos only; post-audit score stands). Companion PR: a private downstream repository (issue/PR reference removed).
