### PR TITLE
fix(tests): the YAML gate reached only top-level — 30 artifacts never parsed

### DIFF
--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -276,8 +276,18 @@ if python3 -c "import yaml" 2>/dev/null; then
 import glob, io, os, sys, yaml
 root = sys.argv[1]
 bad = []
-for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
-    for p in sorted(glob.glob(os.path.join(root, pat))):
+seen = set()
+# `**` + recursive=True: Python's `*` does NOT cross `/`, unlike git's pathspec of the
+# same shape. With the non-recursive patterns this gate never saw agents/consultants/*.md
+# nor commands/*/*.md — 30 artifacts that were reported as covered. See issue #327.
+# NOTE both halves are load-bearing: `**` without recursive=True behaves as plain `*`.
+for pat in ("skills/**/SKILL.md", "agents/**/*.md", "commands/**/*.md"):
+    for p in sorted(glob.glob(os.path.join(root, pat), recursive=True)):
+        seen.add(os.path.relpath(p, root))   # REACHED — must precede every `continue`
+                                             # below, or `seen` records "parsed" while the
+                                             # assertion claims "reached" (they differ for
+                                             # files with no frontmatter, which are skipped
+                                             # on purpose and are NOT a reach gap).
         if os.path.basename(p) == "README.md":
             continue                      # docs, not artifacts (same rule as above)
         try:
@@ -289,6 +299,27 @@ for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
             bad.append(f"{os.path.relpath(p, root)} :: {str(e).splitlines()[0]}")
         except Exception as e:
             bad.append(f"{os.path.relpath(p, root)} :: {type(e).__name__}: {e}")
+
+# REACH ASSERTION — the gate must not silently under-reach again (issue #327).
+# git's pathspec `*` crosses `/`, so these patterns are the ground truth for what
+# SHOULD have been parsed. Degrade-safe: no git / not a repo -> skip, never fail,
+# because this validator also runs from an installed plugin dir with no .git.
+try:
+    import subprocess
+    tracked = set()
+    for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
+        out = subprocess.run(["git", "-C", root, "ls-files", pat],
+                             capture_output=True, text=True, timeout=10)
+        if out.returncode != 0:
+            raise RuntimeError("git unavailable")
+        tracked.update(f for f in out.stdout.split() if os.path.basename(f) != "README.md")
+    missed = sorted(tracked - seen)
+    if missed:
+        bad.append(f"REACH GAP :: {len(missed)} tracked artifact(s) the glob never parsed, "
+                   f"e.g. {missed[0]} — the gate under-reaches (see #327)")
+except Exception:
+    pass                                  # no git here; the glob fix above still applies
+
 print("\n".join(bad))
 PYEOF
 )

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -331,7 +331,10 @@ if os.path.exists(os.path.join(root, ".git")):
                                  capture_output=True, text=True, timeout=10)
             if out.returncode != 0:
                 raise OSError(f"git ls-files rc={out.returncode}")
-            tracked.update(f.replace("\\", "/") for f in out.stdout.split()
+            # splitlines(): git ls-files is newline-delimited. `.split()` would corrupt any
+            # tracked path containing spaces (zero today — probed — but the gate's whole
+            # purpose is to not silently under-report again, per #327).
+            tracked.update(f.replace("\\", "/") for f in out.stdout.splitlines()
                            if os.path.basename(f) != "README.md")
         missed = sorted(tracked - seen)
         if missed:

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -283,7 +283,14 @@ seen = set()
 # NOTE both halves are load-bearing: `**` without recursive=True behaves as plain `*`.
 for pat in ("skills/**/SKILL.md", "agents/**/*.md", "commands/**/*.md"):
     for p in sorted(glob.glob(os.path.join(root, pat), recursive=True)):
-        seen.add(os.path.relpath(p, root))   # REACHED — must precede every `continue`
+        # REACHED — must precede every `continue` below (see note under the except).
+        # `.replace(os.sep, "/")`: on Windows os.path.relpath returns `agents\foo.md`
+        # while `git ls-files` ALWAYS emits `/`, so without this every artifact lands in
+        # `tracked - seen` and the assertion reports a false total reach gap on every run.
+        # os.sep (not a literal "\\"): on POSIX os.sep == "/" so this is a no-op, which
+        # matters because `\` is a legal filename character there and a literal replace
+        # would corrupt it.
+        seen.add(os.path.relpath(p, root).replace(os.sep, "/"))
                                              # below, or `seen` records "parsed" while the
                                              # assertion claims "reached" (they differ for
                                              # files with no frontmatter, which are skipped

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -311,26 +311,45 @@ for pat in ("skills/**/SKILL.md", "agents/**/*.md", "commands/**/*.md"):
 # git's pathspec `*` crosses `/`, so these patterns are the ground truth for what
 # SHOULD have been parsed. Degrade-safe: no git / not a repo -> skip, never fail,
 # because this validator also runs from an installed plugin dir with no .git.
-try:
+# `.git` absent is the ONE legitimate skip (installed plugin dir) — silent by design.
+# Anything else is reported: a control that disables itself on any error is not a control,
+# it is an invisible bypass. Narrow excepts only, so a real bug in this block propagates
+# and is caught by the rc check in the shell above rather than swallowed here.
+if os.path.exists(os.path.join(root, ".git")):
     import subprocess
-    tracked = set()
-    for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
-        out = subprocess.run(["git", "-C", root, "ls-files", pat],
-                             capture_output=True, text=True, timeout=10)
-        if out.returncode != 0:
-            raise RuntimeError("git unavailable")
-        tracked.update(f for f in out.stdout.split() if os.path.basename(f) != "README.md")
-    missed = sorted(tracked - seen)
-    if missed:
-        bad.append(f"REACH GAP :: {len(missed)} tracked artifact(s) the glob never parsed, "
-                   f"e.g. {missed[0]} — the gate under-reaches (see #327)")
-except Exception:
-    pass                                  # no git here; the glob fix above still applies
+    try:
+        tracked = set()
+        for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
+            out = subprocess.run(["git", "-C", root, "ls-files", pat],
+                                 capture_output=True, text=True, timeout=10)
+            if out.returncode != 0:
+                raise OSError(f"git ls-files rc={out.returncode}")
+            tracked.update(f.replace("\\", "/") for f in out.stdout.split()
+                           if os.path.basename(f) != "README.md")
+        missed = sorted(tracked - seen)
+        if missed:
+            bad.append(f"REACH GAP :: {len(missed)} tracked artifact(s) the glob never parsed, "
+                       f"e.g. {missed[0]} — the gate under-reaches (see #327)")
+    except (OSError, subprocess.SubprocessError) as e:
+        # .git IS here, so git failing is an anomaly, not the expected no-repo case.
+        bad.append(f"REACH ASSERTION DID NOT RUN :: {type(e).__name__}: {e} — "
+                   f"the under-reach guard was skipped; treat coverage as UNVERIFIED")
 
 print("\n".join(bad))
 PYEOF
-)
-    if [ -z "$YAML_BAD" ]; then
+) || YAML_RC=$?
+    YAML_RC=${YAML_RC:-0}
+    # `|| YAML_RC=$?` on the assignment above is load-bearing: this script runs under
+    # `set -euo pipefail` (line 9), so a bare `X=$(python3 ...)` that exits non-zero
+    # ABORTS the whole script right there — the run does fail (safe), but with no
+    # message saying why, and any check written after it is unreachable. The `||`
+    # keeps the failure local so it can be reported instead of just ending the script.
+    # Emptiness alone is NOT the test: a python crash exits non-zero with EMPTY stdout,
+    # which reads as "nothing bad found". Per script-safety §6 the authority is the
+    # captured exit code.
+    if [ "$YAML_RC" -ne 0 ]; then
+        fail "frontmatter YAML check crashed (python rc=$YAML_RC) — result is UNKNOWN, not clean"
+    elif [ -z "$YAML_BAD" ]; then
         pass "all artifact frontmatter parses as YAML"
     else
         while IFS= read -r line; do [ -n "$line" ] && fail "unparseable frontmatter: $line"; done <<< "$YAML_BAD"

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -272,6 +272,13 @@ fi
 # Capability-detected: PyYAML absent → WARN, never a red build for a missing dep.
 echo "Validating frontmatter parses as YAML..."
 if python3 -c "import yaml" 2>/dev/null; then
+    # Initialize IN THIS SCOPE before the capture below. `YAML_RC` is a generic-enough
+    # name that an outer wrapper may already export it; without this reset a SUCCESSFUL
+    # python run never executes `|| YAML_RC=$?`, so the inherited value survives and the
+    # gate reports a crash that never happened. `${VAR:-0}` does NOT cover this: it
+    # substitutes only when unset/null, not when set to garbage. Never read a variable
+    # you did not initialize in your own scope.
+    YAML_RC=0
     YAML_BAD=$(python3 - "$PLUGIN_ROOT" <<'PYEOF'
 import glob, io, os, sys, yaml
 root = sys.argv[1]
@@ -338,7 +345,6 @@ if os.path.exists(os.path.join(root, ".git")):
 print("\n".join(bad))
 PYEOF
 ) || YAML_RC=$?
-    YAML_RC=${YAML_RC:-0}
     # `|| YAML_RC=$?` on the assignment above is load-bearing: this script runs under
     # `set -euo pipefail` (line 9), so a bare `X=$(python3 ...)` that exits non-zero
     # ABORTS the whole script right there — the run does fail (safe), but with no


### PR DESCRIPTION
Closes #327

## What

`tests/validate-plugin.sh`'s YAML-parse gate globbed `agents/*.md` and `commands/*.md` **non-recursively**. Python's `*` does not cross `/` — unlike git's pathspec of the same shape — so **30 artifacts had never been parsed** while every run reported *"all artifact frontmatter parses as YAML"*.

That is the same failure shape as the defect the gate was built to fix, one level up. PR #322's own rationale was *"a grep answers 'does the text contain?', never 'does the parser accept?'"* — correct, and then its **reach** was never measured.

## Changes

| Change | Why |
|---|---|
| `**` patterns **+ `recursive=True`** | Both are load-bearing: `**` *without* the flag behaves as plain `*`, so a half-fix would have looked right and changed nothing. |
| **REACH ASSERTION** | `git ls-files` is the ground truth for what *should* have been parsed. The gate now **fails** if it ever under-reaches again. Degrade-safe: no git / not a repo → skipped, because this validator also runs from installed plugin dirs with no `.git`. |

The assertion is the root fix. Without it, this exact class recurs silently — it has already bitten three times in one session (an artifact count, a validator-coverage table, and this gate).

## Re-measured on current `main`

The counts in #327 had already moved (`transmute` added a skill and a command), so they were re-derived rather than copied:

```
skills/*/SKILL.md      83  →  83   (unchanged — skills are always one level deep)
agents/*.md            28  →  49   (+21, agents/consultants/)
commands/*.md          38  →  47   (+9,  commands/*/)
                      149  → 179   reach gain: 30
```

## Verification — controls, not inspection

| Control | Result |
|---|---|
| **Blast** | `validate-plugin.sh` rc=0 (unpiped), *"all artifact frontmatter parses as YAML"*, *"Plugin is ready for use!"* |
| **Positive** | recursive glob reaches 30 more files (149 → 179) |
| **Negative** | revert the glob, keep the assertion → `REACH GAP :: 30 tracked artifact(s)…` fires |
| **git-absent** | complete tree minus `.git` → rc=0, zero false positives; **identical to `origin/main` on the same tree** (one variable varied) |

⚠️ **The negative control caught a defect in the assertion itself.** `seen.add()` initially sat *after* the `continue` that skips files without frontmatter — so it recorded *"parsed"* while the assertion claimed *"reached"*, and reported **7 deliberately-skipped files as a reach gap**. A reach assertion with a reach defect. Moved to the first line of the loop body; it now reports the true **30**.

An earlier run of that same degrade test also gave a false `rc=1` — caused by my copying an *incomplete* tree, not by the fix. Re-run with one variable varied (same tree, `origin/main`'s script vs mine) it was identical. Both are recorded because the session's recurring lesson is precisely that an instrument's reach must be proven, not assumed.

## Risk

Docs/test-tooling only; no runtime path. Blast measured zero. Fully revertible.
