### PR TITLE
fix(tests): round 5 — splitlines() closes the last latent reach-guard gap

### DIFF
--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -331,7 +331,10 @@ if os.path.exists(os.path.join(root, ".git")):
                                  capture_output=True, text=True, timeout=10)
             if out.returncode != 0:
                 raise OSError(f"git ls-files rc={out.returncode}")
-            tracked.update(f.replace("\\", "/") for f in out.stdout.split()
+            # splitlines(): git ls-files is newline-delimited. `.split()` would corrupt any
+            # tracked path containing spaces (zero today — probed — but the gate's whole
+            # purpose is to not silently under-report again, per #327).
+            tracked.update(f.replace("\\", "/") for f in out.stdout.splitlines()
                            if os.path.basename(f) != "README.md")
         missed = sorted(tracked - seen)
         if missed:


### PR DESCRIPTION
## [PR-as-Documentation-Prompt]

**Context.** Stacked on #333 (head `198c64b`). Qodo flagged `.split()` corrupting space-containing paths; my probe measured **zero current exposure** (no space-paths in tracked artifact globs) and CodeRabbit concurred ("no current exposure … future false-failure path"). For a validator whose entire purpose is *never silently under-report again* (#327's lesson), shipping a known false-failure path is the wrong trade — the fix is one word and strictly more correct.

**Objective.** Close the last open finding on #333 so the stack converges fully.

### Change
`out.stdout.split()` → `out.stdout.splitlines()` (+ comment). git `ls-files` output is newline-delimited; `split()` also splits on spaces/tabs.

### Ownership note (multi-agents-wip-aware)
Parallel session owns #333 (their rounds 2–4 fixed Qodo #1/#2 + a YAML_RC scope bug). This stacked PR follows the #332 pattern: touches nothing on their branch, theirs to merge.

### Checks
- `tests/validate-plugin.sh` rc=0 · diff: +5/−1 lines, one file · guardrail-surface: 0 hits (CI test script, not hook/rule/allowlist).