### PR TITLE
fix(tests): NUL-delimited ls-files + fsdecode — CodeRabbit's #333 finding, carried forward

### DIFF
--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -327,14 +327,16 @@ if os.path.exists(os.path.join(root, ".git")):
     try:
         tracked = set()
         for pat in ("skills/*/SKILL.md", "agents/*.md", "commands/*.md"):
-            out = subprocess.run(["git", "-C", root, "ls-files", pat],
-                                 capture_output=True, text=True, timeout=10)
+            out = subprocess.run(["git", "-C", root, "ls-files", "-z", pat],
+                                 capture_output=True, timeout=10)
             if out.returncode != 0:
                 raise OSError(f"git ls-files rc={out.returncode}")
-            # splitlines(): git ls-files is newline-delimited. `.split()` would corrupt any
-            # tracked path containing spaces (zero today — probed — but the gate's whole
-            # purpose is to not silently under-report again, per #327).
-            tracked.update(f.replace("\\", "/") for f in out.stdout.splitlines()
+            # `-z` + byte-split on NUL + os.fsdecode: paths are preserved EXACTLY
+            # (spaces, backslashes, non-UTF-8 bytes). No separator munging: git always
+            # emits `/`, and `\\` is a legal POSIX filename character — replacing it
+            # would corrupt such a path. (CodeRabbit round 6; supersedes the splitlines
+            # fix, which still split on whitespace runs.)
+            tracked.update(f for f in (os.fsdecode(b) for b in out.stdout.split(b"\0") if b)
                            if os.path.basename(f) != "README.md")
         missed = sorted(tracked - seen)
         if missed:

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -332,10 +332,12 @@ if os.path.exists(os.path.join(root, ".git")):
             if out.returncode != 0:
                 raise OSError(f"git ls-files rc={out.returncode}")
             # `-z` + byte-split on NUL + os.fsdecode: paths are preserved EXACTLY
-            # (spaces, backslashes, non-UTF-8 bytes). No separator munging: git always
-            # emits `/`, and `\\` is a legal POSIX filename character — replacing it
-            # would corrupt such a path. (CodeRabbit round 6; supersedes the splitlines
-            # fix, which still split on whitespace runs.)
+            # (spaces, backslashes, non-UTF-8 bytes — and newlines, which are legal in
+            # POSIX filenames and would break any line-based split). No separator munging:
+            # git always emits `/`, and `\` is a legal POSIX filename character — replacing
+            # it would corrupt such a path. (CodeRabbit round 6. Note: the intermediate
+            # splitlines() step DID handle spaces correctly; what it could not survive is a
+            # newline-in-path — that residual is what `-z` closes.)
             tracked.update(f for f in (os.fsdecode(b) for b in out.stdout.split(b"\0") if b)
                            if os.path.basename(f) != "README.md")
         missed = sorted(tracked - seen)


### PR DESCRIPTION
## [PR-as-Documentation-Prompt]

**Context.** CodeRabbit's full review of #333 @ `265ad99` (CHANGES_REQUESTED, **1 actionable, Minor**) landed ~3 min before #333 merged — the finding never closed: tracked-file collection must preserve paths exactly.

**Objective.** Close it against main: `git ls-files -z`, byte-split on NUL, `os.fsdecode()`, retain git's forward slashes, drop `replace("\\\\", "/")` (corrupts legal POSIX filenames containing a backslash). Supersedes the `splitlines()` step; same contract, exact now.

### Verification
- `tests/validate-plugin.sh` rc=0 — the reach assertion itself is the A/B (runs the `-z` path vs the glob, reports no gap).
- guardrail-surface: 0 hits (CI test script) · +8/−6, one file.