### PR TITLE
fix(tests): shell frontmatter loops recurse via find — close #336

### DIFF
--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -137,7 +137,11 @@ echo ""
 echo "Checking commands..."
 
 COMMAND_COUNT=0
-for cmd in "$PLUGIN_ROOT/commands"/*.md; do
+# find, not a glob: bash's `*` does NOT cross `/` (and globstar needs bash 4+,
+# absent on macOS's stock 3.2) — the old loop silently never saw commands/*/*.md.
+# Sibling of issue #327 / PR #333; measured hole: #336. `while read` (not a
+# `for` over $(...)) so paths with spaces survive.
+while IFS= read -r cmd; do
     if [ -f "$cmd" ]; then
         cmd_name=$(basename "$cmd")
         if [ "$cmd_name" != "README.md" ]; then
@@ -150,7 +154,7 @@ for cmd in "$PLUGIN_ROOT/commands"/*.md; do
             ((COMMAND_COUNT++)) || true
         fi
     fi
-done
+done < <(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | sort)
 
 if [ $COMMAND_COUNT -eq 0 ]; then
     warn "No commands found"
@@ -163,7 +167,9 @@ echo ""
 echo "Checking agents..."
 
 AGENT_COUNT=0
-for agent in "$PLUGIN_ROOT/agents"/*.md; do
+# Same reach fix as the commands loop above (#336): `find` recurses where
+# `agents/*.md` could not — 21 consultants were invisible to this presence check.
+while IFS= read -r agent; do
     if [ -f "$agent" ]; then
         agent_name=$(basename "$agent")
         if [ "$agent_name" != "README.md" ]; then
@@ -176,7 +182,7 @@ for agent in "$PLUGIN_ROOT/agents"/*.md; do
             ((AGENT_COUNT++)) || true
         fi
     fi
-done
+done < <(find "$PLUGIN_ROOT/agents" -type f -name '*.md' | sort)
 
 if [ $AGENT_COUNT -eq 0 ]; then
     warn "No agents found"

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -141,20 +141,27 @@ COMMAND_COUNT=0
 # absent on macOS's stock 3.2) — the old loop silently never saw commands/*/*.md.
 # Sibling of issue #327 / PR #333; measured hole: #336. `while read` (not a
 # `for` over $(...)) so paths with spaces survive.
+# Messages use the RELATIVE path (not basename): with recursion, homonymous files
+# in different subdirs would print identically (Qodo #337). The dir-existence
+# guard keeps a missing dir on the old code path's behavior (count=0 -> warn),
+# without find's stderr noise — the earlier structure gate is the loud reporter.
+if [ -d "$PLUGIN_ROOT/commands" ]; then
 while IFS= read -r cmd; do
     if [ -f "$cmd" ]; then
         cmd_name=$(basename "$cmd")
+        cmd_rel="${cmd#"$PLUGIN_ROOT"/}"
         if [ "$cmd_name" != "README.md" ]; then
             # Check for frontmatter
             if head -1 "$cmd" | grep -q "^---"; then
-                pass "$cmd_name has frontmatter"
+                pass "$cmd_rel has frontmatter"
             else
-                warn "$cmd_name missing frontmatter"
+                warn "$cmd_rel missing frontmatter"
             fi
             ((COMMAND_COUNT++)) || true
         fi
     fi
 done < <(find "$PLUGIN_ROOT/commands" -type f -name '*.md' | sort)
+fi
 
 if [ $COMMAND_COUNT -eq 0 ]; then
     warn "No commands found"
@@ -169,20 +176,24 @@ echo "Checking agents..."
 AGENT_COUNT=0
 # Same reach fix as the commands loop above (#336): `find` recurses where
 # `agents/*.md` could not — 21 consultants were invisible to this presence check.
+# Relative-path messages + dir guard, same rationale as the commands loop.
+if [ -d "$PLUGIN_ROOT/agents" ]; then
 while IFS= read -r agent; do
     if [ -f "$agent" ]; then
         agent_name=$(basename "$agent")
+        agent_rel="${agent#"$PLUGIN_ROOT"/}"
         if [ "$agent_name" != "README.md" ]; then
             # Check for frontmatter
             if head -1 "$agent" | grep -q "^---"; then
-                pass "$agent_name has frontmatter"
+                pass "$agent_rel has frontmatter"
             else
-                warn "$agent_name missing frontmatter"
+                warn "$agent_rel missing frontmatter"
             fi
             ((AGENT_COUNT++)) || true
         fi
     fi
 done < <(find "$PLUGIN_ROOT/agents" -type f -name '*.md' | sort)
+fi
 
 if [ $AGENT_COUNT -eq 0 ]; then
     warn "No agents found"


### PR DESCRIPTION
Closes #336.

## [PR-as-Documentation-Prompt]

**Context.** Sibling of #327, still live on main: #333/#335 fixed the *Python YAML gate*; the *shell presence loops* ~130 lines above had the identical `*`-doesn't-cross-`/` defect — 21 nested agents (`agents/consultants/`) + 9 nested commands never received the missing-frontmatter check, and their absence corrupted the counts (`No commands found` when only nested exist).

**Objective.** Same reach discipline as #333: recurse the presence check.

### Change (`tests/validate-plugin.sh`, 2 loops)
- `"$PLUGIN_ROOT/{commands,agents}"/*.md` glob loop → `find -type f -name '*.md' | sort` via **process substitution** (`while IFS= read -r`).
- **Why find, not globstar**: `shopt -s globstar` requires bash 4+; macOS stock bash is 3.2 — the fix would itself fail on the operator's machine. `find` is POSIX and version-free.
- **Why process substitution, not pipe**: `find | while` forks a subshell and the count is lost (the loop's own `((COUNT++))` would silently never reach the summary — the same silent-under-report class this issue is about).
- README.md exclusion, warn/pass semantics, count logic: unchanged.

### Verification (controls, not claims)
| Control | Result |
|---|---|
| Positive: nested no-frontmatter fixtures planted | `⚠ tmp-broken-336.md missing frontmatter` + `⚠ sub336.md missing frontmatter` — **caught** (were invisible before) |
| Counts with fixtures | 49 agents / 47 commands = the issue's own `git ls-files` numbers |
| Negative: fixtures removed | 48 / 46 (Δ1 = README.md exclusion, pre-existing) · full validator **rc=0** |

guardrail-surface: 0 hits (CI test script, not hook/rule/allowlist).