### PR TITLE
fix(changelog): restore Keep a Changelog order — preamble and [Unreleased] sat below a release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -279,11 +279,13 @@ front-door answering *"what should I focus on now? who asked me for what, by whe
 ## [1.22.1] - 2026-08-10
 
 ### Fixed
+
 - Sync `packaging/opencode-maos` version to plugin SSOT; wire `validate-skill-frontmatter` into `tests/validate-plugin.sh`; extend `version-sync.yml` to package manifests
 - `.agents/skills/multi-agent-os/SKILL.md` + `.claude/skills/multi-agent-os/SKILL.md`: add Agent Skills frontmatter (`name`/`description`) so `npx skills` no longer skips them
 - Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
 
 ### Added
+
 - `scripts/validate-skill-frontmatter.sh` + `npm run validate:skills`
 - `docs/multi-host-packaging.md` install matrix + agent id notes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,9 @@
 # Changelog
 
-## [1.22.1] - 2026-08-10
-
-### Fixed
-- Sync `packaging/opencode-maos` version to plugin SSOT; wire `validate-skill-frontmatter` into `tests/validate-plugin.sh`; extend `version-sync.yml` to package manifests
-
-
-### Fixed
-- `.agents/skills/multi-agent-os/SKILL.md` + `.claude/skills/multi-agent-os/SKILL.md`: add Agent Skills frontmatter (`name`/`description`) so `npx skills` no longer skips them
-- Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
-
-### Added
-- `scripts/validate-skill-frontmatter.sh` + `npm run validate:skills`
-- `docs/multi-host-packaging.md` install matrix + agent id notes
-
-
 All notable changes to the Multi-Agent OS plugin will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
 
 ## [Unreleased]
 
@@ -291,6 +275,17 @@ front-door answering *"what should I focus on now? who asked me for what, by whe
 - Distinct from siblings: `maos-concierge` (framework-facing) · `work-compass` (aggregation engine it routes to) ·
   `pulse` (single-session re-orientation) · `reactivate`/Entelecheia (the agent-facing twin) · `ops-strategist`
   (the optional user-scope brain). Named by `skills/anima` per the naming authority.
+
+## [1.22.1] - 2026-08-10
+
+### Fixed
+- Sync `packaging/opencode-maos` version to plugin SSOT; wire `validate-skill-frontmatter` into `tests/validate-plugin.sh`; extend `version-sync.yml` to package manifests
+- `.agents/skills/multi-agent-os/SKILL.md` + `.claude/skills/multi-agent-os/SKILL.md`: add Agent Skills frontmatter (`name`/`description`) so `npx skills` no longer skips them
+- Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
+
+### Added
+- `scripts/validate-skill-frontmatter.sh` + `npm run validate:skills`
+- `docs/multi-host-packaging.md` install matrix + agent id notes
 
 ## [1.22.0] - 2026-07-22
 


### PR DESCRIPTION
**[PR-as-Correction-Prompt]**

## Context

`CHANGELOG.md` declares it follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) —
and violated it. Measured on `main@416d1bf`:

| defect | line | should be |
|---|---|---|
| `## [1.22.1] - 2026-08-10` sits directly under `# Changelog` | 3 | below `[Unreleased]` |
| the preamble ("All notable changes… / Keep a Changelog / SemVer") is orphaned mid-document | 18 | line 3, under the title |
| `[Unreleased]` sits **below** a released version | 24 | top, above the newest release |
| `### Fixed` appears twice inside the same `[1.22.1]` section | 5 and 9 | one merged block |

**Root cause** — anchor choice, not automation. `19f9d8c` (#318) inserted the release
section at *"top of file"* instead of at the `## [Unreleased]` anchor; `eb388e0` (#319)
then appended a second `### Fixed` into it. No script writes this file
(`check-release-coherence.py` only reads it), so this is a one-shot repair — no
recurring mechanism is warranted.

## Objective

Restore the declared convention with a **purely structural** change: move, never rewrite.

## Acceptance — verified, not asserted

- **Content preservation by multiset**: sorted non-blank lines, before vs after →
  `1465 → 1464`, the single delta being the duplicated `### Fixed` header.
  All 5 bullets and all prose byte-identical.
- **Order**: `# Changelog`(1) → preamble(3) → `[Unreleased]`(8) → `[1.22.1]`(279) → `[1.22.0]`(290)
- `bash tests/validate-plugin.sh` → exit 0
- `gitleaks detect --no-git` → no leaks (7.37 MB scanned)

## Scope boundary

`release-coherence.yml` gates PRs titled `chore(release):` on
`ALLOWED_RELEASE_PATHS = {plugin.json, CHANGELOG.md}` — it is **not** the surface that
would have caught this, and this is not a release PR. The systemic gap (requiring a
CHANGELOG entry when a PR touches `skills/`/`agents/`/`commands/`) is already tracked
in **#278** and is deliberately out of scope here.

## Cross-links

- introduced by: #318 (`19f9d8c`), compounded by #319 (`eb388e0`)
- related: #278 (CI changelog enforcement)
- unaffected: `[Unreleased]` content (incl. `refine-braindump-to-prompt` v0.3.0) is moved as-is
