### PR TITLE
docs(pr-agent): record the measured 33% drift of the Jira-key rule (declaration != mechanism)

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,8 +1,38 @@
 # Qodo PR Agent — multi-agent-os (OSS, community-agnostic)
 #
-# Tracking system: Linear VKO (NOT Jira).
+# Tracking system: Linear VKO. Jira appears throughout this repo as an
+# INTEGRATION SUBJECT (maos-mcp-hub ships an Atlassian/Jira gateway; see
+# AGENTS.md:93 and ADR-002 "VKO-88: Jira search endpoint migration") — NOT as
+# this repo's own tracker. The two are distinct and the distinction is the
+# whole point of the carve-out below.
 # Purpose: prevent recurring false-positive "missing Jira key" findings on PRs
 # of this open-source repository.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# CITATIONS — required by the Bot-Config Correction Discipline for any edict
+#
+# (1) MECHANISM (official vendor doc for `extra_instructions`):
+#     https://qodo-merge-docs.qodo.ai/usage-guide/additional_configurations/
+#     https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file/configuration-options
+#     Per-tool free-text guidance under each tool's namespace ([pr_reviewer],
+#     [pr_description], [pr_code_suggestions]). Repo-level file = `.pr_agent.toml`
+#     at the root of the default branch.
+#
+# (2) GOVERNANCE ANCHOR:
+#     rules/pr-governance-unified.md § "Bot-Config Correction Discipline"
+#       (v1.2.0, 2026-07-01) — the 5 binding rules for a teach-the-bot edict.
+#     skills/bot-finding-arbiter/bot-config-registry.md — SSOT bot→config map;
+#       the Qodo row names `.pr_agent.toml` / `extra_instructions` as the
+#       verified teaching surface, `repo-fixable? = yes`.
+#
+# (3) VERIFIER > GENERATOR (Discipline rule 2 — the bot-wrong verdict is NOT
+#     self-asserted; it rests on a deterministic, executable oracle):
+#       `.githooks/pre-push:19` →
+#         VALID_PATTERN="^(feature|feat|bugfix|fix|chore|docs|refactor|test|ci|hotfix)\/.*$"
+#       The repo's OWN enforced branch contract requires NO ticket key of any
+#       kind. f=0, re-runnable, independent of any reviewer's judgment.
+#       Corroborated by AGENTS.md:90 (`feature/<id>-slug`, no key format mandated).
+# ─────────────────────────────────────────────────────────────────────────────
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # ⚠️ MEASURED DRIFT — read this BEFORE "fixing" the Jira rule again (2026-08-15)
@@ -21,7 +51,8 @@
 # deterministic layer, not in this config").
 #
 # DISPOSITION when the finding fires:
-#   ✅ dismiss that occurrence (it is a verified false positive for THIS repo)
+#   ✅ dismiss that occurrence — false positive for THIS repo, verified against
+#      the deterministic oracle in CITATION (3), not by reviewer judgment
 #   ⛔ do NOT add a third, louder restatement of the rule below — the rule is
 #      already explicit; a louder declaration cannot fix a missing mechanism,
 #      and writing one is theater (a 2026-08-15 session started to do exactly

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -3,6 +3,36 @@
 # Tracking system: Linear VKO (NOT Jira).
 # Purpose: prevent recurring false-positive "missing Jira key" findings on PRs
 # of this open-source repository.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# ⚠️ MEASURED DRIFT — read this BEFORE "fixing" the Jira rule again (2026-08-15)
+#
+# The instructions below are already the strongest form available: they name the
+# rule, the tracker, and the literal regex. Qodo still emits the finding anyway.
+#
+#   Measured over the 6 most-recent PRs at 2026-08-15:
+#     #344 FIRED · #338 FIRED · #343 ok · #341 ok · #340 ok · #337 ok
+#     → ~33% violation rate (2/6). Obeyed most of the time; drifts the rest.
+#
+# ROOT CAUSE — `extra_instructions` is a DECLARATION, not a MECHANISM: soft prompt
+# guidance to an LLM reviewer, with no runtime interlock. It is honored
+# probabilistically and therefore drifts. This is the same failure shape the
+# decision-macro spec admits of itself ("the real block lives in the EXTERNAL
+# deterministic layer, not in this config").
+#
+# DISPOSITION when the finding fires:
+#   ✅ dismiss that occurrence (it is a verified false positive for THIS repo)
+#   ⛔ do NOT add a third, louder restatement of the rule below — the rule is
+#      already explicit; a louder declaration cannot fix a missing mechanism,
+#      and writing one is theater (a 2026-08-15 session started to do exactly
+#      that before measuring that the fix already existed, twice).
+#   ⛔ NEVER extend this file to suppress a security or logic finding. This
+#      carve-out covers a mis-scoped TRACEABILITY convention only.
+#
+# A real fix would need enforcement outside the reviewer (a repo gate that
+# evaluates the PR before Qodo, or an upstream Qodo option that is a hard
+# setting rather than prose). Neither exists today — hence: record, don't re-fix.
+# ─────────────────────────────────────────────────────────────────────────────
 
 [config]
 # This is primarily a documentation + shell-scripts + markdown skills repo.


### PR DESCRIPTION
**[PR-as-Documentation-Prompt]**

## Context

The Jira-key false-positive suppression in `.pr_agent.toml` has existed since **2026-04-17** in its strongest available form — it names the rule, the tracker (Linear VKO), and the literal regex `[A-Z][A-Z0-9]+-\d+`. Qodo emitted the finding anyway on **#344** (2026-08-15, HIGH severity), blocking it on an unresolved thread.

## Objective

Record the **measured** drift rate at the point of failure, so the next agent does not write a third restatement of a rule that already exists twice.

## Citations (required by the Bot-Config Correction Discipline)

Qodo's HIGH finding on this PR was **VALID** — a bot-config edict must carry the mechanism doc and a governance anchor, and the first revision carried the measurement without either. Added in `d660299`:

| # | Citation | Reference |
|---|---|---|
| 1 | **Mechanism** (official vendor doc) | [`extra_instructions` usage guide](https://qodo-merge-docs.qodo.ai/usage-guide/additional_configurations/) · [configuration options](https://docs.qodo.ai/qodo-documentation/qodo-merge/configuration/configuration-file/configuration-options) — per-tool free-text guidance under each namespace; repo file = `.pr_agent.toml` at default-branch root |
| 2 | **Governance anchor** | `rules/pr-governance-unified.md` § "Bot-Config Correction Discipline" (v1.2.0, 2026-07-01) + `skills/bot-finding-arbiter/bot-config-registry.md` (SSOT map — Qodo row = `.pr_agent.toml`/`extra_instructions`, `repo-fixable? = yes`) |
| 3 | **Verifier > generator** (rule 2) | `.githooks/pre-push:19` → `VALID_PATTERN="^(feature\|feat\|bugfix\|fix\|chore\|docs\|refactor\|test\|ci\|hotfix)\/.*$"` — the repo's own **enforced** branch contract requires **no ticket key of any kind**. `f=0`, re-runnable. Corroborated by `AGENTS.md:90` |

**Citation 3 closes a gap the finding did not name.** Discipline rule 2 requires the *bot-wrong* verdict to be **independently verified**, not self-asserted. The first revision measured the drift itself (generator = verifier). The verdict now rests on an executable oracle instead.

## Correction to this PR's own premise

The file header read `Tracking system: Linear VKO (NOT Jira)`. That flat negation is **imprecise**: `AGENTS.md:93` and `ADR-002` **do** reference Jira — as an **integration subject** (`maos-mcp-hub` ships an Atlassian/Jira gateway; *"VKO-88: Jira search endpoint migration"*), not as this repo's tracker. Corrected in `d660299`.

Stating it as an ungrounded negation was the same *declaration-without-mechanism* failure this PR exists to document — found while assembling citation 3.

## Measurement

| PR | jira-finding fired? |
|---|---|
| #344 | FIRED |
| #338 | FIRED |
| #343 / #341 / #340 / #337 | ok |

**2/6 → ~33% violation rate.** Positive control: the GraphQL probe finds qodo threads on both #344 and #343, so a `0` is a genuine absence, not a blind instrument.

## Root cause

`extra_instructions` is a **DECLARATION, not a MECHANISM** — soft prompt guidance to an LLM reviewer with no runtime interlock. It is honored probabilistically (~67%) and drifts.

There is therefore **no config fix available for the drift**. A louder declaration cannot supply a missing mechanism. (The config *surface* is repo-fixable per the registry; the *drift* is not.)

## Discipline compliance (all 5 rules)

| Rule | Status |
|---|---|
| 1. Never suppress a valid security/logic finding | ✅ nothing suppressed — comment-only, `extra_instructions` untouched |
| 2. Verifier > generator | ✅ deterministic oracle, citation 3 |
| 3. Repo-fixable only | ✅ registry Qodo row = `repo-fixable? yes`; surface verified present |
| 4. Narrowest teaching form | ✅ narrowest possible — adds **no** teaching, only a record |
| 5. Reviewed PR, never silent | ✅ this PR |

## Acceptance

- [x] No new rule added; no behavior changed (comment-only, +63/-2 total)
- [x] TOML re-validated with `tomllib` — negative control confirms the validator rejects a broken toml
- [x] gitleaks clean
- [x] Disposition documented: dismiss-per-occurrence; never extend this carve-out to a security/logic finding
- [x] `CHANGELOG.md` deliberately untouched — a concurrent session is restructuring it (#344 merged; `feat/changelog-required-gate` → #348 open)

## Risk / rollback

Comment-only in a bot-review config. Revert = `git revert`. Not a guardrail-enforcing rule/hook/allowlist; governed by the Bot-Config Correction Discipline, whose 5 gates are satisfied above.