### PR TITLE
feat(transmute): v0.2.0 generic enhance matrix — source×transform×cast×emit

### DIFF
--- a/commands/transmute.md
+++ b/commands/transmute.md
@@ -22,14 +22,14 @@ bounds). This file is the command surface only. Soul-name: *Proteus*.
 | Flag | Default | Allowed values |
 |---|---|---|
 | `"<source>"` (positional) | *required* | path · glob · inline text · `-` (stdin). Empty/unfilled placeholder → STOP-ERROR |
-| `--transforms` | `analyze,refine` | ordered comma list (analyze, critique, meta-critique, red-team, validate, fix, enhance, refine, sanitize, harmonize, dogfood); `auto` = infer |
+| `--transforms` | `analyze,refine` | ordered comma list (analyze, critique, meta-critique, red-team, validate, fix, enhance, expand, refine, polish, sanitize, harmonize, compliance (=validate+sanitize), dogfood); `auto` = infer |
 | `--to-type` | `same-as-source` | `prompt` · `agentic-tool:{skill\|command\|agent\|subagent\|rule\|memory\|hook\|webhook\|event\|trigger\|mcp\|plugin\|marketplace}` · `audience-recast` · `artifact:{md\|html\|pdf\|slides\|diagram\|confluence\|gamma\|canva}` · `ledger` · `ticket`/`ticket:{jira\|linear}` |
 | `--output-target` | *(report inline)* | comma sinks: `stdout` · `clipboard` · `vault[:path]`/`obsidian[:path]` · `path:P` · `git-repo:P` · `agentic-tool:kind:path` · `jira[:key]` · `linear[:key]` · `confluence[:space]` · `gamma[:deck]` · `canva[:design]` · `bitbucket:P` · `github:P` · `atlassian:P` |
 | `--mode` | `dry-run` | `dry-run` · `run` · `dogfood` (aliases: `--dry-run`/`--run`/`--dogfood`) |
 | `--principles` | `auto` | inherit host governance corpus by reference (`auto`=full 40+ list; csv validated) |
 | `--user-lang` | `pt-BR` | operator-facing prose |
 | `--agentic-lang` | `en-US` | rendered-artifact language |
-| `--agentic-format` | `json-rpc` | alias of `--output=json-rpc` (`method`+`params` per [C06]) |
+| `--agentic-format` | `table` | alias of `--output` — when passed overrides `--output`; default `table`. Use `json-rpc` for agent-to-agent per [C06] |
 | `--output` | `table` | `table` · `json` · `json-rpc` |
 | `--max-rounds` | `12` | hard cap for looped verbs |
 

--- a/commands/transmute.md
+++ b/commands/transmute.md
@@ -1,6 +1,6 @@
 ---
 name: transmute
-description: Transmute ONE source of any kind (text · prompt · draft · braindump · doc · code · agentic-tool) through a transformation menu (analyze · critique · red-team · validate · fix · enhance · refine · sanitize · harmonize) and CAST it into a target type (same-as-source default · prompt · agentic-tool · audience-recast · artifact · ledger · ticket) emitted to one-or-more sinks (stdout · clipboard · vault · path · git-repo · agentic-tool). Thin router composing existing primitives. Safe default dry-run.
+description: Transmute ONE source of any kind (text · prompt · draft · braindump · doc · code · agentic-tool) through a transformation menu (analyze · critique · meta-critique · red-team · validate · fix · enhance · refine · sanitize · harmonize · compliance) and CAST it into a target type (same-as-source default · prompt · agentic-tool · audience-recast · artifact · ledger · ticket) emitted to one-or-more sinks (stdout · clipboard · vault/obsidian · path · git-repo · jira · linear · atlassian · bitbucket · github · confluence · gamma · canva · agentic-tool). Thin router composing existing primitives. Safe default dry-run.
 ---
 
 # /transmute Command
@@ -23,12 +23,13 @@ bounds). This file is the command surface only. Soul-name: *Proteus*.
 |---|---|---|
 | `"<source>"` (positional) | *required* | path · glob · inline text · `-` (stdin). Empty/unfilled placeholder → STOP-ERROR |
 | `--transforms` | `analyze,refine` | ordered comma list (analyze, critique, meta-critique, red-team, validate, fix, enhance, refine, sanitize, harmonize, dogfood); `auto` = infer |
-| `--to-type` | `same-as-source` | `prompt` · `agentic-tool:{skill\|command\|agent\|rule\|memory\|mcp\|hook\|plugin}` · `audience-recast` · `artifact:{md\|html\|pdf\|slides\|diagram}` · `ledger` · `ticket` |
-| `--output-target` | *(report inline)* | comma sinks: `stdout` · `clipboard` · `vault:path` · `path:P` · `git-repo:P` · `agentic-tool:kind:path` |
+| `--to-type` | `same-as-source` | `prompt` · `agentic-tool:{skill\|command\|agent\|subagent\|rule\|memory\|hook\|webhook\|event\|trigger\|mcp\|plugin\|marketplace}` · `audience-recast` · `artifact:{md\|html\|pdf\|slides\|diagram\|confluence\|gamma\|canva}` · `ledger` · `ticket`/`ticket:{jira\|linear}` |
+| `--output-target` | *(report inline)* | comma sinks: `stdout` · `clipboard` · `vault[:path]`/`obsidian[:path]` · `path:P` · `git-repo:P` · `agentic-tool:kind:path` · `jira[:key]` · `linear[:key]` · `confluence[:space]` · `gamma[:deck]` · `canva[:design]` · `bitbucket:P` · `github:P` · `atlassian:P` |
 | `--mode` | `dry-run` | `dry-run` · `run` · `dogfood` (aliases: `--dry-run`/`--run`/`--dogfood`) |
-| `--principles` | `auto` | inherit host governance corpus by reference |
+| `--principles` | `auto` | inherit host governance corpus by reference (`auto`=full 40+ list; csv validated) |
 | `--user-lang` | `pt-BR` | operator-facing prose |
 | `--agentic-lang` | `en-US` | rendered-artifact language |
+| `--agentic-format` | `json-rpc` | alias of `--output=json-rpc` (`method`+`params` per [C06]) |
 | `--output` | `table` | `table` · `json` · `json-rpc` |
 | `--max-rounds` | `12` | hard cap for looped verbs |
 

--- a/skills/transmute/SKILL.md
+++ b/skills/transmute/SKILL.md
@@ -79,7 +79,7 @@ escalate, never auto-act. **The gitleaks/PII gate before emission is non-negotia
 
 ```text
 INTAKE    := resolve <source> (path | inline | pipe | glob) and TYPE it
-            (text · prompt · draft · braindump · doc · code · agentic-tool · report)
+            (text · prompt · draft · braindump · doc · code · agentic-tool · email · folder · report)
             + resolve params; detect unfilled template placeholder (e.g. "{{BRAINDUMP}}"
               verbatim) -> STOP-ERROR naming the placeholder (do not transmute the wrapper)
 COMPREHEND := lossless movement ONLY (dissect · type · relate · catalogue · prism DoD)
@@ -88,7 +88,7 @@ COMPREHEND := lossless movement ONLY (dissect · type · relate · catalogue · 
 TRANSFORM := apply --transforms menu, in canonical order:
             sanitize-first (stop-bleeding) -> analyze -> critique -> meta-critique
             -> red-team -> validate -> fix/solve -> enhance/expand -> refine/polish
-            -> converge/harmonize. Each verb lands on its primitive (§Composition).
+            -> converge/harmonize -> compliance (=validate+sanitize). Each verb lands on its primitive (§Composition).
             Bounded by the economic stop (n*, per convergence-engine); NEVER unbounded.
 CAST      := resolve target type (--to-type | default same-as-source, dynamic)
             and route to the OWNING sibling (§Cast router). Naming a cast artifact
@@ -140,15 +140,15 @@ in-repo column with a one-line diagnostic, never a hard failure.
 
 | Flag | Default | Notes |
 |---|---|---|
-| `<source>` (positional) | *required* | path · glob · inline text · `email` · `braindump` · `-` (stdin pipe). Empty or unfilled placeholder → `STOP-ERROR` |
-| `--transforms` | `analyze,refine` | ordered comma list from the verb families above; `auto` = infer from source+target. PT verbs auto-mapped (see §Cast router). |
+| `<source>` (positional) | *required* | path · glob · inline text · `email` · `braindump` · `folder` · `artifact` · `-` (stdin pipe). Empty or unfilled placeholder → `STOP-ERROR` |
+| `--transforms` | `analyze,refine` | ordered comma list from the verb families above (`analyze`, `critique`, `meta-critique`, `red-team`, `validate`, `fix`, `enhance`, `expand`, `refine`, `polish`, `sanitize`, `harmonize`, `compliance` (=`validate`+`sanitize`), `dogfood`); `auto` = infer from source+target. PT verbs auto-mapped (see §Cast router). |
 | `--to-type` | `same-as-source` | see §Cast router; `same-as-source` = **dynamic calculated** (type preserved); explicit `prompt`/`artifact:*/`/`agentic-tool:*`/`ticket` overrides |
 | `--output-target` | *(none = report inline)* | comma sinks `stdout[,]{clipboard\|vault[:path]\|obsidian[:path]\|path:P\|git-repo:P\|agentic-tool:kind:path\|jira[:key]\|linear[:key]\|confluence[:space]\|gamma[:deck]\|canva[:design]\|bitbucket:P\|github:P\|atlassian:P}` — membership test per §EMIT (REACHABLE·RENDER DEFINED·CAN REFUSE). `obsidian` is alias of `vault`; `git-repo` covers `iketrans`/`vek-ai-toolkit`/`akasha` per `persist-locus` gate |
 | `--mode` | `dry-run` | `dry-run` (report+plan only) · `run` (execute writes) · `dogfood` (run, then validate-on-self + ledger). Aliases `--dry-run`/`--run`/`--dogfood` accepted |
 | `--principles` | `auto` | inherit host governance corpus BY REFERENCE (worktree · PDCA · S-SDLC · DRY/KISS/YAGNI · anti-over-eng · anti-theater · secure/privacy-by-design · LGPD/GDPR · boy-scout …) — never inline the corpus. `auto` = full corpus; `list` = csv subset validated against corpus (e.g. `GIT-WORKTREES-MANDATORY,IDEMPOTENT,SSOT,DRY`); unknown token → `STOP-ERROR` with valid list |
 | `--user-lang` | `pt-BR` | operator-facing prose (`pt-BR` default) |
 | `--agentic-lang` | `en-US` | language of the rendered artifact (`en-US` default, json-rpc payload) |
-| `--agentic-format` | `json-rpc` | alias of `--output=json-rpc` (per `[C06]` notification shape `method`+`params`, no `id`); `table`/`json` also valid |
+| `--agentic-format` | `table` | alias of `--output` — when passed overrides `--output`; default `table` (same as `--output`). `json-rpc` is the recommended value for agent-to-agent calls per `[C06]` (`method`+`params`, no `id`) |
 | `--output` | `table` | `table` \| `json` \| `json-rpc` (notification shape per `[C06]`). `--agentic-format` is alias |
 | `--max-rounds` | `12` | hard cap for any looped verb → `STOP-HITL` on exhaustion |
 

--- a/skills/transmute/SKILL.md
+++ b/skills/transmute/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: transmute
-version: "0.1.3"
+version: "0.2.0"
 description: >-
   Transmute ONE source of ANY kind (text · prompt · draft · braindump · doc · code ·
-  agentic-tool · report) through a menu of transformations (comprehend · analyze ·
+  agentic-tool · email · report) through a menu of transformations (comprehend · analyze ·
   critique · meta-critique · validate · red-team · fix · enhance · expand · refine ·
-  sanitize · harmonize) and CAST it into a chosen target type (same-as-source default ·
-  prompt · agentic-tool · audience-recast · artifact md/pdf/html · ledger · ticket)
-  emitted to one-or-more sinks (stdout · clipboard · vault · path · git-repo ·
-  agentic-tool). Source-agnostic generalization of the fixed-pair siblings — a thin
+  sanitize · harmonize · compliance) and CAST it into a chosen target type (same-as-source default ·
+  prompt · agentic-tool · audience-recast · artifact md/pdf/html/confluence/gamma/canva · ledger · ticket)
+  emitted to one-or-more sinks (stdout · clipboard · vault/obsidian · path · git-repo ·
+  agentic-tool · jira · linear · atlassian · bitbucket · github · confluence · gamma · canva). Source-agnostic generalization of the fixed-pair siblings — a thin
   router that COMPOSES in-repo primitives (refine-braindump-to-prompt,
   agentic-tool-forge, content-recast, converge, red-team, audit, pii-masking) and
   reimplements nothing. Soul-name: Proteus. Triggers: "transmute", "/transmute",
@@ -106,14 +106,16 @@ consumes. DONE when EMIT reports (or, under `--dry-run`, when the plan is emitte
 
 | `--to-type` | Route to | Notes |
 |---|---|---|
-| `same-as-source` *(default)* | inline TRANSFORM output | source type from INTAKE; no re-cast |
-| `prompt` | `refine-braindump-to-prompt` (source=braindump) · `agents/prompt-context-engineer` + profile (else) | the prompt-craft seat |
-| `agentic-tool:{skill\|command\|agent\|rule\|memory\|mcp\|hook\|plugin}` | `agentic-tool-forge` | type-decision router SSOT is the forge's; naming → `anima`; worktree→branch→PR per `[C04]` |
+| `same-as-source` *(default)* | inline TRANSFORM output | source type from INTAKE; no re-cast; **dynamic calculated** per `--output-target` |
+| `prompt` | `refine-braindump-to-prompt` (source=braindump → Lapidary) · `agents/prompt-context-engineer` + profile (else) | the prompt-craft seat; enhanced-prompt + gauntlet-prompt via profile `gauntlet-loop` |
+| `agentic-tool:{skill\|command\|agent\|subagent\|rule\|memory\|hook\|webhook\|event\|trigger\|mcp\|plugin\|marketplace}` | `agentic-tool-forge` | type-decision router SSOT is the forge's; naming → `anima`; worktree→branch→PR per `[C04]`; marketplace needs `[C12]` provenance |
 | `audience-recast` | `content-recast` | faithfulness guard lives there |
-| `artifact:{md\|html\|pdf\|slides\|diagram}` | renderers (`document-generate` · `archify` · `make-pdf` · host-native) | never re-implement a renderer |
+| `artifact:{md\|html\|pdf\|slides\|diagram\|confluence\|gamma\|canva}` | renderers (`document-generate` · `archify` · `make-pdf` · Gamma MCP · Canva fallback · atlassian-concierge) | never re-implement a renderer; `confluence` via atlassian MCP, `gamma`/`canva` via slides renderer |
 | `ledger` | `directive-braindump-triage` | provenance ledger |
 | `vault-artifact` | `braindump-distill` (eko-engram *Alambique*, user-scope IF vault mounted) | vault-side standing protocol — PARA placement + ledger + `persist-locus` routing; transmute routes there, never reimplements placement |
-| `ticket` | `ticket-as-prompt` (user-scope, IF installed) | Jira/Linear render |
+| `ticket` / `ticket:{jira\|linear}` | `ticket-as-prompt` (user-scope, IF installed) + `atlassian-concierge` / `vek-issue-router` | Jira/Linear render; `jira` = Atlassian, `linear` = Linear; backlog-ticket kind |
+
+> **PT-verb mapping (operator dump → canonical TRANSFORM):** `analisado→analyze` · `dissecado/destrinchado→COMPREHEND dissect·catalogue·relate` · `investigado→analyze+research` · `criticado→critique` · `meta-criticado→meta-critique` · `validado→validate` · `revisto→critique+validate` · `corrigido→fix/solve` · `enhanced/improved/expanded→enhance/expand` · `refinado/lapidado→refine/polish` · `sanitizado→sanitize` · `harmonizado→converge/harmonize` · `compliance→validate+sanitize` (LGPD/GDPR/secure-by-design).
 
 The router EMITS invocations (anti-NIH); a missing optional primitive degrades to the
 in-repo column with a one-line diagnostic, never a hard failure.
@@ -138,15 +140,16 @@ in-repo column with a one-line diagnostic, never a hard failure.
 
 | Flag | Default | Notes |
 |---|---|---|
-| `<source>` (positional) | *required* | path · glob · inline text · `-` (stdin pipe). Empty or unfilled placeholder → `STOP-ERROR` |
-| `--transforms` | `analyze,refine` | ordered comma list from the verb families above; `auto` = infer from source+target |
-| `--to-type` | `same-as-source` | see §Cast router |
-| `--output-target` | *(none = report inline)* | comma sinks `stdout[,]{clipboard\|vault:path\|path:P\|git-repo:P\|agentic-tool:kind:path}` — membership test per §EMIT |
-| `--mode` | `dry-run` | `dry-run` (report+plan only) · `run` (execute writes) · `dogfood` (run, then validate-on-self + ledger) |
-| `--principles` | `auto` | inherit host governance corpus BY REFERENCE (worktree · PDCA · S-SDLC · DRY/KISS/YAGNI · anti-over-eng · anti-theater · secure/privacy-by-design · LGPD/GDPR · boy-scout …) — never inline the corpus |
-| `--user-lang` | `pt-BR` | operator-facing prose |
-| `--agentic-lang` | `en-US` | language of the rendered artifact |
-| `--output` | `table` | `table` \| `json` \| `json-rpc` (notification shape per `[C06]`) |
+| `<source>` (positional) | *required* | path · glob · inline text · `email` · `braindump` · `-` (stdin pipe). Empty or unfilled placeholder → `STOP-ERROR` |
+| `--transforms` | `analyze,refine` | ordered comma list from the verb families above; `auto` = infer from source+target. PT verbs auto-mapped (see §Cast router). |
+| `--to-type` | `same-as-source` | see §Cast router; `same-as-source` = **dynamic calculated** (type preserved); explicit `prompt`/`artifact:*/`/`agentic-tool:*`/`ticket` overrides |
+| `--output-target` | *(none = report inline)* | comma sinks `stdout[,]{clipboard\|vault[:path]\|obsidian[:path]\|path:P\|git-repo:P\|agentic-tool:kind:path\|jira[:key]\|linear[:key]\|confluence[:space]\|gamma[:deck]\|canva[:design]\|bitbucket:P\|github:P\|atlassian:P}` — membership test per §EMIT (REACHABLE·RENDER DEFINED·CAN REFUSE). `obsidian` is alias of `vault`; `git-repo` covers `iketrans`/`vek-ai-toolkit`/`akasha` per `persist-locus` gate |
+| `--mode` | `dry-run` | `dry-run` (report+plan only) · `run` (execute writes) · `dogfood` (run, then validate-on-self + ledger). Aliases `--dry-run`/`--run`/`--dogfood` accepted |
+| `--principles` | `auto` | inherit host governance corpus BY REFERENCE (worktree · PDCA · S-SDLC · DRY/KISS/YAGNI · anti-over-eng · anti-theater · secure/privacy-by-design · LGPD/GDPR · boy-scout …) — never inline the corpus. `auto` = full corpus; `list` = csv subset validated against corpus (e.g. `GIT-WORKTREES-MANDATORY,IDEMPOTENT,SSOT,DRY`); unknown token → `STOP-ERROR` with valid list |
+| `--user-lang` | `pt-BR` | operator-facing prose (`pt-BR` default) |
+| `--agentic-lang` | `en-US` | language of the rendered artifact (`en-US` default, json-rpc payload) |
+| `--agentic-format` | `json-rpc` | alias of `--output=json-rpc` (per `[C06]` notification shape `method`+`params`, no `id`); `table`/`json` also valid |
+| `--output` | `table` | `table` \| `json` \| `json-rpc` (notification shape per `[C06]`). `--agentic-format` is alias |
 | `--max-rounds` | `12` | hard cap for any looped verb → `STOP-HITL` on exhaustion |
 
 `--dry-run`/`--run`/`--dogfood` are accepted as aliases of `--mode`. Dynamic runtime
@@ -192,9 +195,10 @@ Exactly ONE terminal marker per turn — the `/goal` Stop-hook contract:
 
 ## Protocol Rules
 
-- **Safe default**: `--mode=dry-run`; writes only under `--mode=run|dogfood`.
+- **Safe default**: `--mode=dry-run`; writes only under `--mode=run|dogfood`. `--dry-run` emits plan as `json-rpc` when `--agentic-format=json-rpc`.
+- **Principles by-reference**: `--principles` never inlines the corpus; unknown principle → `STOP-ERROR` listing valid 40+ principals (GIT-WORKTREES-MANDATORY, GIT-PR-SUBMIT, IDEMPOTENT, SSOT, DRY, CLEAN-CODE, ANTI-OVER-ENG, ANTI-THEATER, LGPD-COMPLIANCE, etc). Dynamic runtime params beyond this list are computed per delegated primitive, never invented.
 - **Worktree discipline always on** for any `git-repo`/`agentic-tool` sink
-  (`skills/worktree-policy`); never commit to main.
+  (`skills/worktree-policy`); never commit to main. `iketrans`/`vek-ai-toolkit`/`akasha` are `git-repo:` kinds, same gate.
 - **Delegation depth ≤ 2; parallel fan-out ≤ 3**; DNA-geracional transcribed to every
   delegate ("delegar não isenta a responsabilidade recebida").
 - **Sanitize-first on dirty sources** (stop-bleeding-before-root-cause); gitleaks+PII
@@ -264,6 +268,7 @@ router added no routing). Dormant-by-design otherwise.
 
 ## Versioning
 
+- v0.2.0 — **generic enhance matrix (round n+9 /n+10)**: source×transform×cast×emit fully parametrizable per operator `/enhance` spec. **Cast router**: `agentic-tool:*` extended to `subagent/rule/memory/hook/webhook/event/trigger/mcp/plugin/marketplace`; `artifact:*` adds `confluence/gamma/canva`; `ticket` now `ticket:{jira|linear}`; `obsidian` alias of `vault`. **Sink axis**: `--output-target` adds `obsidian`, `jira`, `linear`, `confluence`, `gamma`, `canva`, `bitbucket`, `github`, `atlassian` (all mapped through `vault`/`git-repo`/`atlassian-concierge`/`ticket-as-prompt` renderers). **PT-verb mapping** table. **`--principles` validation** (csv against 40+ governance corpus; by-reference). **`--agentic-format=json-rpc`** alias + `--dry-run/--run/--dogfood` aliases documented. **COMPREHEND**: source kinds now include `email`·`folder`·`braindump`. **Prisma**: output/format/target as first-class `--to-type`+`--output-target` test (REACHABLE·RENDER DEFINED·CAN REFUSE). Dogfood targets: `braindump-distill.*`, `prompt-gauntlet-loop`, `prompt-transkriptor-import`, `theca/_inbox/2026-08-*.braindump.md` → `prompt`/`gauntlet-prompt`/`agentic-tool` at `obsidian/akasha/maos/vek-ai-toolkit/iketrans`. No new rival skill — extends Proteus per forge ≥50% gate.
 - v0.1.3 — **cross-harness SSOT consolidation** (round n+5 recon): recon of the
   eko-engram ledger revealed the vault family (2026-08-14) reached the OPPOSITE
   verdict on the same directive-class ("dropped: new generic enhancer skill —


### PR DESCRIPTION
Transmute v0.2.0 — generic enhance matrix parametrizável (round n+10).

**Vault complement:** `a private downstream repository's pages/enhance.md` (*Atelier*) + `pages/enhance.prompt.md` + `resources/agentic-tools/enhance.spec.yaml` + ledger row n+10 (já persistidos no vault, fora deste PR).

**Este PR (repo):**
- Cast router: `agentic-tool:*` +subagent/rule/memory/hook/webhook/event/trigger/mcp/plugin/marketplace; `artifact:*` +confluence/gamma/canva; `ticket:{jira|linear}`; `obsidian` alias vault
- Sink axis `--output-target`: obsidian/jira/linear/confluence/atlassian/bitbucket/github/gamma/canva/iketrans (git-repo kind) via reachable·render·can-refuse
- PT-verb mapping (analisado→analyze … harmonizado→harmonize)
- --principles auto|csv by-reference (40+), --agentic-format json-rpc alias, --dry-run/--run/--dogfood aliases
- Dogfood: braindump-distill.*, prompt-gauntlet-loop, transkriptor-import, theca/_inbox/2026-08-*.braindump.md → prompt/gauntlet/agentic-tool at obsidian/akasha/maos/(redacted)/iketrans

**Gate:** forge ≥50% → EXTEND-not-FORK (Proteus, não rival). SSOT split: WHERE=persist-locus · HOW=Lapidary · WHICH=transmute · vault=Alambique+Atelier.

Refs: braindump-distill.ledger.md n+10, agentic-tool-forge, anima Atelier

<!--ORCH-STATUS: STOP-DONE -->

