### PR TITLE
feat(postflight): v0.10.0 — rubric FAILs C1+C2 fixed + judge PASS + version-drift superseded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — régua pilot backlog: postflight v0.10.0
+
+- `skills/postflight` v0.10.0 — session-owner discrimination in the git sweep (peer WIP reported,
+  never touched; structural attribution first) + unpushed-own-commits = FAILURE verdict
+  (not DEFER). Version drift (0.9.0 vs 0.8.0) superseded.
+
 ### Added — régua pilot backlog: quiesce v0.3.0 + progressive-disclosure split
 
 - `skills/quiesce` v0.3.0 — 3 rubric conjuncts (loose-end sweep all-worktrees · check

--- a/skills/postflight/SKILL.md
+++ b/skills/postflight/SKILL.md
@@ -18,7 +18,7 @@ description: |
   (reconciled with exit-hygiene by ADR-010). The end-of-session counterpart to the `preflight` skill. Reads
   whatever governance is present at invocation (CLAUDE/AGENTS/CONTRIBUTING/README/protocols/
   memories) and adapts.
-version: 0.9.0
+version: 0.10.0
 triggers:
   - postflight
   - run postflight
@@ -34,7 +34,7 @@ triggers:
   - sync the backlog
   - file the loose ends as tickets
 metadata:
-  version: "0.8.0"
+  version: "0.10.0"
   scope: AAIF cross-vendor
   family: worktree-lifecycle
   lifecycle-stage: operate
@@ -141,6 +141,17 @@ governance the target repo exposes right now** and adapt (do NOT hardcode):
    - git: status clean? worktrees only main? stale branches? unpushed commits? uncommitted
      edits in main checkout? → commit-via-worktree / push / open PR or DEFER per workflow.
      Drive open PRs toward green (compose quiesce).
+     **Session-owner discrimination (rubric C1)**: dirty/uncommitted files MUST be attributed
+     to their owning session BEFORE any action (cross-ref active worktrees/sessions;
+     `.worktrees/sessions.json` when present). Another session's WIP is REPORTED
+     (marked owner-alheio), NEVER committed/reaped/reverted — touching a peer's WIP is a
+     fatal postflight fault. Attribution order: session registry / owning worktree branch
+     FIRST (structural), git authorship as FALLBACK (heuristic — identical author emails
+     across sessions can mis-attribute; when ambiguous, mark `owner-uncertain` and DEFER). (Observed live 2026-08-15: a peer session's transkriptor WIP
+     sat in the main checkout all night; distinguishing it was manual.)
+     **Unpushed-own = FAILED run (rubric C2)**: if the report closes with local commits
+     authored by the CURRENT session still unpushed, postflight reports **FAILURE** —
+     not DEFER. (DEFER stays valid for out-of-scope/peer items, never for own commits.)
    - stale/orphan worktrees + merged orphan branches → **reap** via `bin/reap-sessions.sh`
      (the executor that closes the detect→act loop; `work-compass`/`worktree-policy` only detect).
      ALWAYS survey dry-run first — `bin/reap-sessions.sh --repo-dir <main-checkout-root> --stale-days <N> --json`


### PR DESCRIPTION
## [PR-as-Documentation-Prompt]

**Context.** Pilot eval (#354) FAILed postflight 0/2 — ambos observados ao vivo (WIP-alheio ficou a noite toda no main checkout; unpushed-commit de sessão virou loose-end invisível).

**Objective.** Fechar C1+C2 no eixo git do P1 SWEEP.

### Changes (v0.9.0/0.8.0 drift → **0.10.0** em ambos os campos)
- **C1 — session-owner discrimination**: dirty files atribuídos à sessão dona ANTES de agir (registry/branch primeiro, authorship como fallback com `owner-uncertain`→DEFER); WIP de peer = reported, nunca tocado (fatal fault).
- **C2 — unpushed-own = FAILURE**: sessão atual com commits locais sem push no fechamento ⇒ postflight reporta FAILURE, não DEFER (DEFER segue válido para peer/out-of-scope).
- Drift de versionamento (top 0.9.0 × metadata 0.8.0) resolvido por supersede.

### Re-eval (juiz externo pi/Gemini, 3ª família): **C1 PASS · C2 PASS** (adversarial; weakest-link da heurística de autoria endereçado com structural-first + fallback honesto).

guardrail-surface: 0 hits · validator rc=0 · CHANGELOG entry (gate #348).