### PR TITLE
feat(governance): port question-batch-gate — opt-in Stop-hook against question-batching

### DIFF
--- a/plugin-scripts/governance/question-batch-gate.sh
+++ b/plugin-scripts/governance/question-batch-gate.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# question-batch-gate v1.1.0 — Stop-event advisory gate against QUESTION-BATCHING.
+#
+# COMMUNITY PORT (2026-08-18): dogfooded 16/1622 real fires (~1%) over 2026-07-25 to
+#   2026-08-18 in an operator's private `~/.claude` corpus before landing here — well
+#   past the ≥2-cycle bar (`dogfooding-mandate` R1). Ported VERBATIM (byte-identical
+#   logic; this repo's generic `set -euo pipefail` hook convention is deliberately
+#   NOT applied — see "HOW it is safe / FAIL-SAFE" below, which the script's own
+#   red-teamed design depends on). The `WHY`/`Refs` sections below cite the SOURCE
+#   host's rule corpus by name as the ORIGIN of the pattern (Grice's Cooperative
+#   Principle · mixed-initiative interaction discipline) — a consumer repo need not
+#   have those exact files; the mechanism (heuristic question-count → advisory nudge
+#   → self-answer-first) is host-agnostic. **NOT wired into this repo's own
+#   `hooks/hooks.json` Stop[] array** — adding it there would silently change Stop-
+#   event behaviour for every consumer that runs `/sync` or installs fresh, which is
+#   an operator-confirmed decision (`[C13]`-equivalent), never an implicit one. A
+#   consumer opts in by adding a `Stop[].hooks[]` entry pointing at this script.
+#
+# v1.1.0 (2026-07-29) ORDER FIX — measured, not guessed. See the block above the
+#   counting stage: the path-safety gate used to run BEFORE the count, so the two
+#   id-skip paths logged a HARDCODED `questions:0`. In the first 55 real invocations
+#   after wiring, 19 (~35%) took that path — those ledger rows were indistinguishable
+#   from a genuine zero-question turn, i.e. the self-blinding free-negative this very
+#   header warns about. Counting is pure string work (no path, no filesystem), so it
+#   now runs first; the allowlist gate sits immediately before the ONLY place the ids
+#   become a path (the one-shot marker). Behaviour is unchanged on every other axis:
+#   still always exit 0, still never injects without a claimable one-shot marker,
+#   BLOCKING-2 traversal defence intact (proved by 2 dedicated tests).
+#
+# WHY (the operator's own root cause, 2026-07-25, verbatim pt-BR preserved per
+#   `language-policy-en-pt` §3): "eu faço uma pergunta ela devolve +2, eu delego uma
+#   tarefa ela me pergunta +10 coisas ... passou de 3 tarefas ao mesmo tempo, começo a
+#   me perder". The AI is his primary load AMPLIFIER. `rules/user-rules.md` §Behavior
+#   ("Cognitive load — I am the amplifier") binds **≤1 question per turn**, and
+#   `harmonic` L10 / `agentic-first` §1.1.1 / `end-of-action-briefing` §7.1 all say the
+#   same thing — yet NOTHING measured it. This hook is the missing fire-point.
+#
+# WHAT it measures (name == instrument, deliberately narrow per the "9 doors" lesson in
+#   `agentic-observability-protocol` §4.1): the count of operator-facing questions in
+#   `last_assistant_message`. It does NOT measure WIP — `~/.claude/todos/` does not
+#   exist on this platform (probed 2026-07-25: 0 files; positive control `state/` = 1),
+#   so concurrent-task count is NOT observable from a hook. Naming it `wip-*` would
+#   promise WIP and deliver a question count — the exact name-vs-instrument gap.
+#
+# HOW it is safe:
+#   * NEVER blocks. Always exit 0. Never exit 2 (exit 2 on Stop *prevents stopping*).
+#   * LOOP-SAFE. Injecting additionalContext at Stop continues the turn, so an
+#     always-firing gate would never let the agent stop. Guard = one-shot per
+#     `prompt_id`, claimed with an ATOMIC `mkdir` (POSIX-atomic; a check-then-write
+#     pair is TOCTOU-racy and was proven so by red-team). Deliberately does NOT rely
+#     on `stop_hook_active` (Skopos: do not depend on a field the docs did not show
+#     for this event — even though the binary does emit it).
+#   * FAIL-SAFE. Missing dep / malformed input / unset HOME / write failure → exit 0.
+#     A broken gate must degrade to the pre-gate baseline, never break a turn.
+#   * PATH-SAFE. `session_id`/`prompt_id` come from the payload and are therefore
+#     UNTRUSTED input to a filesystem path — they are rejected unless they match a
+#     strict safe charset (`script-safety` §1; the sibling `context-handoff-monitor.js`
+#     already guards this exact risk).
+#   * MEASURABLE. EVERY invocation appends to `ledger.jsonl` — including the skip
+#     paths — because a hook that is silent AND logs nothing is indistinguishable from
+#     "installed and healthy" (the self-blinding free-negative, `agentic-observability-
+#     protocol` §4.1). There is a plain-text fallback for the jq-missing case.
+#
+# HONEST LIMITS (anti-theater — stated, not glossed):
+#   * The count is a HEURISTIC over markdown, not a parse of intent. Excluded:
+#     fenced code (``` and ~~~), blockquotes (quoted operator voice), ATX headings
+#     ("## Why?"), and table rows. Emphasis markers are stripped first so the agent's
+#     own mandated bold style (`**Question?**`) is still counted.
+#       - The §4.1 STATUS CHECKLIST tokens `persisted?` / `boy-scout?` live in a
+#         FENCED BULLET LIST (end-of-action-briefing-protocol.md:105) and in prose
+#         (:101, :116) — NOT in a table row. Verified by reading the file after a
+#         red-team falsified an earlier, fabricated claim to the contrary.
+#   * Rhetorical questions in prose are still counted → default threshold is 2, not 1.
+#   * A `?` followed immediately by an emoji is not counted.
+#   * If fence markers are unbalanced, fence-exclusion is disabled (fail toward
+#     counting) so an unclosed fence cannot silently swallow a whole message.
+#   * It cannot see `AskUserQuestion` tool calls (absent from `last_assistant_message`).
+#   * `last_assistant_message` may be truncated by the harness (unverified residual) —
+#     questions past any cut would be invisible.
+#   * It is advisory: it reminds the agent, it cannot force a rewrite.
+#
+# NOT WIRED BY THIS FILE. `settings.json` is `[C17]` §2 HUMAN_DOMAIN / `[C13]` —
+#   operator-confirmed only, and must also land in `templates/settings.template.json`.
+#
+# Tests: hooks/tests/question-batch-gate.test.sh
+# Refs: rules/user-rules.md §Behavior · harmonic-self-conduct-laws L10 ·
+#       agentic-first-decision-protocol §1.1/§1.1.1 · end-of-action-briefing §7.1/§4.1 ·
+#       loose-end-triage-queue (Taxis) · agentic-observability-protocol (Metron) ·
+#       environment-capability-reconnaissance (Skopos) §1.1.1 · script-safety §1 ·
+#       red-teaming-mandatory-trigger (Elenchus, H6) · ai-as-pwd-axiom §2 (WARN-default)
+set -uo pipefail 2>/dev/null || true
+
+# ${HOME:-/tmp} — with `set -u`, a bare $HOME aborts the script BEFORE any fail-safe
+# guard can run (red-team BLOCKING #1: reproduced exit 1 under `env -u HOME`).
+STATE_DIR="${QBG_STATE_DIR:-${HOME:-/tmp}/.claude/state/question-batch-gate}"
+THRESHOLD="${QBG_MAX_QUESTIONS:-2}"
+case "$THRESHOLD" in ''|*[!0-9]*) THRESHOLD=2 ;; esac
+[ -n "$STATE_DIR" ] || exit 0
+mkdir -p "$STATE_DIR" 2>/dev/null || exit 0
+LEDGER="$STATE_DIR/ledger.jsonl"
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || NOW="unknown"
+
+# log <skip-reason|""> <questions> <fired> — ALWAYS called exactly once per invocation.
+log() {
+  if command -v jq >/dev/null 2>&1; then
+    jq -cn --arg t "$NOW" --arg session "${sid:-}" --arg prompt "${pid:-}" \
+           --arg skipped "$1" --argjson q "$2" --argjson fired "$3" \
+      '{t:$t,session:$session,prompt_id:$prompt,questions:$q,fired:$fired}
+       + (if $skipped == "" then {} else {skipped:$skipped} end)' \
+      >> "$LEDGER" 2>/dev/null || true
+  else
+    printf '{"t":"%s","skipped":"%s","questions":%s,"fired":%s,"note":"jq-missing"}\n' \
+      "$NOW" "$1" "$2" "$3" >> "$LEDGER" 2>/dev/null || true
+  fi
+}
+
+sid=""; pid=""
+command -v jq >/dev/null 2>&1 || { log "no_jq" 0 false; exit 0; }
+
+payload="$(cat 2>/dev/null)" || { log "no_stdin" 0 false; exit 0; }
+[ -n "$payload" ] || { log "empty_stdin" 0 false; exit 0; }
+
+msg="$(printf '%s' "$payload" | jq -r '.last_assistant_message // ""' 2>/dev/null)" \
+  || { log "bad_json" 0 false; exit 0; }
+sid="$(printf '%s' "$payload" | jq -r '.session_id // ""' 2>/dev/null)" || sid=""
+pid="$(printf '%s' "$payload" | jq -r '.prompt_id  // ""' 2>/dev/null)" || pid=""
+
+[ -n "$msg" ] || { log "empty_message" 0 false; exit 0; }
+
+# ---------------------------------------------------------------------------
+# Count operator-facing questions. Runs BEFORE the path-safety gate below
+# because counting is PURE STRING PROCESSING — it builds no path, touches no
+# filesystem, and therefore needs no allowlist.
+#
+# (v1.1.0 ORDER FIX — measured, not guessed. In the first 55 real invocations
+#  after wiring, 19 (~35%) hit `unsafe_or_absent_prompt_id`, and the old order
+#  logged a HARDCODED `questions:0` on that path because the count had not run
+#  yet. Those rows were indistinguishable from a genuine zero-question turn —
+#  the self-blinding free-negative this file's own header warns about
+#  (`agentic-observability-protocol` §4.1). The count is now always real.
+#  Empirically the harness omits `prompt_id` intermittently WITHIN a single
+#  session — `166633bd…` logged one invocation with a prompt_id and a later one
+#  without — so this is not a per-session property that could be predicted.)
+# ---------------------------------------------------------------------------
+questions="$(printf '%s\n' "$msg" | awk '
+  { lines[NR] = $0; if ($0 ~ /^[[:space:]]*(```|~~~)/) fences++ }
+  END {
+    trust_fence = (fences % 2 == 0)     # unbalanced => do not let a fence swallow text
+    infence = 0
+    for (i = 1; i <= NR; i++) {
+      l = lines[i]
+      if (l ~ /^[[:space:]]*(```|~~~)/) { if (trust_fence) infence = !infence; continue }
+      if (trust_fence && infence)  continue
+      if (l ~ /^[[:space:]]*>/)    continue   # blockquote = quoted operator voice
+      if (l ~ /^[[:space:]]*\|/)   continue   # table row
+      if (l ~ /^[[:space:]]*#/)    continue   # ATX heading ("## Why?")
+      gsub(/[*_`~]/, "", l)                   # strip emphasis so **Question?** counts
+      l = l " "
+      n += gsub(/\?[)"\]}]*[[:space:]]/, "", l)
+    }
+    print n + 0
+  }
+' 2>/dev/null)" || questions=0
+case "$questions" in ''|*[!0-9]*) questions=0 ;; esac
+
+# Under threshold: nothing to claim, nothing to inject. Log the REAL count and
+# leave — reached whether or not the ids are path-safe (v1.1.0 order fix).
+if [ "$questions" -le "$THRESHOLD" ]; then log "" "$questions" false; exit 0; fi
+
+# ---------------------------------------------------------------------------
+# Path-safety gate — sited HERE, immediately before the ONLY place `sid`/`pid`
+# become a filesystem path. They are UNTRUSTED payload fields, so they are
+# rejected unless they match a strict allowlist, never a denylist
+# (`script-safety` §1; red-team BLOCKING #2 proved `session_id:"../../../../tmp/x"`
+# escaped $STATE_DIR). Absent/unsafe ids mean the one-shot marker cannot be
+# claimed, and WITHOUT that loop-guard an advisory injection at Stop could
+# re-fire forever — so this still skips, but now it skips having MEASURED and
+# LOGGED the real question count instead of a hardcoded 0.
+# ---------------------------------------------------------------------------
+safe_id() { case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; *) return 0 ;; esac; }
+safe_id "$pid" || { log "unsafe_or_absent_prompt_id" "$questions" false; exit 0; }
+safe_id "$sid" || { log "unsafe_session_id" "$questions" false; exit 0; }
+
+# ---------------------------------------------------------------------------
+# One-shot claim: ATOMIC mkdir. Succeeds for exactly one racer.
+# ---------------------------------------------------------------------------
+marker="$STATE_DIR/${#sid}.${sid}.${#pid}.${pid}.marker.d"
+if ! mkdir "$marker" 2>/dev/null; then log "idempotent" "$questions" false; exit 0; fi
+log "" "$questions" true
+
+# Bounded housekeeping: drop one-shot markers older than 7 days. Scoped to our own
+# dir, depth-1, literal suffix — never a computed path (`script-safety` §1).
+find "$STATE_DIR" -maxdepth 1 -type d -name '*.marker.d' -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+
+read -r -d '' advice <<EOF || true
+⚠️ question-batch-gate: this turn ends with ${questions} operator-facing questions (threshold ${THRESHOLD}).
+
+The operator's binding constraint (\`rules/user-rules.md\` §Behavior — "Cognitive load — I am the amplifier"): **≤1 question per turn**, because each question he answers generates ~2 more tasks for him, and past ~3 concurrent tasks he loses the thread.
+
+Before ending the turn: self-answer what you can (\`harmonic\` L10), run the MoE→Council ladder on the rest (\`agentic-first\` §1.1.1), and keep AT MOST the one question whose answer genuinely changes your next step — asked via \`AskUserQuestion\` with a recommended option first (\`end-of-action-briefing\` §7.1). Return finished work, not a question batch.
+
+(Advisory only — nothing is blocked. Heuristic count; fenced code, blockquotes, headings and table rows are excluded. One injection per prompt.)
+EOF
+
+jq -cn --arg ctx "$advice" \
+  '{hookSpecificOutput:{hookEventName:"Stop",additionalContext:$ctx}}' 2>/dev/null || true
+
+exit 0

--- a/tests/governance/test-question-batch-gate.sh
+++ b/tests/governance/test-question-batch-gate.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env sh
+# question-batch-gate.test.sh — deterministic tests for the Stop-event question-batch
+# gate. Every case below is either a documented behaviour or a REPRODUCTION of a
+# red-team finding (H6 governance artifact — `red-teaming-mandatory-trigger`).
+# Covers: firing threshold · the four exclusions (fence / blockquote / table / heading)
+# · bold-question counting (the agent's own mandated emphasis style) · unbalanced-fence
+# fail-toward-counting · one-shot idempotency · BLOCKING-1 unset HOME · BLOCKING-2 path
+# traversal via payload-controlled session_id/prompt_id · BLOCKING-3 the ledger logs
+# EVERY invocation incl. skips · threshold injection. Uses a temp QBG_STATE_DIR —
+# never touches the real ~/.claude/state/. License: MIT.
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"      # tests/governance/
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"  # multi-agent-os path convention (see test-worktree-gate.sh)
+HOOK="$PROJECT_ROOT/plugin-scripts/governance/question-batch-gate.sh"
+TMP="$(mktemp -d)"
+QBG_STATE_DIR="$TMP/state"; export QBG_STATE_DIR
+PASS=0; FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  ok   %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  FAIL %s — %s\n' "$1" "$2"; }
+
+# emit <prompt_id> <message> -> stdout of hook; sets RC
+emit() {
+  OUT="$(jq -cn --arg m "$2" --arg p "$1" --arg s "${SID:-sess1}" \
+    '{hook_event_name:"Stop",session_id:$s,prompt_id:$p,last_assistant_message:$m}' \
+    | bash "$HOOK" 2>/dev/null)"; RC=$?
+}
+fired() { printf '%s' "$OUT" | grep -q 'additionalContext'; }
+
+# expect <name> <fire:yes|no> <prompt_id> <message>
+expect() {
+  emit "$3" "$4"
+  [ "$RC" -eq 0 ] || { bad "$1" "exit $RC (must ALWAYS be 0)"; return; }
+  if fired; then g=yes; else g=no; fi
+  [ "$g" = "$2" ] && ok "$1" || bad "$1" "expected fire=$2 got=$g"
+}
+
+printf '\n# threshold\n'
+expect "3 questions fires"            yes t1 "Qual caminho?
+Sigo com o merge?
+Abro o PR?"
+expect "1 question silent"            no  t2 "Pronto. Quer que eu mergeie?"
+expect "2 questions (== threshold)"   no  t3 "O que acha?
+Sigo?"
+expect "3 questions on ONE line"      yes t4 "a? b? c?"
+
+printf '\n# exclusions (self-inflicted false positives)\n'
+expect "fenced code with ?"           no  x1 'Veja:
+```bash
+grep "why?" f
+test -f a?
+[ -n "$x" ] && echo ok?
+```'
+expect "blockquote = operator voice"  no  x2 "> qual é o backlog?
+> em qual harness comecei?
+> o que eu pensava?"
+expect "table row"                    no  x3 "| item | persisted? | boy-scout? |
+| a | y | y |
+| b | y | y |"
+expect "ATX headings"                 no  x4 "## Why?
+### What next?
+#### How?"
+expect "real §4.1 fenced bullet list" no  x5 'Fechando:
+```
+STATUS CHECKLIST
+- gaps · pendings · persisted? · boy-scout? · what-next ->
+```'
+
+printf '\n# counting fidelity (red-team MINOR-6)\n'
+expect "**Bold question?** counts"    yes b1 "**Devo seguir?**
+**Abro o PR?**
+**Mergeio agora?**"
+expect "unbalanced fence must NOT swallow" yes b2 'inicio
+```bash
+echo oi
+Devo seguir?
+Abro o PR?
+Mergeio?'
+
+printf '\n# safety invariants\n'
+expect "idempotent: same prompt_id"   no  t1 "de novo?
+e de novo?
+e mais?"
+
+emit "" "a?
+b?
+c?"
+[ "$RC" -eq 0 ] && ! fired && ok "absent prompt_id -> exit 0, no injection" \
+  || bad "absent prompt_id" "rc=$RC fired?"
+
+printf '' | bash "$HOOK" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "empty stdin -> exit 0" || bad "empty stdin" "nonzero exit"
+
+printf 'not json at all' | bash "$HOOK" >/dev/null 2>&1
+[ $? -eq 0 ] && ok "non-JSON stdin -> exit 0" || bad "non-JSON stdin" "nonzero exit"
+
+# BLOCKING-1: unset HOME must not abort under `set -u`
+O="$(jq -cn '{session_id:"h",prompt_id:"h2",last_assistant_message:"a?\nb?\nc?"}' \
+  | env -u HOME -u QBG_STATE_DIR PATH="$PATH" bash "$HOOK" 2>&1)"; RC=$?
+[ "$RC" -eq 0 ] && ok "unset HOME -> exit 0 (BLOCKING-1)" \
+  || bad "unset HOME" "rc=$RC out=$(printf '%s' "$O" | head -1)"
+
+# BLOCKING-2: payload-controlled ids must never escape STATE_DIR
+VICTIM="$TMP/victim"; mkdir -p "$VICTIM"
+SID="../../victim/pwned" emit "p9" "a?
+b?
+c?"
+[ ! -e "$VICTIM/1.pwned.2.p9.marker.d" ] && [ "$RC" -eq 0 ] \
+  && ok "traversal via session_id blocked (BLOCKING-2)" \
+  || bad "traversal session_id" "escaped to $VICTIM"
+SID=sess1 emit "../../victim/x" "a?
+b?
+c?"
+[ ! -e "$VICTIM/1.x.marker.d" ] && [ "$RC" -eq 0 ] \
+  && ok "traversal via prompt_id blocked (BLOCKING-2)" \
+  || bad "traversal prompt_id" "escaped to $VICTIM"
+
+# BLOCKING-3: the ledger must record EVERY invocation, including skips
+L="$QBG_STATE_DIR/ledger.jsonl"
+if [ -s "$L" ]; then
+  ok "ledger written ($(wc -l < "$L" | tr -d ' ') lines)"
+  grep -q '"skipped"' "$L" && ok "skip paths are logged (BLOCKING-3)" \
+    || bad "skip logging" "no skipped:* line — silent==healthy blind spot"
+  grep -q '"fired":true' "$L" && ok "fired events logged" || bad "fired logging" "none"
+else
+  bad "ledger" "empty or missing"
+fi
+
+# threshold injection
+O="$(jq -cn '{session_id:"s",prompt_id:"inj",last_assistant_message:"a?\nb?\nc?\nd?"}' \
+  | QBG_MAX_QUESTIONS='2 ; touch '"$TMP"'/PWNED' bash "$HOOK" 2>/dev/null)"; RC=$?
+[ ! -e "$TMP/PWNED" ] && [ "$RC" -eq 0 ] && ok "threshold injection inert" \
+  || bad "threshold injection" "command executed"
+
+printf '\n# v1.1.0 order fix: the count must be REAL on the id-skip paths\n'
+# Empirical trigger: 19 of the first 55 real invocations hit
+# `unsafe_or_absent_prompt_id`, and the pre-v1.1.0 order logged a HARDCODED
+# `questions:0` there because the path-safety gate ran BEFORE the count. Those
+# rows were indistinguishable from a genuine zero-question turn.
+OL="$TMP/order-ledger"; mkdir -p "$OL"
+
+# absent prompt_id + 4 real questions -> must still skip, but log questions:4
+jq -cn '{session_id:"ord1",prompt_id:"",last_assistant_message:"a?\nb?\nc?\nd?"}' \
+  | QBG_STATE_DIR="$OL" bash "$HOOK" >/dev/null 2>&1; RC=$?
+OLL="$OL/ledger.jsonl"
+[ "$RC" -eq 0 ] && ok "absent prompt_id still exits 0" \
+  || bad "absent prompt_id exit" "exit $RC"
+grep -q '"questions":4' "$OLL" 2>/dev/null \
+  && ok "absent prompt_id logs the REAL count (4, not hardcoded 0)" \
+  || bad "absent prompt_id count" "expected questions:4, got: $(tail -1 "$OLL" 2>/dev/null)"
+grep -q '"skipped":"unsafe_or_absent_prompt_id"' "$OLL" 2>/dev/null \
+  && ok "absent prompt_id still records the skip reason" \
+  || bad "absent prompt_id skip reason" "missing"
+
+# traversal-unsafe session_id + 3 questions -> skip, real count, no escape
+VICTIM2="$TMP/victim2"; mkdir -p "$VICTIM2"
+jq -cn --arg s "../../../../${VICTIM2#/}/x" \
+  '{session_id:$s,prompt_id:"ord2",last_assistant_message:"a?\nb?\nc?"}' \
+  | QBG_STATE_DIR="$OL" bash "$HOOK" >/dev/null 2>&1
+grep -q '"questions":3' "$OLL" 2>/dev/null \
+  && ok "unsafe session_id logs the REAL count (3)" \
+  || bad "unsafe session_id count" "expected questions:3"
+[ -z "$(ls -A "$VICTIM2" 2>/dev/null)" ] \
+  && ok "unsafe session_id still blocked from escaping (BLOCKING-2 intact)" \
+  || bad "unsafe session_id traversal" "victim dir not empty"
+
+# under-threshold with absent prompt_id -> plain log, no skip reason needed
+jq -cn '{session_id:"ord3",prompt_id:"",last_assistant_message:"tudo pronto."}' \
+  | QBG_STATE_DIR="$OL" bash "$HOOK" >/dev/null 2>&1
+tail -1 "$OLL" 2>/dev/null | grep -q '"questions":0' \
+  && ok "under-threshold + absent id logs a genuine 0" \
+  || bad "under-threshold absent id" "got: $(tail -1 "$OLL" 2>/dev/null)"
+
+# the advisory must STILL fire normally when ids are present (no regression)
+jq -cn '{session_id:"ord4",prompt_id:"ord4p",last_assistant_message:"a?\nb?\nc?"}' \
+  | QBG_STATE_DIR="$OL" bash "$HOOK" 2>/dev/null | grep -q 'additionalContext' \
+  && ok "advisory still fires with valid ids (no regression)" \
+  || bad "advisory regression" "did not fire with valid ids"
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+rm -rf "$TMP"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Community port of a Stop-event advisory hook (`plugin-scripts/governance/question-batch-gate.sh`) that measures operator-facing question count in the last assistant message against a threshold (default 2), heuristically excluding fenced code, blockquotes, ATX headings and table rows, and injects a self-answer-first nudge (Grice's Cooperative Principle · mixed-initiative interaction discipline) when exceeded.

Dogfooded 16/1622 real fires (~1% base rate) over 2026-07-25 -> 2026-08-18 in the originating host's private `~/.claude` corpus before this port -- well past the `dogfooding-mandate` R1 (>=2 real cycles) bar. Ported byte-identical (this repo's generic `set -euo pipefail` convention is deliberately NOT applied to the body -- the script's own fail-safe design, red-teamed twice per its own header, depends on NOT aborting on every error).

## Why it's safe to land

- Always exits 0, never blocks.
- One-shot per `prompt_id` via atomic `mkdir` (loop-safe -- an always-firing gate at Stop would never let the agent stop).
- Path-safety allowlist on `session_id`/`prompt_id` (untrusted payload fields; a red-team proved path-traversal on the naive version).
- Fail-safe on missing deps / malformed input / unset `HOME`.
- Every invocation is logged to a JSONL ledger, including skip paths -- so the mechanism is falsifiable (measured), not just "installed and assumed healthy".
- **Deliberately NOT wired into `hooks/hooks.json` `Stop[]`** -- adding it there would silently change Stop-event behavior for every consumer on `/sync` or fresh install. That is an operator-confirmed decision (mirrors this framework's own `[C13]`/HUMAN_DOMAIN discipline for settings/hook wiring), never an implicit one. Shipped as an available, tested, opt-in reference implementation; a consumer adds their own `Stop[].hooks[]` entry to activate it.

## Test plan
- [x] `bash tests/governance/test-question-batch-gate.sh` -- 29/29 passed, 0 failed (retargeted the path helper to this repo's `tests/governance` -> `plugin-scripts/governance` convention, following the `test-worktree-gate.sh` precedent; zero logic changes)
- [x] `bash tests/validate-plugin.sh` -- 0 errors, 0 warnings
- [x] `gitleaks git --staged` -- 0 leaks, 21KB scanned
- [ ] Operator/bot review of the "deliberately not wired" framing + whether a follow-up PR should offer an opt-in wiring snippet in a doc