### PR TITLE
fix(governance): question-batch-gate — resync ledger fix + fix vacuous traversal tests + validator gap

### DIFF
--- a/plugin-scripts/governance/question-batch-gate.sh
+++ b/plugin-scripts/governance/question-batch-gate.sh
@@ -1,5 +1,20 @@
 #!/usr/bin/env bash
-# question-batch-gate v1.1.0 — Stop-event advisory gate against QUESTION-BATCHING.
+# question-batch-gate v1.1.1 — Stop-event advisory gate against QUESTION-BATCHING.
+#
+# v1.1.1 (2026-08-18) LEDGER + LENGTH-BOUND FIX — re-synced from the source-of-
+#   truth fix (issue #366 finding 1): (a) a too-long session_id/prompt_id
+#   (payload-controlled, charset-checked only, no length bound) could make the
+#   one-shot `mkdir` fail with ENAMETOOLONG; (b) EVERY mkdir failure — a
+#   genuine duplicate-prompt replay OR a real operational failure
+#   (ENAMETOOLONG, EACCES, ENOSPC, read-only STATE_DIR) — was logged
+#   identically as "idempotent", hiding the failure case behind the expected-
+#   and-safe one. Fixed: `safe_id()` now also rejects ids over 128 chars
+#   (closes the ENAMETOOLONG root cause directly); the claim block now checks
+#   whether the marker dir actually EXISTS after a failed mkdir to tell a real
+#   duplicate from any other error (logged as "marker_claim_failed" instead of
+#   "idempotent"). Not a TOCTOU risk — no security decision hinges on the
+#   distinction, only the ledger label; either way the hook still skips and
+#   exits 0.
 #
 # COMMUNITY PORT (2026-08-18): dogfooded 16/1622 real fires (~1%) over 2026-07-25 to
 #   2026-08-18 in an operator's private `~/.claude` corpus before landing here — well
@@ -177,7 +192,7 @@ if [ "$questions" -le "$THRESHOLD" ]; then log "" "$questions" false; exit 0; fi
 # re-fire forever — so this still skips, but now it skips having MEASURED and
 # LOGGED the real question count instead of a hardcoded 0.
 # ---------------------------------------------------------------------------
-safe_id() { case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; *) return 0 ;; esac; }
+safe_id() { case "$1" in ''|*[!A-Za-z0-9._-]*) return 1 ;; esac; [ "${#1}" -le 128 ]; }
 safe_id "$pid" || { log "unsafe_or_absent_prompt_id" "$questions" false; exit 0; }
 safe_id "$sid" || { log "unsafe_session_id" "$questions" false; exit 0; }
 
@@ -185,7 +200,16 @@ safe_id "$sid" || { log "unsafe_session_id" "$questions" false; exit 0; }
 # One-shot claim: ATOMIC mkdir. Succeeds for exactly one racer.
 # ---------------------------------------------------------------------------
 marker="$STATE_DIR/${#sid}.${sid}.${#pid}.${pid}.marker.d"
-if ! mkdir "$marker" 2>/dev/null; then log "idempotent" "$questions" false; exit 0; fi
+if ! mkdir "$marker" 2>/dev/null; then
+  # Disambiguate a genuine duplicate-prompt replay (the marker dir already
+  # exists) from any other mkdir failure — see the v1.1.1 header note.
+  if [ -d "$marker" ]; then
+    log "idempotent" "$questions" false
+  else
+    log "marker_claim_failed" "$questions" false
+  fi
+  exit 0
+fi
 log "" "$questions" true
 
 # Bounded housekeeping: drop one-shot markers older than 7 days. Scoped to our own

--- a/tests/governance/test-question-batch-gate.sh
+++ b/tests/governance/test-question-batch-gate.sh
@@ -100,19 +100,33 @@ O="$(jq -cn '{session_id:"h",prompt_id:"h2",last_assistant_message:"a?\nb?\nc?"}
   | env -u HOME -u QBG_STATE_DIR PATH="$PATH" bash "$HOOK" 2>&1)"; RC=$?
 [ "$RC" -eq 0 ] && ok "unset HOME -> exit 0 (BLOCKING-1)" \
   || bad "unset HOME" "rc=$RC out=$(printf '%s' "$O" | head -1)"
+# Issue #366 finding 4: with HOME unset, the hook falls back to
+# ${HOME:-/tmp}/.claude/state/question-batch-gate = /tmp/.claude/state/
+# question-batch-gate — a REAL path outside $TMP, left uncleaned and
+# polluting later test runs' idempotency path (stray markers accumulate
+# across CI runs on a shared /tmp). Bounded, literal, non-computed path.
+rm -rf "/tmp/.claude/state/question-batch-gate" 2>/dev/null || true
 
-# BLOCKING-2: payload-controlled ids must never escape STATE_DIR
+# BLOCKING-2: payload-controlled ids must never escape STATE_DIR. Assert on
+# directory-EMPTINESS of the victim dir, not a specific filename — issue #366
+# finding 2: the original assertions checked for "$VICTIM/1.pwned.2.p9.marker.d"
+# / "$VICTIM/1.x.marker.d", but the hook's actual marker format is
+# "${#sid}.${sid}.${#pid}.${pid}.marker.d" (both filenames omitted the
+# length-prefix), so those exact paths could never exist regardless of
+# whether the guard held or regressed — the assertion was vacuous. The
+# emptiness check (already used correctly below for the unsafe-session_id
+# ord2 case) is robust to the exact marker-naming format.
 VICTIM="$TMP/victim"; mkdir -p "$VICTIM"
 SID="../../victim/pwned" emit "p9" "a?
 b?
 c?"
-[ ! -e "$VICTIM/1.pwned.2.p9.marker.d" ] && [ "$RC" -eq 0 ] \
+[ -z "$(ls -A "$VICTIM" 2>/dev/null)" ] && [ "$RC" -eq 0 ] \
   && ok "traversal via session_id blocked (BLOCKING-2)" \
   || bad "traversal session_id" "escaped to $VICTIM"
 SID=sess1 emit "../../victim/x" "a?
 b?
 c?"
-[ ! -e "$VICTIM/1.x.marker.d" ] && [ "$RC" -eq 0 ] \
+[ -z "$(ls -A "$VICTIM" 2>/dev/null)" ] && [ "$RC" -eq 0 ] \
   && ok "traversal via prompt_id blocked (BLOCKING-2)" \
   || bad "traversal prompt_id" "escaped to $VICTIM"
 
@@ -177,6 +191,25 @@ jq -cn '{session_id:"ord4",prompt_id:"ord4p",last_assistant_message:"a?\nb?\nc?"
   | QBG_STATE_DIR="$OL" bash "$HOOK" 2>/dev/null | grep -q 'additionalContext' \
   && ok "advisory still fires with valid ids (no regression)" \
   || bad "advisory regression" "did not fire with valid ids"
+
+printf '\n# issue #366 fix 1a: overlong ids are rejected (closes the ENAMETOOLONG root cause)\n'
+LONG="$(awk 'BEGIN{s="";for(i=0;i<129;i++)s=s "a"; print s}')"  # 129 chars, over the 128 cap
+O="$(jq -cn --arg s "$LONG" '{session_id:$s,prompt_id:"okpid",last_assistant_message:"a?\nb?\nc?"}' \
+  | bash "$HOOK" 2>/dev/null)"; RC=$?
+[ "$RC" -eq 0 ] && ! printf '%s' "$O" | grep -q additionalContext \
+  && ok "overlong session_id rejected, no injection" \
+  || bad "overlong session_id" "rc=$RC out=$O"
+
+printf '\n# issue #366 fix 1b: a non-duplicate mkdir failure logs marker_claim_failed, not idempotent\n'
+FL="$TMP/failstate"; mkdir -p "$FL"
+MARKER="$FL/3.fl1.3.fl2.marker.d"
+: > "$MARKER"   # pre-existing FILE (not dir) at the exact marker path the hook targets
+jq -cn '{session_id:"fl1",prompt_id:"fl2",last_assistant_message:"a?\nb?\nc?"}' \
+  | QBG_STATE_DIR="$FL" bash "$HOOK" >/dev/null 2>&1
+FLL="$FL/ledger.jsonl"
+tail -1 "$FLL" 2>/dev/null | grep -q '"skipped":"marker_claim_failed"' \
+  && ok "mkdir-failure-not-a-duplicate logs marker_claim_failed (not idempotent)" \
+  || bad "marker_claim_failed" "got: $(tail -1 "$FLL" 2>/dev/null)"
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 rm -rf "$TMP"

--- a/tests/validate-plugin.sh
+++ b/tests/validate-plugin.sh
@@ -110,6 +110,40 @@ for script in "session-start.sh" "pre-delegate.sh" "post-delegate.sh" "session-e
 done
 echo ""
 
+# Governance script: question-batch-gate.sh (issue #366 finding 3 — this script
+# had NO existence/exec-bit/test-pass check in this validator, so a future
+# accidental chmod -x or move would go undetected by plugin validation)
+echo "Checking governance scripts..."
+
+QBG_HOOK="$PLUGIN_ROOT/plugin-scripts/governance/question-batch-gate.sh"
+QBG_TEST="$PLUGIN_ROOT/tests/governance/test-question-batch-gate.sh"
+if [ -f "$QBG_HOOK" ]; then
+    pass "plugin-scripts/governance/question-batch-gate.sh exists"
+    if [ -x "$QBG_HOOK" ]; then
+        pass "plugin-scripts/governance/question-batch-gate.sh is executable"
+    else
+        fail "plugin-scripts/governance/question-batch-gate.sh is not executable"
+    fi
+else
+    fail "plugin-scripts/governance/question-batch-gate.sh missing"
+fi
+
+if [ -f "$QBG_TEST" ]; then
+    if [ -x "$QBG_TEST" ]; then
+        pass "tests/governance/test-question-batch-gate.sh is executable"
+    else
+        fail "tests/governance/test-question-batch-gate.sh is not executable"
+    fi
+    if bash "$QBG_TEST" >/dev/null 2>&1; then
+        pass "tests/governance/test-question-batch-gate.sh passes"
+    else
+        fail "tests/governance/test-question-batch-gate.sh FAILED (run 'bash tests/governance/test-question-batch-gate.sh' for details)"
+    fi
+else
+    fail "tests/governance/test-question-batch-gate.sh missing"
+fi
+echo ""
+
 # Every artifact the loops below actually visit is recorded here (repo-relative) so the
 # reach assertion at the end can PROVE the walk did not under-reach. #337 fixed the
 # reach; this makes a future regression impossible to land silently. See #336.


### PR DESCRIPTION
## Summary
Closes #366 (4 CodeRabbit findings on PR #365, the question-batch-gate community port):

1. **Ledger mislabeled every mkdir failure as `idempotent`** — conflated a genuine duplicate-prompt replay with a real operational failure (ENAMETOOLONG from an unbounded id, EACCES, ENOSPC, read-only STATE_DIR). Re-synced from the source-of-truth fix (`ekson73/akasha-claude#307`): `safe_id()` now bounds ids to 128 chars; the claim block distinguishes a true duplicate (marker dir exists) from any other failure (`marker_claim_failed`).
2. **The two BLOCKING-2 traversal assertions were vacuous** — checked filenames that omitted the hook's actual length-prefix, so they could never exist regardless of whether the guard held or regressed. Switched to a directory-emptiness check (the same pattern already correctly used later in the file for the unsafe-session_id case).
3. **`validate-plugin.sh` had zero coverage of this hook/test** — added existence + exec-bit + test-pass check mirroring the existing `session-tip.sh` pattern.
4. **The unset-HOME test polluted `/tmp/.claude/state/question-batch-gate`** across runs — added cleanup of that literal, non-computed path.

Also added 2 new deterministic tests exercising both sub-parts of fix 1.

## Test plan
- [x] `bash -n` on all 3 modified files
- [x] Code (excluding comments) confirmed byte-identical to the akasha source-of-truth fix
- [x] Full suite: **31/31 passing** (`bash tests/governance/test-question-batch-gate.sh`)
- [x] `bash tests/validate-plugin.sh` — 0 errors, 0 warnings

## Risk + rollback
Low risk: test-only + disambiguation-only changes, no behavioral change to the hook's fire/skip/exit-0 contract. `git revert` if anything regresses.

## Refs
Closes #366. Source-of-truth companion: ekson73/akasha-claude#307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)