### PR TITLE
test(rubrics): pilot re-run — delta 18%→88% + decompose provenance nit fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — decompose threshold provenance (pilot re-run nit)
+
+- `skills/decompose-abstract-to-measurable` — depth-cap 3 + materiality-prune 0.05 now carry
+  declared provenance (design guardrails, operator-tunable; never presented as measured).
+  Found by the external judge in the post-fix pilot re-run.
+
 ### Fixed — work-compass v1.3.2 (Eisenhower queue-job noise)
 
 - `bin/work-compass-aggregate.py` — `importance_rank()` no longer counts an automated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — pilot re-run (delta medido)
+
+- `docs/rubrics/pilot-rerun-2026-08-18.md` — 3/17 → 15/17 (88%; 100% no escopo legítimo).
+  morning-briefing curou pelo port; praxis-audit FAILs = critérios mis-scoped com disposição D2.
+
 ### Fixed — decompose threshold provenance (pilot re-run nit)
 
 - `skills/decompose-abstract-to-measurable` — depth-cap 3 + materiality-prune 0.05 now carry

--- a/docs/rubrics/pilot-rerun-2026-08-18.md
+++ b/docs/rubrics/pilot-rerun-2026-08-18.md
@@ -1,0 +1,26 @@
+# Piloto RE-RUN — delta pós-fixes (2026-08-18)
+
+> Juiz externo pi/Gemini (3ª família; claude org-limit persiste) × rubricas v0.1 × skills em main pós-fixes (#355-#360, #375, #378).
+> Mesma disciplina do piloto original: blind à derivação, "absent evidence ⇒ FAIL", adversarial.
+
+## Delta
+
+| Skill | Piloto (08-16) | Re-run (08-18) | Nota |
+|---|---|---|---|
+| quiesce | 0/3 | **3/3** ✅ | conjuncts operando |
+| agentic-delegation | 0/2 | **2/2** ✅ | artifact-verification + fallback-chain verbatim |
+| decompose-abstract-to-measurable | 0/2 | **2/2** ✅ | após nit-fix #378 (2 números sem provenance pegos NO RE-RUN — a régua acha até o resto) |
+| postflight | 0/2 | **2/2** ✅ | owner-discrimination + FAILURE-verdict |
+| directive-braindump-triage | 1/2 | **2/2** ✅ | atomicidade banner↔ledger |
+| agentic-tool-forge | 2/2 | **2/2** ✅ | sustentado (adversarial caveat: §0 escape-clause pode pular recon — registrado) |
+| morning-briefing | 0/2 | **2/2** ✅ | o port v1.7.0 (#375) trouxe Pulse/zero-counts — **o FAIL curou pela disposição, não por patch** |
+| praxis-audit | 0/2 | **0/2** | ESPERADO: critérios mis-scoped (disposição D2: migram p/ v0.2) — não é falha do skill |
+| **TOTAL** | **3/17 (18%)** | **15/17 (88%)** | os 2 FAILs restantes são os critérios com disposição registrada |
+
+## Leitura
+- Escopo legítimo: **15/15 = 100%** nos critérios corretamente escopados.
+- Os 2 FAILs de praxis-audit são a régua detectando erro de AUTORIA da rubrica (disposição D2 já registrada — migram para a rubrica de PR-review no v0.2).
+- O re-run já pagou um dividendo extra: o nit de decompose (2 números) só apareceu porque a régua rodou de novo. **Re-run = onde a régua pega o que o fix esqueceu.**
+
+## Conclusão do ciclo
+A régua v0.1 completa seu primeiro ciclo de melhoria fechado com delta medido: 18% → 88% (100% no escopo legítimo). Critérios, fixes, juiz externo e deltas todos persistidos. v0.2 é o próximo ciclo (migração de critérios + Camada 1 contrafactual das 66 dormant).

--- a/skills/decompose-abstract-to-measurable/SKILL.md
+++ b/skills/decompose-abstract-to-measurable/SKILL.md
@@ -146,7 +146,11 @@ predicate**). Individuation **surfaces the part-level divergence a generic avera
 
 Guards (non-negotiable):
 - **depth-cap 3** (root→leaf) — over-decomposition is analysis-paralysis.
+  *(provenance: design guardrail, operator-tunable — not a measurement; 3 ≈ the empirical
+  task→subtask→step depth of SDLC trees. Raise only with a recorded reason.)*
 - **materiality-prune** — drop a branch whose global flow `< 0.05`; it can't move the answer.
+  *(provenance: design guardrail, operator-tunable — a 5% materiality cutoff mirrors the
+  audit-materiality convention; it is a declared design choice, never a measured constant.)*
 - **shared sub-concept = one node with two parents** (a DAG, not a duplicated subtree).
 - **no cycles** (the script rejects them) — recursion must bottom out.
 - **deepen by sensitivity** — only split further the branches near a band boundary; leave settled branches shallow.


### PR DESCRIPTION
## [PR-as-Documentation-Prompt]

**Context.** Re-run do piloto (#354) após os fixes (#355-#360, #375) — a régua mede seu próprio delta. Juiz externo pi/Gemini (claude org-limit persiste), mesma disciplina blind/adversarial.

**Objective.** Medir o delta + fechar o nit que o próprio re-run achou.

### Delta medido
**3/17 (18%) → 15/17 (88%)** — 100% nos critérios corretamente escopados. morning-briefing curou pelo PORT (#375), não por patch; praxis-audit 0/2 = critérios mis-scoped com disposição D2 registrada (migram no v0.2).

### O bônus do re-run
O juiz pegou 2 números sem provenance em decompose (depth-cap 3 · materiality-prune 0.05) que o fix original deixou — agora declarados design-guardrails operator-tunable. Re-eval: PASS.

**Re-run é onde a régua pega o que o fix esqueceu.** Documento: `docs/rubrics/pilot-rerun-2026-08-18.md`. CHANGELOG entries · guardrail-surface 0 hits · validator rc=0.