### PR TITLE
feat(atomize-and-route): Diairesis — decompose any content into typed knowledge atoms + deterministic routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — atomize-and-route (Diairesis) v1.0.0
+
+- `bin/atomize-and-route` + `skills/atomize-and-route/SKILL.md` — deterministic
+  format+destination resolver and idempotent capture/routing ledger for typed
+  knowledge atoms (norm/procedure/role/insight/fact/decision/work/gap/pendency/
+  idea/braindump-seed/template/example/question/answer), per §Q1.2 KRDR. `route`
+  resolves WHERE+WHAT-FORMAT for one atom-type+scope; `ledger --append` records a
+  raw capture event; `ledger --query --unrouted` lists atoms awaiting a routing
+  decision. AAIF cross-vendor (POSIX Bash 3.2 + jq only). 27/27 tests.
+
+### Fixed — atomize-and-route lock-loop could spin forever on a wedged/dead holder
+
+- `bin/atomize-and-route` — the mkdir-lock retry loop (mirrored from
+  `bin/artifact-registry`'s own pattern — same bug is pre-existing there too,
+  tracked as a follow-up) had no upper bound: once the steal-threshold (50
+  attempts) was crossed, every subsequent iteration re-attempted the steal and
+  `continue`d PAST the `sleep`, producing an unbounded busy-spin if the lock was
+  held by a process that never releases it. Found by amazon-q-developer +
+  coderabbitai on PR #380. Fixed via a shared `acquire_lock()` helper with a
+  hard attempt cap (`ATOMIZE_ROUTE_LOCK_MAX_ATTEMPTS`, default 200 ≈ 20s) that
+  exits 1 instead of hanging, a periodic (not every-iteration) steal attempt,
+  and an unconditional sleep every iteration. +5 regression tests incl. a fast
+  env-overridden timeout proof.
+
 ### Added — pilot re-run (delta medido)
 
 - `docs/rubrics/pilot-rerun-2026-08-18.md` — 3/17 → 15/17 (88%; 100% no escopo legítimo).

--- a/bin/atomize-and-route
+++ b/bin/atomize-and-route
@@ -1,0 +1,257 @@
+#!/usr/bin/env bash
+# MAOS — Atomize & Route · deterministic path-resolution for typed knowledge atoms
+#   (soul-name: Diairesis — διαίρεσις, the Platonic method of collection-and-division)
+# ----------------------------------------------------------------------------
+# WHY: `skills/atomize-and-route/SKILL.md` (Diairesis) decomposes any content
+#   into TYPED atoms (norm/procedure/role/insight/fact/decision/work/gap/
+#   idea/template/question), but deciding WHERE each atom-type lands + in what
+#   FORMAT is a deterministic lookup, not a cognitive act — exactly the class
+#   of decision that belongs in a script, not a prompt (Gordian: don't spend
+#   tokens re-deriving a fixed table every invocation). This bin is that table,
+#   made runnable + testable + idempotent, mirroring `bin/artifact-registry`'s
+#   conventions (same audit-dir, same ledger discipline, same exit-code scheme).
+#
+# Two verbs:
+#   route  — resolve (format, destination) for ONE atom-type + scope; prints
+#            the resolution (human or --json); with --dry-run, resolves ONLY
+#            (never writes the ledger). Without --dry-run, appends a ROUTED
+#            ledger entry (the routing DECISION, not the atom's persisted
+#            content — persistence itself stays the caller's job, per the
+#            SKILL.md P6 phase and the "capture ≠ auto-persist" guard CEL
+#            already established).
+#   ledger — append a raw atom-capture event (`--append`) OR list atoms still
+#            awaiting a routing decision (`--query --unrouted`).
+#
+# Ledger (machine-local, gitignored — mirrors artifact-registry's audit-state
+#   convention, NOT a repo artifact):
+#   ${ATOMIZE_ROUTE_DIR:-$HOME/.claude/audit}/atomize-and-route.jsonl
+#
+# Portability: AAIF cross-vendor — POSIX Bash 3.2 + jq only (no associative
+#   arrays, no ${var^^}); atomic append via mkdir-lock (POSIX, same pattern as
+#   artifact-registry). No org-specific content — promotion-eligible per Layer
+#   Purity.
+# Idempotent: re-`route`-ing the identical (atom_id) is a no-op on the ledger
+#   (the resolution itself is a pure function of --type/--scope, so re-running
+#   `route` twice always PRINTS the same answer regardless of ledger state).
+# Exit codes ([C06]): 0 success (incl. idempotent no-op / dry-run) ·
+#   1 usage/validation · 2 setup (jq missing).
+set -euo pipefail
+
+REG_DIR="${ATOMIZE_ROUTE_DIR:-$HOME/.claude/audit}"
+REG="$REG_DIR/atomize-and-route.jsonl"
+
+command -v jq >/dev/null 2>&1 || { echo "atomize-and-route: jq is required" >&2; exit 2; }
+
+usage() {
+  cat <<EOF
+MAOS atomize-and-route (Diairesis) — deterministic format+destination lookup
+for typed knowledge atoms, + an idempotent capture/routing ledger.
+
+USAGE
+  $(basename "$0") route --type <atom-type> --scope <scope> [--content-hint "<text>"] [--dry-run] [--json]
+  $(basename "$0") ledger --append '<json-line>'
+  $(basename "$0") ledger --query --unrouted [--json]
+
+route — resolve WHERE + WHAT-FORMAT for one atom:
+  --type <t>           REQUIRED. one of: norm|procedure|role|insight|fact|reference|
+                        decision|work|gap|pendency|idea|braindump-seed|template|
+                        example|question|answer
+  --scope <s>          REQUIRED. one of: self|user|project|work|community|corporate|
+                        durable-personal  (per KRDR §Q1 layer taxonomy)
+  --content-hint "<t>" free text describing the atom (recorded, not parsed — the
+                        caller/SKILL.md already classified --type; this bin does
+                        NOT re-classify from prose)
+  --atom-id <id>        stable id for ledger idempotency (default: sha1 of type+scope+hint+ts-less content)
+  --dry-run             resolve + print only; never touch the ledger
+  --json                machine output (default: human, to stderr summary + stdout path)
+
+ledger --append — record a raw capture event (usually from a caller like the
+  CEL hook's on-demand marker, BEFORE a routing decision has been made):
+  --append '<json>'    one JSON object; MUST include at least {atom_id, kind}
+
+ledger --query --unrouted — list captured atoms with no matching 'routed' event
+  (i.e. captured but never resolved via 'route') — the drain target for
+  SessionStart / postflight batch reconciliation.
+
+EXIT CODES ([C06]): 0 success · 1 usage/validation · 2 setup (jq missing)
+
+EXAMPLES
+  $(basename "$0") route --type norm --scope user --dry-run
+  $(basename "$0") route --type insight --scope project --content-hint "CEL background-agent lesson"
+  $(basename "$0") ledger --append '{"atom_id":"a1","kind":"insight","text":"..."}'
+  $(basename "$0") ledger --query --unrouted --json
+EOF
+  exit 0
+}
+
+[ $# -eq 0 ] && usage
+VERB="$1"; shift || true
+case "$VERB" in route|ledger) ;; --help|-h|help) usage ;; *) echo "unknown verb '$VERB' (use: route | ledger)" >&2; exit 1 ;; esac
+
+need_val() { [ "$2" -ge 2 ] || { echo "$1 requires a value" >&2; exit 1; }; case "$3" in -?*) echo "$1 requires a value (got option '$3')" >&2; exit 1 ;; esac; }
+
+# =====================================================================
+# The taxonomy table (atom-type -> format + destination + gate note).
+# ONE row per §Q1.2 KRDR type; a jq lookup keeps this a pure function.
+# =====================================================================
+TAXONOMY_JSON='{
+  "norm":            {"format":"markdown+frontmatter",   "destination_template":"~/.claude/rules/<slug>.md",                 "gate":"must-fire-every-session AND cross-project AND high-stakes else memory/doc"},
+  "procedure":       {"format":"skill-or-command",        "destination_template":"<repo>/skills/<slug>/SKILL.md",             "gate":"community(maos) vs corporate(vek-ai-toolkit) per scope"},
+  "role":            {"format":"agent",                   "destination_template":"<repo>/agents/<slug>.md",                   "gate":"registry lookup before creating"},
+  "insight":         {"format":"markdown",                "destination_template":"~/.claude/projects/<enc>/memory/<slug>.md","gate":"anti-bloat: elevate to norm only if Triple-touch (>=3x)"},
+  "fact":            {"format":"markdown-or-notebooklm",  "destination_template":"~/.claude/docs/<slug>.md",                  "gate":"prefer NotebookLM source for research/reference material"},
+  "reference":       {"format":"markdown-or-notebooklm",  "destination_template":"~/.claude/docs/<slug>.md",                  "gate":"prefer NotebookLM source for research/reference material"},
+  "decision":        {"format":"markdown+frontmatter",    "destination_template":"~/.claude/docs/decisions/<slug>.md",       "gate":"ADR-style; cite decision-capture skill"},
+  "work":            {"format":"tracker-item",            "destination_template":"tracker:<vek-jira|linear|gh-issue>",       "gate":"eko L4 routing: Vek->Jira, personal->Linear, repo->GH Issue"},
+  "gap":             {"format":"tracker-item-or-ledger",  "destination_template":"tracker-or-taxis-queue",                    "gate":"loose-end-triage-queue tiers; never silent-drop"},
+  "pendency":        {"format":"tracker-item-or-ledger",  "destination_template":"tracker-or-taxis-queue",                    "gate":"loose-end-triage-queue tiers; never silent-drop"},
+  "idea":            {"format":"markdown-dendron",        "destination_template":"~/eko-engram/pages/<slug>.md",              "gate":"durable-personal; use plans/ instead if scratch/session-scoped"},
+  "braindump-seed":  {"format":"markdown-dendron",        "destination_template":"~/eko-engram/pages/<slug>.md",              "gate":"durable-personal; use plans/ instead if scratch/session-scoped"},
+  "template":        {"format":"markdown",                "destination_template":"~/eko-engram/templates/<slug>.md",         "gate":"or <repo>/templates/ if repo-specific"},
+  "example":         {"format":"markdown",                "destination_template":"~/eko-engram/templates/<slug>.md",         "gate":"or <repo>/templates/ if repo-specific"},
+  "question":        {"format":"markdown-or-tracker",     "destination_template":"~/.claude/projects/<enc>/memory/<slug>.md","gate":"tracker only if independently actionable"},
+  "answer":          {"format":"markdown-or-tracker",     "destination_template":"~/.claude/projects/<enc>/memory/<slug>.md","gate":"tracker only if independently actionable"}
+}'
+
+VALID_SCOPES="self user project work community corporate durable-personal"
+
+resolve_scope_prefix() {
+  # scope only refines destination presentation, never the format decision —
+  # a pure lookup, kept separate from TAXONOMY_JSON so the two axes (WHAT
+  # FORMAT vs WHICH LAYER) don't get conflated inside one table (KRDR §Q1
+  # is WHERE/layer; KRDR §Q1.2 is WHAT-TYPE/format — this bin composes both).
+  case "$1" in
+    self)             echo "self-scope (session-local, not persisted beyond this turn)" ;;
+    user)             echo "user-scope (~/.claude, auto-loaded cross-project)" ;;
+    project)          echo "project-scope (this repo's own memory/docs)" ;;
+    work)             echo "work-scope (Vek: Jira VKS, corp toolkit)" ;;
+    community)        echo "community-scope (multi-agent-os)" ;;
+    corporate)        echo "corporate-scope (vek-ai-toolkit)" ;;
+    durable-personal) echo "durable-personal-scope (~/eko-engram, git-backed)" ;;
+    *) echo "" ;;
+  esac
+}
+
+# ---- route ------------------------------------------------------------------
+if [ "$VERB" = "route" ]; then
+  TYPE=""; SCOPE=""; HINT=""; ATOM_ID=""; DRYRUN=0; JSONOUT=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --type)         need_val "$1" "$#" "${2:-}"; TYPE="$2"; shift 2 ;;
+      --scope)        need_val "$1" "$#" "${2:-}"; SCOPE="$2"; shift 2 ;;
+      --content-hint) need_val "$1" "$#" "${2:-}"; HINT="$2"; shift 2 ;;
+      --atom-id)      need_val "$1" "$#" "${2:-}"; ATOM_ID="$2"; shift 2 ;;
+      --dry-run)      DRYRUN=1; shift ;;
+      --json)         JSONOUT=1; shift ;;
+      --help|-h)      usage ;;
+      *) echo "unknown option '$1' for 'route'" >&2; exit 1 ;;
+    esac
+  done
+
+  [ -n "$TYPE" ]  || { echo "route: --type is required" >&2; exit 1; }
+  [ -n "$SCOPE" ] || { echo "route: --scope is required" >&2; exit 1; }
+
+  ROW="$(printf '%s' "$TAXONOMY_JSON" | jq -c --arg t "$TYPE" '.[$t] // empty')"
+  [ -n "$ROW" ] || { echo "route: unknown --type '$TYPE' (see --help for the taxonomy)" >&2; exit 1; }
+
+  SCOPE_NOTE="$(resolve_scope_prefix "$SCOPE")"
+  [ -n "$SCOPE_NOTE" ] || { echo "route: unknown --scope '$SCOPE' (valid: $VALID_SCOPES)" >&2; exit 1; }
+
+  [ -n "$ATOM_ID" ] || ATOM_ID="$(printf '%s|%s|%s' "$TYPE" "$SCOPE" "$HINT" | { command -v shasum >/dev/null 2>&1 && shasum -a 1 || sha1sum; } 2>/dev/null | cut -c1-12)"
+  [ -n "$ATOM_ID" ] || ATOM_ID="unresolved-$$"
+
+  RESULT="$(printf '%s' "$ROW" | jq -c \
+    --arg type "$TYPE" --arg scope "$SCOPE" --arg scope_note "$SCOPE_NOTE" \
+    --arg atom_id "$ATOM_ID" --arg hint "$HINT" \
+    '. + {atom_id:$atom_id, type:$type, scope:$scope, scope_note:$scope_note} + (if $hint != "" then {content_hint:$hint} else {} end)')"
+
+  if [ "$JSONOUT" -eq 1 ]; then
+    printf '%s\n' "$RESULT"
+  else
+    printf 'atomize-and-route: %s (%s) -> %s [%s]\n' "$TYPE" "$(printf '%s' "$RESULT" | jq -r .format)" "$(printf '%s' "$RESULT" | jq -r .destination_template)" "$SCOPE" >&2
+    printf 'gate: %s\n' "$(printf '%s' "$RESULT" | jq -r .gate)" >&2
+    printf '%s\n' "$(printf '%s' "$RESULT" | jq -r .destination_template)"
+  fi
+
+  [ "$DRYRUN" -eq 1 ] && exit 0
+
+  mkdir -p "$REG_DIR"; touch "$REG"
+  # idempotency: an identical atom_id already has a 'routed' event -> no-op
+  if jq -R 'fromjson? // empty' "$REG" 2>/dev/null \
+     | jq -se --arg id "$ATOM_ID" 'any(.event=="routed" and .atom_id==$id)' >/dev/null 2>&1; then
+    printf 'atomize-and-route: %s already routed (no-op)\n' "$ATOM_ID" >&2
+    exit 0
+  fi
+  TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  EVENT="$(printf '%s' "$RESULT" | jq -c --arg ts "$TS" '. + {event:"routed", ts:$ts}')"
+
+  LOCK_DIR="$REG_DIR/.lock-atomize-and-route"
+  i=0
+  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+    i=$((i+1)); [ "$i" -ge 50 ] && { mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null || true; rm -rf "$LOCK_DIR.stale.$$" 2>/dev/null || true; continue; }
+    sleep 0.1
+  done
+  trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+  printf '%s\n' "$EVENT" >> "$REG"
+  rm -rf "$LOCK_DIR" 2>/dev/null || true; trap - EXIT INT TERM
+  exit 0
+fi
+
+# ---- ledger -------------------------------------------------------------
+if [ "$VERB" = "ledger" ]; then
+  APPEND=""; QUERY=0; UNROUTED=0; JSONOUT=0
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --append)   need_val "$1" "$#" "${2:-}"; APPEND="$2"; shift 2 ;;
+      --query)    QUERY=1; shift ;;
+      --unrouted) UNROUTED=1; shift ;;
+      --json)     JSONOUT=1; shift ;;
+      --help|-h)  usage ;;
+      *) echo "unknown option '$1' for 'ledger'" >&2; exit 1 ;;
+    esac
+  done
+
+  if [ -n "$APPEND" ]; then
+    printf '%s' "$APPEND" | jq -e 'type == "object" and has("atom_id") and has("kind")' >/dev/null 2>&1 \
+      || { echo "ledger --append: payload must be a JSON object with at least {atom_id, kind}" >&2; exit 1; }
+    mkdir -p "$REG_DIR"; touch "$REG"
+    ATOM_ID="$(printf '%s' "$APPEND" | jq -r .atom_id)"
+    if jq -R 'fromjson? // empty' "$REG" 2>/dev/null \
+       | jq -se --arg id "$ATOM_ID" 'any(.event=="captured" and .atom_id==$id)' >/dev/null 2>&1; then
+      printf 'atomize-and-route: %s already captured (no-op)\n' "$ATOM_ID" >&2
+      exit 0
+    fi
+    TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    EVENT="$(printf '%s' "$APPEND" | jq -c --arg ts "$TS" '. + {event:"captured", ts:$ts}')"
+    LOCK_DIR="$REG_DIR/.lock-atomize-and-route"
+    i=0
+    while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+      i=$((i+1)); [ "$i" -ge 50 ] && { mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null || true; rm -rf "$LOCK_DIR.stale.$$" 2>/dev/null || true; continue; }
+      sleep 0.1
+    done
+    trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
+    printf '%s\n' "$EVENT" >> "$REG"
+    rm -rf "$LOCK_DIR" 2>/dev/null || true; trap - EXIT INT TERM
+    exit 0
+  fi
+
+  if [ "$QUERY" -eq 1 ] && [ "$UNROUTED" -eq 1 ]; then
+    [ -f "$REG" ] || { [ "$JSONOUT" -eq 1 ] && echo '[]' || echo "atomize-and-route: no ledger yet (0 unrouted)" >&2; exit 0; }
+    RESULT="$(jq -R 'fromjson? // empty' "$REG" \
+      | jq -s '
+          ( map(select(.event=="routed")) | map(.atom_id) ) as $routed
+          | map(select(.event=="captured" and (.atom_id as $id | $routed | index($id) | not)))
+        ')"
+    if [ "$JSONOUT" -eq 1 ]; then
+      printf '%s\n' "$RESULT"
+    else
+      N="$(printf '%s' "$RESULT" | jq 'length')"
+      printf 'atomize-and-route: %s unrouted atom(s)\n' "$N" >&2
+      printf '%s' "$RESULT" | jq -r '.[] | "  [\(.kind)] \(.atom_id) — \(.text // .content_hint // "(no text)")"'
+    fi
+    exit 0
+  fi
+
+  echo "ledger: use --append '<json>' OR --query --unrouted" >&2
+  exit 1
+fi

--- a/bin/atomize-and-route
+++ b/bin/atomize-and-route
@@ -115,6 +115,34 @@ TAXONOMY_JSON='{
 
 VALID_SCOPES="self user project work community corporate durable-personal"
 
+# Lock-loop bounds (env-overridable — testability + tuning, mirrors ATOMIZE_ROUTE_DIR).
+# amazon-q + coderabbitai (PR #380) both flagged the ORIGINAL loop (copied from
+# bin/artifact-registry's own lock pattern — the bug is pre-existing there too,
+# tracked as a same-shape follow-up fix): once the steal-threshold was crossed,
+# EVERY subsequent iteration re-attempted mv+rm and `continue`d PAST the `sleep`,
+# with no upper bound on total attempts — a bare-metal busy-spin that never exits
+# if the lock is held by a wedged/dead process. Fixed via one shared helper with
+# a hard attempt CAP (exit 1, never hang) + a periodic (not every-iteration) steal
+# + an unconditional sleep every iteration (no more skip-the-sleep-on-continue).
+LOCK_MAX_ATTEMPTS="${ATOMIZE_ROUTE_LOCK_MAX_ATTEMPTS:-200}"   # ~20s worst-case @ 0.1s sleep
+LOCK_SLEEP="${ATOMIZE_ROUTE_LOCK_SLEEP:-0.1}"
+LOCK_STEAL_EVERY=50
+
+acquire_lock() { # <lock-dir> -> blocks until mkdir succeeds; exit 1 on timeout (never hangs)
+  local ld="$1" i=0
+  while ! mkdir "$ld" 2>/dev/null; do
+    i=$((i + 1))
+    if [ "$i" -ge "$LOCK_MAX_ATTEMPTS" ]; then
+      echo "atomize-and-route: lock '$ld' still held after $i attempts — giving up (not hanging)" >&2
+      exit 1
+    fi
+    if [ $((i % LOCK_STEAL_EVERY)) -eq 0 ]; then
+      mv "$ld" "$ld.stale.$$" 2>/dev/null && rm -rf "$ld.stale.$$" 2>/dev/null || true
+    fi
+    sleep "$LOCK_SLEEP"
+  done
+}
+
 resolve_scope_prefix() {
   # scope only refines destination presentation, never the format decision —
   # a pure lookup, kept separate from TAXONOMY_JSON so the two axes (WHAT
@@ -186,11 +214,7 @@ if [ "$VERB" = "route" ]; then
   EVENT="$(printf '%s' "$RESULT" | jq -c --arg ts "$TS" '. + {event:"routed", ts:$ts}')"
 
   LOCK_DIR="$REG_DIR/.lock-atomize-and-route"
-  i=0
-  while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-    i=$((i+1)); [ "$i" -ge 50 ] && { mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null || true; rm -rf "$LOCK_DIR.stale.$$" 2>/dev/null || true; continue; }
-    sleep 0.1
-  done
+  acquire_lock "$LOCK_DIR"
   trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
   printf '%s\n' "$EVENT" >> "$REG"
   rm -rf "$LOCK_DIR" 2>/dev/null || true; trap - EXIT INT TERM
@@ -224,11 +248,7 @@ if [ "$VERB" = "ledger" ]; then
     TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     EVENT="$(printf '%s' "$APPEND" | jq -c --arg ts "$TS" '. + {event:"captured", ts:$ts}')"
     LOCK_DIR="$REG_DIR/.lock-atomize-and-route"
-    i=0
-    while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-      i=$((i+1)); [ "$i" -ge 50 ] && { mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null || true; rm -rf "$LOCK_DIR.stale.$$" 2>/dev/null || true; continue; }
-      sleep 0.1
-    done
+    acquire_lock "$LOCK_DIR"
     trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
     printf '%s\n' "$EVENT" >> "$REG"
     rm -rf "$LOCK_DIR" 2>/dev/null || true; trap - EXIT INT TERM

--- a/bin/tests/atomize-and-route.test.sh
+++ b/bin/tests/atomize-and-route.test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Tests for bin/atomize-and-route — deterministic format+destination resolver
+# + capture/routing ledger (Diairesis). Bash 3.2-safe, self-contained.
+# Run: bash bin/tests/atomize-and-route.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+BIN="$DIR/../atomize-and-route"
+
+pass=0 ; fail=0
+ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  \xe2\x9c\x97 %s\n      got: [%s]\n' "$1" "$2"; }
+has()  { case "$2" in *"$1"*) ok "$3" ;; *) no "$3" "$2" ;; esac; }
+hasnt(){ case "$2" in *"$1"*) no "$3" "$2" ;; *) ok "$3" ;; esac; }
+eq()   { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
+
+printf 'atomize-and-route.test.sh\n'
+
+# isolate ledger from the real one (never write to $HOME/.claude/audit in tests)
+TMPDIR_TEST="$(mktemp -d 2>/dev/null || mktemp -d -t aar)"
+export ATOMIZE_ROUTE_DIR="$TMPDIR_TEST"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# --- usage / validation -------------------------------------------------
+o="$("$BIN" 2>&1)"; rc=$?
+eq "0" "$rc" 'bare invocation (usage) exits 0'
+
+o="$("$BIN" bogus-verb 2>&1)"; rc=$?
+eq "1" "$rc" 'unknown verb exits 1'
+
+o="$("$BIN" route --scope user 2>&1)"; rc=$?
+eq "1" "$rc" 'route without --type exits 1'
+has 'is required' "$o" 'route without --type gives a usage-shaped error'
+
+o="$("$BIN" route --type norm 2>&1)"; rc=$?
+eq "1" "$rc" 'route without --scope exits 1'
+
+o="$("$BIN" route --type not-a-real-type --scope user --dry-run 2>&1)"; rc=$?
+eq "1" "$rc" 'route with unknown --type exits 1'
+
+o="$("$BIN" route --type norm --scope not-a-real-scope --dry-run 2>&1)"; rc=$?
+eq "1" "$rc" 'route with unknown --scope exits 1'
+
+# --- resolution correctness across atom types ---------------------------
+o="$("$BIN" route --type norm --scope user --dry-run --json 2>/dev/null)"
+has '.claude/rules' "$o" 'norm resolves under ~/.claude/rules'
+has 'markdown+frontmatter' "$o" 'norm format is markdown+frontmatter'
+
+o="$("$BIN" route --type procedure --scope community --dry-run --json 2>/dev/null)"
+has 'SKILL.md' "$o" 'procedure resolves to a SKILL.md path'
+
+o="$("$BIN" route --type insight --scope project --dry-run --json 2>/dev/null)"
+has 'memory' "$o" 'insight resolves under memory/'
+
+o="$("$BIN" route --type idea --scope durable-personal --dry-run --json 2>/dev/null)"
+has 'eko-engram' "$o" 'idea resolves under eko-engram'
+
+o="$("$BIN" route --type work --scope work --dry-run --json 2>/dev/null)"
+has 'tracker' "$o" 'work resolves to a tracker destination'
+
+o="$("$BIN" route --type gap --scope self --dry-run --json 2>/dev/null)"
+has 'taxis' "$o" 'gap resolves to the Taxis triage queue (loose-end-triage-queue)'
+
+# --- determinism (same input -> byte-identical output, ignoring atom_id) --
+o1="$("$BIN" route --type norm --scope user --dry-run --json 2>/dev/null | jq -c 'del(.atom_id)')"
+o2="$("$BIN" route --type norm --scope user --dry-run --json 2>/dev/null | jq -c 'del(.atom_id)')"
+eq "$o1" "$o2" 'route resolution is deterministic (identical type+scope -> identical answer)'
+
+# --- --dry-run truly never writes the ledger ----------------------------
+"$BIN" route --type norm --scope user --dry-run --json >/dev/null 2>&1
+[ -f "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl" ] && no '--dry-run writes nothing to the ledger' "file exists" || ok '--dry-run writes nothing to the ledger'
+
+# --- non-dry-run: writes + is idempotent --------------------------------
+"$BIN" route --type norm --scope user --atom-id test-atom-1 --json >/dev/null 2>&1
+n1="$(wc -l < "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl" | tr -d ' ')"
+eq "1" "$n1" 'first non-dry-run route appends exactly 1 ledger line'
+
+"$BIN" route --type norm --scope user --atom-id test-atom-1 --json >/dev/null 2>&1
+n2="$(wc -l < "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl" | tr -d ' ')"
+eq "1" "$n2" 're-routing the identical atom_id is idempotent (no duplicate line)'
+
+# --- ledger --append + --query --unrouted -------------------------------
+rm -f "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl"
+"$BIN" ledger --append '{"atom_id":"cap-1","kind":"insight","text":"unrouted example"}' >/dev/null 2>&1
+"$BIN" ledger --append '{"atom_id":"cap-2","kind":"insight","text":"will be routed"}' >/dev/null 2>&1
+"$BIN" route --type insight --scope project --atom-id cap-2 --json >/dev/null 2>&1
+
+o="$("$BIN" ledger --query --unrouted --json 2>/dev/null)"
+has 'cap-1' "$o" '--query --unrouted lists a captured-but-never-routed atom'
+hasnt '"atom_id":"cap-2"' "$o" '--query --unrouted excludes an atom that WAS routed'
+
+# ledger --append is itself idempotent on identical atom_id
+"$BIN" ledger --append '{"atom_id":"cap-1","kind":"insight","text":"unrouted example"}' >/dev/null 2>&1
+n3="$(grep -c '"event":"captured"' "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl" 2>/dev/null || echo 0)"
+eq "2" "$n3" 're-appending the identical captured atom_id is idempotent (still 2 captured events total)'
+
+# --- empty-ledger graceful degradation -----------------------------------
+rm -f "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl"
+o="$("$BIN" ledger --query --unrouted --json 2>/dev/null)"
+eq "[]" "$o" 'empty/absent ledger --query --unrouted returns [] cleanly'
+
+printf '\n%s passed, %s failed\n' "$pass" "$fail"
+[ "$fail" -eq 0 ]

--- a/bin/tests/atomize-and-route.test.sh
+++ b/bin/tests/atomize-and-route.test.sh
@@ -99,5 +99,33 @@ rm -f "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl"
 o="$("$BIN" ledger --query --unrouted --json 2>/dev/null)"
 eq "[]" "$o" 'empty/absent ledger --query --unrouted returns [] cleanly'
 
+# --- lock-loop bound (amazon-q + coderabbitai finding, PR #380): a HELD lock
+#     must exit 1 promptly, never spin forever. Pre-hold the lock dir, cap the
+#     attempts tiny via the env overrides, and assert (a) it exits non-zero
+#     (b) it does NOT hang (bounded wall-clock) (c) it never wrote the ledger.
+rm -f "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl"
+mkdir -p "$ATOMIZE_ROUTE_DIR/.lock-atomize-and-route"   # simulate a wedged/dead holder
+START_TS="$(date +%s 2>/dev/null || echo 0)"
+ATOMIZE_ROUTE_LOCK_MAX_ATTEMPTS=3 ATOMIZE_ROUTE_LOCK_SLEEP=0.01 \
+  "$BIN" route --type norm --scope user --atom-id lock-test-1 --json >/dev/null 2>/tmp/aar-lock-test-err.$$
+rc=$?
+END_TS="$(date +%s 2>/dev/null || echo 0)"
+ELAPSED=$((END_TS - START_TS))
+eq "1" "$rc" 'a HELD lock exits 1 (not 0, not a hang) once the attempt cap is reached'
+[ "$ELAPSED" -le 5 ] && ok 'a HELD lock gives up within a few seconds (bounded, not an infinite spin)' \
+  || no 'a HELD lock gives up within a few seconds (bounded, not an infinite spin)' "elapsed=${ELAPSED}s"
+has 'giving up' "$(cat /tmp/aar-lock-test-err.$$ 2>/dev/null)" 'the timeout error names itself (not a silent hang)'
+rm -f /tmp/aar-lock-test-err.$$
+# the ledger FILE may legitimately exist (line "mkdir -p; touch" runs BEFORE the
+# lock, same as the pre-existing code) — the bug-relevant assertion is that NO
+# event line for this atom_id was written despite the lock never being acquired.
+hasnt 'lock-test-1' "$(cat "$ATOMIZE_ROUTE_DIR/atomize-and-route.jsonl" 2>/dev/null)" \
+  'a timed-out lock attempt writes NO ledger event for the atom (even though touch pre-creates the file)'
+rm -rf "$ATOMIZE_ROUTE_DIR/.lock-atomize-and-route"   # release the simulated holder
+
+# once the lock is free again, the SAME atom_id routes normally (no lingering state)
+o="$("$BIN" route --type norm --scope user --atom-id lock-test-1 --dry-run --json 2>/dev/null)"
+has 'norm' "$o" 'after the lock frees, a fresh route call for the same atom_id still works'
+
 printf '\n%s passed, %s failed\n' "$pass" "$fail"
 [ "$fail" -eq 0 ]

--- a/skills/atomize-and-route/SKILL.md
+++ b/skills/atomize-and-route/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: atomize-and-route
+description: |
+  Given ANY content (braindump · prompt · doc · transcript · insight · gap · pendency ·
+  idea · template) decompose it into TYPED knowledge atoms (norm · procedure · role ·
+  insight · fact/reference · decision · work · gap/pendency · idea/braindump-seed ·
+  template/example · question/answer), classify each (context · scope · domain ·
+  confidence), relate them into a DAG (recursive/sequential/interdependent/
+  interconnected/disconnected/parallel per cowork-process-topology-protocol §5),
+  resolve WHERE + WHAT-FORMAT each one persists (via bin/atomize-and-route, the
+  deterministic KRDR-derived taxonomy lookup), gate-and-persist (H6 governance-self-edit
+  → red-team + council-gate; everything else passes straight through), and verify every
+  routed target is REAL and openable before reporting DONE. Composes — does NOT
+  duplicate — directive-braindump-triage (directive-only, DONE/OPEN/DROP classification),
+  graphify (code/folder → knowledge-graph, source of the EXTRACTED/INFERRED provenance
+  convention this skill reuses), council-gate (Boule — the H6 pre-persist gate),
+  red-teaming-mandatory-trigger (Elenchus — the H6 adversarial check), and
+  artifact-registry (dedup before creating any NEW agentic-tool as a `procedure`/`role`
+  atom). Use when the operator wants raw, mixed, un-typed content turned into
+  persisted, correctly-placed knowledge instead of one more untyped memory file.
+  Cross-vendor AAIF.
+triggers:
+  - atomize this
+  - route this content
+  - turn this braindump into knowledge
+  - what type of atom is this and where should it go
+  - atomize e roteie isto
+  - decompor este conteúdo em átomos
+  - classify and persist this
+version: 1.0.0
+---
+
+# Atomize & Route (soul-name: *Diairesis*)
+
+> **Diairesis** (διαίρεσις) — Plato's method of *collection and division* (Phaedrus 265d-266b):
+> gather the scattered particulars, then cut the whole "at its natural joints" rather than
+> hacking it arbitrarily. System-name (the slug/trigger/filename) is `atomize-and-route`;
+> *Diairesis* is display-only, per Anima envelope-safety (`[[anima]] §3.4`).
+
+## Purpose
+
+Close the gap between the corpus's existing **doctrine** (KRDR `§Q1.2` — decides artifact
+TYPE and, since this skill, FORMAT — see the companion rule PATCH) and its existing
+**auto-fire molds** (CEL: hook → ledger → drain → close) by supplying the missing
+**executable, generic atomizer**: one pipeline that takes ANY content, decomposes it into
+typed atoms, and resolves + persists each one idempotently — instead of every atom becoming
+one more untyped file in `projects/*/memory/`.
+
+**This skill does NOT introduce a new auto-fire mechanism.** Capture (broad + on-demand)
+stays the CEL hook's job (`akasha-claude` `hooks/learn-from-correction.js`, extended with a
+`kind` axis by the companion PR); this skill is the **batch/deliberate** processor that
+consumes CEL's ledger (and any other raw content) and turns it into persisted, gated,
+verified knowledge.
+
+## When to use
+
+- A braindump/transcript/doc mixes multiple KINDS of knowledge (a rule-worthy norm next to
+  a one-off insight next to three unrelated TODOs) and nothing separates them.
+- The CEL ledger (`~/.claude/state/learn-from-correction/ledger.jsonl`) has captured atoms
+  awaiting a routing decision (`bin/atomize-and-route ledger --query --unrouted`).
+- The operator wants "make this a rule / skill / ticket / memory entry" decided systematically,
+  not ad-hoc per request.
+
+## When **not** to use
+
+- The content is ALREADY one clear type and the destination is obvious (skip straight to
+  writing it — this skill exists for the *mixed/ambiguous* case, not to ceremony a single fact).
+- A directive-braindump needs DONE/OPEN/DROP classification against the corpus, not
+  atom-typing → use `directive-braindump-triage` instead (sibling, distinct axis).
+- A codebase/folder needs a knowledge graph → use `graphify` (this skill reuses its
+  `EXTRACTED/INFERRED` provenance convention, never re-derives it).
+- Real-time auto-capture of a correction/insight as it's said → that's the CEL hook, already
+  running; this skill processes its ledger, it doesn't replace it.
+
+## The Pipeline (P0–P7)
+
+### P0 — RECON (Skopos / CASC Gate-0)
+Before atomizing anything: probe the corpus + check `bin/artifact-registry lookup --purpose`
+(does a tool/rule for this exact intent already exist?) + check this skill's OWN ledger
+(`bin/atomize-and-route ledger --query --unrouted`) for idempotency — never re-atomize
+content already fully routed. Cite `environment-capability-reconnaissance` (`akasha-claude`).
+
+### P1 — ATOMIZE
+Decompose the input into ONE-CONCEPT-PER-ATOM pieces (Zettelkasten discipline), each tagged
+`EXTRACTED` (verbatim / directly stated) or `INFERRED` (derived/synthesized) — the exact
+honest-provenance convention `graphify` already uses; do not invent a second vocabulary.
+Assign each atom a provisional TYPE from the 12-row taxonomy below (§ Taxonomy).
+
+### P2 — CLASSIFY
+Per atom: **context** (what surrounding state it depends on) · **scope** (self · user ·
+project · work · community · corporate · durable-personal — per `scope-discipline-pre-creation`
+`§Q1`) · **domain/category** · **tags** · **confidence** (0-1, honest — an atom you're guessing
+the type of is LOW confidence, not silently rounded up).
+
+### P3 — RELATE
+Build a DAG over the atoms using the SIX relation types from
+`cowork-process-topology-protocol.md §5`: **recursive** · **sequential** ·
+**interdependent** · **interconnected** · **disconnected** · **parallel**. Do not invent a
+7th type. A disconnected atom is a valid, common outcome (most braindumps are NOT one
+coherent tree) — don't force false relations to make the DAG "look complete."
+
+### P4 — ROUTE
+For each atom, call `bin/atomize-and-route route --type <type> --scope <scope> --dry-run
+--json` to resolve (format, destination, gate) deterministically. This is a **pure lookup**
+(the KRDR taxonomy table, executable) — the atomizing/classifying above is the cognitive
+work; routing is not. Emit a 1-line-per-atom manifest before persisting anything.
+
+### P5 — CRITICIZE / VALIDATE / AUDIT (Gordian-proportional)
+Most atoms (memory · docs · plans · tracker items · eko-engram pages) route straight through
+— no council needed (`over-engineering-circuit-breaker` / Gordian: don't gate what isn't
+high-stakes). **The ONE mandatory gate**: an atom of type `norm` whose `route` resolution
+lands under `~/.claude/rules/` (i.e. it clears the KRDR must-fire-every-session ∧
+cross-project ∧ high-stakes bar) is an **H6 governance-self-edit**
+(`red-teaming-mandatory-trigger` — *Elenchus*) → an independent red-team is MANDATORY before
+persisting, AND the persist itself routes through `council-gate` (*Boule*) rather than being
+self-authorized. Cite both skills; do not re-implement either gate here.
+
+### P6 — PERSIST
+Apply the routed atoms idempotently (re-running P6 on the same atom set is a no-op — the
+`route` ledger entry IS the idempotency key). Stamp `agent-created` provenance on anything
+that becomes a tracker ticket (per `agent-ticket-provenance`, `akasha-claude`). Append the
+`routed` events via `bin/atomize-and-route route` (non-dry-run) as each atom actually lands.
+
+### P7 — VERIFY + brief
+Mente Tomé + `anti-theater-grounding-protocol` R3: **every atom reported DONE must cite a
+target that is REAL and openable** (a file that exists, a ticket key that resolves, a
+committed line). Never report a route as "persisted" from the resolution string alone —
+confirm the write. Close with the 5-state Visual Status Legend
+(`end-of-action-briefing-protocol §4.1`) if the caller wants a briefing.
+
+## Taxonomy (the executable table lives in `bin/atomize-and-route`, NOT duplicated here)
+
+| Atom type | Format | Default destination | Gate |
+|---|---|---|---|
+| `norm` | markdown+frontmatter | `~/.claude/rules/` (only if must-fire ∧ cross-project ∧ high-stakes) | **H6 → red-team + council-gate** |
+| `procedure` | skill/command | `multi-agent-os` (community) / `vek-ai-toolkit` (corporate) | dedup via `artifact-registry lookup` first |
+| `role` | agent | `multi-agent-os agents/` | dedup via `artifact-registry lookup` first |
+| `insight` | markdown | `projects/*/memory/` | elevate to `norm` only on Triple-touch (≥3×) |
+| `fact` / `reference` | markdown or NotebookLM source | `~/.claude/docs/` or NotebookLM | prefer NotebookLM for research material |
+| `decision` | markdown+frontmatter (ADR) | `~/.claude/docs/decisions/` | cite `decision-capture` |
+| `work` | tracker item | Jira (Vek) · Linear (personal) · GH Issue (repo) | eko L4 routing |
+| `gap` / `pendency` | tracker or ledger | Taxis triage tiers | never silent-drop |
+| `idea` / `braindump-seed` | markdown (Dendron) | `~/eko-engram/pages/` (durable) or `plans/` (scratch) | durable vs session-scoped |
+| `template` / `example` | markdown | `~/eko-engram/templates/` or repo `templates/` | |
+| `question` / `answer` | markdown or tracker | `projects/*/memory/` | tracker only if independently actionable |
+
+Run `bin/atomize-and-route --help` for the live, executable version of this table (the SSOT —
+this markdown copy is illustrative and MAY drift; the bin is authoritative).
+
+## Verification (golden E2E)
+
+Input (synthetic, mixed): *"CEL background-agent delegations can go silent across a session
+boundary (root-caused twice today) — also, remember to check PR #309 tomorrow, and here's a
+Dendron page idea for 'agentic delegation failure modes'."*
+
+1. **P1 ATOMIZE** → 3 atoms: (a) `EXTRACTED` insight — "background-agent silent-death,
+   root-caused 2×"; (b) `EXTRACTED` pendency — "check PR #309 tomorrow"; (c) `INFERRED`
+   braindump-seed — "agentic delegation failure modes" (synthesized from (a), not verbatim).
+2. **P2 CLASSIFY** → (a) scope=user, confidence=0.9 · (b) scope=project, confidence=0.95 ·
+   (c) scope=durable-personal, confidence=0.7 (it's a page IDEA, not the content itself).
+3. **P3 RELATE** → (c) is **sequential** on (a) (the page would elaborate the insight); (b) is
+   **disconnected** from both (unrelated PR check).
+4. **P4 ROUTE** (dry-run, this session, verified against the real bin):
+   ```
+   $ bin/atomize-and-route route --type insight --scope user --dry-run
+   ~/.claude/projects/<enc>/memory/<slug>.md
+   $ bin/atomize-and-route route --type pendency --scope project --dry-run
+   tracker-or-taxis-queue
+   $ bin/atomize-and-route route --type braindump-seed --scope durable-personal --dry-run
+   ~/eko-engram/pages/<slug>.md
+   ```
+5. **P5** — none of the three clears the `norm`+`rules/` bar → no red-team/council needed;
+   all pass straight through.
+6. **P6/P7** — (a)/(c) would persist as markdown files, (b) as a Taxis-tier tracker note; each
+   confirmed openable before reporting DONE.
+
+This is a REAL dry-run against the shipped `bin/atomize-and-route` (not hypothetical output) —
+re-run it yourself to reproduce.
+
+## Dogfood
+
+This SKILL.md's own genesis is an atomize-and-route instance: the operator's original
+Ultrathink braindump (4-part A/B/C/D ask) was itself decomposed into exactly the atom types
+this pipeline names — `norm` (the KRDR format-axis patch), `procedure` (this skill + its bin),
+`insight` (the background-agent-silent-death lesson, captured mid-build), `idea`
+(`~/eko-engram/` as a destination) — and routed via the P0-P7 steps above, including the P5
+gate (the KRDR patch, being a `norm` destined for `~/.claude/rules/`, went through the
+red-team+council discipline in its own PR, not this one — see the companion `akasha-claude`
+PR for that gate's application).
+
+## Distinct-from-siblings (DRY — composes, never duplicates)
+
+| Sibling | Distinct axis |
+|---|---|
+| `directive-braindump-triage` | classifies DIRECTIVES against the corpus (DONE/OPEN/DROP); this skill classifies ANY content into TYPED ATOMS and routes them — orthogonal, composable (triage first if the input is directive-shaped, then atomize the OPEN residual) |
+| `graphify` | code/folder → knowledge graph (structural); this skill is content → typed+routed atoms (destination-oriented) — shares the `EXTRACTED/INFERRED` provenance tag only |
+| `council-gate` (*Boule*) | the H6 pre-persist authorization mechanism this skill's P5 invokes, never reimplements |
+| `red-teaming-mandatory-trigger` (*Elenchus*) | the H6 adversarial-check trigger predicate this skill's P5 invokes, never reimplements |
+| `artifact-registry` | the dedup ledger this skill's P0 + `procedure`/`role` routing consult before creating anything new |
+| `corpus-firing-audit` | audits whether EXISTING rules fire; this skill decides where a NEW atom should land — different question, same corpus |
+
+## Related
+
+- `bin/atomize-and-route` (the executable taxonomy + ledger; the P4 primitive)
+- `bin/tests/atomize-and-route.test.sh`
+- `skills/directive-braindump-triage/SKILL.md`
+- `skills/graphify/SKILL.md`
+- `skills/council-gate/SKILL.md`
+- `skills/red-teaming-mandatory-trigger` (`akasha-claude` rule — cross-repo cite)
+- `skills/artifact-registry` (`bin/artifact-registry`)
+- Companion PR (`akasha-claude`): `hooks/learn-from-correction.js` `kind`-axis extension +
+  `rules/scope-discipline-pre-creation.md` format-axis + `§Q1.3` Fire-Point Binding patch.
+- Origin plan: `~/.claude/plans/ultrathink-analise-critique-busque-procu-rosy-clover.md`
+
+## Versioning
+
+v1.0.0 (2026-08-20) — bootstrap. Composes existing primitives (KRDR taxonomy → executable
+bin, `graphify` provenance convention, `council-gate`/`red-teaming-mandatory-trigger` H6
+gate, `artifact-registry` dedup); introduces zero new auto-fire mechanism (capture stays
+CEL's job). Built inline (not via background Agent-tool delegation) after that delegation
+mode silently stalled for this exact task earlier the same day — see
+`feedback_background_agent_silent_death_diairesis_dropped.md` (`akasha-claude` memory).


### PR DESCRIPTION
## Summary
- Ships the missing **generic, executable atomizer** the corpus lacked: `bin/atomize-and-route` (deterministic atom-type+scope → format+destination+gate resolver, POSIX bash 3.2 + jq, mirrors `bin/artifact-registry` conventions) + `skills/atomize-and-route/SKILL.md` (the P0-P7 cognitive pipeline, soul-name **Diairesis**).
- Composes — never duplicates — `directive-braindump-triage`, `graphify`'s EXTRACTED/INFERRED provenance convention, `council-gate` (Boule) + `red-teaming-mandatory-trigger` (Elenchus) for the one mandatory gate (a `norm` atom destined for `~/.claude/rules/` = H6 governance-self-edit), and `artifact-registry` for dedup (pre-creation lookup: `CLEAR`, 0 real duplicates).
- Companion PR in `akasha-claude` (CEL hook `kind`-axis extension + `scope-discipline-pre-creation` format-axis/`§Q1.3` patch) completes the composite from the origin plan.

## Context
Built **inline this turn**, not via background `Agent`-tool delegation — that mode silently stalled on this exact task earlier the same day (two empty worktrees, zero commits, no report-back). Root-caused + recorded in `akasha-claude` memory `feedback_background_agent_silent_death_diairesis_dropped.md`.

## Test plan
- [x] `bin/tests/atomize-and-route.test.sh` — 22/22 passing (usage/validation, resolution correctness across 6 atom types, determinism, `--dry-run` writes nothing, idempotency of both `route` and `ledger --append`, empty-ledger graceful degradation)
- [x] `bash tests/validate-plugin.sh` — 0 errors, 0 warnings, PASSED
- [x] SKILL.md's golden E2E re-verified as a **real** dry-run against the shipped bin (not hypothetical)
- [x] `gitleaks detect` — no leaks found

## Risk + rollback
Purely additive (2 new files + 1 new skill dir); zero existing behavior touched. Rollback = revert the merge commit.