### PR TITLE
fix(artifact-registry): bound the lock-retry loop (same-shape follow-up to #380)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — artifact-registry lock-loop could spin forever on a wedged/dead holder
+
+- `bin/artifact-registry` — same-shape follow-up to the `bin/atomize-and-route`
+  fix (PR #380): the mkdir-lock retry loop had no upper bound — once the
+  steal-threshold (50 attempts) was crossed, every subsequent iteration
+  re-attempted the steal and `continue`d PAST the `sleep`, producing an
+  unbounded busy-spin if the lock was held by a process that never releases
+  it. Fixed via a shared `acquire_lock()` helper with a hard attempt cap
+  (`ARTIFACT_REGISTRY_LOCK_MAX_ATTEMPTS`, default 200 ≈ 20s) that exits 1
+  instead of hanging, a periodic (not every-iteration) steal attempt, and an
+  unconditional sleep every iteration. New `bin/tests/artifact-registry.test.sh`
+  (18/18 passing — record/lookup/dedup coverage this script previously had none
+  of, plus the lock-timeout regression proof).
+
 ### Added — atomize-and-route (Diairesis) v1.0.0
 
 - `bin/atomize-and-route` + `skills/atomize-and-route/SKILL.md` — deterministic

--- a/bin/artifact-registry
+++ b/bin/artifact-registry
@@ -116,6 +116,34 @@ fi
 # tokenizer used by lookup (lowercase, split on non-alnum, drop tokens <=2, unique)
 TOK_JQ='ascii_downcase | gsub("[^a-z0-9]+";" ") | split(" ") | map(select(length>2)) | unique'
 
+# Lock-loop bounds (env-overridable — testability + tuning). The ORIGINAL loop
+# here had no upper bound: once the steal-threshold (50 attempts) was crossed,
+# every subsequent iteration re-attempted the steal and `continue`d PAST the
+# `sleep`, producing an unbounded busy-spin if the lock was held by a
+# wedged/dead process. Same shape found + fixed in the sibling `bin/atomize-and-
+# route` (which mirrored this exact pattern) by amazon-q-developer +
+# coderabbitai on `multi-agent-os#380`; this is the promised same-shape
+# follow-up fix to the origin. Bounded via a hard attempt cap (exit 1, never
+# hang), a periodic (not every-iteration) steal, and an unconditional sleep.
+LOCK_MAX_ATTEMPTS="${ARTIFACT_REGISTRY_LOCK_MAX_ATTEMPTS:-200}"   # ~20s worst-case @ 0.1s sleep
+LOCK_SLEEP="${ARTIFACT_REGISTRY_LOCK_SLEEP:-0.1}"
+LOCK_STEAL_EVERY=50
+
+acquire_lock() { # <lock-dir> -> blocks until mkdir succeeds; exit 1 on timeout (never hangs)
+  local ld="$1" i=0
+  while ! mkdir "$ld" 2>/dev/null; do
+    i=$((i + 1))
+    if [ "$i" -ge "$LOCK_MAX_ATTEMPTS" ]; then
+      echo "artifact-registry: lock '$ld' still held after $i attempts — giving up (not hanging)" >&2
+      exit 1
+    fi
+    if [ $((i % LOCK_STEAL_EVERY)) -eq 0 ]; then
+      mv "$ld" "$ld.stale.$$" 2>/dev/null && rm -rf "$ld.stale.$$" 2>/dev/null || true
+    fi
+    sleep "$LOCK_SLEEP"
+  done
+}
+
 # ---- lookup -----------------------------------------------------------------
 if [ "$VERB" = "lookup" ]; then
   [ -f "$REG" ] || { if [ "$JSONOUT" -eq 1 ]; then echo '{"verdict":"CLEAR","matches":[],"note":"registry empty"}'; else echo "artifact-registry lookup: CLEAR (registry empty)" >&2; fi; exit 0; }
@@ -181,11 +209,7 @@ fi
 
 # atomic append under mkdir-lock (POSIX-atomic)
 LOCK_DIR="$REG_DIR/.lock-artifact-registry"
-i=0
-while ! mkdir "$LOCK_DIR" 2>/dev/null; do
-  i=$((i+1)); [ "$i" -ge 50 ] && { mv "$LOCK_DIR" "$LOCK_DIR.stale.$$" 2>/dev/null || true; rm -rf "$LOCK_DIR.stale.$$" 2>/dev/null || true; continue; }
-  sleep 0.1
-done
+acquire_lock "$LOCK_DIR"
 trap 'rm -rf "$LOCK_DIR" 2>/dev/null || true' EXIT INT TERM
 printf '%s\n' "$EVENT" >> "$REG"
 rm -rf "$LOCK_DIR" 2>/dev/null || true; trap - EXIT INT TERM

--- a/bin/tests/artifact-registry.test.sh
+++ b/bin/tests/artifact-registry.test.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Tests for bin/artifact-registry — dedup-memory for Anima (naming) & Forge
+# (creation), + the mkdir-lock bound (multi-agent-os#380 follow-up: this file's
+# lock loop mirrors the SAME shape amazon-q/coderabbitai flagged in
+# bin/atomize-and-route). Bash 3.2-safe, self-contained.
+# Run: bash bin/tests/artifact-registry.test.sh
+set -uo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+BIN="$DIR/../artifact-registry"
+
+pass=0 ; fail=0
+ok() { pass=$((pass + 1)); printf '  \xe2\x9c\x93 %s\n' "$1"; }
+no() { fail=$((fail + 1)); printf '  \xe2\x9c\x97 %s\n      got: [%s]\n' "$1" "$2"; }
+has()  { case "$2" in *"$1"*) ok "$3" ;; *) no "$3" "$2" ;; esac; }
+hasnt(){ case "$2" in *"$1"*) no "$3" "$2" ;; *) ok "$3" ;; esac; }
+eq()   { [ "$1" = "$2" ] && ok "$3" || no "$3" "got=[$2] want=[$1]"; }
+
+printf 'artifact-registry.test.sh\n'
+
+# isolate ledger from the real one (never write to $HOME/.claude/audit in tests)
+TMPDIR_TEST="$(mktemp -d 2>/dev/null || mktemp -d -t ar)"
+export ARTIFACT_REGISTRY_DIR="$TMPDIR_TEST"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# --- usage / validation -------------------------------------------------
+o="$("$BIN" 2>&1)"; rc=$?
+eq "0" "$rc" 'bare invocation (usage) exits 0'
+
+o="$("$BIN" bogus-verb 2>&1)"; rc=$?
+eq "1" "$rc" 'unknown verb exits 1'
+
+o="$("$BIN" record 2>&1)"; rc=$?
+eq "1" "$rc" 'record without --kind exits 1'
+
+o="$("$BIN" record --kind bogus --slug x 2>&1)"; rc=$?
+eq "1" "$rc" 'record with invalid --kind exits 1'
+
+o="$("$BIN" record --kind name 2>&1)"; rc=$?
+eq "1" "$rc" 'record without --slug exits 1'
+
+o="$("$BIN" record --kind name --slug 'bad slug!' 2>&1)"; rc=$?
+eq "1" "$rc" 'record with an invalid slug charset exits 1'
+
+# --- empty-registry lookup graceful degradation -------------------------
+o="$("$BIN" lookup --purpose "anything" --json 2>/dev/null)"
+has 'CLEAR' "$o" 'lookup on an empty/absent registry returns CLEAR cleanly'
+
+# --- record + lookup round trip -----------------------------------------
+o="$("$BIN" record --kind name --slug praxis-audit --type skill \
+  --purpose "audit the session's own enacted methods for theater" --dry-run 2>/dev/null)"
+has 'praxis-audit' "$o" 'record --dry-run prints the event JSON'
+[ -f "$ARTIFACT_REGISTRY_DIR/artifact-registry.jsonl" ] \
+  && no '--dry-run writes nothing to the ledger' 'file exists' \
+  || ok '--dry-run writes nothing to the ledger'
+
+"$BIN" record --kind name --slug praxis-audit --type skill \
+  --purpose "audit the session's own enacted methods for theater" >/dev/null 2>&1
+o="$("$BIN" lookup --purpose "session method audit theater" --json 2>/dev/null)"
+has 'DUP-RISK' "$o" 'lookup with an overlapping purpose flags DUP-RISK (synonym catch)'
+has 'praxis-audit' "$o" 'DUP-RISK match names the prior slug'
+
+o="$("$BIN" lookup --purpose "completely unrelated topic xyz" --json 2>/dev/null)"
+has 'CLEAR' "$o" 'lookup with a non-overlapping purpose is CLEAR'
+
+# --- idempotency ----------------------------------------------------------
+n1="$(wc -l < "$ARTIFACT_REGISTRY_DIR/artifact-registry.jsonl" | tr -d ' ')"
+"$BIN" record --kind name --slug praxis-audit --type skill \
+  --purpose "audit the session's own enacted methods for theater" >/dev/null 2>&1
+n2="$(wc -l < "$ARTIFACT_REGISTRY_DIR/artifact-registry.jsonl" | tr -d ' ')"
+eq "$n1" "$n2" 're-recording the identical (kind,slug,purpose) is idempotent (no duplicate line)'
+
+# --- lock-loop bound (multi-agent-os#380 follow-up — same fix as
+#     bin/atomize-and-route): a HELD lock must exit 1 promptly, never spin
+#     forever. Pre-hold the lock dir, cap the attempts tiny via the env
+#     overrides, and assert (a) exit non-zero (b) bounded wall-clock
+#     (c) no ledger event written for the blocked record.
+mkdir -p "$ARTIFACT_REGISTRY_DIR/.lock-artifact-registry"   # simulate a wedged/dead holder
+START_TS="$(date +%s 2>/dev/null || echo 0)"
+ARTIFACT_REGISTRY_LOCK_MAX_ATTEMPTS=3 ARTIFACT_REGISTRY_LOCK_SLEEP=0.01 \
+  "$BIN" record --kind name --slug lock-test-slug --purpose "lock timeout probe" \
+  >/dev/null 2>/tmp/ar-lock-test-err.$$
+rc=$?
+END_TS="$(date +%s 2>/dev/null || echo 0)"
+ELAPSED=$((END_TS - START_TS))
+eq "1" "$rc" 'a HELD lock exits 1 (not 0, not a hang) once the attempt cap is reached'
+[ "$ELAPSED" -le 5 ] && ok 'a HELD lock gives up within a few seconds (bounded, not an infinite spin)' \
+  || no 'a HELD lock gives up within a few seconds (bounded, not an infinite spin)' "elapsed=${ELAPSED}s"
+has 'giving up' "$(cat /tmp/ar-lock-test-err.$$ 2>/dev/null)" 'the timeout error names itself (not a silent hang)'
+rm -f /tmp/ar-lock-test-err.$$
+hasnt 'lock-test-slug' "$(cat "$ARTIFACT_REGISTRY_DIR/artifact-registry.jsonl" 2>/dev/null)" \
+  'a timed-out lock attempt writes NO ledger event for the record'
+rm -rf "$ARTIFACT_REGISTRY_DIR/.lock-artifact-registry"   # release the simulated holder
+
+# once the lock is free again, a fresh record call works normally
+"$BIN" record --kind name --slug lock-test-slug --purpose "lock timeout probe" >/dev/null 2>&1
+o="$("$BIN" lookup --slug lock-test-slug --json 2>/dev/null)"
+has 'lock-test-slug' "$o" 'after the lock frees, a fresh record call succeeds normally'
+
+echo
+if [ "$fail" -eq 0 ]; then echo "ALL PASS ✓"; else echo "FAILURES ✗"; fi
+exit "$fail"


### PR DESCRIPTION
## Summary
- `bin/artifact-registry` — same-shape follow-up promised in #380: this file's own mkdir-lock pattern is what `bin/atomize-and-route` mirrored, and the infinite-loop bug amazon-q-developer + coderabbitai found there (once the 50-attempt steal-threshold was crossed, every subsequent iteration re-attempted the steal and `continue`d past `sleep`, spinning forever on a wedged/dead lock-holder) was pre-existing here too — this file is in fact the origin of the copied pattern.
- Fixed via a shared `acquire_lock()` helper: hard attempt cap (`ARTIFACT_REGISTRY_LOCK_MAX_ATTEMPTS`, default 200 ≈ 20s) that exits 1 instead of hanging, a periodic (not every-iteration) steal, and an unconditional sleep every iteration — mirrors the fix already merged in `bin/atomize-and-route`.
- New `bin/tests/artifact-registry.test.sh` (this script had **zero** test coverage before this PR) — 18 assertions covering usage/validation, empty-registry lookup, record+lookup round trip incl. the DUP-RISK synonym-catch, record idempotency, and the lock-timeout regression proof.

## Test plan
- [x] `bash bin/tests/artifact-registry.test.sh` — 18/18 passing (new file)
- [x] `bash tests/validate-plugin.sh` — 0 errors, 0 warnings
- [x] `gitleaks detect --no-git` — no leaks
- [x] `bash -n bin/artifact-registry` — syntax OK
- [x] manual smoke test: `record --dry-run` / `record` / `lookup` DUP-RISK+CLEAR all still behave identically on the fast (uncontended) path

## Risk + rollback
Low risk — fast-path (uncontended lock) behavior is byte-identical (single `mkdir` succeeds immediately); only the contended/timeout path changes, from "hang forever" to "exit 1 after ~20s with a clear error". Rollback = revert this commit.

Refs: #380 (the origin PR + review findings that surfaced this bug shape)