### PR TITLE
fix(transmute): normalize the cast before every collision branch (round-6 follow-up to #386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     INTAKE is an unfilled placeholder -> `STOP-ERROR`. Multi-source fan-in is
     out of scope here (no iteration/ordering/aggregation semantics exist) and
     routes to `atomize-and-route` or `converge`.
+  - **Both spellings supplied with DIFFERENT values -> `STOP-HITL`.** Normalization
+    fills an *empty* slot; it never arbitrates a disagreement. `--to-type=prompt
+    --cast-to=artifact:pdf` is two explicit incompatible casts for one slot —
+    picking by assignment order would silently discard one.
+  - **`same-as-source` counts as a contending cast when supplied EXPLICITLY.** It
+    is the `--to-type` default AND a legitimate explicit type-preserving value;
+    omitting it from the step-0 non-artifact list let
+    `--target-format=pdf --to-type=same-as-source` bypass the check and overwrite
+    the very preservation requested. The *implicit* default does not contend.
   - **Normalize the cast BEFORE every collision branch.** `--cast-to` translates
     to `--to-type` *first*; from there "an explicit cast" means the normalized
     `--to-type` however the caller spelled it. A caller may legitimately mix the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     INTAKE is an unfilled placeholder -> `STOP-ERROR`. Multi-source fan-in is
     out of scope here (no iteration/ordering/aggregation semantics exist) and
     routes to `atomize-and-route` or `converge`.
+  - **Normalize the cast BEFORE every collision branch.** `--cast-to` translates
+    to `--to-type` *first*; from there "an explicit cast" means the normalized
+    `--to-type` however the caller spelled it. A caller may legitimately mix the
+    canonical form with an alias (`--to-type=prompt --target-format=pdf`), so a
+    check keyed on the alias spelling alone would not fire and the value-space
+    test would silently overwrite the cast. Stated once; both the step-0
+    pre-check and the `--target-style` table read the normalized cast.
   - `--target-format` resolves **slot-contention first, then value-space, then
     `--cast-to`, `STOP-HITL` last** — this skill has two independent format
     axes (artifact vs report) and collapsing them would misread a valid request

--- a/skills/transmute/SKILL.md
+++ b/skills/transmute/SKILL.md
@@ -208,7 +208,15 @@ column, translate to the right column rather than report the param as unsupporte
 > means *the normalized `--to-type`, however the caller spelled it*. A caller may legitimately mix
 > the canonical form with an alias (`--to-type=prompt --target-format=pdf`), so any check keyed on
 > the alias spelling alone would **not fire** — the value-space test would then run and silently
-> overwrite the requested cast. This normalization is what makes the step-0 pre-check and the
+> overwrite the requested cast.
+>
+> ⛔ **If BOTH spellings are supplied and normalize to DIFFERENT values → `STOP-HITL`.** Normalization
+> fills an *empty* slot; it never arbitrates a disagreement. `--to-type=prompt --cast-to=artifact:pdf`
+> is two explicit, incompatible casts for one slot — applying either assignment order would silently
+> discard the other. Name both readings and stop; **never pick by order**. (Same values → no
+> conflict, proceed.)
+>
+> This normalization is what makes the step-0 pre-check and the
 > `--target-style` routing table below spelling-agnostic; do not re-introduce a spelling-specific
 > test in either.
 
@@ -230,7 +238,11 @@ column, translate to the right column rather than report the param as unsupporte
 >    the single-valued `--to-type` slot as `artifact:<value>`. So when the `--target-format` value is
 >    **artifact-only** AND an explicit cast is present — **normalized per the rule above, so either
 >    spelling counts (`--to-type` canonical or `--cast-to` alias)** — naming a **non-artifact** family (`prompt` ·
->    `agentic-tool:*` · `audience-recast` · `ledger` · `ticket`), both requests claim that one slot
+>    `agentic-tool:*` · `audience-recast` · `ledger` · `ticket` · **`same-as-source` when supplied
+>    EXPLICITLY** — it is a type-preserving cast like any other, and omitting it from this list lets
+>    `--target-format=pdf --to-type=same-as-source` bypass the check and overwrite the very
+>    preservation the caller asked for; the *implicit* default `same-as-source` does **not** contend,
+>    since filling an unset slot is exactly what the alias is for), both requests claim that one slot
 >    with incompatible values → **`STOP-HITL`**, naming the collision. ⛔ Do **not** let the
 >    value-space test run first here: it would set `--to-type=artifact:<value>` and *silently
 >    overwrite the requested cast*. Unlike `--target-style` below, an artifact format is **not**

--- a/skills/transmute/SKILL.md
+++ b/skills/transmute/SKILL.md
@@ -203,6 +203,15 @@ column, translate to the right column rather than report the param as unsupporte
 | `--target-style` | ⚠️ **no direct equivalent** | see note below |
 | `*-recovery()` default | ⚠️ **per-parameter — NOT one idiom** | see the recovery note below |
 
+> **⛔ NORMALIZE BEFORE BRANCHING — every collision check below reads the *normalized* cast, never a
+> spelling.** Translate `--cast-to` → `--to-type` **first**; from that point on "an explicit cast"
+> means *the normalized `--to-type`, however the caller spelled it*. A caller may legitimately mix
+> the canonical form with an alias (`--to-type=prompt --target-format=pdf`), so any check keyed on
+> the alias spelling alone would **not fire** — the value-space test would then run and silently
+> overwrite the requested cast. This normalization is what makes the step-0 pre-check and the
+> `--target-style` routing table below spelling-agnostic; do not re-introduce a spelling-specific
+> test in either.
+
 > **⚠️ `--from` is SINGULAR — `{{sources}}` must be expanded BEFORE INTAKE.** This skill guarantees
 > ONE source end-to-end (INTAKE types one source; the `--output=json` contract carries one `source`
 > object). No iteration, ordering, or aggregation semantics are defined, so the alias does **not**
@@ -215,11 +224,12 @@ column, translate to the right column rather than report the param as unsupporte
 > independent format axes*: the **artifact's** format
 > (`--to-type=artifact:{md\|html\|pdf\|slides\|diagram\|confluence\|gamma\|canva}`) and the
 > **report's** format (`--output`/`--agentic-format` = `table\|json\|json-rpc`). Resolve in this
-> order — **slot-contention first, then value-space, then `--cast-to`, `STOP-HITL` last**:
+> order — **slot-contention first, then value-space, then the normalized cast, `STOP-HITL` last**:
 >
 > 0. **Slot-contention pre-check — runs BEFORE the value-space test.** An artifact-axis value needs
 >    the single-valued `--to-type` slot as `artifact:<value>`. So when the `--target-format` value is
->    **artifact-only** AND an explicit `--cast-to` names a **non-artifact** family (`prompt` ·
+>    **artifact-only** AND an explicit cast is present — **normalized per the rule above, so either
+>    spelling counts (`--to-type` canonical or `--cast-to` alias)** — naming a **non-artifact** family (`prompt` ·
 >    `agentic-tool:*` · `audience-recast` · `ledger` · `ticket`), both requests claim that one slot
 >    with incompatible values → **`STOP-HITL`**, naming the collision. ⛔ Do **not** let the
 >    value-space test run first here: it would set `--to-type=artifact:<value>` and *silently
@@ -254,14 +264,15 @@ column, translate to the right column rather than report the param as unsupporte
 > assigning it to the report axis where it is invalid.
 >
 > **⚠️ `--target-style` has no equivalent — and deliberately so.** Style is not a transmute param.
-> `--user-lang`/`--agentic-lang` are *language*, not *style* — do not conflate them. Route by intent:
+> `--user-lang`/`--agentic-lang` are *language*, not *style* — do not conflate them. Route by intent
+> (and read "explicit cast" below as the **normalized** cast — either spelling, per the rule above):
 >
 > ⛔ **`--to-type` is single-valued** (one of `prompt` · `agentic-tool:*` · `audience-recast` ·
 > `artifact:*` · `ledger` · `ticket` — see `commands/transmute.md` §Flags). So the style route
-> depends on whether an **explicit `--cast-to` is also present**; it must never silently overwrite a
+> depends on whether an **explicit cast is also present (normalized — either spelling)**; it must never silently overwrite a
 > requested cast:
 >
-> | Intent of `--target-style` | No explicit `--cast-to` | WITH an explicit `--cast-to` | Owner |
+> | Intent of `--target-style` | No explicit cast | WITH an explicit cast (normalized) | Owner |
 > |---|---|---|---|
 > | audience / register / tone (exec · junior · non-technical) | `--to-type=audience-recast` | cast **wins** `--to-type`; apply the recast as a **preprocessing transform** before the cast | `content-recast` (owns the faithfulness guard) |
 > | prompt shape / rigor profile | `--to-type=prompt` + profile (e.g. `gauntlet-loop`) | cast **wins** `--to-type`; apply the prompt-shaping as a **preprocessing transform** | per §Cast router: `refine-braindump-to-prompt` when `source=braindump`; `agents/prompt-context-engineer` + profile otherwise |
@@ -435,9 +446,11 @@ router added no routing). Dormant-by-design otherwise.
   aliasing cannot silently resolve: **`--from` is SINGULAR** (an unexpanded literal `{{sources}}`
   reaching INTAKE is an unfilled placeholder → `STOP-ERROR`; multi-source fan-in has no
   iteration/ordering/aggregation semantics here and routes to `atomize-and-route` / `converge`);
-  **`--target-format` resolves value-space → `--cast-to` → `STOP-HITL`** (two independent format
-  axes exist — artifact vs report — so a naive collapse would misread a valid
-  `--cast-to=artifact:pdf --target-format=json`; value in neither axis → `STOP-ERROR`); and
+  **`--target-format` resolves slot-contention (step 0) → value-space → normalized cast →
+  `STOP-HITL`** (two independent format axes exist — artifact vs report — so a naive collapse would
+  misread a valid `--cast-to=artifact:pdf --target-format=json`; but an artifact-only value plus a
+  non-artifact cast contend for the single `--to-type` slot and must `STOP-HITL` **before** the
+  value-space test, or the cast is silently overwritten; value in neither axis → `STOP-ERROR`); and
   **`--target-style` has no equivalent by design** (audience/register → `content-recast`, which
   owns the faithfulness guard; prompt-shape → the `prompt` profile; language ≠ style;
   undeterminable → `STOP-HITL`). Ledger:


### PR DESCRIPTION
`[PR-as-Correction-Prompt]` — follow-up to #386 (merged at round 5).

## Context

#386 merged at `cc0e3da` on head `765810c` (**round 5**) while `chatgpt-codex-connector`'s round-6 findings were still being addressed. The fixes were committed locally but the push landed **after** the branch was auto-deleted by `delete_branch_on_merge` — so they never reached `main`.

Verified by content (not SHA — squash rewrites it):

| In `main` after #386 | Present? |
|---|---|
| round 5 — step-0 slot-contention pre-check | ✅ yes |
| round 6 — P1 normalization rule | ❌ **no** |
| round 6 — P2 version-note ordering fix | ❌ **no** |

## Objectives — the two defects still live in `main`

**P1 (was `SKILL.md:223`) — the step-0 check is keyed on the ALIAS spelling.** It tests only for `--cast-to`. A caller may legitimately mix the canonical form with the alias:

```
--to-type=prompt --target-format=pdf
```

The check does **not** fire, step 1 sets `--to-type=artifact:pdf`, and the requested `prompt` cast is **silently overwritten** — the exact failure round 5 was written to prevent, one spelling over. The `--target-style` table carried the identical distinction.

**Fix:** ONE normalization rule, stated once immediately after the alias table — translate `--cast-to` → `--to-type` **first**; from there *"an explicit cast"* means the normalized `--to-type` however the caller spelled it. Both branches consume it. `grep 'explicit `--cast-to`'` now returns **0**.

**P2 (was `SKILL.md:440`) — stale in-skill version note** asserted the pre-round-5 ordering (value-space before cast), contradicting the normative rule ~200 lines above and instructing an agent to do exactly what step-0 forbids. Updated, and **swept for siblings**: every ordering statement in `SKILL.md` + `CHANGELOG.md` now agrees.

## Acceptance

- [x] P1 normalization present · P2 ordering corrected · **0** spelling-specific tests remain
- [x] `validate-plugin` exit=0 — 0 errors, 0 warnings
- [x] changelog gate — `contract changed (1 entry) and CHANGELOG.md updated — ok`
- [x] push verified **by effect** (`git ls-remote` → `d6818a7`), not by a local `git log`

## Risk + rollback

Documentation-level contract only; no parser, no behavior code. Single-commit revert. Does **not** touch a guardrail surface (`skills/` + `CHANGELOG.md`) → R2 does not fire.

## Refs

`#386` (merged `cc0e3da`) · `#385` · `agentic-first-decision-protocol` §4.7.2 (verifier>generator — the finding came from a cross-brand reviewer, which is why it caught what the same-brand pass did not)
