### PR TITLE
docs(preflight): resolve #390 — deliberate frontmatter divergence from postflight

### DIFF
--- a/skills/preflight/SKILL.md
+++ b/skills/preflight/SKILL.md
@@ -30,6 +30,11 @@ metadata:
   lifecycle-stage: operate
   cross_link_slug: preflight
   dogfood_status: in-progress
+  pairs-with: postflight   # reciprocal of postflight's `pairs-with: preflight`
+  # id/type/status/owner/dogfooding_validation deliberately OMITTED (issue #390): that block
+  # predates and is non-conformant with ADR-005 (docs/adrs/ADR-005-dogfood-cycle-ledger.md),
+  # which supersedes per-skill dogfood tracking with a canonical ledger; it is also unconsumed
+  # by any repo tooling and inconsistent in shape even among its 4 adopters. See PR for evidence.
 allowed-tools: Read, Glob, Grep, Bash
 ---
 


### PR DESCRIPTION
## Decision: document-the-divergence (NOT blind harmonization) — closes #390

### Evidence (delegated audit by claude-code sub-agent; parent-verified claim-by-claim)

| Claim | Verification |
|---|---|
| CI enforces only `name`+`description` (`scripts/validate-skill-frontmatter.sh`) | ✅ regex-confirmed |
| `id`/`type`/`status`/`owner`/`dogfooding_validation` unconsumed by tooling | ✅ 0 hits in `scripts/` + `bin/` |
| Block is non-conformant with **ADR-005** (canonical dogfood-cycle ledger; per-skill island ledgers = anti-DRY/SSOT, migrate to `~/.claude/audit/dogfood-cycles.jsonl`) | ✅ ADR-005 text confirmed |
| 4 adopters shape-inconsistent (root-nested vs `metadata:`-nested) | ✅ cited in audit |

### What this PR does (5-line diff)

1. **Documents the deliberate omission in-place** (frontmatter comment: why that block is NOT copied to preflight — ADR-005 supersedes it; decorative; inconsistent)
2. **`pairs-with: postflight`** added to preflight — reciprocal of postflight's existing `pairs-with: preflight` (orthogonal, zero-risk symmetry fix)

### What it deliberately does NOT do

Copy the `id`/`type`/`status`/`owner`/`dogfooding_validation` block into preflight — that would extend a non-conformant pattern to a 5th file instead of converging on ADR-005's canonical ledger.

### Follow-up candidate (out of scope here)

The 4 adopters' block could migrate to ADR-005's canonical ledger in a dedicated PR (touches 4 files; deserves its own review).

---
Work executed in isolated worktree by delegated claude-code session (headless, git-permission-gated); commit/push/PR finished by parent pi session after claim-by-claim output audit (DNA Geracional: delegated ≠ unaccountable).