### PR TITLE
chore: gitignore .codegraph index cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ step*_logs.txt
 
 # research-dossier render output (build artifact, never committed)
 out/
+
+# codegraph index cache (local tool state, never committed)
+.codegraph/


### PR DESCRIPTION
Local `.codegraph/` index state sits untracked at the repo root — same class as the tool caches already ignored (`out/`, `.worktrees/`). Additive 3-line .gitignore entry; nothing else touched.