### PR TITLE
fix(sync-agentic-tools): first-wins + private-org namespacing for rule collisions

### DIFF
--- a/bin/sync-agentic-tools.sh
+++ b/bin/sync-agentic-tools.sh
@@ -36,6 +36,13 @@ link() { # link <target> <linkpath>
   if [ -e "$linkpath" ] && [ ! -L "$linkpath" ]; then
     say "SKIP (real file, not ours): $linkpath"; return 0
   fi
+  if [ -L "$linkpath" ]; then
+    cur="$(readlink "$linkpath")"
+    if [ "$cur" = "$target" ]; then return 0; fi
+    say "REPOINT ($cur -> $target): $linkpath"
+    if [ "$APPLY" = 1 ]; then ln -sfn "$target" "$linkpath"; fi
+    return 0
+  fi
   say "LINK  $linkpath -> $target"
   if [ "$APPLY" = 1 ]; then ln -sfn "$target" "$linkpath"; fi
   return 0
@@ -69,7 +76,15 @@ for repo in "${REPOS[@]}"; do
   [ -d "$repo/rules" ] || continue
   for f in "$repo"/rules/*.md; do
     has_fm "$f" description || say "WARN (no description, loads-but-lurks): $f"
-    link "$f" "$RULES_DIR/$(basename "$f")"
+    base="$(basename "$f")"
+    if [ "$repo" = "$VEK" ] && [ -f "$MAOS/rules/$base" ]; then
+      if diff -q "$MAOS/rules/$base" "$f" >/dev/null 2>&1; then
+        say "TRUE-DUP (identical to maos canonical): $base"; continue
+      fi
+      link "$f" "$RULES_DIR/vek-$base"   # vek overlay of a maos rule -> namespaced
+      continue
+    fi
+    link "$f" "$RULES_DIR/$base"
   done
 done
 


### PR DESCRIPTION
7 nomes de rule existem nos 2 repos; só 4 são byte-idênticas — 3 são overlays privados genuínos. O loop ingênuo deixava a cópia privada sobrescrever o link canônico maos. Agora: idêntica ⇒ TRUE-DUP skip; overlay privado divergente ⇒ link namespaced `<private-org>-<nome>.md`; `link()` ganha REPOINT quando o alvo desejado muda (corrige os 3 links atualmente apontados para a cópia errada). Verificado em dry-run.
