### PR TITLE
fix(commands): morning-briefing card — post-merge review hardening + changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `morning-briefing` command card (#403, review-hardened #404)
+
+- `commands/morning-briefing.md` (new) — thin command surface for the existing
+  `skills/morning-briefing` skill, closing the gap where the skill loaded
+  model-side but `/morning-briefing` resolved to nothing (skill ≠ command).
+  Card pattern per `commands/quiesce.md`; flags documented from the skill's own
+  interface (`--mode` · `--scope` verb family + modifiers · `--lang` ·
+  `--clipboard` · `--save [path?]` + `--save-overwrite` + no-save default).
+
 ### Added — DIMG v4 uniform cascade (operator refinement same-day, 5th iteration)
 
 - Cascata uniforme em todos os tiers: dev/hml = barra → GO, senão

--- a/commands/morning-briefing.md
+++ b/commands/morning-briefing.md
@@ -15,11 +15,12 @@ command surface only.
 ```text
 /morning-briefing [--mode=briefing|recap] [--scope=current|down|sideways|up|forward] \
                   [--depth N] [--height N] [--breadth all|N] [--lang <BCP-47>] \
-                  [--clipboard] [--save]
+                  [--clipboard] [--save [path?]] [--save-overwrite]
 ```
 
 All flags are optional — bare `/morning-briefing` runs the default 7-section
-briefing in the auto-detected language.
+briefing in the auto-detected language, writes nothing to disk (no-save default)
+and copies nothing to the clipboard.
 
 ## Flags
 
@@ -29,7 +30,8 @@ briefing in the auto-detected language.
 | `--scope` | `current` | Compass verb: `current` (here/now) · `down` · `sideways` · `up` · `forward` |
 | `--depth` / `--height` / `--breadth` | skill defaults | Modifiers on the scope verb |
 | `--lang` | auto-detect | BCP-47; 5-step cascade (flag → LC_MESSAGES → LANG → AGENTS.md → en-us) |
-| `--clipboard` | off | Copy the rendered briefing to the system clipboard (gitleaks pre-copy guard) |
-| `--save` | per skill | Persist the rendered output per the skill's save policy |
+| `--clipboard` | off | Copy the rendered briefing **or recap** to the system clipboard (mode-agnostic destination sink; gitleaks pre-copy guard, stdout preserved when no clipboard tool is found) |
+| `--save [path?]` | off (no-save default) | Persist the rendered briefing/recap to disk. Optional path; when omitted, the skill resolves the destination via its 4-step cascade (explicit → repo `.claude/sessions/` → AAIF user-scope docs dir → cwd). 5 safety guards incl. no-silent-overwrite and gitleaks pre-write scan |
+| `--save-overwrite` | off | Modifier for `--save`: permits replacing an existing target file. Without it, `--save` aborts on an existing path instead of overwriting |
 
 Never re-implement briefing logic here — change the skill, not this card.


### PR DESCRIPTION
CodeRabbit post-merge review do #403 (2 Minor + 1 P1, todos válidos — verificados contra a interface real da skill): documenta `--save [path?]` + `--save-overwrite` + default no-save; `--clipboard` como sink mode-agnostic (briefing OU recap); adiciona a entrada de CHANGELOG que faltou (consumable per entry-classifier).