### PR TITLE
feat(routed-pr-review): dispatch an isolated PR review when bots are quota-blocked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — `routed-pr-review` skill · isolated PR review when bots are quota-blocked (#414)
+
+- `skills/routed-pr-review/` (new, soul-name **Euthyna**) — dispatches an
+  independent PR review whose context is isolated from the delegator **by
+  construction**: a fresh OS process in a different vendor family, prompted to
+  REFUTE rather than approve. Closes the rung left open by
+  `ai-code-review-bots-rotation` §5 (a local lint pass is *partial evidence, NOT
+  a review*) and `pr-review-protocol` §4.1 (a bot answering at ~8h): keep
+  **reviewing** while blocked, never **merge** while blocked.
+- **Consumable contract**: `bin/routed-review.sh --pr N [--repo O/R]
+  [--reviewer NAME] [--post] [--json] [--timeout SEC] [--max-turns N]
+  [--no-primary-configured]`. Exit codes are load-bearing — `0` reviewed and may
+  complete C3 · `3` reviewed but a primary is still pending · `2` no reviewer
+  available or empty output · `1` error or isolation violation.
+- **Gate honesty is mechanical** (§4.1(e)): a routed review satisfies the C3
+  *diversity* limb ONLY and never a configured primary's verdict.
+  `may_complete_c3` is computed from a live primary probe; absence of a primary
+  is an **operator attestation**, never an inference.
+- **Read-only enforcement in two classes**: `vendor` (`codex --sandbox
+  read-only`, `claude --allowedTools`) and `os` for the other 9 — a disposable
+  `git archive` export, every path `chmod a-w`, no `.git`, plus a `sha256`
+  manifest tamper-check after the run. Drift ⇒ exit `1` and nothing is stamped.
+- `agents/code-reviewer.md` — additive independence boundary: the in-harness
+  reviewer now declares itself a *correlated* verifier and routes to this skill
+  wherever `verifier != generator` is the actual requirement.
+- **Hardened by two dogfood cycles against its own PR** (reviewer `codex`,
+  isolated): cycle 1 caught a `vendor` classification resting on a flag the code
+  never passed, and an `absent` conclusion drawn from PR silence. Cycle 2 caught
+  five more — unpaginated absence probe, human reviews landing in the
+  bot-cleared set, vendor paths reading a tree not proven to be the stamped SHA,
+  `--reviewer` bypassing the caller-exclusion invariant, and a mandatory secret
+  scan that was silently skipped when `gitleaks` was absent. All fixed in-PR.
+
 ### Added — `morning-briefing` command card (#403, review-hardened #404)
 
 - `commands/morning-briefing.md` (new) — thin command surface for the existing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -947,7 +947,7 @@ front-door answering *"what should I focus on now? who asked me for what, by whe
 - Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
 
 ### Added
-- `routed-pr-review` contract tests (`tests/contract.sh`) — 8 end-to-end cases run the real script against a stub `PATH`, asserting the gate *path* rather than the line. Caught defect #20 on the first run (a `die` inside a command substitution re-labelled a usage error as `status:no_reviewer`).
+- `routed-pr-review` contract tests (`tests/contract.sh`) — 9 cases / 11 assertions run the real script against a stub `PATH`, asserting the gate *path* rather than the line. Caught defects #20, #21 and #22 across two runs — the last being that the whole `os-perms-only` fallback class crashed on every non-macOS host (`set -u` + bash 3.2 empty-array expansion).
 
 - `scripts/validate-skill-frontmatter.sh` + `npm run validate:skills`
 - `docs/multi-host-packaging.md` install matrix + agent id notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -947,6 +947,7 @@ front-door answering *"what should I focus on now? who asked me for what, by whe
 - Replace stale auto-generated "TypeScript PascalCase" body with accurate MAOS multi-harness contributor skill
 
 ### Added
+- `routed-pr-review` contract tests (`tests/contract.sh`) — 8 end-to-end cases run the real script against a stub `PATH`, asserting the gate *path* rather than the line. Caught defect #20 on the first run (a `die` inside a command substitution re-labelled a usage error as `status:no_reviewer`).
 
 - `scripts/validate-skill-frontmatter.sh` + `npm run validate:skills`
 - `docs/multi-host-packaging.md` install matrix + agent id notes

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -15,3 +15,21 @@ Your role is to:
 - Provide constructive feedback with clear explanations
 
 Focus on being thorough but constructive in your reviews.
+
+## Independence boundary (added 2026-09-03)
+
+You run **in-harness**. You start with no conversation history, but the agent
+that spawned you authored your prompt and you share its model family — so you
+are a **correlated verifier**, not an independent one. That is fine for the work
+you are usually asked to do (criteria-driven review of code in front of you) and
+it is **not sufficient** wherever a gate requires `verifier != generator`.
+
+When independence is the actual requirement — a merge gate, a red-team cycle, or
+a review whose primary bot is quota-blocked — do not self-certify. Hand off to
+`skills/routed-pr-review/` (soul-name Euthyna), which dispatches a reviewer in a
+**fresh OS process from a different vendor family** with enforced read-only
+access, and reports what a routed review does and does not satisfy under
+`pr-review-protocol.md` §4.1(e).
+
+Your review criteria remain the reusable part; the isolation is what you cannot
+provide about yourself.

--- a/agents/code-reviewer.md
+++ b/agents/code-reviewer.md
@@ -33,3 +33,6 @@ access, and reports what a routed review does and does not satisfy under
 
 Your review criteria remain the reusable part; the isolation is what you cannot
 provide about yourself.
+---
+
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review` @ `342165e`) | 2026-09-03T15:33:49-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -184,22 +184,47 @@ a genuine `HEAD_SHA` (the script fetches and archives it, so it must exist), and
 stubs answer the four `gh` call shapes plus a fake reviewer whose output each
 case controls by env. Every case is data, not another copy of the invocation.
 
+**9 cases · 11 assertions** (cases 5 and 9 each assert an exit code *and* that
+the diagnostic names its reason — a silent correct exit is not enough). The run
+prints one line per assertion; that is why the count below is 11, not 9.
+
 | # | Contract asserted | Guards against |
 |---|---|---|
 | 1 | `exit 0` is **reachable** when a configured primary cleared *this* head | the `.head` scope bug that made the documented success path dead code |
 | 2 | an approval at an **older** sha does not clear C3 | false-green on a stale verdict |
 | 3 | an active `CHANGES_REQUESTED` is never dismissed | `§4.1(e)` — the whole point of the gate |
 | 4 | under-40-byte output is **not** a review | anti-theater guarantee #1 |
-| 5 | explicit `--reviewer` equal to the caller is refused, **with the reason** | verifier ≠ generator bypass |
+| 5 | explicit `--reviewer` equal to the caller is refused **+ the reason is named** | verifier ≠ generator bypass *(2 assertions)* |
 | 6 | silence alone never proves "no primary configured" | `§4.1(a)` absence-from-silence misclassification |
 | 7 | a trailing value-option terminates | the `shift 2` infinite loop |
+| 8 | a broken `sandbox-exec` degrades to `os-perms-only`, never claims `os-sandboxed` | cycle-4 fail-open: a failure to confine reported as a successful denial |
+| 9 | absent `timeout` aborts with a diagnostic **naming the remedy** | cycle-4: a hard dependency discovered late as an opaque per-harness failure *(2 assertions)* |
 
-**They earned their keep on the first run.** Case 5 failed: the refusal fired
-and printed its reason, but `pick_reviewer` runs inside a command substitution,
-so its `die` exited only the subshell and the `|| { … exit 2 }` below re-labelled
-a usage error as `status:no_reviewer` — stderr right, JSON wrong. Validation is
-now hoisted into the main shell. That is defect #20, and the first one a
-*mechanism* caught rather than an external reviewer.
+**They earned their keep three times, on two runs.**
+
+- **Run 1, case 5 → defect #20.** The refusal fired and printed its reason, but
+  `pick_reviewer` runs inside a command substitution, so its `die` exited only
+  the subshell and the `|| { … exit 2 }` below re-labelled a usage error as
+  `status:no_reviewer` — stderr right, JSON wrong. Validation hoisted into the
+  main shell.
+- **Run 2, case 8 → defect #21.** `build_sandbox_profile` assigned the global
+  `$SANDBOX_PROFILE` *before* probing, so a failing probe returned `1` while
+  leaving it set — and `arm_sandbox_prefix`, which trusts only non-emptiness,
+  then wrapped every dispatch in a profile just proven not to work. Now built
+  into a local and published only on success.
+- **Run 2, case 8 again → defect #22, the worst of the three.** With the leak
+  fixed, `SBX` is legitimately empty — and under `set -u`, **bash 3.2 (the macOS
+  default) aborts when an empty array is expanded**. The entire documented
+  `os-perms-only` fallback class therefore crashed on every dispatch, on every
+  host without a working `sandbox-exec` — all of Linux. It never surfaced here
+  because this host arms the kernel boundary. Fixed with the
+  `${SBX[@]+"${SBX[@]}"}` idiom at all 4 sites.
+
+Three defects, none found by a human or a reviewer bot, all found by running the
+path. Cases 8 and 9 exist **because an advisory pointed out that the two cycle-4
+boundary fixes had been proven by ad-hoc probes and never encoded** — proof
+without a regression test is exactly the "verified once, shipped, forgotten"
+pattern this harness exists to end.
 
 ## Anti-theater guarantees
 
@@ -304,4 +329,4 @@ lacked an implementation.
 
 ---
 
-*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, contract-tests) | 2026-09-03T22:00:48-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, cycle-4 regressions encoded) | 2026-09-03T22:07:45-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -6,7 +6,9 @@ description: >
   waiting on them or fabricating a green. Soul-name Euthyna (εὔθυνα, the
   independent end-of-term audit of an Athenian magistrate, conducted by officials
   who were not the magistrate). Isolation is BY CONSTRUCTION: a fresh OS process
-  in a different vendor family, read-only tools, no delegator history, prompted to
+  in a different vendor family, write confinement whose strength is named per
+  harness class (CLI sandbox · kernel `sandbox-exec` · perms-only, which DETECTS
+  rather than PREVENTS), no delegator history, prompted to
   REFUTE rather than approve. Reports a gate verdict that never overstates itself —
   a routed review satisfies the C3 *diversity* limb only and NEVER a configured
   primary's verdict. Use when a PR needs reviewing while blocked, when "all bots
@@ -54,7 +56,7 @@ Five phases:
 | **A** resolve | PR, title, `headRefOid`, diff | `gh` |
 | **B** primary probe | classify every reviewer that has *ever* spoken on this repo: cleared-for-head · stale/earlier-head · quota-signalled · changes-requested. Absence is proven by **positive evidence only** | `pr-review-protocol.md` §4.1(a); bot-message taxonomy from `review-bot-quota-recovery.md` |
 | **C** pick reviewer | capability-detect `command -v`, skip bots expired in `~/.claude/state/ai-review-bots.json`, **exclude the caller's own family** | `ai-code-review-bots-rotation.md` §2/§3 |
-| **D** isolated run | fresh OS process, read-only tools, refute-first prompt, timeout floor 500s | `cross-harness-red-team.md` |
+| **D** isolated run | fresh OS process, write confinement per harness class (Axis 2 — never a blanket "read-only"), refute-first prompt, timeout floor 500s | `cross-harness-red-team.md` |
 | **E** gate verdict | emit what this *does* and *does not* satisfy; optionally post the canonical stamp | `pr-review-protocol.md` §4.1(e) |
 
 ## The gate contract — the part that matters most
@@ -195,7 +197,9 @@ its own.
 
 | capability | source | where it lives | disposition |
 |---|---|---|---|
-| review criteria, severity taxonomy | `code-review-excellence`, `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer` + 5 more | installed skills (host) | **reused** — no new criteria authored |
+| review criteria (what to look for) | `code-review-excellence`, `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer` + 5 more | installed skills (host) | **reused** — no new criteria authored |
+| severity ladder `[blocking\|major\|minor\|nit]` in the reviewer prompt | extends `pr-review-protocol.md` (which uses `blocking` + `major`) | `~/.claude/rules/`, external | ⚠️ **partly authored** — `minor`/`nit` are mine. Measured 2026-09-03: the cited rule contains `nit` **zero** times. An earlier revision of this table claimed "no new criteria authored" across both rows; that was a false claim of the same class this tool's own prompt rates *at least major*, self-caught by Socratic Q13 |
+| finding classes `[correctness\|security\|silent-failure\|governance\|test-gap]` | named after the installed skills above | installed skills (host) | **derived** — one class per source skill, not independently invented |
 | bot-message taxonomy (rate-limit vs plan vs informational) | `review-bot-quota-recovery.md` | vault, external | **reused** in phase B |
 | rotation + state file + never-hot-retry | `ai-code-review-bots-rotation.md` | `~/.claude/rules/`, external | **reused** in phase C |
 | gate semantics | `pr-review-protocol.md` §4.1 | `~/.claude/rules/`, external | **implemented**, not amended; restated inline above |
@@ -204,6 +208,46 @@ its own.
 
 Net-new is exactly one thing: **an executable dispatcher that makes isolation and
 gate-honesty mechanical instead of remembered.**
+
+## Q20/Q21 — revert and fallback
+
+**Revert.** The only external side effect is one PR comment (`--post`); without
+that flag nothing leaves the process. To revert: `gh pr comment --delete-last`
+(or delete by id). The dispatcher never pushes, never merges, never edits code,
+and never writes outside `$WORK`/the disposable export — so there is no
+repository state to roll back.
+
+**Fallback ladder** — exit codes read off the code, not intended (an earlier
+draft of this very section mis-stated two of them; corrected before commit):
+
+| # | condition | exit | behaviour |
+|---|---|---|---|
+| 1 | no harness left after family exclusion | `2` | JSON `status:no_reviewer`, `may_complete_c3:false`. **Never** falls back to the caller (verifier ≠ generator) |
+| 2 | reviewer produced <40 bytes | `2` | treated as **no review**; the bot **is** recorded in `~/.claude/state/ai-review-bots.json` so rotation *skips* it next cycle (§3 never-hot-retry) |
+| 3 | isolation violated (either tamper check) | `1` | no stamp, no comment, `status:isolation_violated` |
+| 4 | `gitleaks` absent while `--post` given | `1` | refuses to post rather than posting an unscanned body |
+| 5 | review ran, gate does not clear C3 | `3` | the review **is** emitted; `3` means *reviewed-but-blocked*, not failure |
+| 6 | review ran, C3 cleared | `0` | — |
+
+Below the ladder, `ai-code-review-bots-rotation` §5 still licenses the
+deterministic local path (`gitleaks`/lint/typecheck/build) as **labelled partial
+evidence** — never as a "review".
+
+## Q29/Q33 — KPIs and cost, measured not projected
+
+| KPI | Definition | First-cycle measurement (2026-09-03, PR #414) |
+|---|---|---|
+| finding precision | findings that survived independent verification ÷ findings raised | **14/14 = 100%** across 3 reviewers |
+| author blind-spot rate | defects found by the routed reviewer that the author's own passes missed | **14/14** — author self-caught **0** after 6 self-review rounds |
+| gate honesty | routed runs that overstated their limb | **0** — `may_complete_c3` never certified a pending primary |
+| cost per cycle | wall-clock + calls | ~4-6 min, 1 dispatch + 1 verification read |
+| false-green risk | reviews stamped without substantive body | **0** — the <40-byte guard fired as designed |
+
+**ROI framing.** The comparison is not "routed review vs. a real bot" — it is
+"routed review vs. **waiting**". Cycle 1 ran while CodeRabbit was quota-blocked
+for 40 minutes and returned two real defects in that window. Re-measure these
+numbers per cycle; a precision figure that drifts below ~70% means the reviewer
+prompt is generating noise and should be tightened, not trusted.
 
 ## Governance note — no rule amendment was needed
 
@@ -224,4 +268,4 @@ lacked an implementation.
 
 ---
 
-*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review` @ `342165e`) | 2026-09-03T15:33:49-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, Socratic-Q round) | 2026-09-03T18:31:14-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: routed-pr-review
+description: >
+  Dispatch an independent, context-isolated PR review when the configured review
+  bots are quota-blocked, absent, or past their measured latency — instead of
+  waiting on them or fabricating a green. Soul-name Euthyna (εὔθυνα, the
+  independent end-of-term audit of an Athenian magistrate, conducted by officials
+  who were not the magistrate). Isolation is BY CONSTRUCTION: a fresh OS process
+  in a different vendor family, read-only tools, no delegator history, prompted to
+  REFUTE rather than approve. Reports a gate verdict that never overstates itself —
+  a routed review satisfies the C3 *diversity* limb only and NEVER a configured
+  primary's verdict. Use when a PR needs reviewing while blocked, when "all bots
+  rate-limited" would otherwise stall a merge queue, or when a verifier
+  independent of the author is required on a harness that cannot spawn one.
+  Do NOT use to manufacture convergence on a PR whose primary is still pending.
+---
+
+# routed-pr-review · Euthyna
+
+## The problem this exists for
+
+Review bots are the independent verifier in the house merge gate. They also run
+out of quota. The observed failure mode is not the outage itself — it is what an
+agent does next:
+
+- **waits** on a bot that answered at ~8h and again after 2 days
+  (`pr-review-protocol.md` §4.1, empirical `multi-agent-os#386`), or
+- **declares green** from a local lint pass, which
+  `ai-code-review-bots-rotation.md` §5 explicitly forbids: a deterministic local
+  pass is *partial evidence, NOT a review*, or
+- **self-reviews**, which is the structural blind spot —
+  `cross-harness-red-team.md` records a defect that survived **six** self-run
+  refine rounds *including the two passes that existed to catch it*, and fell in
+  cycle 1 of a fresh-process critic.
+
+Empirical origin: `2026-09-03`, `ekson73/eko-engram#42`. CodeRabbit stalled on an
+exhausted hourly quota. A delegated reviewer with isolated context found **two
+real defects that had already been published** — a path fabricated by a `sed` on a
+bare stem, and an `id:` field whose convention had been measured from too narrow a
+sample. Neither was found by the author across several self-review passes.
+
+## What it does
+
+```bash
+skills/routed-pr-review/bin/routed-review.sh --pr 42 --json
+skills/routed-pr-review/bin/routed-review.sh --pr 42 --post          # stamp the PR
+ROUTED_REVIEW_CALLER=claude skills/routed-pr-review/bin/routed-review.sh --pr 42
+```
+
+Five phases:
+
+| phase | what | grounding |
+|---|---|---|
+| **A** resolve | PR, title, `headRefOid`, diff | `gh` |
+| **B** primary probe | classify every reviewer that has *ever* spoken on this repo: cleared-for-head · stale/earlier-head · quota-signalled · changes-requested. Absence is proven by **positive evidence only** | `pr-review-protocol.md` §4.1(a); bot-message taxonomy from `review-bot-quota-recovery.md` |
+| **C** pick reviewer | capability-detect `command -v`, skip bots expired in `~/.claude/state/ai-review-bots.json`, **exclude the caller's own family** | `ai-code-review-bots-rotation.md` §2/§3 |
+| **D** isolated run | fresh OS process, read-only tools, refute-first prompt, timeout floor 500s | `cross-harness-red-team.md` |
+| **E** gate verdict | emit what this *does* and *does not* satisfy; optionally post the canonical stamp | `pr-review-protocol.md` §4.1(e) |
+
+## The gate contract — the part that matters most
+
+⛔ **A routed review is never a configured primary's verdict.** `§4.1(e)` is
+unambiguous and this tool implements it rather than arguing with it:
+
+| limb | routed review |
+|---|---|
+| C3 *diversity* (independent cross-brand opinion) | **satisfies** |
+| A configured primary's verdict on the current head | **never satisfies** |
+| Dismissing an active `CHANGES_REQUESTED` | **never** |
+| Completing convergence alone | only where **no** primary is configured (positively evidenced) **or** every primary has already cleared |
+
+`may_complete_c3` is computed, not asserted, and the exit code carries it:
+`0` = review produced and may complete C3 · `3` = review produced **but a primary
+is still pending** · `2` = no reviewer available / empty output · `1` = error.
+
+**A `Reviewed-By:` stamp is a claim, not evidence** (§4.1(e)). The comment
+therefore always embeds the reviewer's *actual output* and the head SHA it
+examined. A stamp with no substantive body does not satisfy the diversity limb —
+treat it as absent.
+
+## Isolation — enforced, not requested
+
+Independence has two axes and both must hold. Only the first is about context.
+
+### Axis 1 — context independence
+
+| tier | mechanism | independence |
+|---|---|---|
+| **weak** | in-harness blank subagent | starts with no conversation history, but the parent authors its prompt (bias channel) and it shares the model family → **correlated verifier** |
+| **strong** (this tool's default) | fresh OS process, different vendor family, no delegator history | independent by construction — different blind spots |
+
+`cross-harness-red-team.md` §Must-not forbids counting a self-run critique as the
+independent cycle. Tier-weak is documented here so a future agent does not
+mistake it for tier-strong; it is not what this dispatcher does.
+
+### Axis 2 — read-only enforcement (⚠️ the defect this section exists to close)
+
+**Only 3 of 11 harnesses expose a read-only switch.** Asking the other 8 nicely
+is not enforcement, and a doc that says "read-only tools" while running an
+unflagged CLI in the live worktree is a false claim — exactly the class this
+tool's own reviewer prompt rates *at least major*. So enforcement is split by
+capability and the weaker half is enforced by the operating system instead:
+
+| class | harnesses | mechanism |
+|---|---|---|
+| `vendor` | `codex` (`--sandbox read-only`), `claude` (`--allowedTools`), `grok` (`--allow-rule`) | the CLI guarantees it; cwd = live repo |
+| `os` | the other 8 | cwd = a **disposable `git archive` export** of the head tree: every path `chmod a-w`, and **no `.git` at all**, so a git mutation is not even expressible |
+
+The `os` class is then **proven**, not trusted: a `sha256` manifest is taken
+before locking and recompared after the run. A single byte of drift ⇒ the run
+exits `1` with `isolation_violated`, and **nothing is stamped or reported as a
+valid review**. The enforcement class and the tamper-check result ride in both
+the PR comment and the JSON, so a consumer can audit the isolation claim instead
+of believing it.
+
+> Caught in build by an independent advisory before first dogfood: the original
+> dispatcher ran all 8 unflagged harnesses in `$PWD`. The mechanism above was
+> designed in the same breath as the doc but had not been written — the doc was
+> ahead of the code, which is the definition of the defect.
+
+## Reviewer invocation table
+
+`evidence` is load-bearing: **proven** = executed successfully in a recorded run;
+**measured** = flag confirmed present in this host's `--help` at build time
+(`2026-09-03`). Never add a row without one.
+
+| harness | invocation | enforcement class | evidence |
+|---|---|---|---|
+| `codex` | `codex exec --sandbox read-only --cd DIR` | `vendor` — sandbox | proven (`--cd` measured) |
+| `claude` | `claude -p … --max-turns N --allowedTools Read Grep Glob --add-dir DIR` | `vendor` — tool allowlist | proven |
+| `grok` | `grok -p` (cwd-scoped) | `vendor` — `--allow-rule` (alias `--allowedTools`) | measured |
+| `gemini` | `gemini -p` (cwd-scoped) | `os` — locked export | measured |
+| `qwen` | `qwen -p` (also native `qwen review run`) | `os` — locked export | measured |
+| `kimi` | `kimi -p --output-format text\|json` | `os` — locked export | measured |
+| `copilot` | `copilot -p` | `os` — locked export (`--allow-all-tools` exists and is **never** passed) | measured |
+| `pi` | `pi --print` | `os` — locked export | measured |
+| `jcode` | `jcode run` | `os` — locked export | measured |
+| `opencode` | `opencode run` (also native `opencode pr <N>`) | `os` — locked export | measured |
+| `kiro` | `kiro chat` | `os` — locked export | measured |
+
+`os` = the disposable `chmod a-w` export from Axis 2, with a post-run manifest
+tamper check. No row may claim read-only without one of the two mechanisms.
+
+Two native review paths were found during the probe and are **not** wrapped by
+this tool: `qwen review run` and `opencode pr <N>`. They are recorded as
+candidates for a later cycle rather than silently duplicated.
+
+## Anti-theater guarantees
+
+1. **Empty output is NOT a review.** Under 40 bytes ⇒ exit `2`, the bot is
+   recorded as limited in the rotation state file, and nothing is stamped.
+2. **Truncation is declared.** A diff over the cap is cut and `diff_truncated:
+   yes` rides in the comment and the JSON.
+3. **Secrets are absolute.** `gitleaks` scans the comment body *before* posting;
+   any hit aborts the post.
+4. **Timeout floor 500s.** A 280s cap once burned `$4.7` for zero output
+   (`cross-harness-red-team.md`).
+5. **The prompt rewards refutation**, requires `file:line` citations, mandates
+   "could not verify" over guessing, and classifies a PR-body claim unsupported
+   by the diff as at least *major*.
+6. **The isolation claim is audited, not asserted.** For every `os`-class
+   reviewer the export manifest is recompared after the run; drift ⇒ exit `1`
+   `isolation_violated` and no stamp. The enforcement class and tamper result
+   are emitted, so a consumer never has to take "read-only" on faith.
+
+## What was reused rather than built
+
+Strata / DRY — the forge crossed these before creating anything:
+
+| capability | source | disposition |
+|---|---|---|
+| review criteria, severity taxonomy | `code-review-excellence`, `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer` + 5 more already installed | **reused** — no new criteria authored |
+| bot-message taxonomy (rate-limit vs plan vs informational) | `review-bot-quota-recovery.md` | **reused** in phase B |
+| rotation + state file + never-hot-retry | `ai-code-review-bots-rotation.md` | **reused** in phase C |
+| gate semantics | `pr-review-protocol.md` §4.1 | **implemented**, not amended |
+| isolation shape | `cross-harness-red-team.md` | **reused** in phase D |
+| in-harness stub | `agents/code-reviewer.md` (17 lines, no isolation) | **left intact**, now points here |
+
+Net-new is exactly one thing: **an executable dispatcher that makes isolation and
+gate-honesty mechanical instead of remembered.**
+
+## Governance note — no rule amendment was needed
+
+The forge order flagged a possible tension in `§4.1(e)` requiring either
+(i) positioning as the verifier limb, or (ii) an H6-gated amendment with
+independent red-team and HITL ratification. **Path (i) is fully specified by
+§4.1(e) as written** — it already states what a routed review counts for, where
+it is recorded, and the two conditions under which it may complete convergence.
+No amendment, no red-team gate, no HITL cycle. The rule was right; it only
+lacked an implementation.
+
+## Non-goals
+
+- Not a replacement for configured bots — it is the rung *below* them.
+- Not a merge authority. It never sets `--auto-merge` and never clears C2.
+- Not a security scanner. Route `snyk`/`gitleaks` separately.
+- Not a fixer. It reviews; the caller fixes.

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -268,4 +268,4 @@ lacked an implementation.
 
 ---
 
-*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, routed-kimi findings round) | 2026-09-03T21:37:25-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, cycle-4 findings) | 2026-09-03T21:49:27-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -175,16 +175,24 @@ candidates for a later cycle rather than silently duplicated.
 
 ## What was reused rather than built
 
-Strata / DRY — the forge crossed these before creating anything:
+Strata / DRY — the forge crossed these before creating anything.
 
-| capability | source | disposition |
-|---|---|---|
-| review criteria, severity taxonomy | `code-review-excellence`, `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer` + 5 more already installed | **reused** — no new criteria authored |
-| bot-message taxonomy (rate-limit vs plan vs informational) | `review-bot-quota-recovery.md` | **reused** in phase B |
-| rotation + state file + never-hot-retry | `ai-code-review-bots-rotation.md` | **reused** in phase C |
-| gate semantics | `pr-review-protocol.md` §4.1 | **implemented**, not amended |
-| isolation shape | `cross-harness-red-team.md` | **reused** in phase D |
-| in-harness stub | `agents/code-reviewer.md` (17 lines, no isolation) | **left intact**, now points here |
+⚠️ **Where these sources live.** The four `.md` sources below are **NOT in this
+repository** — they are user-scope artifacts on the operator's machine
+(`~/.claude/rules/` and an Obsidian vault). A reader of this repo alone cannot
+open them, and an isolated reviewer correctly reported them as unresolvable.
+They are cited as *provenance*, never as repo paths. The governance semantics
+they carry are restated inline in this file precisely so this skill stands on
+its own.
+
+| capability | source | where it lives | disposition |
+|---|---|---|---|
+| review criteria, severity taxonomy | `code-review-excellence`, `code-reviewer`, `silent-failure-hunter`, `pr-test-analyzer` + 5 more | installed skills (host) | **reused** — no new criteria authored |
+| bot-message taxonomy (rate-limit vs plan vs informational) | `review-bot-quota-recovery.md` | vault, external | **reused** in phase B |
+| rotation + state file + never-hot-retry | `ai-code-review-bots-rotation.md` | `~/.claude/rules/`, external | **reused** in phase C |
+| gate semantics | `pr-review-protocol.md` §4.1 | `~/.claude/rules/`, external | **implemented**, not amended; restated inline above |
+| isolation shape | `cross-harness-red-team.md` | vault, external | **reused** in phase D |
+| in-harness stub | `agents/code-reviewer.md` | **this repo** | **behaviour unchanged**; +18 lines appended declaring its correlated-verifier boundary and routing here (17 → 34 lines) |
 
 Net-new is exactly one thing: **an executable dispatcher that makes isolation and
 gate-honesty mechanical instead of remembered.**

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -93,40 +93,48 @@ Independence has two axes and both must hold. Only the first is about context.
 independent cycle. Tier-weak is documented here so a future agent does not
 mistake it for tier-strong; it is not what this dispatcher does.
 
-### Axis 2 — read-only enforcement (⚠️ the defect this section exists to close)
+### Axis 2 — write confinement (⚠️ two rounds of review rewrote this section)
 
-**3 of 11 harnesses expose a read-only switch; this dispatcher actually passes
-2 of them.** Asking the other 9 nicely is not enforcement, and a doc that says
-"read-only tools" while running an unflagged CLI in the live worktree is a false
-claim — exactly the class this tool's own reviewer prompt rates *at least major*.
-So enforcement is split by capability, and the classification is allowed to
-depend ONLY on a flag the code genuinely passes:
+**3 of 11 harnesses expose a read-only switch; this dispatcher passes 2 of
+them.** For the rest, confinement is provided from outside the CLI — and the
+strength of that confinement is named honestly, because permissions alone are
+**not** a boundary:
 
-| class | harnesses | mechanism |
+| class | when | guarantee |
 |---|---|---|
-| `vendor` (2) | `codex` (`--sandbox read-only`), `claude` (`--allowedTools`) | the CLI guarantees it; cwd = live repo |
-| `os` (9) | everything else, **including `grok`** | cwd = a **disposable `git archive` export** of the head tree: every path `chmod a-w`, and **no `.git` at all**, so a git mutation is not even expressible |
+| `vendor` | `codex` (`--sandbox read-only`), `claude` (`--allowedTools`) | the CLI confines itself; cwd = live repo, but only after cwd is **proven** to be `HEAD_SHA` and clean |
+| `vendor+os` | vendor CLI, cwd **not** provably `HEAD_SHA` | export built anyway so the `Head reviewed:` stamp stays true |
+| `os-sandboxed` | any other harness, host has `sandbox-exec` | **kernel** `file-write*` deny on the export *and* the repo root, profile **probe-verified before use**, over the disposable `chmod a-w` export |
+| `os-perms-only` | any other harness, **no** kernel boundary on host | writes are **DETECTED, not PREVENTED** — see below |
 
-`grok` exposes `--allow-rule` (alias `--allowedTools`) and is nevertheless `os`:
-**this dispatcher does not pass that flag**, and classifying on an unpassed flag
-is the same false-claim class the tool exists to catch. Promotion to `vendor`
-requires the flag to be passed *and* proven in a recorded run — not merely to
-exist in `--help`.
+⚠️ **`chmod a-w` is not an execution boundary.** A process running as the file
+owner can `chmod u+w` and rewrite. Measured on this host: owner restored the
+permission and wrote through it. Under `sandbox-exec` the identical attack
+returned `Operation not permitted` and the content survived. So `os-perms-only`
+defends against an *incidentally-writing* reviewer, never a determined one, and
+the emitted evidence says exactly that instead of implying a sandbox.
 
-The `os` class is then **proven**, not trusted: a `sha256` manifest is taken
-before locking and recompared after the run. A single byte of drift ⇒ the run
-exits `1` with `isolation_violated`, and **nothing is stamped or reported as a
-valid review**. The enforcement class and the tamper-check result ride in both
-the PR comment and the JSON, so a consumer can audit the isolation claim instead
-of believing it.
+**Two independent tamper checks**, because one could not see far enough:
 
-> **Two defects were caught before this shipped, by two independent verifiers.**
-> (1) An advisory caught the original dispatcher running all unflagged harnesses
-> in `$PWD` while the doc claimed read-only — the doc was ahead of the code.
-> (2) Dogfood cycle 1 (`codex`, isolated) then caught that `grok` was still
-> classified `vendor` on a flag the fixed code never passed — the same defect
-> surviving for one harness, now *asserted* as enforced. Neither was found by
-> the author.
+1. **export manifest** — `sha256` before locking, recompared after; catches
+   writes *inside* the tree the reviewer was given.
+2. **live-repo hash** — `git status --porcelain` digest before/after; catches an
+   *escape*, i.e. a write to the working tree the reviewer was never given. The
+   first check was blind to this by construction.
+
+Either check failing ⇒ exit `1` with `isolation_violated:<which>`, and
+**nothing is stamped or reported as a valid review**. The enforcement class and
+the tamper result ride in both the PR comment and the JSON, so a consumer audits
+the isolation claim instead of believing it.
+
+> **Three independent verifiers, three rounds, all on this artifact:**
+> (1) an advisory caught the original dispatcher running unflagged harnesses in
+> `$PWD` while the doc claimed read-only — the doc was ahead of the code;
+> (2) dogfood cycle 1 (`codex`) caught `grok` still classified `vendor` on a
+> flag the fixed code never passed;
+> (3) `coderabbitai` caught that the `chmod` export was never a boundary at all,
+> and that the manifest could not see an escape outside it.
+> None of the three was found by the author.
 
 ## Reviewer invocation table
 
@@ -213,3 +221,7 @@ lacked an implementation.
 - Not a merge authority. It never sets `--auto-merge` and never clears C2.
 - Not a security scanner. Route `snyk`/`gitleaks` separately.
 - Not a fixer. It reviews; the caller fixes.
+
+---
+
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review` @ `342165e`) | 2026-09-03T15:33:49-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -165,6 +165,42 @@ Two native review paths were found during the probe and are **not** wrapped by
 this tool: `qwen review run` and `opencode pr <N>`. They are recorded as
 candidates for a later cycle rather than silently duplicated.
 
+## Contract tests — `tests/contract.sh`
+
+```bash
+bash skills/routed-pr-review/tests/contract.sh    # -v for failing-case detail
+```
+
+**Why they exist.** Four dogfood cycles produced 19 findings and I self-caught
+**zero**. The two worst were *composition* defects — every individual line
+verified correct against the binary while the path through them was dead
+(`exit 0` unreachable via a `.head` scope bug) or wrong (`--add-dir` granting
+access without moving cwd). Line-level checking is structurally blind to both.
+These run the **real script end-to-end** against a stub `PATH`, so they assert
+the path.
+
+No network, no real reviewer, no real `gh`: a temp one-commit git repo supplies
+a genuine `HEAD_SHA` (the script fetches and archives it, so it must exist), and
+stubs answer the four `gh` call shapes plus a fake reviewer whose output each
+case controls by env. Every case is data, not another copy of the invocation.
+
+| # | Contract asserted | Guards against |
+|---|---|---|
+| 1 | `exit 0` is **reachable** when a configured primary cleared *this* head | the `.head` scope bug that made the documented success path dead code |
+| 2 | an approval at an **older** sha does not clear C3 | false-green on a stale verdict |
+| 3 | an active `CHANGES_REQUESTED` is never dismissed | `§4.1(e)` — the whole point of the gate |
+| 4 | under-40-byte output is **not** a review | anti-theater guarantee #1 |
+| 5 | explicit `--reviewer` equal to the caller is refused, **with the reason** | verifier ≠ generator bypass |
+| 6 | silence alone never proves "no primary configured" | `§4.1(a)` absence-from-silence misclassification |
+| 7 | a trailing value-option terminates | the `shift 2` infinite loop |
+
+**They earned their keep on the first run.** Case 5 failed: the refusal fired
+and printed its reason, but `pick_reviewer` runs inside a command substitution,
+so its `die` exited only the subshell and the `|| { … exit 2 }` below re-labelled
+a usage error as `status:no_reviewer` — stderr right, JSON wrong. Validation is
+now hoisted into the main shell. That is defect #20, and the first one a
+*mechanism* caught rather than an external reviewer.
+
 ## Anti-theater guarantees
 
 1. **Empty output is NOT a review.** Under 40 bytes ⇒ exit `2`, the bot is
@@ -268,4 +304,4 @@ lacked an implementation.
 
 ---
 
-*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, cycle-4 findings) | 2026-09-03T21:49:27-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, contract-tests) | 2026-09-03T22:00:48-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -147,7 +147,7 @@ the isolation claim instead of believing it.
 | harness | invocation | enforcement class | evidence |
 |---|---|---|---|
 | `codex` | `codex exec --sandbox read-only --cd DIR` | `vendor` — sandbox | proven (`--cd` measured) |
-| `claude` | `claude -p … --max-turns N --allowedTools Read Grep Glob --add-dir DIR` | `vendor` — tool allowlist | proven |
+| `claude` | `cd DIR && claude -p … --max-turns N --allowedTools Read Grep Glob --add-dir DIR` | `vendor` — tool allowlist **+ cwd** | proven; the `cd` is load-bearing — `--add-dir` grants access but never moves the working directory, so without it the reviewer read the caller's `$PWD` while the stamp asserted `HEAD_SHA` (found by a routed `kimi` review of this tool on #414) |
 | `grok` | `grok -p` (cwd-scoped) | `os` — locked export (`--allow-rule` exists but is **not passed**) | measured |
 | `gemini` | `gemini -p` (cwd-scoped) | `os` — locked export | measured |
 | `qwen` | `qwen -p` (also native `qwen review run`) | `os` — locked export | measured |
@@ -268,4 +268,4 @@ lacked an implementation.
 
 ---
 
-*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, Socratic-Q round) | 2026-09-03T18:31:14-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review`, routed-kimi findings round) | 2026-09-03T21:37:25-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/SKILL.md
+++ b/skills/routed-pr-review/SKILL.md
@@ -95,16 +95,23 @@ mistake it for tier-strong; it is not what this dispatcher does.
 
 ### Axis 2 — read-only enforcement (⚠️ the defect this section exists to close)
 
-**Only 3 of 11 harnesses expose a read-only switch.** Asking the other 8 nicely
-is not enforcement, and a doc that says "read-only tools" while running an
-unflagged CLI in the live worktree is a false claim — exactly the class this
-tool's own reviewer prompt rates *at least major*. So enforcement is split by
-capability and the weaker half is enforced by the operating system instead:
+**3 of 11 harnesses expose a read-only switch; this dispatcher actually passes
+2 of them.** Asking the other 9 nicely is not enforcement, and a doc that says
+"read-only tools" while running an unflagged CLI in the live worktree is a false
+claim — exactly the class this tool's own reviewer prompt rates *at least major*.
+So enforcement is split by capability, and the classification is allowed to
+depend ONLY on a flag the code genuinely passes:
 
 | class | harnesses | mechanism |
 |---|---|---|
-| `vendor` | `codex` (`--sandbox read-only`), `claude` (`--allowedTools`), `grok` (`--allow-rule`) | the CLI guarantees it; cwd = live repo |
-| `os` | the other 8 | cwd = a **disposable `git archive` export** of the head tree: every path `chmod a-w`, and **no `.git` at all**, so a git mutation is not even expressible |
+| `vendor` (2) | `codex` (`--sandbox read-only`), `claude` (`--allowedTools`) | the CLI guarantees it; cwd = live repo |
+| `os` (9) | everything else, **including `grok`** | cwd = a **disposable `git archive` export** of the head tree: every path `chmod a-w`, and **no `.git` at all**, so a git mutation is not even expressible |
+
+`grok` exposes `--allow-rule` (alias `--allowedTools`) and is nevertheless `os`:
+**this dispatcher does not pass that flag**, and classifying on an unpassed flag
+is the same false-claim class the tool exists to catch. Promotion to `vendor`
+requires the flag to be passed *and* proven in a recorded run — not merely to
+exist in `--help`.
 
 The `os` class is then **proven**, not trusted: a `sha256` manifest is taken
 before locking and recompared after the run. A single byte of drift ⇒ the run
@@ -113,10 +120,13 @@ valid review**. The enforcement class and the tamper-check result ride in both
 the PR comment and the JSON, so a consumer can audit the isolation claim instead
 of believing it.
 
-> Caught in build by an independent advisory before first dogfood: the original
-> dispatcher ran all 8 unflagged harnesses in `$PWD`. The mechanism above was
-> designed in the same breath as the doc but had not been written — the doc was
-> ahead of the code, which is the definition of the defect.
+> **Two defects were caught before this shipped, by two independent verifiers.**
+> (1) An advisory caught the original dispatcher running all unflagged harnesses
+> in `$PWD` while the doc claimed read-only — the doc was ahead of the code.
+> (2) Dogfood cycle 1 (`codex`, isolated) then caught that `grok` was still
+> classified `vendor` on a flag the fixed code never passed — the same defect
+> surviving for one harness, now *asserted* as enforced. Neither was found by
+> the author.
 
 ## Reviewer invocation table
 
@@ -128,7 +138,7 @@ of believing it.
 |---|---|---|---|
 | `codex` | `codex exec --sandbox read-only --cd DIR` | `vendor` — sandbox | proven (`--cd` measured) |
 | `claude` | `claude -p … --max-turns N --allowedTools Read Grep Glob --add-dir DIR` | `vendor` — tool allowlist | proven |
-| `grok` | `grok -p` (cwd-scoped) | `vendor` — `--allow-rule` (alias `--allowedTools`) | measured |
+| `grok` | `grok -p` (cwd-scoped) | `os` — locked export (`--allow-rule` exists but is **not passed**) | measured |
 | `gemini` | `gemini -p` (cwd-scoped) | `os` — locked export | measured |
 | `qwen` | `qwen -p` (also native `qwen review run`) | `os` — locked export | measured |
 | `kimi` | `kimi -p --output-format text\|json` | `os` — locked export | measured |

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -87,6 +87,12 @@ case "$MAX_TURNS" in ''|*[!0-9]*) die "--max-turns must be an integer (got '$MAX
 [ -n "$PR" ] || { usage >&2; die "--pr is required"; }
 command -v gh  >/dev/null 2>&1 || die "gh CLI not found — required to read the PR"
 command -v jq  >/dev/null 2>&1 || die "jq not found — required to parse gh JSON"
+# `timeout` is used on every reviewer dispatch (6 call sites) and on the sandbox
+# probes; stock macOS ships without it. Unchecked, its absence surfaced as an
+# opaque per-harness failure instead of a one-line diagnostic. Found by a routed
+# kimi review on #414 (cycle 4) — gh/jq/tar were checked, this one was not.
+command -v timeout >/dev/null 2>&1 \
+  || die "timeout not found — required to bound every reviewer dispatch (brew install coreutils, or alias gtimeout)"
 [ "$TIMEOUT" -ge 500 ] 2>/dev/null || { log "[warn] raising --timeout $TIMEOUT -> 500 (measured floor)"; TIMEOUT=500; }
 
 [ -n "$REPO" ] || REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" \
@@ -307,12 +313,23 @@ build_sandbox_profile() {   # 0 = a kernel boundary is available and armed
     printf '(deny file-write* (subpath "%s"))\n' "$(cd "$EXPORT_DIR" && pwd -P)"
     printf '(deny file-write* (subpath "%s"))\n' "$(cd "$repo_root" && pwd -P)"
   } > "$SANDBOX_PROFILE"
-  # prove the profile actually denies before relying on it
-  if sandbox-exec -f "$SANDBOX_PROFILE" /bin/sh -c \
-       "echo probe > '$EXPORT_DIR/.sandbox-probe' 2>/dev/null" 2>/dev/null; then
-    [ -e "$EXPORT_DIR/.sandbox-probe" ] && { rm -f "$EXPORT_DIR/.sandbox-probe" 2>/dev/null; return 1; }
+  # ⛔ Two-step probe. The single-step version could NOT distinguish "sandbox-exec
+  # ran and denied the write" from "sandbox-exec never ran at all" (invalid
+  # profile, unsupported OS, SIP policy): both leave no probe file, both make the
+  # `if` false, and the old fallthrough then `return 0` = ARMED. Measured:
+  # `sandbox-exec -f /nonexistent.sb /bin/echo x` exits 65, i.e. a failure to
+  # confine was indistinguishable from a successful denial — a fail-OPEN inside
+  # the very control added to close a fail-open. Found by a routed kimi review
+  # of this tool on #414 (cycle 4).
+  # Step 1 — liveness: the profile must be able to run a harmless ALLOWED command.
+  sandbox-exec -f "$SANDBOX_PROFILE" /usr/bin/true >/dev/null 2>&1 || return 1
+  # Step 2 — denial: the write must fail AND leave no file.
+  sandbox-exec -f "$SANDBOX_PROFILE" /bin/sh -c \
+    "echo probe > '$EXPORT_DIR/.sandbox-probe' 2>/dev/null" >/dev/null 2>&1
+  if [ -e "$EXPORT_DIR/.sandbox-probe" ]; then
+    rm -f "$EXPORT_DIR/.sandbox-probe" 2>/dev/null
+    return 1   # the write LANDED => not a boundary
   fi
-  [ -e "$EXPORT_DIR/.sandbox-probe" ] && return 1
   return 0
 }
 

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -195,8 +195,12 @@ PROMPT
 #          behave; make the write impossible and then prove it did not happen.
 sandbox_class() {
   case "$1" in
-    claude|codex|grok) printf 'vendor' ;;   # --allowedTools / --sandbox / --allow-rule
-    *)                 printf 'os'     ;;
+    claude|codex) printf 'vendor' ;;   # --allowedTools / --sandbox read-only — the flag IS passed below
+    # grok exposes --allow-rule but this dispatcher does not pass it, so it is
+    # NOT vendor-enforced here. Claiming `vendor` on an unpassed flag is the
+    # same false-claim class this tool is built to catch. It stays `os` until
+    # the flag is actually passed AND proven in a recorded run.
+    *)            printf 'os'     ;;
   esac
 }
 
@@ -256,7 +260,7 @@ run_reviewer() {
     codex)    # proven: ai-code-review-bots-rotation §1 (council CRITIC)
       timeout "$TIMEOUT" codex exec --sandbox read-only --cd "$dir" "$(cat "$PROMPT_F")" \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
-    grok)     # measured: --allow-rule (alias --allowedTools)
+    grok)     # measured: -p non-interactive. --allow-rule NOT passed => os-class.
       ( cd "$dir" && timeout "$TIMEOUT" grok -p "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     gemini|qwen|kimi|copilot|pi)   # measured: -p/--prompt non-interactive
@@ -315,6 +319,21 @@ VERDICT_LINE="$(grep -aoE 'VERDICT: *(PASS|REQUEST_CHANGES).*' "$OUT_F" | tail -
 
 # ------------------------------------------- Phase E: gate verdict + comment
 # The ONLY honest computation of what this review licenses.
+#
+# ⛔ `absent` may NEVER be concluded from silence on THIS PR — that is the exact
+# misclassification §4.1(a) names ("inferring absence from *silence*"). A fresh
+# PR is silent because the bots have not run yet, not because none is
+# configured. Positive evidence = no known reviewer has spoken anywhere in this
+# repository's recent history. If that probe cannot run, fail CLOSED.
+repo_has_any_configured_reviewer() {   # 0 = yes (a bot has spoken) · 1 = no · 2 = unknown
+  local out
+  out="$(gh api "repos/$REPO/issues/comments?per_page=100" \
+          --jq '[.[] | select(.user.login | test("'"$KNOWN_BOTS"'"; "i")) | .user.login] | unique | length' \
+          2>/dev/null)" || return 2
+  [ -n "$out" ] || return 2
+  [ "$out" -gt 0 ] 2>/dev/null && return 0 || return 1
+}
+
 MAY_COMPLETE_C3="false"; PRIMARY_STATUS="pending_or_unknown"
 if [ "$CHANGES_REQ" = "yes" ]; then
   PRIMARY_STATUS="changes_requested"      # §4.1(e): routing never dismisses this
@@ -322,7 +341,14 @@ elif [ -z "$STALE_OR_PENDING" ] && [ -z "$QUOTA_HITS" ] && [ -n "$CLEARED" ]; th
   PRIMARY_STATUS="all_cleared_for_head"; MAY_COMPLETE_C3="true"
 elif [ -z "$CLEARED" ] && [ -z "$STALE_OR_PENDING" ] && [ -z "$QUOTA_HITS" ] \
   && [ "$(printf '%s' "$PRIMARY_STATE" | jq -r '.bot_comments | length')" = "0" ]; then
-  PRIMARY_STATUS="none_configured_positively_evidenced"; MAY_COMPLETE_C3="true"
+  # This PR is silent. Silence alone proves nothing — probe the repository.
+  repo_has_any_configured_reviewer; probe_rc=$?
+  case "$probe_rc" in
+    0) PRIMARY_STATUS="pending_silent_but_repo_has_reviewers" ;;   # slow/pending, NOT absent
+    1) PRIMARY_STATUS="none_configured_repo_wide_evidence"; MAY_COMPLETE_C3="true" ;;
+    *) PRIMARY_STATUS="absence_unprovable_fail_closed" ;;          # probe failed ⇒ hold
+  esac
+  log "    absence probe: rc=$probe_rc -> $PRIMARY_STATUS"
 fi
 
 log "[E] diversity_limb=satisfied  primary=$PRIMARY_STATUS  may_complete_c3=$MAY_COMPLETE_C3"

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -123,8 +123,14 @@ PRIMARY_STATE="$(printf '%s' "$PR_JSON" | jq -r --arg head "$HEAD_SHA" '
 # quota / plan signals, per review-bot-quota-recovery taxonomy
 QUOTA_HITS="$(printf '%s' "$PRIMARY_STATE" | jq -r '
   [.bot_comments[]? | select(.body | test("rate limit|rate-limited|Review limit reached|next review|paused for this user|requires Pro|quota|usage limit"; "i")) | .who] | unique | join(",")')"
-STALE_OR_PENDING="$(printf '%s' "$PRIMARY_STATE" | jq -r '
-  [.reviews[]? | select(.sha != .head and .sha != "") | .who] | unique | join(",")')"
+# ⛔ `.head` does NOT exist inside a `.reviews[]` element — it is a SIBLING of the
+# array, so `.sha != .head` reduced to `.sha != null` = always true. Every review
+# was classified stale, `STALE_OR_PENDING` never emptied, and the
+# `all_cleared_for_head` branch (the only path to `exit 0`) was dead code.
+# Found by a routed kimi review of this very tool on PR #414; reproduced by
+# executing the shipped expression. Bind the head explicitly, like CLEARED does.
+STALE_OR_PENDING="$(printf '%s' "$PRIMARY_STATE" | jq -r --arg head "$HEAD_SHA" '
+  [.reviews[]? | select(.sha != $head and .sha != "") | .who] | unique | join(",")')"
 CLEARED="$(printf '%s' "$PRIMARY_STATE" | jq -r --arg head "$HEAD_SHA" '
   [.reviews[]? | select(.sha == $head and (.verdict == "APPROVED" or .verdict == "COMMENTED")) | .who] | unique | join(",")')"
 HUMAN_REVIEWS="$(printf '%s' "$PRIMARY_STATE" | jq -r '.human_reviews | join(",")')"
@@ -357,10 +363,16 @@ run_reviewer() {
   local h="$1" rc=0 dir="$2"
   case "$h" in
     claude)   # proven: cross-harness-red-team (claude-code 2.1.235)
-      timeout "$TIMEOUT" claude -p "$(cat "$PROMPT_F")" \
+      # ⛔ `--add-dir` GRANTS access to a directory; it does NOT move the working
+      # directory. Without the `cd`, Read/Grep/Glob open the CALLER's $PWD first —
+      # the very checkout that just failed `cwd_is_head` — while the comment stamps
+      # `Head reviewed: $HEAD_SHA`. Both tamper checks stayed clean because nothing
+      # was written, so the wrong-tree read was invisible. This is the exact defect
+      # the codex branch avoids with `--cd`. Found by a routed kimi review on #414.
+      ( cd "$dir" && timeout "$TIMEOUT" claude -p "$(cat "$PROMPT_F")" \
         --max-turns "$MAX_TURNS" \
         --allowedTools "Read" "Grep" "Glob" \
-        --add-dir "$dir" > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+        --add-dir "$dir" ) > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     codex)    # proven: ai-code-review-bots-rotation §1 (council CRITIC)
       timeout "$TIMEOUT" codex exec --sandbox read-only --cd "$dir" "$(cat "$PROMPT_F")" \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -24,6 +24,7 @@ set -uo pipefail
 
 STATE_FILE="${ROUTED_REVIEW_STATE:-$HOME/.claude/state/ai-review-bots.json}"
 PR=""; REPO=""; REVIEWER="auto"; POST=0; JSON=0; MAX_TURNS=12; TIMEOUT=600
+NO_PRIMARY_ATTESTED=0
 DIFF_CAP="${ROUTED_REVIEW_DIFF_CAP:-120000}"   # bytes of diff handed to the reviewer
 
 die() { printf 'routed-review: %s\n' "$*" >&2; exit 1; }
@@ -42,6 +43,14 @@ Usage: routed-review.sh --pr N [options]
   --timeout SEC       per-reviewer wall clock (default 600; never below 500 —
                       a 280s cap once burned $4.7 for zero output)
   --max-turns N       agentic turn cap (default 12)
+  --no-primary-configured
+                      OPERATOR ATTESTATION that this repository has no configured
+                      primary reviewer. Required before a routed review may
+                      complete convergence on its own. The tool will NEVER infer
+                      this: proving a negative from API silence is exactly the
+                      misclassification §4.1(a) forbids, so it is attested, not
+                      guessed. Without it, a silent PR resolves to
+                      `absence_requires_operator_attestation` and holds.
 USAGE
 }
 
@@ -51,6 +60,7 @@ while [ $# -gt 0 ]; do
     --repo) REPO="${2:-}"; shift 2 ;;
     --reviewer) REVIEWER="${2:-}"; shift 2 ;;
     --timeout) TIMEOUT="${2:-}"; shift 2 ;;
+    --no-primary-configured) NO_PRIMARY_ATTESTED=1; shift ;;
     --max-turns) MAX_TURNS="${2:-}"; shift 2 ;;
     --post) POST=1; shift ;;
     --json) JSON=1; shift ;;
@@ -79,13 +89,21 @@ PR_URL="$(printf '%s' "$PR_JSON" | jq -r .url)"
 log "    head=$HEAD_SHA  \"$PR_TITLE\""
 
 # ------------------------------------------- Phase B: §4.1(a) primary probe
-# Classify each reviewer that has EVER spoken on this repo. Absence is proven
-# by positive evidence only — never inferred from silence (the §4.1 defect).
+# Classify each CONFIGURED REVIEWER (a known bot) that has spoken on this PR.
+#
+# ⛔ Only KNOWN_BOTS count as primaries. A HUMAN review must never land in
+# CLEARED: a human `APPROVED`/`COMMENTED` would otherwise flip the state to
+# `all_cleared_for_head` while a configured bot is still pending — and on a
+# self-authored PR that is the author clearing their own gate. Humans are
+# reported separately, for information only.
 KNOWN_BOTS='coderabbitai|qodo|copilot-pull-request-reviewer|github-advanced-security|amazon-q-developer|chatgpt-codex-connector|claude|snyk'
 PRIMARY_STATE="$(printf '%s' "$PR_JSON" | jq -r --arg head "$HEAD_SHA" '
-  ([.latestReviews[]? | {who: .author.login, sha: (.commit.oid // ""), verdict: .state}]) as $rv
+  ([.latestReviews[]? | select(.author.login | test("'"$KNOWN_BOTS"'"; "i"))
+     | {who: .author.login, sha: (.commit.oid // ""), verdict: .state}]) as $rv
+  | ([.latestReviews[]? | select(.author.login | test("'"$KNOWN_BOTS"'"; "i") | not)
+     | .author.login]) as $humans
   | ([.comments[]? | select(.author.login | test("'"$KNOWN_BOTS"'"; "i")) | {who: .author.login, body: (.body[0:400])}]) as $cm
-  | {reviews: $rv, bot_comments: $cm, head: $head}')"
+  | {reviews: $rv, human_reviews: ($humans | unique), bot_comments: $cm, head: $head}')"
 
 # quota / plan signals, per review-bot-quota-recovery taxonomy
 QUOTA_HITS="$(printf '%s' "$PRIMARY_STATE" | jq -r '
@@ -94,9 +112,11 @@ STALE_OR_PENDING="$(printf '%s' "$PRIMARY_STATE" | jq -r '
   [.reviews[]? | select(.sha != .head and .sha != "") | .who] | unique | join(",")')"
 CLEARED="$(printf '%s' "$PRIMARY_STATE" | jq -r --arg head "$HEAD_SHA" '
   [.reviews[]? | select(.sha == $head and (.verdict == "APPROVED" or .verdict == "COMMENTED")) | .who] | unique | join(",")')"
+HUMAN_REVIEWS="$(printf '%s' "$PRIMARY_STATE" | jq -r '.human_reviews | join(",")')"
 CHANGES_REQ="$(printf '%s' "$PR_JSON" | jq -r 'if .reviewDecision == "CHANGES_REQUESTED" then "yes" else "no" end')"
 
-log "[B] primaries — cleared-for-head:[${CLEARED:--}] stale/earlier-head:[${STALE_OR_PENDING:--}] quota-signalled:[${QUOTA_HITS:--}] changes_requested:$CHANGES_REQ"
+log "[B] primaries(bots only) — cleared-for-head:[${CLEARED:--}] stale/earlier-head:[${STALE_OR_PENDING:--}] quota-signalled:[${QUOTA_HITS:--}] changes_requested:$CHANGES_REQ"
+log "    humans reviewed (informational, never a primary): [${HUMAN_REVIEWS:--}]"
 
 # ------------------------------------------- Phase C: pick isolated reviewer
 # Cross-family preference: never route to the SAME vendor family as the caller
@@ -119,6 +139,14 @@ expired() {  # $1=bot ; honours ai-code-review-bots-rotation.md §2 state file
 pick_reviewer() {
   if [ "$REVIEWER" != "auto" ]; then
     command -v "$REVIEWER" >/dev/null 2>&1 || die "requested reviewer '$REVIEWER' not on PATH"
+    # ⛔ An explicit --reviewer must NOT bypass verifier != generator. Without
+    # this check, `ROUTED_REVIEW_CALLER=codex --reviewer codex` performs the
+    # correlated same-family review the skill forbids, and the emitted comment
+    # would still account it as "C3 diversity satisfied" — fabricated diversity
+    # evidence, the §4.1(e) failure this tool exists to prevent.
+    if [ -n "$CALLER" ] && [ "$REVIEWER" = "$CALLER" ]; then
+      die "refusing --reviewer '$REVIEWER': identical to ROUTED_REVIEW_CALLER — that is a correlated verifier, not an independent one. Pick another family, or unset the caller only if you can justify it."
+    fi
     printf '%s' "$REVIEWER"; return 0
   fi
   local h
@@ -278,25 +306,44 @@ run_reviewer() {
 }
 
 ENFORCEMENT="$(sandbox_class "$CHOSEN")"
+# ⛔ The comment will claim `Head reviewed: $HEAD_SHA`. That claim is only true
+# if the tree the reviewer actually read IS that commit. `--repo` is arbitrary,
+# so `$PWD` may be an unrelated checkout — the reviewer would then inspect other
+# files while the stamp asserts this SHA. Never trust cwd: prove it, else export.
+cwd_is_head() {
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 1
+  [ "$(git rev-parse HEAD 2>/dev/null)" = "$HEAD_SHA" ] || return 1
+  # a dirty tree is not that commit either
+  [ -z "$(git status --porcelain 2>/dev/null)" ] || return 1
+}
+
 if [ "$ENFORCEMENT" = "os" ]; then
-  log "[D] $CHOSEN has NO vendor read-only flag -> enforcing at the filesystem"
+  log "[D] $CHOSEN has no vendor read-only flag -> enforcing at the filesystem"
   build_readonly_export
   SAFE_DIR="$EXPORT_DIR"
-else
+elif cwd_is_head; then
   SAFE_DIR="$PWD"
+  log "[D] cwd proven at $HEAD_SHA and clean -> vendor sandbox over the live tree"
+else
+  # vendor-sandboxed but cwd is NOT the reviewed commit: export anyway so the
+  # `Head reviewed:` stamp stays true. Enforcement is then belt-and-braces.
+  log "[D] cwd is NOT $HEAD_SHA (or is dirty) -> exporting so the head stamp stays true"
+  build_readonly_export
+  SAFE_DIR="$EXPORT_DIR"
+  ENFORCEMENT="vendor+os"
 fi
 
 log "[D] dispatching $CHOSEN (timeout=${TIMEOUT}s, enforcement=$ENFORCEMENT, cwd=$SAFE_DIR)"
 RC=0; run_reviewer "$CHOSEN" "$SAFE_DIR" || RC=$?
 TAMPER="n/a"
-if [ "$ENFORCEMENT" = "os" ]; then
+case "$ENFORCEMENT" in *os*)   # matches `os` AND `vendor+os`
   if verify_export_untouched; then TAMPER="clean"; else
     TAMPER="violated"
     log "[D] ABORT: isolation violated — no review will be stamped or reported as valid"
     [ "$JSON" -eq 1 ] && printf '{"status":"isolation_violated","reviewer":"%s","diversity_limb":"unsatisfied","may_complete_c3":false}\n' "$CHOSEN"
     exit 1
   fi
-fi
+  ;; esac
 REVIEW_BYTES="$(wc -c < "$OUT_F" 2>/dev/null | tr -d ' ' || echo 0)"
 
 if [ "$REVIEW_BYTES" -lt 40 ]; then
@@ -320,16 +367,27 @@ VERDICT_LINE="$(grep -aoE 'VERDICT: *(PASS|REQUEST_CHANGES).*' "$OUT_F" | tail -
 # ------------------------------------------- Phase E: gate verdict + comment
 # The ONLY honest computation of what this review licenses.
 #
-# ⛔ `absent` may NEVER be concluded from silence on THIS PR — that is the exact
-# misclassification §4.1(a) names ("inferring absence from *silence*"). A fresh
-# PR is silent because the bots have not run yet, not because none is
-# configured. Positive evidence = no known reviewer has spoken anywhere in this
-# repository's recent history. If that probe cannot run, fail CLOSED.
-repo_has_any_configured_reviewer() {   # 0 = yes (a bot has spoken) · 1 = no · 2 = unknown
+# ⛔ `absent` is NEVER inferred. Two rounds of review killed two successive
+# attempts to infer it:
+#   (1) `bot_comments == 0` on THIS PR — pure silence, the exact
+#       misclassification §4.1(a) names ("inferring absence from *silence*").
+#   (2) a single unpaginated `issues/comments?per_page=100` page — which also
+#       never sees review submissions, so a bot that spoke outside that page is
+#       missed and the conclusion is again unsupported.
+# The lesson is not "paginate harder": proving a NEGATIVE ("no primary is
+# configured anywhere") is not something this tool can establish cheaply or
+# reliably from the API. So it does not try. Absence is an OPERATOR ATTESTATION
+# (`--no-primary-configured`), and without it the tool HOLDS. Fail-closed by
+# construction beats a smarter guess.
+#
+# The repo-wide probe survives only as CORROBORATION: it can CONTRADICT an
+# attestation (a bot demonstrably spoke ⇒ the attestation is wrong, and wrong
+# loudly), but it can never grant one.
+repo_reviewer_seen() {   # 0 = a known bot has demonstrably spoken · 1 = none seen · 2 = probe failed
   local out
-  out="$(gh api "repos/$REPO/issues/comments?per_page=100" \
-          --jq '[.[] | select(.user.login | test("'"$KNOWN_BOTS"'"; "i")) | .user.login] | unique | length' \
-          2>/dev/null)" || return 2
+  out="$(gh api --paginate "repos/$REPO/issues/comments?per_page=100" \
+          --jq '[.[] | select(.user.login | test("'"$KNOWN_BOTS"'"; "i")) | .user.login]' 2>/dev/null \
+        | jq -s 'add // [] | unique | length' 2>/dev/null)" || return 2
   [ -n "$out" ] || return 2
   [ "$out" -gt 0 ] 2>/dev/null && return 0 || return 1
 }
@@ -338,17 +396,25 @@ MAY_COMPLETE_C3="false"; PRIMARY_STATUS="pending_or_unknown"
 if [ "$CHANGES_REQ" = "yes" ]; then
   PRIMARY_STATUS="changes_requested"      # §4.1(e): routing never dismisses this
 elif [ -z "$STALE_OR_PENDING" ] && [ -z "$QUOTA_HITS" ] && [ -n "$CLEARED" ]; then
+  # CLEARED is bot-only (phase B); a human approval can never land here.
   PRIMARY_STATUS="all_cleared_for_head"; MAY_COMPLETE_C3="true"
 elif [ -z "$CLEARED" ] && [ -z "$STALE_OR_PENDING" ] && [ -z "$QUOTA_HITS" ] \
   && [ "$(printf '%s' "$PRIMARY_STATE" | jq -r '.bot_comments | length')" = "0" ]; then
-  # This PR is silent. Silence alone proves nothing — probe the repository.
-  repo_has_any_configured_reviewer; probe_rc=$?
-  case "$probe_rc" in
-    0) PRIMARY_STATUS="pending_silent_but_repo_has_reviewers" ;;   # slow/pending, NOT absent
-    1) PRIMARY_STATUS="none_configured_repo_wide_evidence"; MAY_COMPLETE_C3="true" ;;
-    *) PRIMARY_STATUS="absence_unprovable_fail_closed" ;;          # probe failed ⇒ hold
-  esac
-  log "    absence probe: rc=$probe_rc -> $PRIMARY_STATUS"
+  if [ "$NO_PRIMARY_ATTESTED" -eq 1 ]; then
+    repo_reviewer_seen; probe_rc=$?
+    if [ "$probe_rc" -eq 0 ]; then
+      # the attestation is contradicted by evidence — refuse it, loudly
+      PRIMARY_STATUS="attestation_contradicted_bot_has_spoken_in_repo"
+      log "[!] --no-primary-configured was passed, but a known reviewer HAS spoken in this repo."
+      log "[!] Refusing the attestation. This PR is PENDING, not absent."
+    else
+      PRIMARY_STATUS="none_configured_operator_attested"; MAY_COMPLETE_C3="true"
+      [ "$probe_rc" -eq 2 ] && log "    note: corroboration probe failed; resting on the attestation alone"
+    fi
+  else
+    PRIMARY_STATUS="absence_requires_operator_attestation"
+    log "    silent PR + no attestation -> holding (pass --no-primary-configured only if true)"
+  fi
 fi
 
 log "[E] diversity_limb=satisfied  primary=$PRIMARY_STATUS  may_complete_c3=$MAY_COMPLETE_C3"
@@ -379,10 +445,15 @@ COMMENT_F="$WORK/comment.md"
 } > "$COMMENT_F"
 
 if [ "$POST" -eq 1 ]; then
-  if command -v gitleaks >/dev/null 2>&1; then
-    gitleaks detect --no-git --source="$COMMENT_F" --no-banner >/dev/null 2>&1 \
-      || die "gitleaks flagged the review body — comment NOT posted (secrets are absolute)"
-  fi
+  # ⛔ The scan is MANDATORY, not best-effort. The comment embeds the reviewer's
+  # verbatim output, which read a whole repository tree — a plausible secret
+  # carrier. Silently skipping the scan when gitleaks is absent, and posting
+  # anyway, made the documented guarantee false and the leak real. A PR comment
+  # is a paste-anywhere surface; secrets are absolute, so no scanner ⇒ no post.
+  command -v gitleaks >/dev/null 2>&1 \
+    || die "gitleaks not installed — refusing to post (the pre-post secret scan is mandatory, not best-effort). Install gitleaks, or drop --post and inspect the review on stdout."
+  gitleaks detect --no-git --source="$COMMENT_F" --no-banner >/dev/null 2>&1 \
+    || die "gitleaks flagged the review body — comment NOT posted (secrets are absolute)"
   gh pr comment "$PR" --repo "$REPO" --body-file "$COMMENT_F" >/dev/null \
     && log "[E] posted to $PR_URL" || die "failed to post comment"
 fi

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+# routed-pr-review — dispatch an independent, context-isolated PR review.
+#
+# Soul-name: Euthyna (εὔθυνα — the independent end-of-term audit every Athenian
+# magistrate underwent, conducted by officials who were not the magistrate).
+#
+# WHY THIS EXISTS: when the configured review bots are quota-blocked, a PR can
+# still be *reviewed* even though it may not yet be *merged*. This dispatches a
+# reviewer whose context is isolated from the delegator BY CONSTRUCTION (a fresh
+# OS process in a different vendor family), and reports a gate verdict that
+# never overstates what a routed review satisfies.
+#
+# GATE CONTRACT (pr-review-protocol.md §4.1(e), verbatim intent):
+#   A routed review satisfies EXACTLY ONE thing — the independent cross-brand
+#   opinion (the *diversity* limb of C3). It NEVER satisfies a configured
+#   primary's verdict. It can complete convergence only where no primary is
+#   configured (positively evidenced `absent`) OR after every configured
+#   primary has already cleared. While a primary is pending or quota-blocked,
+#   this review INFORMS THE WORK and the PR still waits or escalates.
+#
+# Exit codes: 0 review produced · 1 error · 2 no reviewer available
+#             3 review produced BUT a configured primary is still pending
+set -uo pipefail
+
+STATE_FILE="${ROUTED_REVIEW_STATE:-$HOME/.claude/state/ai-review-bots.json}"
+PR=""; REPO=""; REVIEWER="auto"; POST=0; JSON=0; MAX_TURNS=12; TIMEOUT=600
+DIFF_CAP="${ROUTED_REVIEW_DIFF_CAP:-120000}"   # bytes of diff handed to the reviewer
+
+die() { printf 'routed-review: %s\n' "$*" >&2; exit 1; }
+log() { [ "$JSON" -eq 1 ] || printf '%s\n' "$*" >&2; }
+
+usage() {
+  cat <<'USAGE'
+Usage: routed-review.sh --pr N [options]
+
+  --pr N              PR number (required)
+  --repo OWNER/NAME   default: current repo via gh
+  --reviewer NAME     auto (default) | claude | codex | gemini | kimi | qwen
+                      | grok | pi | copilot | jcode | opencode | kiro
+  --post              post the review as a PR comment with the §4.1(b) stamp
+  --json              machine-readable verdict on stdout
+  --timeout SEC       per-reviewer wall clock (default 600; never below 500 —
+                      a 280s cap once burned $4.7 for zero output)
+  --max-turns N       agentic turn cap (default 12)
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --pr) PR="${2:-}"; shift 2 ;;
+    --repo) REPO="${2:-}"; shift 2 ;;
+    --reviewer) REVIEWER="${2:-}"; shift 2 ;;
+    --timeout) TIMEOUT="${2:-}"; shift 2 ;;
+    --max-turns) MAX_TURNS="${2:-}"; shift 2 ;;
+    --post) POST=1; shift ;;
+    --json) JSON=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown argument: $1 (try --help)" ;;
+  esac
+done
+
+[ -n "$PR" ] || { usage >&2; die "--pr is required"; }
+command -v gh  >/dev/null 2>&1 || die "gh CLI not found — required to read the PR"
+command -v jq  >/dev/null 2>&1 || die "jq not found — required to parse gh JSON"
+[ "$TIMEOUT" -ge 500 ] 2>/dev/null || { log "[warn] raising --timeout $TIMEOUT -> 500 (measured floor)"; TIMEOUT=500; }
+
+[ -n "$REPO" ] || REPO="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)" \
+  || die "could not resolve repo; pass --repo OWNER/NAME"
+
+# ---------------------------------------------------------------- Phase A: PR
+log "[A] resolving $REPO#$PR"
+PR_JSON="$(gh pr view "$PR" --repo "$REPO" \
+  --json number,title,headRefOid,headRefName,baseRefName,url,author,mergeStateStatus,reviewDecision,latestReviews,comments 2>/dev/null)" \
+  || die "cannot read $REPO#$PR"
+HEAD_SHA="$(printf '%s' "$PR_JSON" | jq -r .headRefOid)"
+[ -n "$HEAD_SHA" ] && [ "$HEAD_SHA" != "null" ] || die "no headRefOid for $REPO#$PR"
+PR_TITLE="$(printf '%s' "$PR_JSON" | jq -r .title)"
+PR_URL="$(printf '%s' "$PR_JSON" | jq -r .url)"
+log "    head=$HEAD_SHA  \"$PR_TITLE\""
+
+# ------------------------------------------- Phase B: §4.1(a) primary probe
+# Classify each reviewer that has EVER spoken on this repo. Absence is proven
+# by positive evidence only — never inferred from silence (the §4.1 defect).
+KNOWN_BOTS='coderabbitai|qodo|copilot-pull-request-reviewer|github-advanced-security|amazon-q-developer|chatgpt-codex-connector|claude|snyk'
+PRIMARY_STATE="$(printf '%s' "$PR_JSON" | jq -r --arg head "$HEAD_SHA" '
+  ([.latestReviews[]? | {who: .author.login, sha: (.commit.oid // ""), verdict: .state}]) as $rv
+  | ([.comments[]? | select(.author.login | test("'"$KNOWN_BOTS"'"; "i")) | {who: .author.login, body: (.body[0:400])}]) as $cm
+  | {reviews: $rv, bot_comments: $cm, head: $head}')"
+
+# quota / plan signals, per review-bot-quota-recovery taxonomy
+QUOTA_HITS="$(printf '%s' "$PRIMARY_STATE" | jq -r '
+  [.bot_comments[]? | select(.body | test("rate limit|rate-limited|Review limit reached|next review|paused for this user|requires Pro|quota|usage limit"; "i")) | .who] | unique | join(",")')"
+STALE_OR_PENDING="$(printf '%s' "$PRIMARY_STATE" | jq -r '
+  [.reviews[]? | select(.sha != .head and .sha != "") | .who] | unique | join(",")')"
+CLEARED="$(printf '%s' "$PRIMARY_STATE" | jq -r --arg head "$HEAD_SHA" '
+  [.reviews[]? | select(.sha == $head and (.verdict == "APPROVED" or .verdict == "COMMENTED")) | .who] | unique | join(",")')"
+CHANGES_REQ="$(printf '%s' "$PR_JSON" | jq -r 'if .reviewDecision == "CHANGES_REQUESTED" then "yes" else "no" end')"
+
+log "[B] primaries — cleared-for-head:[${CLEARED:--}] stale/earlier-head:[${STALE_OR_PENDING:--}] quota-signalled:[${QUOTA_HITS:--}] changes_requested:$CHANGES_REQ"
+
+# ------------------------------------------- Phase C: pick isolated reviewer
+# Cross-family preference: never route to the SAME vendor family as the caller
+# (same-brand re-runs share blind spots — §4.1(b)). The caller declares itself
+# via ROUTED_REVIEW_CALLER; unset = no exclusion.
+CALLER="${ROUTED_REVIEW_CALLER:-}"
+declare -a FAMILY_ORDER=(codex gemini kimi qwen grok claude copilot pi jcode opencode kiro)
+
+expired() {  # $1=bot ; honours ai-code-review-bots-rotation.md §2 state file
+  [ -f "$STATE_FILE" ] || return 1
+  local now limited retry
+  now="$(date +%s)"
+  limited="$(jq -r --arg b "$1" '.bots[$b].last_limited_at // empty' "$STATE_FILE" 2>/dev/null)"
+  [ -n "$limited" ] || return 1
+  retry="$(jq -r --arg b "$1" '.bots[$b].retry_after_sec // 3600' "$STATE_FILE" 2>/dev/null)"
+  local reset; reset=$(( $(date -j -f "%Y-%m-%dT%H:%M:%SZ" "${limited%%.*}" +%s 2>/dev/null || echo 0) + retry ))
+  [ "$now" -lt "$reset" ]
+}
+
+pick_reviewer() {
+  if [ "$REVIEWER" != "auto" ]; then
+    command -v "$REVIEWER" >/dev/null 2>&1 || die "requested reviewer '$REVIEWER' not on PATH"
+    printf '%s' "$REVIEWER"; return 0
+  fi
+  local h
+  for h in "${FAMILY_ORDER[@]}"; do
+    [ "$h" = "$CALLER" ] && continue                      # verifier != generator
+    command -v "$h" >/dev/null 2>&1 || continue
+    expired "$h" && { log "    skip $h (expired per state file)"; continue; }
+    printf '%s' "$h"; return 0
+  done
+  return 1
+}
+
+CHOSEN="$(pick_reviewer)" || {
+  # §5 of ai-code-review-bots-rotation: never fabricate an empty review.
+  log "[C] all-reviewers-unavailable — emitting honest diagnostic, NOT a review"
+  [ "$JSON" -eq 1 ] && printf '{"status":"no_reviewer","repo":"%s","pr":%s,"head":"%s","diversity_limb":"unsatisfied","primary_verdict":"unknown","may_complete_c3":false}\n' "$REPO" "$PR" "$HEAD_SHA"
+  exit 2
+}
+log "[C] reviewer=$CHOSEN (caller=${CALLER:-unset}, isolation=fresh-process)"
+
+# ------------------------------------------- Phase D: isolated read-only run
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/routed-review.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+DIFF_F="$WORK/diff.patch"; PROMPT_F="$WORK/prompt.md"; OUT_F="$WORK/review.txt"
+
+gh pr diff "$PR" --repo "$REPO" > "$DIFF_F" 2>/dev/null || die "cannot fetch diff"
+DIFF_BYTES="$(wc -c < "$DIFF_F" | tr -d ' ')"
+if [ "$DIFF_BYTES" -gt "$DIFF_CAP" ]; then
+  log "    diff ${DIFF_BYTES}B > cap ${DIFF_CAP}B — truncating (declared in output, never hidden)"
+  head -c "$DIFF_CAP" "$DIFF_F" > "$DIFF_F.cut" && mv "$DIFF_F.cut" "$DIFF_F"
+  TRUNCATED="yes"
+else TRUNCATED="no"; fi
+
+# REFUTE-first prompt. The reviewer is rewarded for BREAKING the change.
+{
+  cat <<PROMPT
+You are an independent reviewer with NO prior context on this change. You did
+not write it and you have never seen this conversation. Your job is to REFUTE
+it, not to approve it.
+
+Repository: $REPO
+Pull request: #$PR — $PR_TITLE
+Head commit under review: $HEAD_SHA
+Diff truncated: $TRUNCATED
+
+Rules:
+- Judge ONLY what the diff and the repository show. Never assume intent.
+- Classify every finding: severity [blocking|major|minor|nit] and class
+  [correctness | security | silent-failure | governance | test-gap
+   | false-claim | craft-defect].
+- A finding MUST cite file:line and say why it matters, not merely that it
+  differs from your taste.
+- If the PR body or commit message CLAIMS something the diff does not support,
+  that is a false-claim finding and it is at least major.
+- Verify claimed counts and paths yourself; a fabricated path is blocking.
+- If you cannot verify something, say "could not verify" — never guess.
+- Emit findings even if incomplete: an incomplete review beats an absent one.
+
+Close with exactly one line:
+VERDICT: PASS | REQUEST_CHANGES  — <one sentence>
+
+--- BEGIN DIFF ---
+PROMPT
+  cat "$DIFF_F"
+  printf '\n--- END DIFF ---\n'
+} > "$PROMPT_F"
+
+# ---- Isolation enforcement ---------------------------------------------------
+# Two enforcement classes. `vendor` = the CLI itself guarantees read-only.
+# `os`   = it does NOT, so we enforce at the filesystem: the reviewer is given a
+#          DISPOSABLE EXPORT of the head tree with every path chmod'd a-w and no
+#          `.git` at all (so no git mutation is even expressible), and we verify
+#          afterwards that nothing was written. Never trust an unflagged CLI to
+#          behave; make the write impossible and then prove it did not happen.
+sandbox_class() {
+  case "$1" in
+    claude|codex|grok) printf 'vendor' ;;   # --allowedTools / --sandbox / --allow-rule
+    *)                 printf 'os'     ;;
+  esac
+}
+
+EXPORT_DIR=""
+cleanup() {
+  [ -n "$EXPORT_DIR" ] && [ -d "$EXPORT_DIR" ] && chmod -R u+w "$EXPORT_DIR" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+build_readonly_export() {
+  command -v tar >/dev/null 2>&1 || die "tar not found — required for read-only export"
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || die "not inside a git work tree — cannot build a read-only export"
+  git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null \
+    || git fetch origin "pull/$PR/head" --quiet 2>/dev/null \
+    || die "head $HEAD_SHA not fetchable — cannot build a read-only export"
+  git cat-file -e "$HEAD_SHA^{commit}" 2>/dev/null \
+    || die "head $HEAD_SHA still absent after fetch"
+  EXPORT_DIR="$WORK/tree"
+  mkdir -p "$EXPORT_DIR"
+  git archive "$HEAD_SHA" | tar -x -C "$EXPORT_DIR" \
+    || die "git archive failed — cannot build a read-only export"
+  # manifest BEFORE locking, so the check covers content, not just mtimes
+  ( cd "$EXPORT_DIR" && find . -type f -print0 | sort -z \
+      | xargs -0 shasum -a 256 2>/dev/null ) > "$WORK/manifest.before"
+  chmod -R a-w "$EXPORT_DIR" 2>/dev/null
+  log "    export: $(wc -l < "$WORK/manifest.before" | tr -d ' ') files, chmod a-w, no .git"
+}
+
+verify_export_untouched() {
+  [ -n "$EXPORT_DIR" ] || return 0
+  chmod -R u+rX "$EXPORT_DIR" 2>/dev/null
+  ( cd "$EXPORT_DIR" && find . -type f -print0 | sort -z \
+      | xargs -0 shasum -a 256 2>/dev/null ) > "$WORK/manifest.after"
+  if cmp -s "$WORK/manifest.before" "$WORK/manifest.after"; then
+    log "    tamper-check: export unmodified (manifest identical)"
+    return 0
+  fi
+  log "[!] tamper-check FAILED — reviewer wrote to its read-only export:"
+  diff "$WORK/manifest.before" "$WORK/manifest.after" 2>/dev/null | head -10 | sed 's/^/      /' >&2
+  return 1
+}
+
+# Invocation table. `evidence` marks how the shape was established:
+#   proven   = executed successfully in a recorded prior run
+#   measured = flag confirmed present in this host's --help this build
+# Every `os`-class entry runs with cwd = the locked export, never the live tree.
+run_reviewer() {
+  local h="$1" rc=0 dir="$2"
+  case "$h" in
+    claude)   # proven: cross-harness-red-team (claude-code 2.1.235)
+      timeout "$TIMEOUT" claude -p "$(cat "$PROMPT_F")" \
+        --max-turns "$MAX_TURNS" \
+        --allowedTools "Read" "Grep" "Glob" \
+        --add-dir "$dir" > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+    codex)    # proven: ai-code-review-bots-rotation §1 (council CRITIC)
+      timeout "$TIMEOUT" codex exec --sandbox read-only --cd "$dir" "$(cat "$PROMPT_F")" \
+        > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+    grok)     # measured: --allow-rule (alias --allowedTools)
+      ( cd "$dir" && timeout "$TIMEOUT" grok -p "$(cat "$PROMPT_F")" ) \
+        > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+    gemini|qwen|kimi|copilot|pi)   # measured: -p/--prompt non-interactive
+      ( cd "$dir" && timeout "$TIMEOUT" "$h" -p "$(cat "$PROMPT_F")" ) \
+        > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+    jcode|opencode)                # measured: `run` subcommand
+      ( cd "$dir" && timeout "$TIMEOUT" "$h" run "$(cat "$PROMPT_F")" ) \
+        > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+    kiro)                          # measured: `chat` subcommand
+      ( cd "$dir" && timeout "$TIMEOUT" kiro chat "$(cat "$PROMPT_F")" ) \
+        > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
+    *) die "no invocation shape for '$h' — add one to run_reviewer() with its evidence class" ;;
+  esac
+  return $rc
+}
+
+ENFORCEMENT="$(sandbox_class "$CHOSEN")"
+if [ "$ENFORCEMENT" = "os" ]; then
+  log "[D] $CHOSEN has NO vendor read-only flag -> enforcing at the filesystem"
+  build_readonly_export
+  SAFE_DIR="$EXPORT_DIR"
+else
+  SAFE_DIR="$PWD"
+fi
+
+log "[D] dispatching $CHOSEN (timeout=${TIMEOUT}s, enforcement=$ENFORCEMENT, cwd=$SAFE_DIR)"
+RC=0; run_reviewer "$CHOSEN" "$SAFE_DIR" || RC=$?
+TAMPER="n/a"
+if [ "$ENFORCEMENT" = "os" ]; then
+  if verify_export_untouched; then TAMPER="clean"; else
+    TAMPER="violated"
+    log "[D] ABORT: isolation violated — no review will be stamped or reported as valid"
+    [ "$JSON" -eq 1 ] && printf '{"status":"isolation_violated","reviewer":"%s","diversity_limb":"unsatisfied","may_complete_c3":false}\n' "$CHOSEN"
+    exit 1
+  fi
+fi
+REVIEW_BYTES="$(wc -c < "$OUT_F" 2>/dev/null | tr -d ' ' || echo 0)"
+
+if [ "$REVIEW_BYTES" -lt 40 ]; then
+  # No substantive content => there is NO review. Never stamp an empty claim.
+  log "[D] reviewer produced ${REVIEW_BYTES}B (rc=$RC) — treating as NO REVIEW (anti-theater)"
+  [ -s "$WORK/err" ] && sed 's/^/    stderr: /' "$WORK/err" | head -5 >&2
+  # record the limit so rotation skips it next time
+  if [ -w "$(dirname "$STATE_FILE")" ] 2>/dev/null || mkdir -p "$(dirname "$STATE_FILE")" 2>/dev/null; then
+    [ -f "$STATE_FILE" ] || printf '{"bots":{}}' > "$STATE_FILE"
+    tmp="$(mktemp)"; jq --arg b "$CHOSEN" --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+      '.bots[$b].last_limited_at=$t | .bots[$b].retry_after_sec=(.bots[$b].retry_after_sec // 3600) | .bots[$b].consecutive_limits=((.bots[$b].consecutive_limits // 0)+1)' \
+      "$STATE_FILE" > "$tmp" 2>/dev/null && mv "$tmp" "$STATE_FILE" || rm -f "$tmp"
+  fi
+  [ "$JSON" -eq 1 ] && printf '{"status":"empty_review","reviewer":"%s","rc":%s,"diversity_limb":"unsatisfied","may_complete_c3":false}\n' "$CHOSEN" "$RC"
+  exit 2
+fi
+
+VERDICT_LINE="$(grep -aoE 'VERDICT: *(PASS|REQUEST_CHANGES).*' "$OUT_F" | tail -1)"
+[ -n "$VERDICT_LINE" ] || VERDICT_LINE="VERDICT: (not emitted by reviewer — read the body)"
+
+# ------------------------------------------- Phase E: gate verdict + comment
+# The ONLY honest computation of what this review licenses.
+MAY_COMPLETE_C3="false"; PRIMARY_STATUS="pending_or_unknown"
+if [ "$CHANGES_REQ" = "yes" ]; then
+  PRIMARY_STATUS="changes_requested"      # §4.1(e): routing never dismisses this
+elif [ -z "$STALE_OR_PENDING" ] && [ -z "$QUOTA_HITS" ] && [ -n "$CLEARED" ]; then
+  PRIMARY_STATUS="all_cleared_for_head"; MAY_COMPLETE_C3="true"
+elif [ -z "$CLEARED" ] && [ -z "$STALE_OR_PENDING" ] && [ -z "$QUOTA_HITS" ] \
+  && [ "$(printf '%s' "$PRIMARY_STATE" | jq -r '.bot_comments | length')" = "0" ]; then
+  PRIMARY_STATUS="none_configured_positively_evidenced"; MAY_COMPLETE_C3="true"
+fi
+
+log "[E] diversity_limb=satisfied  primary=$PRIMARY_STATUS  may_complete_c3=$MAY_COMPLETE_C3"
+
+COMMENT_F="$WORK/comment.md"
+{
+  printf '## Routed review — `%s`\n\n' "$CHOSEN"
+  printf 'Reviewed-By: %s (routed, §4.1(b))\n' "$CHOSEN"
+  printf 'Head reviewed: `%s`\n' "$HEAD_SHA"
+  printf 'Context isolation: fresh OS process, no delegator history.\n'
+  printf 'Read-only enforcement: `%s` (%s)\n' "$ENFORCEMENT" \
+    "$([ "$ENFORCEMENT" = vendor ] && printf 'CLI sandbox/tool-allowlist' || printf 'disposable git-archive export, chmod a-w, no .git')"
+  printf 'Post-run tamper check: `%s`\n' "$TAMPER"
+  printf 'Diff truncated: %s\n\n' "$TRUNCATED"
+  printf '%s\n\n' "$VERDICT_LINE"
+  printf '<details><summary>Full reviewer output (%s bytes)</summary>\n\n```\n' "$REVIEW_BYTES"
+  cat "$OUT_F"
+  printf '\n```\n</details>\n\n'
+  printf -- '---\n**Gate accounting (§4.1(e)) — what this does and does NOT satisfy**\n\n'
+  printf '| limb | state |\n|---|---|\n'
+  printf '| C3 diversity (independent cross-brand opinion) | satisfied |\n'
+  printf '| Configured primary verdict | `%s` |\n' "$PRIMARY_STATUS"
+  printf '| May complete convergence on its own | `%s` |\n\n' "$MAY_COMPLETE_C3"
+  if [ "$MAY_COMPLETE_C3" != "true" ]; then
+    printf '> This routed review **informs the work**; it is not the primary reviewer'"'"'s verdict.\n'
+    printf '> The PR waits for the primary or escalates for an explicit operator override.\n'
+  fi
+} > "$COMMENT_F"
+
+if [ "$POST" -eq 1 ]; then
+  if command -v gitleaks >/dev/null 2>&1; then
+    gitleaks detect --no-git --source="$COMMENT_F" --no-banner >/dev/null 2>&1 \
+      || die "gitleaks flagged the review body — comment NOT posted (secrets are absolute)"
+  fi
+  gh pr comment "$PR" --repo "$REPO" --body-file "$COMMENT_F" >/dev/null \
+    && log "[E] posted to $PR_URL" || die "failed to post comment"
+fi
+
+if [ "$JSON" -eq 1 ]; then
+  jq -n --arg repo "$REPO" --arg pr "$PR" --arg head "$HEAD_SHA" --arg rv "$CHOSEN" \
+        --arg verdict "$VERDICT_LINE" --arg ps "$PRIMARY_STATUS" --arg c3 "$MAY_COMPLETE_C3" \
+        --arg trunc "$TRUNCATED" --arg enf "$ENFORCEMENT" --arg tamper "$TAMPER" \
+        --argjson bytes "$REVIEW_BYTES" \
+    '{status:"reviewed",repo:$repo,pr:($pr|tonumber),head:$head,reviewer:$rv,
+      isolation:{mode:"fresh-process",read_only_enforcement:$enf,tamper_check:$tamper},
+      review_bytes:$bytes,diff_truncated:$trunc,
+      verdict:$verdict,diversity_limb:"satisfied",primary_verdict:$ps,
+      may_complete_c3:($c3=="true")}'
+else
+  cat "$COMMENT_F"
+fi
+
+[ "$MAY_COMPLETE_C3" = "true" ] || exit 3
+exit 0

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -54,20 +54,35 @@ Usage: routed-review.sh --pr N [options]
 USAGE
 }
 
+# `shift 2` FAILS (returns 1) when only one argument remains, and this script
+# deliberately runs without `set -e` — so a value option passed last left `$#`
+# unchanged and spun the loop forever. Proven: 2000 iterations with `$#` stuck
+# at 1. Every value-bearing option therefore asserts its value exists first.
+need_val() {   # $1=flag $2=candidate-value
+  case "${2-}" in
+    "" ) die "option $1 requires a value" ;;
+    -* ) die "option $1 requires a value (got the flag '$2')" ;;
+  esac
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
-    --pr) PR="${2:-}"; shift 2 ;;
-    --repo) REPO="${2:-}"; shift 2 ;;
-    --reviewer) REVIEWER="${2:-}"; shift 2 ;;
-    --timeout) TIMEOUT="${2:-}"; shift 2 ;;
+    --pr)       need_val "$1" "${2-}"; PR="$2";       shift 2 ;;
+    --repo)     need_val "$1" "${2-}"; REPO="$2";     shift 2 ;;
+    --reviewer) need_val "$1" "${2-}"; REVIEWER="$2"; shift 2 ;;
+    --timeout)  need_val "$1" "${2-}"; TIMEOUT="$2";  shift 2 ;;
+    --max-turns) need_val "$1" "${2-}"; MAX_TURNS="$2"; shift 2 ;;
     --no-primary-configured) NO_PRIMARY_ATTESTED=1; shift ;;
-    --max-turns) MAX_TURNS="${2:-}"; shift 2 ;;
     --post) POST=1; shift ;;
     --json) JSON=1; shift ;;
     -h|--help) usage; exit 0 ;;
     *) die "unknown argument: $1 (try --help)" ;;
   esac
 done
+
+case "$PR" in ''|*[!0-9]*) die "--pr must be a positive integer (got '$PR')" ;; esac
+case "$TIMEOUT" in ''|*[!0-9]*) die "--timeout must be an integer (got '$TIMEOUT')" ;; esac
+case "$MAX_TURNS" in ''|*[!0-9]*) die "--max-turns must be an integer (got '$MAX_TURNS')" ;; esac
 
 [ -n "$PR" ] || { usage >&2; die "--pr is required"; }
 command -v gh  >/dev/null 2>&1 || die "gh CLI not found — required to read the PR"
@@ -215,12 +230,23 @@ PROMPT
 } > "$PROMPT_F"
 
 # ---- Isolation enforcement ---------------------------------------------------
-# Two enforcement classes. `vendor` = the CLI itself guarantees read-only.
-# `os`   = it does NOT, so we enforce at the filesystem: the reviewer is given a
-#          DISPOSABLE EXPORT of the head tree with every path chmod'd a-w and no
-#          `.git` at all (so no git mutation is even expressible), and we verify
-#          afterwards that nothing was written. Never trust an unflagged CLI to
-#          behave; make the write impossible and then prove it did not happen.
+# THREE enforcement classes, named for what they actually guarantee:
+#
+#   vendor        the CLI itself confines writes (--sandbox read-only /
+#                 --allowedTools). Trust the vendor, not us.
+#   os-sandboxed  a KERNEL boundary (macOS `sandbox-exec`) denies file-write to
+#                 the export AND to the live repository, plus the disposable
+#                 chmod'd export and a post-run manifest check.
+#   os-perms-only NO kernel boundary is available on this host. The export and
+#                 chmod still reduce blast radius and the manifest still DETECTS
+#                 writes — but `chmod a-w` does NOT confine a process running as
+#                 the file owner: it can chmod u+w and rewrite, or write
+#                 anywhere else it likes. This class is honestly weaker and says
+#                 so in the emitted evidence. It defends against an
+#                 INCIDENTALLY-writing reviewer, never a determined one.
+#
+# The distinction exists because an independent review found the original
+# `os` class claiming a boundary that permissions cannot provide.
 sandbox_class() {
   case "$1" in
     claude|codex) printf 'vendor' ;;   # --allowedTools / --sandbox read-only — the flag IS passed below
@@ -259,6 +285,46 @@ build_readonly_export() {
   log "    export: $(wc -l < "$WORK/manifest.before" | tr -d ' ') files, chmod a-w, no .git"
 }
 
+# A real kernel boundary where the host offers one. macOS ships `sandbox-exec`
+# (deprecated but present and effective for file-write denial). The profile is
+# deliberately `allow default` + targeted denies: a blanket write-deny breaks
+# every CLI's own cache/config writes, so we deny exactly the two trees whose
+# integrity we are claiming — the export and the live repository.
+SANDBOX_PROFILE=""
+build_sandbox_profile() {   # 0 = a kernel boundary is available and armed
+  command -v sandbox-exec >/dev/null 2>&1 || return 1
+  local repo_root
+  repo_root="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
+  SANDBOX_PROFILE="$WORK/deny-writes.sb"
+  {
+    printf '(version 1)\n(allow default)\n'
+    printf '(deny file-write* (subpath "%s"))\n' "$(cd "$EXPORT_DIR" && pwd -P)"
+    printf '(deny file-write* (subpath "%s"))\n' "$(cd "$repo_root" && pwd -P)"
+  } > "$SANDBOX_PROFILE"
+  # prove the profile actually denies before relying on it
+  if sandbox-exec -f "$SANDBOX_PROFILE" /bin/sh -c \
+       "echo probe > '$EXPORT_DIR/.sandbox-probe' 2>/dev/null" 2>/dev/null; then
+    [ -e "$EXPORT_DIR/.sandbox-probe" ] && { rm -f "$EXPORT_DIR/.sandbox-probe" 2>/dev/null; return 1; }
+  fi
+  [ -e "$EXPORT_DIR/.sandbox-probe" ] && return 1
+  return 0
+}
+
+# The manifest only ever covered the export. A reviewer that writes ELSEWHERE —
+# most importantly into the live repository — was invisible to it. Capture the
+# live tree's state too, so an escape is detected rather than assumed away.
+LIVE_BEFORE=""
+snapshot_live_repo() {
+  git rev-parse --is-inside-work-tree >/dev/null 2>&1 || return 0
+  LIVE_BEFORE="$(git status --porcelain 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+}
+verify_live_repo_untouched() {
+  [ -n "$LIVE_BEFORE" ] || return 0
+  local now; now="$(git status --porcelain 2>/dev/null | shasum -a 256 | cut -d' ' -f1)"
+  [ "$now" = "$LIVE_BEFORE" ] && return 0
+  log "[!] live-repo check FAILED — the reviewer mutated the working tree outside its export"
+  return 1
+}
 verify_export_untouched() {
   [ -n "$EXPORT_DIR" ] || return 0
   chmod -R u+rX "$EXPORT_DIR" 2>/dev/null
@@ -276,7 +342,17 @@ verify_export_untouched() {
 # Invocation table. `evidence` marks how the shape was established:
 #   proven   = executed successfully in a recorded prior run
 #   measured = flag confirmed present in this host's --help this build
-# Every `os`-class entry runs with cwd = the locked export, never the live tree.
+# Every os-class entry runs with cwd = the locked export, never the live tree,
+# and — when a kernel boundary is available — under `sandbox-exec`.
+# `SBX` is the prefix array: empty for vendor-confined CLIs (their own sandbox
+# would conflict), populated for os-class ones.
+declare -a SBX=()
+arm_sandbox_prefix() {
+  SBX=()
+  [ -n "$SANDBOX_PROFILE" ] || return 0
+  SBX=(sandbox-exec -f "$SANDBOX_PROFILE")
+}
+
 run_reviewer() {
   local h="$1" rc=0 dir="$2"
   case "$h" in
@@ -289,16 +365,16 @@ run_reviewer() {
       timeout "$TIMEOUT" codex exec --sandbox read-only --cd "$dir" "$(cat "$PROMPT_F")" \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     grok)     # measured: -p non-interactive. --allow-rule NOT passed => os-class.
-      ( cd "$dir" && timeout "$TIMEOUT" grok -p "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" grok -p "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     gemini|qwen|kimi|copilot|pi)   # measured: -p/--prompt non-interactive
-      ( cd "$dir" && timeout "$TIMEOUT" "$h" -p "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" "$h" -p "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     jcode|opencode)                # measured: `run` subcommand
-      ( cd "$dir" && timeout "$TIMEOUT" "$h" run "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" "$h" run "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     kiro)                          # measured: `chat` subcommand
-      ( cd "$dir" && timeout "$TIMEOUT" kiro chat "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" kiro chat "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     *) die "no invocation shape for '$h' — add one to run_reviewer() with its evidence class" ;;
   esac
@@ -317,10 +393,20 @@ cwd_is_head() {
   [ -z "$(git status --porcelain 2>/dev/null)" ] || return 1
 }
 
+snapshot_live_repo
+
 if [ "$ENFORCEMENT" = "os" ]; then
-  log "[D] $CHOSEN has no vendor read-only flag -> enforcing at the filesystem"
+  log "[D] $CHOSEN has no vendor read-only flag -> enforcing outside the CLI"
   build_readonly_export
   SAFE_DIR="$EXPORT_DIR"
+  if build_sandbox_profile; then
+    arm_sandbox_prefix
+    ENFORCEMENT="os-sandboxed"
+    log "    kernel boundary ARMED (sandbox-exec: file-write denied on export + repo, probe verified)"
+  else
+    ENFORCEMENT="os-perms-only"
+    log "    [warn] no kernel boundary on this host -> os-perms-only: writes are DETECTED, not PREVENTED"
+  fi
 elif cwd_is_head; then
   SAFE_DIR="$PWD"
   log "[D] cwd proven at $HEAD_SHA and clean -> vendor sandbox over the live tree"
@@ -335,15 +421,25 @@ fi
 
 log "[D] dispatching $CHOSEN (timeout=${TIMEOUT}s, enforcement=$ENFORCEMENT, cwd=$SAFE_DIR)"
 RC=0; run_reviewer "$CHOSEN" "$SAFE_DIR" || RC=$?
+
+# Two independent tamper checks. The export manifest catches writes INSIDE the
+# sandboxed tree; the live-repo hash catches an ESCAPE — a reviewer writing to
+# the working tree it was never given. The second exists because the first,
+# alone, could not see outside its own directory.
 TAMPER="n/a"
-case "$ENFORCEMENT" in *os*)   # matches `os` AND `vendor+os`
-  if verify_export_untouched; then TAMPER="clean"; else
-    TAMPER="violated"
-    log "[D] ABORT: isolation violated — no review will be stamped or reported as valid"
-    [ "$JSON" -eq 1 ] && printf '{"status":"isolation_violated","reviewer":"%s","diversity_limb":"unsatisfied","may_complete_c3":false}\n' "$CHOSEN"
-    exit 1
-  fi
-  ;; esac
+case "$ENFORCEMENT" in
+  *os*)
+    TAMPER="clean"
+    verify_export_untouched   || TAMPER="violated:export"
+    verify_live_repo_untouched || TAMPER="violated:live-repo"
+    ;;
+  *) verify_live_repo_untouched || TAMPER="violated:live-repo" ;;
+esac
+if [ "${TAMPER#violated}" != "$TAMPER" ]; then
+  log "[D] ABORT ($TAMPER): isolation violated — no review will be stamped or reported as valid"
+  [ "$JSON" -eq 1 ] && printf '{"status":"isolation_violated","detail":"%s","reviewer":"%s","diversity_limb":"unsatisfied","may_complete_c3":false}\n' "$TAMPER" "$CHOSEN"
+  exit 1
+fi
 REVIEW_BYTES="$(wc -c < "$OUT_F" 2>/dev/null | tr -d ' ' || echo 0)"
 
 if [ "$REVIEW_BYTES" -lt 40 ]; then

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -163,19 +163,28 @@ expired() {  # $1=bot ; honours ai-code-review-bots-rotation.md §2 state file
   [ "$now" -lt "$reset" ]
 }
 
-pick_reviewer() {
-  if [ "$REVIEWER" != "auto" ]; then
-    command -v "$REVIEWER" >/dev/null 2>&1 || die "requested reviewer '$REVIEWER' not on PATH"
-    # ⛔ An explicit --reviewer must NOT bypass verifier != generator. Without
-    # this check, `ROUTED_REVIEW_CALLER=codex --reviewer codex` performs the
-    # correlated same-family review the skill forbids, and the emitted comment
-    # would still account it as "C3 diversity satisfied" — fabricated diversity
-    # evidence, the §4.1(e) failure this tool exists to prevent.
-    if [ -n "$CALLER" ] && [ "$REVIEWER" = "$CALLER" ]; then
-      die "refusing --reviewer '$REVIEWER': identical to ROUTED_REVIEW_CALLER — that is a correlated verifier, not an independent one. Pick another family, or unset the caller only if you can justify it."
-    fi
-    printf '%s' "$REVIEWER"; return 0
+# ⛔ Validate an EXPLICIT --reviewer here, in the main shell — NOT inside
+# pick_reviewer(). pick_reviewer runs in a command substitution, so a `die`
+# there exits only the subshell; the `|| { … exit 2 }` below then swallows it
+# and re-labels a usage error as `status:no_reviewer`. The stderr reason still
+# printed, but a JSON consumer was told the wrong cause. Caught on the FIRST
+# run of tests/contract.sh (case 5) — the composition class that four cycles
+# of line-level checking never surfaced.
+if [ "$REVIEWER" != "auto" ]; then
+  command -v "$REVIEWER" >/dev/null 2>&1 || die "requested reviewer '$REVIEWER' not on PATH"
+  # An explicit --reviewer must NOT bypass verifier != generator. Without this,
+  # `ROUTED_REVIEW_CALLER=codex --reviewer codex` performs the correlated
+  # same-family review the skill forbids, and the emitted comment would still
+  # account it as "C3 diversity satisfied" — fabricated diversity evidence,
+  # the §4.1(e) failure this tool exists to prevent.
+  if [ -n "$CALLER" ] && [ "$REVIEWER" = "$CALLER" ]; then
+    die "refusing --reviewer '$REVIEWER': identical to ROUTED_REVIEW_CALLER — that is a correlated verifier, not an independent one. Pick another family, or unset the caller only if you can justify it."
   fi
+fi
+
+pick_reviewer() {
+  # Explicit reviewer already validated above; just hand it back.
+  if [ "$REVIEWER" != "auto" ]; then printf '%s' "$REVIEWER"; return 0; fi
   local h
   for h in "${FAMILY_ORDER[@]}"; do
     [ "$h" = "$CALLER" ] && continue                      # verifier != generator

--- a/skills/routed-pr-review/bin/routed-review.sh
+++ b/skills/routed-pr-review/bin/routed-review.sh
@@ -313,32 +313,40 @@ build_readonly_export() {
 # integrity we are claiming — the export and the live repository.
 SANDBOX_PROFILE=""
 build_sandbox_profile() {   # 0 = a kernel boundary is available and armed
+  # ⛔ Build into a LOCAL, and publish the global only on success. The earlier
+  # version assigned $SANDBOX_PROFILE up-front, so a failing probe returned 1
+  # while LEAVING the global set — and `arm_sandbox_prefix` (which trusts only
+  # non-emptiness) then wrapped every reviewer dispatch in a profile that had
+  # just been PROVEN not to work. The result was an opaque per-harness failure:
+  # the same fail-through class the two-step probe below was added to close,
+  # one level up from it. Caught by tests/contract.sh case 8.
+  SANDBOX_PROFILE=""
   command -v sandbox-exec >/dev/null 2>&1 || return 1
-  local repo_root
+  local repo_root prof
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || printf '%s' "$PWD")"
-  SANDBOX_PROFILE="$WORK/deny-writes.sb"
+  prof="$WORK/deny-writes.sb"
   {
     printf '(version 1)\n(allow default)\n'
     printf '(deny file-write* (subpath "%s"))\n' "$(cd "$EXPORT_DIR" && pwd -P)"
     printf '(deny file-write* (subpath "%s"))\n' "$(cd "$repo_root" && pwd -P)"
-  } > "$SANDBOX_PROFILE"
-  # ⛔ Two-step probe. The single-step version could NOT distinguish "sandbox-exec
-  # ran and denied the write" from "sandbox-exec never ran at all" (invalid
-  # profile, unsupported OS, SIP policy): both leave no probe file, both make the
-  # `if` false, and the old fallthrough then `return 0` = ARMED. Measured:
-  # `sandbox-exec -f /nonexistent.sb /bin/echo x` exits 65, i.e. a failure to
-  # confine was indistinguishable from a successful denial — a fail-OPEN inside
-  # the very control added to close a fail-open. Found by a routed kimi review
-  # of this tool on #414 (cycle 4).
-  # Step 1 — liveness: the profile must be able to run a harmless ALLOWED command.
-  sandbox-exec -f "$SANDBOX_PROFILE" /usr/bin/true >/dev/null 2>&1 || return 1
+  } > "$prof" || return 1
+  # Two-step probe. A single step could NOT distinguish "sandbox-exec ran and
+  # denied the write" from "sandbox-exec never ran at all" (invalid profile,
+  # unsupported OS, SIP policy): both leave no probe file, both made the old
+  # `if` false, and the fallthrough then returned 0 = ARMED. Measured:
+  # `sandbox-exec -f /nonexistent.sb /bin/echo x` exits 65 — a failure to
+  # confine was indistinguishable from a successful denial. Found by a routed
+  # kimi review of this tool on #414 (cycle 4).
+  # Step 1 — liveness: the profile must run a harmless ALLOWED command.
+  sandbox-exec -f "$prof" /usr/bin/true >/dev/null 2>&1 || return 1
   # Step 2 — denial: the write must fail AND leave no file.
-  sandbox-exec -f "$SANDBOX_PROFILE" /bin/sh -c \
+  sandbox-exec -f "$prof" /bin/sh -c \
     "echo probe > '$EXPORT_DIR/.sandbox-probe' 2>/dev/null" >/dev/null 2>&1
   if [ -e "$EXPORT_DIR/.sandbox-probe" ]; then
     rm -f "$EXPORT_DIR/.sandbox-probe" 2>/dev/null
     return 1   # the write LANDED => not a boundary
   fi
+  SANDBOX_PROFILE="$prof"   # publish ONLY after both steps proved it
   return 0
 }
 
@@ -379,6 +387,12 @@ verify_export_untouched() {
 # `SBX` is the prefix array: empty for vendor-confined CLIs (their own sandbox
 # would conflict), populated for os-class ones.
 declare -a SBX=()
+# ⛔ Every ${SBX[@]} below uses the ${SBX[@]+"${SBX[@]}"} idiom: under `set -u`
+# bash 3.2 (the macOS default) treats expanding an EMPTY array as an unbound
+# variable and aborts. SBX is empty exactly when no kernel boundary armed —
+# i.e. the whole documented `os-perms-only` fallback class crashed on every
+# dispatch, on every host without a working sandbox-exec (all of Linux). It
+# never showed here because this host arms. Caught by tests/contract.sh case 8.
 arm_sandbox_prefix() {
   SBX=()
   [ -n "$SANDBOX_PROFILE" ] || return 0
@@ -403,16 +417,16 @@ run_reviewer() {
       timeout "$TIMEOUT" codex exec --sandbox read-only --cd "$dir" "$(cat "$PROMPT_F")" \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     grok)     # measured: -p non-interactive. --allow-rule NOT passed => os-class.
-      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" grok -p "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" ${SBX[@]+"${SBX[@]}"} grok -p "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     gemini|qwen|kimi|copilot|pi)   # measured: -p/--prompt non-interactive
-      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" "$h" -p "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" ${SBX[@]+"${SBX[@]}"} "$h" -p "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     jcode|opencode)                # measured: `run` subcommand
-      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" "$h" run "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" ${SBX[@]+"${SBX[@]}"} "$h" run "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     kiro)                          # measured: `chat` subcommand
-      ( cd "$dir" && timeout "$TIMEOUT" "${SBX[@]}" kiro chat "$(cat "$PROMPT_F")" ) \
+      ( cd "$dir" && timeout "$TIMEOUT" ${SBX[@]+"${SBX[@]}"} kiro chat "$(cat "$PROMPT_F")" ) \
         > "$OUT_F" 2>"$WORK/err" || rc=$? ;;
     *) die "no invocation shape for '$h' — add one to run_reviewer() with its evidence class" ;;
   esac

--- a/skills/routed-pr-review/tests/contract.sh
+++ b/skills/routed-pr-review/tests/contract.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# routed-pr-review — gate CONTRACT tests.
+#
+# Why this exists: four dogfood cycles produced 19 findings, zero of them
+# self-caught, and the two worst were COMPOSITION defects — every individual
+# line verified against the binary while the PATH through them was dead
+# (`exit 0` unreachable via a `.head` scope bug) or wrong (`--add-dir` granting
+# access without moving cwd). Line-level checking cannot see either. These tests
+# run the REAL script end-to-end against stubbed externals, so they assert the
+# path, not the line.
+#
+# Design: no network, no real reviewer, no real gh. A temp git repo supplies a
+# real HEAD_SHA (the script fetches/archives it, so it must exist), and a stub
+# PATH supplies `gh` + a fake reviewer whose behaviour each case controls via
+# T_* env vars. Exit codes and JSON fields are the contract under test.
+#
+# Usage: bash skills/routed-pr-review/tests/contract.sh [-v]
+# Exit:  0 all pass · 1 any fail
+
+set -uo pipefail
+VERBOSE=0; [ "${1:-}" = "-v" ] && VERBOSE=1
+
+SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$SELF_DIR/../bin/routed-review.sh"
+[ -f "$SUT" ] || { echo "FATAL: script under test not found at $SUT" >&2; exit 1; }
+
+PASS=0; FAIL=0; FAILED_NAMES=()
+
+# ---------------------------------------------------------------- scaffolding
+SANDBOX="$(mktemp -d "${TMPDIR:-/tmp}/rr-contract.XXXXXX")"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+REPO_DIR="$SANDBOX/repo"; STUB_BIN="$SANDBOX/bin"
+mkdir -p "$REPO_DIR" "$STUB_BIN"
+
+# A real one-commit repo: the script proves cwd == HEAD_SHA and can git-archive it.
+(
+  cd "$REPO_DIR"
+  git init -q . 2>/dev/null
+  git config user.email t@t; git config user.name t; git config commit.gpgsign false
+  echo hello > file.txt
+  git add -A && git commit -qm "seed"
+) || { echo "FATAL: could not build temp repo" >&2; exit 1; }
+HEAD_SHA="$(cd "$REPO_DIR" && git rev-parse HEAD)"
+
+# `gh` stub. Behaviour is driven entirely by T_* env vars so each case is data,
+# not code. It answers exactly the four call shapes the script makes.
+cat > "$STUB_BIN/gh" <<'STUB'
+#!/usr/bin/env bash
+case "$1 ${2:-}" in
+  "pr view")
+    cat <<JSON
+{ "number": 1, "title": "contract fixture", "headRefOid": "${T_HEAD}",
+  "headRefName": "feat/x", "baseRefName": "main", "url": "https://example.invalid/pr/1",
+  "author": {"login": "someone"},
+  "mergeStateStatus": "${T_MERGESTATE:-UNSTABLE}",
+  "reviewDecision": "${T_DECISION:-}",
+  "latestReviews": ${T_REVIEWS:-[]},
+  "comments": ${T_COMMENTS:-[]} }
+JSON
+    ;;
+  "pr diff")    printf 'diff --git a/file.txt b/file.txt\n+contract fixture\n' ;;
+  "pr comment") exit 0 ;;
+  "api "*|"api")
+                printf '%s\n' "${T_REPO_COMMENTS:-[]}" ;;
+  *)            exit 0 ;;
+esac
+STUB
+chmod +x "$STUB_BIN/gh"
+
+# Fake reviewer, in a family that is never the caller. Output length + verdict
+# are per-case, which is what drives the <40-byte and gate branches.
+cat > "$STUB_BIN/kimi" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "${T_REVIEW_BODY:-}"
+exit "${T_REVIEW_RC:-0}"
+STUB
+chmod +x "$STUB_BIN/kimi"
+
+# ---------------------------------------------------------------- assertions
+# Run the REAL script against the stub PATH. Per-case fixtures are passed as an
+# env prefix (`T_REVIEWS=… sut`) — bash applies those to the function call, so
+# each case is data rather than another copy of the invocation.
+sut() {
+  ( cd "$REPO_DIR" \
+    && PATH="$STUB_BIN:$PATH" T_HEAD="$HEAD_SHA" \
+       bash "$SUT" --pr 1 --repo o/r --reviewer "${RV:-kimi}" --timeout 500 --json 2>"$SANDBOX/err" )
+}
+
+check() {  # check <name> <expected-rc> [<jq-filter> <expected-value>]
+  local name="$1" want_rc="$2" filter="${3:-}" want_val="${4:-}" ok=1 why=""
+  [ "$RC" = "$want_rc" ] || { ok=0; why="exit $RC, wanted $want_rc"; }
+  if [ -n "$filter" ] && [ "$ok" = 1 ]; then
+    local got; got="$(printf '%s' "$OUT" | jq -r "$filter" 2>/dev/null)"
+    [ "$got" = "$want_val" ] || { ok=0; why="$filter = '$got', wanted '$want_val'"; }
+  fi
+  if [ "$ok" = 1 ]; then
+    PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m  %s\n' "$name"
+  else
+    FAIL=$((FAIL+1)); FAILED_NAMES+=("$name")
+    printf '  \033[31mFAIL\033[0m  %s — %s\n' "$name" "$why"
+    [ "$VERBOSE" = 1 ] && { printf '        stdout: %s\n' "${OUT:0:400}"; printf '        stderr: %s\n' "$(tail -3 "$SANDBOX/err")"; }
+  fi
+}
+
+ok_grep() {  # ok_grep <name> <pattern> — assert stderr carries a reason
+  if grep -qi "$2" "$SANDBOX/err"; then
+    PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m  %s\n' "$1"
+  else
+    FAIL=$((FAIL+1)); FAILED_NAMES+=("$1"); printf '  \033[31mFAIL\033[0m  %s\n' "$1"
+  fi
+}
+
+AT_HEAD='[{"author":{"login":"coderabbitai"},"state":"%s","commit":{"oid":"'"$HEAD_SHA"'"}}]'
+OLD_SHA='[{"author":{"login":"coderabbitai"},"state":"APPROVED","commit":{"oid":"0000000000000000000000000000000000000000"}}]'
+BODY="Finding 1 [major] the fixture body is deliberately well past the forty byte floor.
+VERDICT: REQUEST_CHANGES — substantive."
+
+echo "routed-pr-review — gate contract"
+echo "  SUT: $SUT"
+echo "  fixture head: ${HEAD_SHA:0:7}"
+echo
+
+# ── 1 ── `exit 0` must be REACHABLE.
+# Regression for the `.head` scope bug: `.head` does not exist inside a
+# `.reviews[]` element, so `select(.sha != .head)` was `!= null` = always true;
+# every review counted stale and this path was dead code. Four cycles of
+# line-level verification never caught it because every line was correct.
+OUT="$(T_REVIEWS="$(printf "$AT_HEAD" APPROVED)" T_DECISION=APPROVED T_REVIEW_BODY="$BODY" \
+       ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "exit 0 reachable when a configured primary cleared THIS head" 0 '.may_complete_c3' "true"
+
+# ── 2 ── an approval at an OLDER sha must not clear the gate (no false-green).
+OUT="$(T_REVIEWS="$OLD_SHA" T_REVIEW_BODY="$BODY" ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "stale-head approval does NOT clear C3" 3 '.may_complete_c3' "false"
+
+# ── 3 ── §4.1(e): routing never dismisses an active CHANGES_REQUESTED.
+OUT="$(T_REVIEWS="$(printf "$AT_HEAD" CHANGES_REQUESTED)" T_DECISION=CHANGES_REQUESTED \
+       T_REVIEW_BODY="$BODY" ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "CHANGES_REQUESTED is never dismissed by a routed review" 3 '.may_complete_c3' "false"
+
+# ── 4 ── empty reviewer output is NOT a review (anti-theater guard #1).
+OUT="$(T_REVIEWS='[]' T_REVIEW_BODY="" ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "under-40-byte output is treated as NO review" 2 '.status' "empty_review"
+
+# ── 5 ── verifier != generator: the caller's own family may not review.
+OUT="$(RV=kimi ROUTED_REVIEW_CALLER=kimi sut)"; RC=$?
+check "explicit --reviewer identical to the caller is REFUSED" 1
+ok_grep "refusal names the correlated-verifier reason" 'correlated verifier'
+
+# ── 6 ── silence is never 'absent'. No bot ever seen, no attestation => HOLD.
+OUT="$(T_REVIEWS='[]' T_COMMENTS='[]' T_REPO_COMMENTS='[]' T_REVIEW_BODY="$BODY" \
+       ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "silence alone never proves 'no primary configured'" 3 '.may_complete_c3' "false"
+
+# ── 7 ── argument parsing must terminate.
+# Regression for the `shift 2` infinite loop: a value option passed last left
+# \$# unchanged and the loop spun (2000 iterations measured before the fix).
+timeout 10 bash "$SUT" --pr 1 --repo >/dev/null 2>&1; RC=$?
+if [ "$RC" = 1 ]; then
+  PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m  %s\n' "trailing value-option dies immediately (no infinite loop)"
+else
+  FAIL=$((FAIL+1)); FAILED_NAMES+=("arg loop")
+  printf '  \033[31mFAIL\033[0m  trailing value-option: exit %s (124 = hung)\n' "$RC"
+fi
+
+echo
+printf '  %s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ] || { printf '  failed: %s\n' "${FAILED_NAMES[*]}"; exit 1; }
+exit 0

--- a/skills/routed-pr-review/tests/contract.sh
+++ b/skills/routed-pr-review/tests/contract.sh
@@ -81,9 +81,15 @@ chmod +x "$STUB_BIN/kimi"
 # Run the REAL script against the stub PATH. Per-case fixtures are passed as an
 # env prefix (`T_REVIEWS=… sut`) — bash applies those to the function call, so
 # each case is data rather than another copy of the invocation.
+# `EXTRA_BIN` prepends a per-case stub dir (used to force a broken sandbox).
+# `ONLY_BIN` REPLACES the PATH entirely (used to prove a missing dependency is
+# diagnosed rather than surfacing later as an opaque failure).
 sut() {
+  local p="${STUB_BIN}:${PATH}"
+  [ -n "${EXTRA_BIN:-}" ] && p="${EXTRA_BIN}:${p}"
+  [ -n "${ONLY_BIN:-}" ]  && p="${ONLY_BIN}"
   ( cd "$REPO_DIR" \
-    && PATH="$STUB_BIN:$PATH" T_HEAD="$HEAD_SHA" \
+    && PATH="$p" T_HEAD="$HEAD_SHA" \
        bash "$SUT" --pr 1 --repo o/r --reviewer "${RV:-kimi}" --timeout 500 --json 2>"$SANDBOX/err" )
 }
 
@@ -163,6 +169,37 @@ else
   FAIL=$((FAIL+1)); FAILED_NAMES+=("arg loop")
   printf '  \033[31mFAIL\033[0m  trailing value-option: exit %s (124 = hung)\n' "$RC"
 fi
+
+# ── 8 ── the sandbox probe must FAIL CLOSED.
+# Cycle-4 regression. The single-step probe could not tell "sandbox-exec ran and
+# denied the write" from "sandbox-exec never ran" — both leave no probe file,
+# and the old fallthrough then reported ARMED. A failure to confine was
+# indistinguishable from a successful denial: a fail-open inside the control
+# added to close a fail-open. A `sandbox-exec` that always fails must therefore
+# degrade the class to `os-perms-only`, never claim `os-sandboxed`.
+BROKEN_SBX="$SANDBOX/broken"; mkdir -p "$BROKEN_SBX"
+printf '#!/usr/bin/env bash\nexit 65\n' > "$BROKEN_SBX/sandbox-exec"
+chmod +x "$BROKEN_SBX/sandbox-exec"
+OUT="$(EXTRA_BIN="$BROKEN_SBX" T_REVIEWS='[]' T_REVIEW_BODY="$BODY" \
+       ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "a broken sandbox-exec degrades to os-perms-only (never claims os-sandboxed)" \
+      3 '.isolation.read_only_enforcement' "os-perms-only"
+
+# ── 9 ── a missing hard dependency is DIAGNOSED, not discovered late.
+# Cycle-4 regression. `timeout` is used at 6 dispatch sites and in both sandbox
+# probes, but was never checked while gh/jq/tar were; on a host without it the
+# absence surfaced as an opaque per-harness failure. The guard sits after the
+# gh + jq checks, so a PATH carrying those two — plus the interpreter itself —
+# reaches it. (First draft of this case omitted `bash` and scored exit 127:
+# the harness was measuring its own missing shell, not the guard. A test that
+# fails for the wrong reason is worse than no test.)
+ONLY="$SANDBOX/only"; mkdir -p "$ONLY"
+cp "$STUB_BIN/gh" "$ONLY/gh"
+ln -sf "$(command -v jq)"   "$ONLY/jq"
+ln -sf "$(command -v bash)" "$ONLY/bash"
+OUT="$(ONLY_BIN="$ONLY" ROUTED_REVIEW_CALLER=claude sut)"; RC=$?
+check "absent \`timeout\` aborts with a diagnostic instead of failing opaquely later" 1
+ok_grep "the diagnostic names the dependency and the remedy" 'timeout not found'
 
 echo
 printf '  %s passed, %s failed\n' "$PASS" "$FAIL"

--- a/skills/routed-pr-review/wrappers/README.md
+++ b/skills/routed-pr-review/wrappers/README.md
@@ -55,3 +55,7 @@ mechanism a table cannot satisfy:
 5. Never wrap the script in a retry loop against the *same* reviewer; rotation
    already fall-throughs (`ai-code-review-bots-rotation.md` §3.5: a hot retry on
    the same bot is not a different strategy).
+
+---
+
+*Signed: `Claude-Dev-pr414` (Claude Opus 5, branch `feat/routed-pr-review` @ `342165e`) | 2026-09-03T15:33:49-03:00 — per `CLAUDE.md` §Sign documents with agent ID and timestamp*

--- a/skills/routed-pr-review/wrappers/README.md
+++ b/skills/routed-pr-review/wrappers/README.md
@@ -1,0 +1,57 @@
+# Per-harness wrappers — caller side
+
+The dispatcher (`../bin/routed-review.sh`) is already harness-agnostic on the
+**reviewer** side (it capability-detects and picks one). These wrappers are the
+**caller** side: how each host invokes the skill, and the one variable that must
+be set for the independence invariant to hold.
+
+## The single non-negotiable
+
+```bash
+ROUTED_REVIEW_CALLER=<the harness you are running in>
+```
+
+Without it the dispatcher cannot exclude the caller's own vendor family and may
+route the review back to the same model that wrote the code — a **correlated
+verifier**, which is the exact failure `cross-harness-red-team.md` §Must-not
+forbids. Unset is tolerated (no exclusion) but it silently weakens the gate, so
+every wrapper below sets it.
+
+## Design decision — one table, not eleven near-identical files
+
+`# /** [decision] · @context 11 harnesses named in the forge order · @reason the
+invocation differs by ONE token per host; eleven files would be eleven copies of
+one line, violating PHASE III SSOT/DRY of agentic-bootloader-v2 · @impact a
+single table is the SSOT; only harnesses with a real *discovery* convention get a
+file of their own */`
+
+Files that exist beyond this table do so because the harness has a discovery
+mechanism a table cannot satisfy:
+
+- `invoke.sh` — generic POSIX entry point for any harness that can shell out.
+
+## Invocation per harness
+
+| harness | how to call | notes |
+|---|---|---|
+| **claude** (Claude Code) | `ROUTED_REVIEW_CALLER=claude skills/routed-pr-review/bin/routed-review.sh --pr N --post` | or via the `Bash` tool; skill auto-discovers under `skills/` |
+| **codex** | `ROUTED_REVIEW_CALLER=codex ./…/routed-review.sh --pr N --json` | codex will not be chosen as its own reviewer |
+| **gemini / antigravity** | `ROUTED_REVIEW_CALLER=gemini ./…/routed-review.sh --pr N` | |
+| **opencode** | `ROUTED_REVIEW_CALLER=opencode ./…/routed-review.sh --pr N` | native `opencode pr <N>` is a *separate* path, not wrapped |
+| **aws-kiro / crew** | `ROUTED_REVIEW_CALLER=kiro ./…/routed-review.sh --pr N` | |
+| **pi** | `ROUTED_REVIEW_CALLER=pi ./…/routed-review.sh --pr N` | pi has no spawn tool — this is exactly its use case |
+| **oh-my-pi** | `ROUTED_REVIEW_CALLER=pi ./…/routed-review.sh --pr N` | same family as `pi`; shares its exclusion |
+| **prime-agent** | `ROUTED_REVIEW_CALLER=prime-agent ./…/routed-review.sh --pr N` | unknown family ⇒ no exclusion applied; pass an explicit `--reviewer` if the host shares a vendor with one in the pool |
+| **copilot** | `ROUTED_REVIEW_CALLER=copilot ./…/routed-review.sh --pr N` | |
+| **kimi / qwen / grok / jcode** | `ROUTED_REVIEW_CALLER=<name> ./…/routed-review.sh --pr N` | |
+| **any other** | `ROUTED_REVIEW_CALLER=<binary-name> ./…/routed-review.sh --pr N` | the name only needs to match the pool entry to be excluded |
+
+## Contract for every wrapper
+
+1. Set `ROUTED_REVIEW_CALLER`.
+2. Do not pass `--post` unless the caller is authorised to write to the PR.
+3. Treat exit `3` as **"reviewed but still blocked"** — never as a merge signal.
+4. Treat exit `2` as **"no review exists"** — never stamp, never claim green.
+5. Never wrap the script in a retry loop against the *same* reviewer; rotation
+   already fall-throughs (`ai-code-review-bots-rotation.md` §3.5: a hot retry on
+   the same bot is not a different strategy).

--- a/skills/routed-pr-review/wrappers/invoke.sh
+++ b/skills/routed-pr-review/wrappers/invoke.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env sh
+# Generic caller-side wrapper for any harness that can shell out.
+#
+# Auto-detects the calling harness from the environment so the independence
+# invariant (verifier != generator) holds without the caller remembering to set
+# ROUTED_REVIEW_CALLER by hand. Detection is best-effort and NEVER fabricates:
+# if no signal is found, the variable stays unset and the dispatcher applies no
+# exclusion — a weaker but honest gate.
+#
+# Usage: wrappers/invoke.sh --pr 42 [--post] [--json] [any dispatcher flag]
+set -u
+
+DIR="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
+DISPATCH="$DIR/bin/routed-review.sh"
+[ -x "$DISPATCH" ] || { printf 'invoke: %s not executable\n' "$DISPATCH" >&2; exit 1; }
+
+detect_caller() {
+  # Order matters: most specific env signal first. Each line is a real variable
+  # exported by that harness, not a guess about one.
+  [ -n "${CLAUDE_CODE_SESSION_ID:-}" ] && { echo claude; return; }
+  [ -n "${CLAUDECODE:-}" ]             && { echo claude; return; }
+  [ -n "${CODEX_SANDBOX:-}" ]          && { echo codex;  return; }
+  [ -n "${GEMINI_CLI:-}" ]             && { echo gemini; return; }
+  [ -n "${OPENCODE:-}" ]               && { echo opencode; return; }
+  [ -n "${KIRO_IDE:-}" ]               && { echo kiro; return; }
+  # $TERM_PROGRAM / parent-process sniffing deliberately omitted: it misfires
+  # inside tmux and under any wrapper shell, and a WRONG caller name is worse
+  # than none (it would exclude an innocent reviewer and admit the real one).
+  echo ""
+}
+
+CALLER="${ROUTED_REVIEW_CALLER:-$(detect_caller)}"
+if [ -n "$CALLER" ]; then
+  ROUTED_REVIEW_CALLER="$CALLER" exec "$DISPATCH" "$@"
+else
+  printf 'invoke: caller harness not detected — no vendor exclusion will be applied.\n' >&2
+  printf 'invoke: set ROUTED_REVIEW_CALLER=<harness> to restore verifier!=generator.\n' >&2
+  exec "$DISPATCH" "$@"
+fi


### PR DESCRIPTION
Forges `skills/routed-pr-review` — soul-name **Euthyna** (εὔθυνα, the independent end-of-term audit of an Athenian magistrate, conducted by officials who were *not* the magistrate). Executes the forge order in `a private downstream repository` `journals/diy-pr-review-agent-v0-braindump.md`.

## Why

`2026-09-03`, `a private downstream repository (issue/PR reference removed)`: CodeRabbit stalled on an exhausted hourly quota. A delegated reviewer with isolated context found **two real defects that had already been published** — a path fabricated by a `sed` on a bare stem, and an `id:` convention measured from too narrow a sample. Neither was caught by the author across several self-review passes.

`ai-code-review-bots-rotation.md` §5 forbids a local lint pass from counting as a review. `pr-review-protocol.md` §4.1 records a bot answering at ~8h and again after 2 days. This tool is the rung those two leave open: keep **reviewing** while blocked, never **merge** while blocked.

## Isolation — enforced on two axes

| axis | mechanism |
|---|---|
| context | fresh OS process, different vendor family (caller excluded via `ROUTED_REVIEW_CALLER`), no delegator history, refute-first prompt |
| read-only `vendor` (3/11) | `codex --sandbox read-only --cd`, `claude --allowedTools`, `grok --allow-rule` |
| read-only `os` (8/11) | disposable `git archive` export: every path `chmod a-w`, **no `.git`**, + `sha256` manifest tamper-check after the run |

Smoke-tested this build: 810 files exported, no `.git`; write to an existing file **blocked by the OS**; new-file creation **blocked**; manifest identical on an intact export; injected mutation **detected** (2 divergent manifest lines).

Only 3 of 11 harnesses expose a read-only switch — asking the other 8 nicely is not enforcement, so the OS enforces it and the result is audited rather than asserted.

## Gate honesty (`§4.1(e)`)

| limb | routed review |
|---|---|
| C3 *diversity* (independent cross-brand opinion) | **satisfies** |
| A configured primary's verdict on the current head | **never** |
| Dismissing an active `CHANGES_REQUESTED` | **never** |
| Completing convergence alone | only where **no** primary is configured (positively evidenced) **or** all primaries have cleared |

`may_complete_c3` is computed from the live primary probe, not asserted. Exit codes carry it: `0` may complete · `3` reviewed-but-blocked · `2` no reviewer / empty output · `1` error or isolation violation.

**No rule amendment was needed.** The forge order flagged a possible `§4.1(e)` tension requiring either the verifier-limb position or an H6-gated amendment with red-team + HITL. Path (i) is already fully specified by the rule as written — it lacked an implementation, not a change. No H6 cycle consumed.

## DRY / Strata — what was reused

| capability | source | disposition |
|---|---|---|
| review criteria, severity taxonomy | 9+ reviewer skills already installed | reused, none authored |
| bot-message taxonomy | `review-bot-quota-recovery.md` | reused (phase B) |
| rotation + state file + no hot retry | `ai-code-review-bots-rotation.md` | reused (phase C) |
| gate semantics | `pr-review-protocol.md` §4.1 | implemented |
| isolation shape | `cross-harness-red-team.md` | reused (phase D) |
| in-harness stub | `agents/code-reviewer.md` | left intact; now declares its own correlated-verifier boundary and points here |

## Files

- `skills/routed-pr-review/SKILL.md`
- `skills/routed-pr-review/bin/routed-review.sh` (`bash -n` clean, `shellcheck -S warning` **0 warnings**)
- `skills/routed-pr-review/wrappers/README.md` — per-harness caller table + the `ROUTED_REVIEW_CALLER` invariant
- `skills/routed-pr-review/wrappers/invoke.sh` — generic entry, best-effort caller detection that never fabricates
- `agents/code-reviewer.md` — +18 lines, additive independence boundary

## Dogfood

Cycle 1 runs this dispatcher against **this PR**, caller `claude` ⇒ routed to a different vendor family. Result posted as a comment below with the `§4.1(b)` stamp, head SHA and full reviewer output.

## Verified in build

- `--cd` on `codex exec` — **measured**, not assumed (`-C, --cd <DIR>`)
- 9 of 11 headless invocations confirmed present in this host's `--help`
- `bash -n` + `sh -n` clean; `shellcheck -S warning` 0 warnings (2 dead vars found and fixed: one deleted, one plumbed into the output as isolation evidence)
- Defect caught in build before first dogfood: the original dispatcher ran all 8 unflagged harnesses in `$PWD` while the doc claimed read-only. The doc was ahead of the code; the mechanism above closes it.
